### PR TITLE
Ponded water/alternative solutions - object-oriented

### DIFF
--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -29,8 +29,8 @@ module SoilHydrologyMod
   use ColumnType        , only : col                
   use PatchType         , only : patch                
 
-  use computeFluxMod                            ! template for the flux module
-  use implicitEulerMod  , only : implicitEuler  ! implicit Euler solver for a single state
+  use computeFluxMod    , only : computeFlux_type ! template for the flux module
+  use implicitEulerMod  , only : implicitEuler    ! implicit Euler solver for a single state
 
   !
   ! !PUBLIC TYPES:
@@ -58,7 +58,7 @@ module SoilHydrologyMod
   private :: QflxH2osfcSurf      ! Compute qflx_h2osfc_surf
   private :: QflxH2osfcDrain     ! Compute qflx_h2osfc_drain
 
-  type, extends(flux_type) :: drainPond_type
+  type, extends(computeFlux_type) :: drainPond_type
      real(r8) :: smoothScale
      real(r8) :: drainMax
    contains

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -28,6 +28,10 @@ module SoilHydrologyMod
   use LandunitType      , only : lun                
   use ColumnType        , only : col                
   use PatchType         , only : patch                
+
+  use computeFluxMod                            ! template for the flux module
+  use implicitEulerMod  , only : implicitEuler  ! implicit Euler solver for a single state
+
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -581,8 +585,16 @@ contains
      logical           , intent(inout) :: truncate_h2osfc_to_zero( bounds%begc: ) ! whether h2osfc should be truncated to 0 to correct for roundoff errors, in order to maintain bit-for-bit the same answers as the old code
      !
      ! !LOCAL VARIABLES:
-     integer :: fc, c
-     real(r8) :: dtime         ! land model time step (sec)
+     procedure(fluxTemplate), pointer :: funcName ! function name
+     integer             :: fc, c               
+     real(r8)            :: dtime                 ! land model time step (sec)
+     real(r8)            :: h2osfc1               ! h2osfc at the end of the time step, given qflx_h2osfc_drain only
+     real(r8)            :: drainMax              ! maximum drainage rate of ponded water
+     real(r8)            :: const                 ! constant in analytical integral
+     real(r8)            :: uFunc                 ! analytical integral
+     real(r8), parameter :: smoothScale=0.05_r8   ! smoothing scale
+     integer(i4b)        :: err                   ! error code
+     character(len=128)  :: message               ! error message
 
      character(len=*), parameter :: subname = 'QflxH2osfcDrain'
      !-----------------------------------------------------------------------
@@ -603,9 +615,31 @@ contains
            truncate_h2osfc_to_zero(c) = .true.
         else
 
+           ! define maximum drainage
+           ! NOTE: check fraction
+           drainMax = frac_h2osfc(c)*qinmax(c)
 
+           ! switch between different numerical solutions
+           select case(ixSolution)
 
-           qflx_h2osfc_drain(c)=min(frac_h2osfc(c)*qinmax(c),h2osfc(c)/dtime)
+              ! constrained Explicit Euler solution with operator splitting (original)
+              case(ixExplicitEuler)
+                 qflx_h2osfc_drain(c)=min(drainMax,h2osfc(c)/dtime)
+
+              ! implicit Euler solution with operator splitting
+              case(ixImplicitEuler)
+                 funcName=>drainPond
+                 call implicitEuler(funcName, dtime, h2osfc(c), h2osfc1, err, message)
+                 if(err/=0) call endrun(subname // ':: '//trim(message))
+                 call drainPond(h2osfc1, qflx_h2osfc_drain(c))
+
+              ! analytical solution with operator splitting
+              case(ixAnalytical)
+                 const   = 1._r8 - 1._r8/(1._r8 - exp(-h2osfc(c)/smoothScale))
+                 uFunc   = -1._r8/(const*exp(drainMax*dtime/smoothScale) - 1._r8)
+                 h2osfc1 = -alog(1._r8 - uFunc)*smoothScale
+                 qflx_h2osfc_drain(c)= (h2osfc1 - h2osfc(c))/dtime
+
            if(h2osfcflag==0) then
               ! ensure no h2osfc
               qflx_h2osfc_drain(c)= max(0._r8,h2osfc(c)/dtime)
@@ -613,6 +647,22 @@ contains
            truncate_h2osfc_to_zero(c) = .false.
         end if
      end do
+
+   contains
+
+      ! model-specific flux routine
+      subroutine drainPond(storage, flux, dfdx)
+      ! dummy variables
+      real(r8), intent(in)           :: storage    ! storage
+      real(r8), intent(out)          :: flux       ! drainage flux
+      real(r8), intent(out),optional :: dfdx       ! derivative
+      ! local variables
+      real(r8)                       :: arg        ! temporary argument
+      ! procedure starts here
+      arg  = exp(-storage/smoothScale)
+      flux = -inputRate*(1._dp - arg)
+      if(present(dfdx)) dfdx = -inputRate*arg/smoothScale
+      end subroutine drainPond
 
    end subroutine QflxH2osfcDrain
 

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -57,6 +57,12 @@ module SoilHydrologyMod
   !-----------------------------------------------------------------------
   real(r8), private :: baseflow_scalar = 1.e-2_r8
 
+  ! !ALTERNATIVE NUMERICAL SOLUTIONS
+  integer, parameter :: ixExplicitEuler=1001  ! constrained Explicit Euler solution with operator splitting (original)
+  integer, parameter :: ixImplicitEuler=1002  ! implicit Euler solution with operator splitting
+  integer, parameter :: ixAnalytical=1003     ! analytical solution with operator splitting
+  integer  :: ixSolution=ixExplicitEuler
+
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
 
@@ -482,12 +488,6 @@ contains
      real(r8) :: activePond    ! ponded water above threshold = h2osfc - h2osfc_thresh
      real(r8) :: h2osfc1       ! h2osfc at the end of the time step, given qflx_h2osfc_surf only
 
-     ! !ALTERNATIVE NUMERICAL SOLUTIONS
-     integer, parameter :: ixExplicitEuler=1001  ! constrained Explicit Euler solution with operator splitting (original)
-     integer, parameter :: ixImplicitEuler=1002  ! implicit Euler solution with operator splitting
-     integer, parameter :: ixAnalytical=1003     ! analytical solution with operator splitting
-     integer  :: ixSolution=ixExplicitEuler
-
      character(len=*), parameter :: subname = 'QflxH2osfcSurf'
      !-----------------------------------------------------------------------
 
@@ -517,7 +517,7 @@ contains
            k_wet=1.0e-4_r8 * sin((rpi/180.) * topo_slope(c))
            dRate=k_wet*frac_infclust
 
-           ! poinding above threshold
+           ! ponding above threshold
            activePond = h2osfc(c) - h2osfc_thresh(c)
 
            ! switch between different numerical solutions
@@ -602,6 +602,9 @@ contains
            qflx_h2osfc_drain(c) = h2osfc(c)/dtime
            truncate_h2osfc_to_zero(c) = .true.
         else
+
+
+
            qflx_h2osfc_drain(c)=min(frac_h2osfc(c)*qinmax(c),h2osfc(c)/dtime)
            if(h2osfcflag==0) then
               ! ensure no h2osfc

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -600,8 +600,6 @@ contains
      real(r8)            :: const                 ! constant in analytical integral
      real(r8)            :: uFunc                 ! analytical integral
      real(r8), parameter :: smoothScale=0.05_r8   ! smoothing scale
-     integer        :: err                   ! error code
-     character(len=128)  :: message               ! error message
 
      character(len=*), parameter :: subname = 'QflxH2osfcDrain'
      !-----------------------------------------------------------------------
@@ -642,9 +640,7 @@ contains
               ! being set for each loop iteration.
               drainPond_inst%smoothScale = smoothScale
               drainPond_inst%drainMax = drainMax
-              call implicitEuler(drainPond_inst, dtime, h2osfc(c), h2osfc1, err, message)
-              if(err/=0) call endrun(subname // ':: '//trim(message))
-              call drainPond_inst%getFlux(h2osfc1, qflx_h2osfc_drain(c))
+              call implicitEuler(drainPond_inst, dtime, h2osfc(c), qflx_h2osfc_drain(c))
 
               ! analytical solution with operator splitting
            case(ixAnalytical)

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -59,10 +59,15 @@ module SoilHydrologyMod
   private :: QflxH2osfcDrain     ! Compute qflx_h2osfc_drain
 
   type, extends(computeFlux_type) :: drainPond_type
-     real(r8) :: smoothScale
-     real(r8) :: drainMax
+     private
+     real(r8), public :: drainMax ! maximum drainage rate of ponded water
+     real(r8), public :: dtime    ! model time step
+     real(r8) :: smoothScale = 0.05_r8  ! smoothing scale
    contains
-     procedure :: getFlux => drainPondFlux
+     procedure :: getFlux => drainPondFlux  ! required method to get the current flux estimate
+     procedure :: drainPondExplicitEuler    ! compute the drainPond flux using an explicit euler method
+     procedure :: drainPondImplicitEuler    ! compute the drainPond flux using an implicit euler method
+     procedure :: drainPondAnalytical       ! compute the drainPond flux using an analytical solution
   end type drainPond_type
 
   !-----------------------------------------------------------------------
@@ -595,11 +600,6 @@ contains
      type(drainPond_type) :: drainPond_inst
      integer             :: fc, c               
      real(r8)            :: dtime                 ! land model time step (sec)
-     real(r8)            :: h2osfc1               ! h2osfc at the end of the time step, given qflx_h2osfc_drain only
-     real(r8)            :: drainMax              ! maximum drainage rate of ponded water
-     real(r8)            :: const                 ! constant in analytical integral
-     real(r8)            :: uFunc                 ! analytical integral
-     real(r8), parameter :: smoothScale=0.05_r8   ! smoothing scale
 
      character(len=*), parameter :: subname = 'QflxH2osfcDrain'
      !-----------------------------------------------------------------------
@@ -611,6 +611,7 @@ contains
      SHR_ASSERT_ALL((ubound(truncate_h2osfc_to_zero) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
      
      dtime = get_step_size()
+     drainPond_inst%dtime = dtime
 
      do fc = 1, num_hydrologyc
         c = filter_hydrologyc(fc)
@@ -622,32 +623,18 @@ contains
 
            ! define maximum drainage
            ! NOTE: check fraction
-           drainMax = frac_h2osfc(c)*qinmax(c)
+           drainPond_inst%drainMax = frac_h2osfc(c)*qinmax(c)
 
            ! switch between different numerical solutions
            select case(ixSolution)
 
-              ! constrained Explicit Euler solution with operator splitting (original)
            case(ixExplicitEuler)
-              qflx_h2osfc_drain(c)=min(drainMax,h2osfc(c)/dtime)
-
-              ! implicit Euler solution with operator splitting
+              call drainPond_inst%drainPondExplicitEuler(h2osfc(c), qflx_h2osfc_drain(c))
            case(ixImplicitEuler)
-              ! The next two lines look like extra overhead, but in a real implementation
-              ! (1) smoothScale could probably be local to the drainPond type; (2)
-              ! drainMax would probably also be local to the drainPond type, and if not,
-              ! it would be an array that is just set once outside a loop, rather than
-              ! being set for each loop iteration.
-              drainPond_inst%smoothScale = smoothScale
-              drainPond_inst%drainMax = drainMax
-              call implicitEuler(drainPond_inst, dtime, h2osfc(c), qflx_h2osfc_drain(c))
-
+              call drainPond_inst%drainPondImplicitEuler(h2osfc(c), qflx_h2osfc_drain(c))
               ! analytical solution with operator splitting
            case(ixAnalytical)
-              const   = 1._r8 - 1._r8/(1._r8 - exp(-h2osfc(c)/smoothScale))
-              uFunc   = -1._r8/(const*exp(drainMax*dtime/smoothScale) - 1._r8)
-              h2osfc1 = -log(1._r8 - uFunc)*smoothScale
-              qflx_h2osfc_drain(c)= (h2osfc1 - h2osfc(c))/dtime
+              call drainPond_inst%drainPondAnalytical(h2osfc(c), qflx_h2osfc_drain(c))
            end select
 
            if(h2osfcflag==0) then
@@ -674,8 +661,43 @@ contains
      if(present(dfdx)) dfdx = -this%drainMax*arg/this%smoothScale
    end subroutine drainPondFlux
 
+   subroutine drainPondExplicitEuler(this, h2osfc, qflx_h2osfc_drain)
+     ! Compute the drainPond flux using an explicit euler method
+     class(drainPond_type), intent(in) :: this
+     real(r8) , intent(in)  :: h2osfc            ! drainPond storage
+     real(r8) , intent(out) :: qflx_h2osfc_drain ! drainage flux
 
-   !-----------------------------------------------------------------------
+     ! constrained Explicit Euler solution with operator splitting (original)
+     qflx_h2osfc_drain = min(this%drainMax, h2osfc/this%dtime)
+   end subroutine drainPondExplicitEuler
+
+   subroutine drainPondImplicitEuler(this, h2osfc, qflx_h2osfc_drain)
+     ! Compute the drainPond flux using an implicit euler method
+     class(drainPond_type), intent(in) :: this
+     real(r8) , intent(in)  :: h2osfc            ! drainPond storage
+     real(r8) , intent(out) :: qflx_h2osfc_drain ! drainage flux
+
+     ! implicit Euler solution with operator splitting
+     call implicitEuler(this, this%dtime, h2osfc, qflx_h2osfc_drain)
+   end subroutine drainPondImplicitEuler
+
+   subroutine drainPondAnalytical(this, h2osfc, qflx_h2osfc_drain)
+     ! Compute the drainPond flux using an analytical solution
+     class(drainPond_type), intent(in) :: this
+     real(r8) , intent(in)  :: h2osfc            ! drainPond storage
+     real(r8) , intent(out) :: qflx_h2osfc_drain ! drainage flux
+
+     real(r8) :: h2osfc1 ! h2osfc at the end of the time step, given qflx_h2osfc_drain only
+     real(r8) :: const   ! constant in analytical integral
+     real(r8) :: uFunc   ! analytical integral
+
+     const   = 1._r8 - 1._r8/(1._r8 - exp(-h2osfc/this%smoothScale))
+     uFunc   = -1._r8/(const*exp(this%drainMax*this%dtime/this%smoothScale) - 1._r8)
+     h2osfc1 = -log(1._r8 - uFunc)*this%smoothScale
+     qflx_h2osfc_drain= (h2osfc1 - h2osfc)/this%dtime
+   end subroutine drainPondAnalytical
+
+     !-----------------------------------------------------------------------
    subroutine TotalSurfaceRunoff(bounds, num_hydrologyc, filter_hydrologyc, &
         num_urbanc, filter_urbanc, &
         waterflux_inst, soilhydrology_inst, saturated_excess_runoff_inst, waterstate_inst)

--- a/src/utils/computeFluxMod.F90
+++ b/src/utils/computeFluxMod.F90
@@ -1,28 +1,28 @@
 module computeFluxMod
 
- ! provides interface for the flux modules
+  ! provides interface for the flux modules
 
- USE nrtype
- implicit none
-
- abstract interface
- subroutine fluxTemplate(x,f,dfdx)
-  USE nrtype
+  use shr_kind_mod      , only : r8 => shr_kind_r8
   implicit none
-  real(dp), intent(in)            :: x    ! state
-  real(dp), intent(out)           :: f    ! f(x)
-  real(dp), intent(out), optional :: dfdx ! derivative
- end subroutine fluxTemplate
- end interface
 
- contains
+  abstract interface
+     subroutine fluxTemplate(x,f,dfdx)
+       use shr_kind_mod      , only : r8 => shr_kind_r8
+       implicit none
+       real(r8), intent(in)            :: x    ! state
+       real(r8), intent(out)           :: f    ! f(x)
+       real(r8), intent(out), optional :: dfdx ! derivative
+     end subroutine fluxTemplate
+  end interface
+
+contains
 
   subroutine getFlux(func, x, f, dfdx)
-   procedure(fluxTemplate), pointer :: func
-   real(dp), intent(in)           :: x    ! state
-   real(dp), intent(out)          :: f    ! f(x)
-   real(dp), intent(out),optional :: dfdx ! derivative
-   call func(x,f,dfdx)
+    procedure(fluxTemplate), pointer :: func
+    real(r8), intent(in)           :: x    ! state
+    real(r8), intent(out)          :: f    ! f(x)
+    real(r8), intent(out),optional :: dfdx ! derivative
+    call func(x,f,dfdx)
   end subroutine getFlux
 
 end module computeFluxMod

--- a/src/utils/computeFluxMod.F90
+++ b/src/utils/computeFluxMod.F90
@@ -5,24 +5,21 @@ module computeFluxMod
   use shr_kind_mod      , only : r8 => shr_kind_r8
   implicit none
 
+  type, abstract :: flux_type
+   contains
+     procedure(getFlux_interface), deferred :: getFlux
+  end type flux_type
+
   abstract interface
-     subroutine fluxTemplate(x,f,dfdx)
+     subroutine getFlux_interface(this,x,f,dfdx)
        use shr_kind_mod      , only : r8 => shr_kind_r8
+       import :: flux_type
        implicit none
+       class(flux_type), intent(in) :: this
        real(r8), intent(in)            :: x    ! state
        real(r8), intent(out)           :: f    ! f(x)
        real(r8), intent(out), optional :: dfdx ! derivative
-     end subroutine fluxTemplate
+     end subroutine getFlux_interface
   end interface
-
-contains
-
-  subroutine getFlux(func, x, f, dfdx)
-    procedure(fluxTemplate), pointer :: func
-    real(r8), intent(in)           :: x    ! state
-    real(r8), intent(out)          :: f    ! f(x)
-    real(r8), intent(out),optional :: dfdx ! derivative
-    call func(x,f,dfdx)
-  end subroutine getFlux
 
 end module computeFluxMod

--- a/src/utils/computeFluxMod.F90
+++ b/src/utils/computeFluxMod.F90
@@ -1,0 +1,28 @@
+module computeFluxMod
+
+ ! provides interface for the flux modules
+
+ USE nrtype
+ implicit none
+
+ abstract interface
+ subroutine fluxTemplate(x,f,dfdx)
+  USE nrtype
+  implicit none
+  real(dp), intent(in)            :: x    ! state
+  real(dp), intent(out)           :: f    ! f(x)
+  real(dp), intent(out), optional :: dfdx ! derivative
+ end subroutine fluxTemplate
+ end interface
+
+ contains
+
+  subroutine getFlux(func, x, f, dfdx)
+   procedure(fluxTemplate), pointer :: func
+   real(dp), intent(in)           :: x    ! state
+   real(dp), intent(out)          :: f    ! f(x)
+   real(dp), intent(out),optional :: dfdx ! derivative
+   call func(x,f,dfdx)
+  end subroutine getFlux
+
+end module computeFluxMod

--- a/src/utils/computeFluxMod.F90
+++ b/src/utils/computeFluxMod.F90
@@ -6,6 +6,11 @@ module computeFluxMod
   implicit none
 
   type, abstract :: computeFlux_type
+     ! flux_name is just used to generate more helpful error messages. This needs to be
+     ! set in initialization. (If that's awkward to accomplish, then we could have a
+     ! deferred procedure getFluxName that simply returns a character string giving the
+     ! name of this flux.)
+     character(len=128) :: flux_name
    contains
      procedure(getFlux_interface), deferred :: getFlux
   end type computeFlux_type

--- a/src/utils/computeFluxMod.F90
+++ b/src/utils/computeFluxMod.F90
@@ -5,17 +5,17 @@ module computeFluxMod
   use shr_kind_mod      , only : r8 => shr_kind_r8
   implicit none
 
-  type, abstract :: flux_type
+  type, abstract :: computeFlux_type
    contains
      procedure(getFlux_interface), deferred :: getFlux
-  end type flux_type
+  end type computeFlux_type
 
   abstract interface
      subroutine getFlux_interface(this,x,f,dfdx)
        use shr_kind_mod      , only : r8 => shr_kind_r8
-       import :: flux_type
+       import :: computeFlux_type
        implicit none
-       class(flux_type), intent(in) :: this
+       class(computeFlux_type), intent(in) :: this
        real(r8), intent(in)            :: x    ! state
        real(r8), intent(out)           :: f    ! f(x)
        real(r8), intent(out), optional :: dfdx ! derivative

--- a/src/utils/implicitEulerMod.F90
+++ b/src/utils/implicitEulerMod.F90
@@ -1,14 +1,14 @@
 module implicitEulerMod
 
   use shr_kind_mod      , only : r8 => shr_kind_r8
-  use computeFluxMod    , only : flux_type
+  use computeFluxMod    , only : computeFlux_type
   implicit none
 
 contains
 
   subroutine implicitEuler(flux_inst, dt, xInit, xNew, err, message)
     ! dummy variables
-    class(flux_type), intent(in) :: flux_inst
+    class(computeFlux_type), intent(in) :: flux_inst
     real(r8), intent(in)     :: dt            ! time step
     real(r8), intent(in)     :: xInit         ! initial state
     real(r8), intent(out)    :: xNew          ! updated state

--- a/src/utils/implicitEulerMod.F90
+++ b/src/utils/implicitEulerMod.F90
@@ -6,9 +6,9 @@ module implicitEulerMod
 
 contains
 
-  subroutine implicitEuler(flux_inst, dt, xInit, xNew, err, message)
+  subroutine implicitEuler(computeFlux_inst, dt, xInit, xNew, err, message)
     ! dummy variables
-    class(computeFlux_type), intent(in) :: flux_inst
+    class(computeFlux_type), intent(in) :: computeFlux_inst
     real(r8), intent(in)     :: dt            ! time step
     real(r8), intent(in)     :: xInit         ! initial state
     real(r8), intent(out)    :: xNew          ! updated state
@@ -31,7 +31,7 @@ contains
     ! iterate
     do iter=1,maxiter
        ! get the flux and derivative
-       call flux_inst%getFlux(xNew, flux, dfdx)
+       call computeFlux_inst%getFlux(xNew, flux, dfdx)
        ! get the residual and the update
        xRes = xNew - (xInit + dt*flux)
        delX = -xRes/(1._r8 - dt*dfdx)

--- a/src/utils/implicitEulerMod.F90
+++ b/src/utils/implicitEulerMod.F90
@@ -1,0 +1,49 @@
+module implicitEulerMod
+
+ USE nrtype
+ USE computeFluxMod
+ implicit none
+
+ contains
+
+ subroutine implicitEuler(funcName, dt, xInit, xNew, err, message)
+ ! dummy variables
+ procedure(fluxTemplate), pointer :: funcName
+ real(dp), intent(in)     :: dt            ! time step
+ real(dp), intent(in)     :: xInit         ! initial state
+ real(dp), intent(out)    :: xNew          ! updated state
+ integer(i4b),intent(out) :: err           ! error code
+ character(*),intent(out) :: message       ! error message
+ ! local variables
+ integer(i4b)             :: iter          ! iteration index
+ integer(i4b),parameter   :: maxiter=20    ! maximum number of iterations
+ real(dp), parameter      :: xTol=1.e-8_dp ! convergence tolerance
+ real(dp)                 :: flux          ! flux
+ real(dp)                 :: dfdx          ! derivative
+ real(dp)                 :: xRes          ! residual error
+ real(dp)                 :: delX          ! state update
+ ! initialiuze routine
+ err=0; message='implicitEuler/'
+
+ ! initialize
+ xNew = xInit
+
+ ! iterate
+ do iter=1,maxiter
+  ! get the flux and derivative
+  call getFlux(funcName, xNew, flux, dfdx)
+  ! get the residual and the update
+  xRes = xNew - (xInit + dt*flux)
+  delX = -xRes/(1._dp - dt*dfdx)
+  ! update and check for convergence
+  xNew = xNew + delX
+  if(abs(delX) < xTol) exit
+  ! check for non-convergence
+  if(iter==maxiter)then
+   message=trim(message)//'the implicit Euler solution did not converge!'
+   err=20; return
+  endif
+ end do
+ end subroutine implicitEuler
+
+end module implicitEulerMod

--- a/src/utils/implicitEulerMod.F90
+++ b/src/utils/implicitEulerMod.F90
@@ -1,14 +1,14 @@
 module implicitEulerMod
 
   use shr_kind_mod      , only : r8 => shr_kind_r8
-  use computeFluxMod
+  use computeFluxMod    , only : flux_type
   implicit none
 
 contains
 
-  subroutine implicitEuler(funcName, dt, xInit, xNew, err, message)
+  subroutine implicitEuler(flux_inst, dt, xInit, xNew, err, message)
     ! dummy variables
-    procedure(fluxTemplate), pointer :: funcName
+    class(flux_type), intent(in) :: flux_inst
     real(r8), intent(in)     :: dt            ! time step
     real(r8), intent(in)     :: xInit         ! initial state
     real(r8), intent(out)    :: xNew          ! updated state
@@ -31,7 +31,7 @@ contains
     ! iterate
     do iter=1,maxiter
        ! get the flux and derivative
-       call getFlux(funcName, xNew, flux, dfdx)
+       call flux_inst%getFlux(xNew, flux, dfdx)
        ! get the residual and the update
        xRes = xNew - (xInit + dt*flux)
        delX = -xRes/(1._r8 - dt*dfdx)

--- a/src/utils/implicitEulerMod.F90
+++ b/src/utils/implicitEulerMod.F90
@@ -1,49 +1,49 @@
 module implicitEulerMod
 
- USE nrtype
- USE computeFluxMod
- implicit none
+  use shr_kind_mod      , only : r8 => shr_kind_r8
+  use computeFluxMod
+  implicit none
 
- contains
+contains
 
- subroutine implicitEuler(funcName, dt, xInit, xNew, err, message)
- ! dummy variables
- procedure(fluxTemplate), pointer :: funcName
- real(dp), intent(in)     :: dt            ! time step
- real(dp), intent(in)     :: xInit         ! initial state
- real(dp), intent(out)    :: xNew          ! updated state
- integer(i4b),intent(out) :: err           ! error code
- character(*),intent(out) :: message       ! error message
- ! local variables
- integer(i4b)             :: iter          ! iteration index
- integer(i4b),parameter   :: maxiter=20    ! maximum number of iterations
- real(dp), parameter      :: xTol=1.e-8_dp ! convergence tolerance
- real(dp)                 :: flux          ! flux
- real(dp)                 :: dfdx          ! derivative
- real(dp)                 :: xRes          ! residual error
- real(dp)                 :: delX          ! state update
- ! initialiuze routine
- err=0; message='implicitEuler/'
+  subroutine implicitEuler(funcName, dt, xInit, xNew, err, message)
+    ! dummy variables
+    procedure(fluxTemplate), pointer :: funcName
+    real(r8), intent(in)     :: dt            ! time step
+    real(r8), intent(in)     :: xInit         ! initial state
+    real(r8), intent(out)    :: xNew          ! updated state
+    integer,intent(out) :: err           ! error code
+    character(*),intent(out) :: message       ! error message
+    ! local variables
+    integer             :: iter          ! iteration index
+    integer,parameter   :: maxiter=20    ! maximum number of iterations
+    real(r8), parameter      :: xTol=1.e-8_r8 ! convergence tolerance
+    real(r8)                 :: flux          ! flux
+    real(r8)                 :: dfdx          ! derivative
+    real(r8)                 :: xRes          ! residual error
+    real(r8)                 :: delX          ! state update
+    ! initialiuze routine
+    err=0; message='implicitEuler/'
 
- ! initialize
- xNew = xInit
+    ! initialize
+    xNew = xInit
 
- ! iterate
- do iter=1,maxiter
-  ! get the flux and derivative
-  call getFlux(funcName, xNew, flux, dfdx)
-  ! get the residual and the update
-  xRes = xNew - (xInit + dt*flux)
-  delX = -xRes/(1._dp - dt*dfdx)
-  ! update and check for convergence
-  xNew = xNew + delX
-  if(abs(delX) < xTol) exit
-  ! check for non-convergence
-  if(iter==maxiter)then
-   message=trim(message)//'the implicit Euler solution did not converge!'
-   err=20; return
-  endif
- end do
- end subroutine implicitEuler
+    ! iterate
+    do iter=1,maxiter
+       ! get the flux and derivative
+       call getFlux(funcName, xNew, flux, dfdx)
+       ! get the residual and the update
+       xRes = xNew - (xInit + dt*flux)
+       delX = -xRes/(1._r8 - dt*dfdx)
+       ! update and check for convergence
+       xNew = xNew + delX
+       if(abs(delX) < xTol) exit
+       ! check for non-convergence
+       if(iter==maxiter)then
+          message=trim(message)//'the implicit Euler solution did not converge!'
+          err=20; return
+       endif
+    end do
+  end subroutine implicitEuler
 
 end module implicitEulerMod


### PR DESCRIPTION
**NOTE: This PR was originally created in the temporary CTSM repository by @billsacks, Sep 8, 2017, where it was NCAR/clm-ctsm#14. I am moving over most of the comments from there: both my own and those of @martynpclark .**

**Original comment from @billsacks Sep 8, 2017 (with references to PRs and commits changed for this new repository)**

NOTE: This PR has not been tested (though it does compile). It is for discussion only.

This is a counterpart to #191 , but with an object-oriented implementation.

In order to facilitate comparison with @martynpclark 's implementation, I started with his changes, and then made changes on top of that. To see just what is different in the object-oriented version, see 98da3bfd . You can see from this that the two versions are very similar. The biggest addition in the OO version is the declaration of a type, which holds input arguments and a type-bound procedure declaration:

```fortran
  type, extends(flux_type) :: drainPond_type
     real(r8) :: smoothScale
     real(r8) :: drainMax
   contains
     procedure :: getFlux => drainPondFlux
  end type drainPond_type
```

I prefer this version over the internal subroutine for the reasons I laid out here: https://github.com/ESCOMP/ctsm/pull/191#issuecomment-354360438

But I'm open to discussion.

Compared with @bandre-ucar 's suggestion: I think the two would be pretty similar. I'm not sure I see any real downsides of this one... Ben's just wouldn't have drainPondFlux be a type-bound procedure. But making drainPondFlux a type-bound procedure opens some additional doors that I hope to show in some upcoming commits.

@mvertens I think you were also interested to see this.