### PR TITLE
Move the solution method 'select case' block to the base class

### DIFF
--- a/src/utils/computeFluxMod.F90
+++ b/src/utils/computeFluxMod.F90
@@ -2,29 +2,169 @@ module computeFluxMod
 
   ! provides interface for the flux modules
 
-  use shr_kind_mod      , only : r8 => shr_kind_r8
-  implicit none
+  use shr_kind_mod , only : r8 => shr_kind_r8
+  use abortutils   , only : endrun
+  use shr_log_mod  , only : errMsg => shr_log_errMsg
+  use clm_varctl   , only : iulog
 
+  implicit none
+  private
+
+  ! Different allowed values for the solution method
+  integer, parameter :: SOLUTION_METHOD_UNSET          = 0
+  integer, parameter :: SOLUTION_METHOD_EXPLICIT_EULER = 1
+  integer, parameter :: SOLUTION_METHOD_IMPLICIT_EULER = 2
+  integer, parameter :: SOLUTION_METHOD_ANALYTICAL     = 3
+
+  integer, parameter :: flux_name_maxlen = 128
+
+  public :: computeFlux_type
   type, abstract :: computeFlux_type
-     ! flux_name is just used to generate more helpful error messages. This needs to be
-     ! set in initialization. (If that's awkward to accomplish, then we could have a
-     ! deferred procedure getFluxName that simply returns a character string giving the
-     ! name of this flux.)
-     character(len=128) :: flux_name
+     private
+
+     character(len=flux_name_maxlen), public :: flux_name = 'UNSET'  ! name of this flux, for output messages
+     integer :: solution_method = SOLUTION_METHOD_UNSET
    contains
-     procedure(getFlux_interface), deferred :: getFlux
+     procedure :: setMetadata  ! Set metadata that are common to all type extensions
+     procedure :: solveForFlux ! Solve for this flux using the chosen solution method
+
+     ! At least one of the following methods should be overridden by each derived class.
+     ! Methods that remain unimplemented will restrict the valid values of
+     ! solution_method for the given flux.
+     procedure :: computeFluxExplicitEuler
+     procedure :: computeFluxImplicitEuler
+     procedure :: computeFluxAnalytical
+
+     ! This method should also be overridden if a derived class wants to be able to use a
+     ! solution method that requires this method, such as implicitEuler. If it is left
+     ! unimplemented, then those solution methods will not be available for the given flux.
+     procedure :: getFlux  ! Get a flux estimate for use in an iterative solution procedure
   end type computeFlux_type
 
-  abstract interface
-     subroutine getFlux_interface(this,x,f,dfdx)
-       use shr_kind_mod      , only : r8 => shr_kind_r8
-       import :: computeFlux_type
-       implicit none
-       class(computeFlux_type), intent(in) :: this
-       real(r8), intent(in)            :: x    ! state
-       real(r8), intent(out)           :: f    ! f(x)
-       real(r8), intent(out), optional :: dfdx ! derivative
-     end subroutine getFlux_interface
-  end interface
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine setMetadata(this, flux_name, solution_method_str)
+    !
+    ! !DESCRIPTION:
+    ! Set metadata that are common to all type extensions of this base class.
+    !
+    ! solution_method_str can be one of:
+    ! - 'explicit_euler'
+    ! - 'implicit_euler'
+    ! - 'analytical'
+    !
+    ! !ARGUMENTS:
+    class(computeFlux_type), intent(inout) :: this
+    character(len=*), intent(in) :: flux_name            ! name of this flux, for output messages
+    character(len=*), intent(in) :: solution_method_str  ! name of this solution method
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'setMetadata'
+    !-----------------------------------------------------------------------
+
+    if (len_trim(flux_name) > flux_name_maxlen) then
+       write(iulog,*) 'flux_name too long'
+       write(iulog,*) trim(flux_name), ' exceeds max length: ', flux_name_maxlen
+       call endrun(msg='flux_name too long: ' // errMsg(sourcefile, __LINE__))
+    end if
+    this%flux_name = flux_name
+
+    select case (solution_method_str)
+    case ('explicit_euler')
+       this%solution_method = SOLUTION_METHOD_EXPLICIT_EULER
+    case ('implicit_euler')
+       this%solution_method = SOLUTION_METHOD_IMPLICIT_EULER
+    case ('analytical')
+       this%solution_method = SOLUTION_METHOD_ANALYTICAL
+    case default
+       write(iulog,*) 'Unknown solution_method: ', trim(solution_method_str)
+       call endrun(msg='Unknown solution method: ' // errMsg(sourcefile, __LINE__))
+    end select
+
+  end subroutine setMetadata
+
+  !-----------------------------------------------------------------------
+  subroutine solveForFlux(this, x, f)
+    !
+    ! !DESCRIPTION:
+    ! Solve for this flux using the chosen solution method
+    !
+    ! !ARGUMENTS:
+    class(computeFlux_type), intent(in) :: this
+    real(r8), intent(in)  :: x ! state
+    real(r8), intent(out) :: f ! flux
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'solveForFlux'
+    !-----------------------------------------------------------------------
+
+    select case(this%solution_method)
+    case(SOLUTION_METHOD_EXPLICIT_EULER)
+       call this%computeFluxExplicitEuler(x, f)
+    case(SOLUTION_METHOD_IMPLICIT_EULER)
+       ! NOTE(wjs, 2017-09-11) At first I thought we could put the call to implicitEuler
+       ! right here. (Aside: in order to avoid a circular dependency, that would require
+       ! moving the implicitEuler routine into this module, or having this solveForFlux in
+       ! a 3rd module that uses both computeFluxMod and implicitEulerMod.) But then I
+       ! realized that not all fluxes (e.g., QflxH2osfcSurf) use that iterative
+       ! implicitEuler method. So we need to allow each flux to determine how to compute
+       ! its own implicit euler-based solution - including whether or not this actually
+       ! involves a call to implicitEuler.
+       call this%computeFluxImplicitEuler(x, f)
+    case(SOLUTION_METHOD_ANALYTICAL)
+       call this%computeFluxAnalytical(x, f)
+    case default
+       write(iulog,*) 'Unknown solution method: ', this%solution_method
+       call endrun(msg='Unknown solution method: ' // errMsg(sourcefile, __LINE__))
+    end select
+
+  end subroutine solveForFlux
+
+  ! ========================================================================
+  ! At least one of the following methods should be overridden by each derived class. We
+  ! are providing empty implementations here (which abort the run if called) to allow
+  ! derived classes to only provide implementations of some subset of these methods. But
+  ! note that methods that remain unimplemented will restrict the valid values of
+  ! solution_method for the given flux.
+  ! ========================================================================
+
+  subroutine computeFluxExplicitEuler(this, x, f)
+    class(computeFlux_type), intent(in) :: this
+    real(r8), intent(in)  :: x ! state
+    real(r8), intent(out) :: f ! flux, f(x)
+    call endrun("computeFluxExplicitEuler not implemented for "//trim(this%flux_name))
+  end subroutine computeFluxExplicitEuler
+
+  subroutine computeFluxImplicitEuler(this, x, f)
+    class(computeFlux_type), intent(in) :: this
+    real(r8), intent(in)  :: x ! state
+    real(r8), intent(out) :: f ! flux, f(x)
+    call endrun("computeFluxImplicitEuler not implemented for "//trim(this%flux_name))
+  end subroutine computeFluxImplicitEuler
+
+  subroutine computeFluxAnalytical(this, x, f)
+    class(computeFlux_type), intent(in) :: this
+    real(r8), intent(in)  :: x ! state
+    real(r8), intent(out) :: f ! flux, f(x)
+    call endrun("computeFluxAnalytical not implemented for "//trim(this%flux_name))
+  end subroutine computeFluxAnalytical
+
+  ! In contrast to the other unimplemented subroutines in the base class, this one is NOT
+  ! called directly by solveForFlux. Rather, it is called by some solution methods, such
+  ! as implicitEuler. If it is left unimplemented, then those solution methods will not
+  ! be available for the given flux.
+  subroutine getFlux(this, x, f, dfdx)
+    class(computeFlux_type), intent(in) :: this
+    real(r8), intent(in)            :: x    ! state
+    real(r8), intent(out)           :: f    ! f(x)
+    real(r8), intent(out), optional :: dfdx ! derivative
+    call endrun("getFlux not implemented for "//trim(this%flux_name))
+  end subroutine getFlux
 
 end module computeFluxMod


### PR DESCRIPTION
**NOTE: This PR was originally created in the temporary CTSM repository by @billsacks, Sep 12, 2017, where it was NCAR/clm-ctsm#15. I am moving over the comments from there.**

**Original comment from @billsacks Sep 12, 2017**

(Note that the setMetadata method is never called here: a full
implementation would need to call that in initialization for each
flux that builds on computeFlux_type.)

The purpose of this change was to remove what would presumably become
duplication of this select case statement throughout the code
base. However, I'm not very happy with how this change turned out. The
particular challenge here was handling the fact that different fluxes
would provide a different set of solution methods. This led me to put
stub methods in the base class that die at runtime if they are not
overridden, but I feel this makes the use of the base class less obvious
and more error-prone. (But I couldn't see a better way to do this - at
least, not with introducing a lot of extra complexity.)

Whether this extra step is worthwhile depends on how many instances of
this select case statement are sprinkled throughout the code, and how
much this is cluttering up the code. But overall, given that we
potentially have a different set of allowed methods for each flux, I'd
prefer not to go with the changes here - instead having some partial
duplication of the select case statements. Or we could go with the
solution suggested here
https://github.com/ESCOMP/ctsm/commit/ea1549007310d67d4ae515aee4747ffc74623408#r26526545
of having function pointers, which would allow moving these select case
statements to initialization (even though that would still involve many
partially-duplicated select case statements throughout the code).

Another problem with the changes here is that there will be some
performance overhead with the additional subroutine calls -
specifically, one extra call to 'solveForFlux' rather than having that
inlined. This is likely very bad with the current implementation -
point-by-point. With an array implementation, this cost is amortized
over all array elements, but may still be non-trivial - and will still
be a high cost for single-point runs.

--

In some ways, this could be clearer & simpler if we kept
computeFlux_type as it was in pondedWater/alternativeSolutions_oo, and
instead introduced a separate class to handle the selection between
methods. That separate class would have the stub implementations of the
various computeFlux methods. Then a flux would be required to provide
(some) implementations of the computeFlux* methods, but it would only
need to provide an implementation of computeFlux_type (i.e., the getFlux
method) if it wanted to call a solution method that required it (like
implicitEuler). The instance of the new class would then need to contain
an instance of the computeFlux child type, so that it can be referenced
by things like comuteFluxImplicitEuler.

The main advantage of this would be to provide a more clear signal about
whether a given flux can be plugged into things like implicitEuler,
which expects an implementation of a particular interface.

However, downsides are:
- Requires more boilerplate to set up the (now) two classes for a given
  flux
- I think there would be some awkwardness / duplication in terms of the
  internal variables that are stored in the class: I think these would
  now be needed in both the computeFlux child class and the new child
  class. (Though there may be some way to get the computeFlux class to
  reference things in the new class, e.g., by having a pointer to an
  object of the new class.)

One possible compromise is: keep the computeFlux_type as it was in
pondedWater/alternativeSolutions_oo, and make that a base class for the
new type. This would provide a more clear signal regarding what's needed
in implicitEuler, and a cleaner mechanism to plug a flux into
implicitEuler even if it doesn't want to extend the new class (because
you could extend computeFlux_type without extending the new class). The
new class would provide a default implementation of getFlux, which just
calls endrun. Then specific flux implementations would extend the new
class, and could then provide implementations for whatever computeFlux*
methods they want, as well as possibly providing an implementation for
getFlux (if needed).
- i.e., the inheritance chain would be: computeFlux_type (abstract
  interface of getFlux) -> some new class (provides stub implementations
  for getFlux and various computeFlux* methods) -> specific flux class
  (provides actual implementations as needed)
- But I'm not sure that buys us much relative to what we had in
  pondedWater/alternativeSolutions_oo: It does make it easier to use
  implicitEuler (for fluxes that don't want the functionalities of the
  new class – i.e., the selection between calculation mechanisms), but
  at the cost of introducing a new class into the design. This could be
  worth doing if this benefit would be useful in practice.

--

Another possibility would be to replace the 'select case' for the
solution method with polymorphism. However, this would require having a
separate class for each solution method for each flux, which feels like
a lot of coding overhead.

In this case, stuff shared between the different solution methods – such
as data that need to be set initially and the getFlux method – could be
in a base class for that flux, and then each solution method would
extend that base class, providing a computeFlux method.

But I think this is too much overhead. I think a better solution than
that would be to ditch the whole select case and solution_method stuff,
and go back to my earlier branch (pondedWater/alternativeSolutions_oo as
referenced in https://github.com/ESCOMP/ctsm/pull/192), and go with the
idea of using function pointers, as suggested by
https://github.com/ESCOMP/ctsm/commit/ea1549007310d67d4ae515aee4747ffc74623408#r26526545