### PR TITLE
Point to a new cime tag

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/CESM-Development/cime
-tag = clm4518/n03/cime5.4.0-alpha.03
+tag = clm4518/n04/cime5.4.0-alpha.03
 required = True
 
 [externals_description]

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -11,15 +11,15 @@
     <entry issue="#60"      >FAIL ERI_N2_Ld9.f19_g17.I2000Clm50BgcCrop.cheyenne_intel.clm-default RUN</entry>
     <entry issue="#65"      >FAIL SMS_Ld5_D_P48x1.f10_f10_musgs.IHistClm50Bgc.hobart_nag.clm-decStart RUN</entry>
     <entry issue="#65"      >FAIL ERP_D_P48x1.f10_f10_musgs.IHistClm50Bgc.hobart_nag.clm-decStart RUN</entry>
-    <entry issue="#65"      >FAIL ERP_D.f10_f10_musgs.IHistClm50Bgc.cheyenne_gnu.clm-decStart RUN</entry>
     <entry issue="#66"      >FAIL ERS_Ly5_P72x1.f10_f10_musgs.IHistClm45BgcCrop.cheyenne_intel.clm-cropMonthOutput RUN</entry>
     <entry issue="#158"     >FAIL ERS_Lm20_Mmpi-serial.1x1_smallvilleIA.I2000Clm50BgcCropGs.cheyenne_gnu.clm-monthly RUN</entry>
     <entry issue="#221"     >FAIL SMS_D_Ld5.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-Fates RUN</entry>
     <entry issue="#221"     >FAIL SMS_D_Lm6.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-Fates RUN</entry>
     <entry issue="#221"     >FAIL SMS_D_Lm6_P144x1.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-Fates RUN</entry>
+    <entry issue="mosart/#3">FAIL ERP_Ld5.f10_f10_musgs.I2000Clm50Vic.cheyenne_gnu.clm-decStart COMPARE_base_rest</entry>
+    <entry issue="mosart/#3">FAIL ERP_D.f10_f10_musgs.IHistClm50Bgc.cheyenne_gnu.clm-decStart COMPARE_base_rest</entry>
   </category>
   <category name="fates">
-    <entry issue="mosart/#3">FAIL ERP_Ld5.f10_f10_musgs.I2000Clm50Vic.cheyenne_gnu.clm-decStart COMPARE_base_rest</entry>
     <entry issue="NGEET/fates#315">FAIL ERP_Ld9.f45_f45.I2000Clm45Fates.hobart_nag.clm-FatesAllVars COMPARE_base_rest</entry>
     <entry issue="NGEET/fates#315">FAIL ERS_Ld60.f45_f45.I2000Clm45Fates.cheyenne_intel.clm-FatesLogging COMPARE_base_rest</entry>
     <entry issue="NGEET/fates#315">FAIL ERS_Ld60.f45_f45.I2000Clm45Fates.cheyenne_intel.clm-Fates COMPARE_base_rest</entry>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,110 @@
 ===============================================================
+Tag name:  clm4_5_18_r274
+Originator(s):  sacks (Bill Sacks)
+Date: Tue Jan 30 05:55:53 MST 2018
+One-line Summary: Fix auto-detection of CIME_MODEL in a standalone checkout
+
+Purpose of changes
+------------------
+
+The auto-detection of whether CIME_MODEL is acme or cesm is broken in
+standalone checkouts of clm4_5_18_r273. (This auto-detection relied on
+whether there was an SVN_EXTERNAL_DIRECTORIES file present at the top
+level.)
+
+This tag points to a new cime version that fixes this issue.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+- #238 - clm4_5_18_r273 requires setting CIME_MODEL
+
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CLM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by: Erik Kluzek
+
+Did you follow the steps in .CLMTrunkChecklist: yes
+
+CLM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  unit-tests (components/clm/src):
+
+    cheyenne - pass
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     cheyenne - not run
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- pass
+    cheyenne_gnu ------ pass
+    hobart_nag -------- pass
+    hobart_pgi -------- pass
+    hobart_intel ------ pass
+
+    Note: I ran the cheyenne tests with CIME_MODEL=cesm defined in my
+    environment, and the hobart tests without this setting.
+
+CLM tag used for the baseline comparisons: clm4_5_18_r273
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: NO
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+
+- cime: clm4518/n03/cime5.4.0-alpha.03 -> clm4518/n04/cime5.4.0-alpha.03
+  Fix to auto-detect that CIME_MODEL=cesm based on presence of
+  manage_externals rather than SVN_EXTERNAL_DIRECTORIES
+
+List all files eliminated: none
+
+List all files added and what they do: none
+
+List all existing files that have been modified, and describe the changes:
+
+========= Fix the documentation of some expected fails
+M       cime_config/testdefs/ExpectedTestFails.xml
+
+===============================================================
+===============================================================
 Tag name:  clm4_5_18_r273
 Originator(s):  sacks (Bill Sacks)
 Date: Fri Jan 26 15:26:06 MST 2018

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  clm4_5_18_r274    sacks 01/30/2018 Fix auto-detection of CIME_MODEL in a standalone checkout
   clm4_5_18_r273    sacks 01/26/2018 Support a standalone checkout from git
   clm4_5_18_r272     erik 01/25/2018 Bring in latest FATES release version to CLM trunk: fates_s1.4.1_a3.0.0_rev2
   clm4_5_18_r271     erik 01/20/2018 Update testlist to v2 and remove yellowstone


### PR DESCRIPTION
This cime tag auto-detects model=cesm based on the presence of
manage_externals

The diffs in this cime tag are simply:

```diff
diff --git a/scripts/lib/CIME/utils.py b/scripts/lib/CIME/utils.py
index 803ac9695..a41656619 100644
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -171,7 +171,8 @@ def get_model():
     # One last try
     if (model is None):
         srcroot = os.path.dirname(os.path.abspath(get_cime_root()))
-        if os.path.isfile(os.path.join(srcroot, "SVN_EXTERNAL_DIRECTORIES")):
+        if os.path.isfile(os.path.join(srcroot, "SVN_EXTERNAL_DIRECTORIES")) \
+           or os.path.isdir(os.path.join(srcroot, "manage_externals")):
             model = 'cesm'
         else:
             model = 'acme'
```

These changes are already on cime master (made by @jedwards4b ); here I have cherry-picked them onto the cime branch that we're using.

Fixes #238 