### PR TITLE
Use cimeroot rather than hard-coded relative path

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -59,6 +59,7 @@ SYNOPSIS
 
      Create the namelist for CLM
 REQUIRED OPTIONS
+     -cimeroot "directory"    Path to cime directory
      -config "filepath"       Read the given CLM configuration cache file.
                               Default: "config_cache.xml".
      -d "directory"           Directory where output namelist file will be written
@@ -245,7 +246,8 @@ sub process_commandline {
   # the array!
   $nl_flags->{'cmdline'} = "@ARGV";
 
-  my %opts = ( config                => "config_cache.xml",
+  my %opts = ( cimeroot              => undef,
+               config                => "config_cache.xml",
                csmdata               => undef,
                clm_usr_name          => undef,
                co2_type              => undef,
@@ -282,6 +284,7 @@ sub process_commandline {
              );
 
   GetOptions(
+             "cimeroot=s"                => \$opts{'cimeroot'},
              "clm_demand=s"              => \$opts{'clm_demand'},
              "co2_ppmv=f"                => \$opts{'co2_ppmv'},
              "co2_type=s"                => \$opts{'co2_type'},
@@ -345,9 +348,9 @@ sub check_for_perl_utils {
   my $cfgdir = shift;
   my $opts_ref = shift;
 
-  # Determine CESM root directory and perl5lib root directory
-  my $cesmroot = abs_path( "$cfgdir/../../../");
-  my $perl5lib_dir = "$cesmroot/cime/utils/perl5lib";
+  # Determine CIME root directory and perl5lib root directory
+  my $cimeroot = $opts_ref->{'cimeroot'};
+  my $perl5lib_dir = "$cimeroot/utils/perl5lib";
 
   #-----------------------------------------------------------------------------
   # Add $perl5lib_dir to the list of paths that Perl searches for modules
@@ -4381,7 +4384,6 @@ sub main {
   my $cfg = read_configure_definition($cfgdir, \%opts);
 
   my $physv      = config_files::clm_phys_vers->new( $cfg->get('phys') );
-  my $cesmroot   = abs_path( "$cfgdir/../../../");
   my $definition = read_namelist_definition($cfgdir, \%opts, \%nl_flags, $physv);
   my $defaults   = read_namelist_defaults($cfgdir, \%opts, \%nl_flags, $cfg, $physv);
 

--- a/bld/configure
+++ b/bld/configure
@@ -52,6 +52,7 @@ OPTIONS
      -cache <file>          Name of output cache file (default: config_cache.xml).
      -cachedir <file>       Name of directory where output cache file is written 
                             (default: CLM build directory).
+     -cimeroot <dir>        REQUIRED: Path to cime directory
      -clm_root <dir>        Root directory of clm source code 
                             (default: directory above location of this script)
      -cppdefs <string>      A string of user specified CPP defines.  Appended to
@@ -122,6 +123,7 @@ my %opts = (
             phys        => "clm4_0",
             nofire      => undef,
             noio        => undef,
+            cimeroot    => undef,
             clm_root    => undef,
             spinup      => "normal",
 	    );
@@ -131,6 +133,7 @@ GetOptions(
     "cache=s"                   => \$opts{'cache'},
     "cachedir=s"                => \$opts{'cachedir'},
     "snicar_frc=s"              => \$opts{'snicar_frc'},
+    "cimeroot=s"                => \$opts{'cimeroot'},       
     "clm_root=s"                => \$opts{'clm_root'},
     "cppdefs=s"                 => \$opts{'cppdefs'},
     "comp_intf=s"               => \$opts{'comp_intf'},
@@ -176,9 +179,9 @@ my %cfg = ();           # build configuration
 # Make sure we can find required perl modules and configuration files.
 # Look for them in the directory that contains the configure script.
 
-my $cesmroot   = abs_path( "$cfgdir/../../../");
-my $casecfgdir = "$cesmroot/cime/scripts/Tools";
-my $perl5lib   = "$cesmroot/cime/utils/perl5lib/";
+my $cimeroot   = $opts{'cimeroot'};
+my $casecfgdir = "$cimeroot/scripts/Tools";
+my $perl5lib   = "$cimeroot/utils/perl5lib/";
 
 # The Build::Config module provides utilities to store and manipulate the configuration.
 my $file = "$perl5lib/Build/Config.pm";

--- a/cime_config/buildcpp
+++ b/cime_config/buildcpp
@@ -16,6 +16,7 @@ def buildcpp(case):
     """
 
     caseroot = case.get_value("CASEROOT")
+    cimeroot = case.get_value("CIMEROOT")
     lnd_root = case.get_value("COMP_ROOT_DIR_LND")
     lnd_grid = case.get_value("LND_GRID")
     mask_grid = case.get_value("MASK_GRID")
@@ -36,8 +37,8 @@ def buildcpp(case):
         os.makedirs(clmconf)
 
     cmd = os.path.join(lnd_root,"bld","configure")
-    command = "%s  %s %s -usr_src %s -comp_intf mct "  \
-              %(cmd, config_opts, clm_config_opts, os.path.join(caseroot,"SourceMods","src.clm")) 
+    command = "%s -cimeroot %s %s %s -usr_src %s -comp_intf mct "  \
+              %(cmd, cimeroot, config_opts, clm_config_opts, os.path.join(caseroot,"SourceMods","src.clm")) 
 
     run_cmd_no_fail(command, from_dir=clmconf)
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -227,11 +227,11 @@ def buildnml(case, caseroot, compname):
 
         cmd = os.path.join(lnd_root,"bld","build-namelist")
 
-        command = ("%s -infile %s -csmdata %s -inputdata %s %s -namelist \"&clm_inparm  start_ymd=%s %s/ \" "
+        command = ("%s -cimeroot %s -infile %s -csmdata %s -inputdata %s %s -namelist \"&clm_inparm  start_ymd=%s %s/ \" "
                    "%s %s -res %s %s -clm_start_type %s -envxml_dir %s -l_ncpl %s "
                    "-lnd_frac %s -glc_nec %s -co2_ppmv %s -co2_type %s -config %s "
                    "%s %s %s"
-                   %(cmd, infile, din_loc_root, inputdata_file, ignore, start_ymd, clm_namelist_opts, 
+                   %(cmd, _CIMEROOT, infile, din_loc_root, inputdata_file, ignore, start_ymd, clm_namelist_opts, 
                      nomeg, usecase, lnd_grid, clmusr, start_type, caseroot, lnd_ncpl, 
                      lndfrac_file, glc_nec, ccsm_co2_ppmv, clm_co2_type, config_cache_file, 
                      clm_bldnml_opts, spinup, tuning))


### PR DESCRIPTION
This is needed to support a standalone checkout, where cime appears in a
different location relative to the bld directory