### PR TITLE
Modularize infiltration

### DIFF
--- a/ChangeLog_branch
+++ b/ChangeLog_branch
@@ -1,4 +1,102 @@
 ===============================================================
+Tag name: ctsm_n06_clm4_5_16_r249
+Originator(s): sacks
+Date: Aug 21, 2017
+One-line Summary: Modularization of Infiltration - first stage
+
+Purpose of changes
+------------------
+
+Separate out the first 3 steps of subroutine Infiltration into more modular
+homes. The biggest piece of this is to introduce a new
+InfiltrationExcessRunoffMod.F90; this will be where alternative
+parameterizations of infiltration excess runoff can be put.
+
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+
+CLM testing:
+
+  build-namelist tests:
+
+    yellowstone - not run
+
+  unit-tests (components/clm/src):
+
+    yellowstone - not run
+
+  tools-tests (components/clm/test/tools):
+
+    yellowstone - not run
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     yellowstone - not run
+
+  regular tests (aux_clm):
+
+    yellowstone_intel - pass
+    yellowstone_pgi - pass
+    yellowstone_gnu - pass
+    cheyenne_intel - pass
+    hobart_nag - pass
+    hobart_pgi - pass
+    hobart_intel - pass
+
+    NOTE: Most tests were run on 24913d0. On the final commit (afdbcf7), I ran
+    only the following tests:
+
+    These test failed without the fix in afdbcf7, so I reran them with that fix:
+
+      ERP_D_Ld5.f10_f10_musgs.I2000Clm50BgcCrop.yellowstone_intel.clm-allActive
+      ERP_D_P15x2_Ld3.f10_f10_musgs.I2000Clm50BgcCrop.yellowstone_intel.clm-cropColdStart
+      ERP_P180x2_D_Ld5.f19_g17.I2000Clm50BgcDvCrop.yellowstone_pgi.clm-crop
+      ERP_D_Ld5.f10_f10_musgs.I2000Clm50BgcCrop.cheyenne_intel.clm-allActive
+      ERP_D_P15x2_Ld3.f10_f10_musgs.I2000Clm50BgcCrop.cheyenne_intel.clm-cropColdStart
+
+    This is the only oldhyd test, and so is the only test that should be
+    affected by this change:
+
+      SMS_D_Ld1_P24x1.f10_f10_musgs.I2000Clm45BgcCrop.hobart_nag.clm-oldhyd
+
+CLM tag used for the baseline comparisons: ctsm_n05_clm4_5_16_r249
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: NO
+
+
+Detailed list of changes
+------------------------
+
+List any svn externals directories updated (cime, rtm, mosart, cism, etc.): none
+
+List all files eliminated: none
+
+List all files added and what they do:
+
+========= Holds the portion of subroutine Infiltration that actually computes
+          the infiltration excess runoff flux. New parameterizations of
+          infiltration excess runoff should be put here.
+A       components/clm/src/biogeophys/InfiltrationExcessRunoffMod.F90
+
+List all existing files that have been modified, and describe the changes:
+
+========= Main changes, as described above
+M       components/clm/src/biogeophys/SoilHydrologyMod.F90
+M       components/clm/src/biogeophys/HydrologyNoDrainageMod.F90
+M       components/clm/src/biogeophys/WaterfluxType.F90
+M       components/clm/src/main/clm_driver.F90
+M       components/clm/src/main/clm_instMod.F90
+
+========= Just add a comment
+M       components/clm/src/biogeophys/SurfRunoffSatMod.F90
+
+===============================================================
+===============================================================
 Tag name: ctsm_n05_clm4_5_16_r249
 Originator(s): sacks
 Date: Aug 17, 2017

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -61,7 +61,7 @@ contains
     use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers, SnowCapping
     use SnowHydrologyMod     , only : SnowWater, BuildSnowFilter 
     use SoilHydrologyMod     , only : CLMVICMap, SetSoilWaterFractions
-    use SoilHydrologyMod     , only : SetQflxTopSoil, Infiltration, TotalSurfaceRunoff
+    use SoilHydrologyMod     , only : SetQflxInputs, Infiltration, TotalSurfaceRunoff
     use SoilHydrologyMod     , only : UpdateUrbanPonding
     use SoilHydrologyMod     , only : WaterTable, PerchedWaterTable
     use SoilHydrologyMod     , only : ThetaBasedWaterTable, RenewCondensation
@@ -184,7 +184,8 @@ contains
            bounds, num_hydrologyc, filter_hydrologyc, col, &
            soilhydrology_inst, soilstate_inst, waterflux_inst)
 
-      call SetQflxTopSoil(bounds, num_hydrologyc, filter_hydrologyc, waterflux_inst)
+      call SetQflxInputs(bounds, num_hydrologyc, filter_hydrologyc, &
+           waterflux_inst, surf_runoff_sat_inst, waterstate_inst)
 
       call Infiltration(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc,&
            energyflux_inst, soilhydrology_inst, soilstate_inst, surf_runoff_sat_inst, &

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -60,7 +60,7 @@ contains
     use clm_time_manager     , only : get_step_size, get_nstep
     use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers, SnowCapping
     use SnowHydrologyMod     , only : SnowWater, BuildSnowFilter 
-    use SoilHydrologyMod     , only : CLMVICMap, SetFracIce
+    use SoilHydrologyMod     , only : CLMVICMap, SetSoilWaterFractions
     use SoilHydrologyMod     , only : SetQflxTopSoil, Infiltration, TotalSurfaceRunoff
     use SoilHydrologyMod     , only : UpdateUrbanPonding
     use SoilHydrologyMod     , only : WaterTable, PerchedWaterTable
@@ -177,7 +177,7 @@ contains
               soilhydrology_inst, waterstate_inst)
       end if
 
-      call SetFracIce(bounds, num_hydrologyc, filter_hydrologyc, &
+      call SetSoilWaterFractions(bounds, num_hydrologyc, filter_hydrologyc, &
            soilhydrology_inst, soilstate_inst, waterstate_inst)
 
       call surf_runoff_sat_inst%SaturatedSurfaceRunoff(&

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -17,6 +17,7 @@ Module HydrologyNoDrainageMod
   use SoilHydrologyType , only : soilhydrology_type
   use SoilStateType     , only : soilstate_type
   use SurfRunoffSatMod  , only : surf_runoff_sat_type
+  use InfiltrationExcessRunoffMod, only : infiltration_excess_runoff_type
   use WaterfluxType     , only : waterflux_type
   use WaterstateType    , only : waterstate_type
   use CanopyStateType   , only : canopystate_type
@@ -43,8 +44,8 @@ contains
        clm_fates, &
        atm2lnd_inst, soilstate_inst, energyflux_inst, temperature_inst, &
        waterflux_inst, waterstate_inst, &
-       soilhydrology_inst, surf_runoff_sat_inst, aerosol_inst, &
-       canopystate_inst, soil_water_retention_curve)
+       soilhydrology_inst, surf_runoff_sat_inst, infiltration_excess_runoff_inst, &
+       aerosol_inst, canopystate_inst, soil_water_retention_curve)
     !
     ! !DESCRIPTION:
     ! This is the main subroutine to execute the calculation of soil/snow
@@ -93,6 +94,7 @@ contains
     type(aerosol_type)       , intent(inout) :: aerosol_inst
     type(soilhydrology_type) , intent(inout) :: soilhydrology_inst
     type(surf_runoff_sat_type), intent(inout) :: surf_runoff_sat_inst
+    type(infiltration_excess_runoff_type), intent(inout) :: infiltration_excess_runoff_inst
     type(canopystate_type)   , intent(inout) :: canopystate_inst
     class(soil_water_retention_curve_type), intent(in) :: soil_water_retention_curve
     !
@@ -187,9 +189,15 @@ contains
       call SetQflxInputs(bounds, num_hydrologyc, filter_hydrologyc, &
            waterflux_inst, surf_runoff_sat_inst, waterstate_inst)
 
+      call infiltration_excess_runoff_inst%InfiltrationExcessRunoff( &
+           bounds, num_hydrologyc, filter_hydrologyc, &
+           soilhydrology_inst, soilstate_inst, surf_runoff_sat_inst, waterflux_inst, &
+           waterstate_inst)
+
       call Infiltration(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc,&
-           energyflux_inst, soilhydrology_inst, soilstate_inst, surf_runoff_sat_inst, &
-           temperature_inst, waterflux_inst, waterstate_inst)
+           infiltration_excess_runoff_inst, &
+           energyflux_inst, soilhydrology_inst, surf_runoff_sat_inst, &
+           waterflux_inst, waterstate_inst)
 
       call TotalSurfaceRunoff(bounds, num_hydrologyc, filter_hydrologyc, &
            num_urbanc, filter_urbanc, &

--- a/src/biogeophys/InfiltrationExcessRunoffMod.F90
+++ b/src/biogeophys/InfiltrationExcessRunoffMod.F90
@@ -332,7 +332,7 @@ contains
                + top_max_moist(c) * basis**(1._r8 + b_infil(c)))/dtime
        end if
        rsurf_vic = min(qflx_in_soil(c), rsurf_vic)
-       qinmax_on_unsaturated_area(c) = (1._r8 - fsat(c)) * 10._r8**(-e_ice*top_icefrac)*(qflx_in_soil(c) - rsurf_vic)
+       qinmax_on_unsaturated_area(c) = 10._r8**(-e_ice*top_icefrac)*(qflx_in_soil(c) - rsurf_vic)
     end do
 
     end associate

--- a/src/biogeophys/InfiltrationExcessRunoffMod.F90
+++ b/src/biogeophys/InfiltrationExcessRunoffMod.F90
@@ -1,0 +1,342 @@
+module InfiltrationExcessRunoffMod
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Type and associated routines for computing infiltration excess runoff and related
+  ! variables
+  !
+  ! !USES:
+#include "shr_assert.h"
+  use shr_kind_mod     , only : r8 => shr_kind_r8
+  use shr_log_mod      , only : errMsg => shr_log_errMsg
+  use decompMod        , only : bounds_type
+  use abortutils       , only : endrun
+  use clm_varctl       , only : iulog, use_vichydro
+  use clm_varcon       , only : spval, e_ice
+  use clm_time_manager , only : get_step_size
+  use SoilHydrologyType, only : soilhydrology_type
+  use SoilStateType    , only : soilstate_type
+  use SurfRunoffSatMod , only : surf_runoff_sat_type
+  use WaterfluxType    , only : waterflux_type
+  use WaterstateType   , only : waterstate_type
+
+  implicit none
+  save
+  private
+
+  ! !PUBLIC TYPES:
+
+  type, public :: infiltration_excess_runoff_type
+     private
+     ! Public data members
+     ! Note: these should be treated as read-only by other modules
+
+     ! These are valid within the hydrology filter.
+     !
+     ! Both of these give averages over the entire column. However, qinmax is implicitly
+     ! 0 over the fraction of the column given by fsat, and qflx_infl_excess is
+     ! implicitly 0 over both fsat and frac_h2osfc.
+     real(r8), pointer, public :: qinmax_col(:)  ! maximum infiltration capacity (mm H2O /s)
+     real(r8), pointer, public :: qflx_infl_excess_col(:)  ! infiltration excess runoff (mm H2O /s)
+
+     ! Private data members
+     integer :: qinmax_method
+   contains
+     ! Public routines
+     procedure, public :: Init
+
+     procedure, public :: InfiltrationExcessRunoff ! Calculate surface runoff due to infiltration excess
+
+     ! Private routines
+     procedure, private :: InitAllocate
+     procedure, private :: InitHistory
+     procedure, private :: InitCold
+
+     procedure, private, nopass :: ComputeQinmaxHksat
+     procedure, private, nopass :: ComputeQinmaxVic
+  end type infiltration_excess_runoff_type
+
+  ! !PRIVATE DATA MEMBERS:
+
+  integer, parameter :: QINMAX_METHOD_HKSAT = 1
+  integer, parameter :: QINMAX_METHOD_VIC  = 2
+
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
+
+contains
+
+  ! ========================================================================
+  ! Infrastructure routines
+  ! ========================================================================
+
+  !-----------------------------------------------------------------------
+  subroutine Init(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize this infiltration_excess_runoff_type object
+    !
+    ! !ARGUMENTS:
+    class(infiltration_excess_runoff_type), intent(inout) :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'Init'
+    !-----------------------------------------------------------------------
+
+    call this%InitAllocate(bounds)
+    call this%InitHistory(bounds)
+    call this%InitCold(bounds)
+
+  end subroutine Init
+
+  !-----------------------------------------------------------------------
+  subroutine InitAllocate(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Allocate memory for this infiltration_excess_runoff_type object
+    !
+    ! !USES:
+    use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
+    !
+    ! !ARGUMENTS:
+    class(infiltration_excess_runoff_type), intent(inout) :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer :: begc, endc
+
+    character(len=*), parameter :: subname = 'InitAllocate'
+    !-----------------------------------------------------------------------
+
+    begc = bounds%begc; endc= bounds%endc
+    allocate(this%qinmax_col          (begc:endc)); this%qinmax_col          (:) = nan
+    allocate(this%qflx_infl_excess_col(begc:endc)); this%qflx_infl_excess_col(:) = nan
+
+  end subroutine InitAllocate
+
+  !-----------------------------------------------------------------------
+  subroutine InitHistory(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize infiltration_excess_runoff_type history variables
+    !
+    ! !USES:
+    use histFileMod , only : hist_addfld1d
+    !
+    ! !ARGUMENTS:
+    class(infiltration_excess_runoff_type), intent(inout) :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'InitHistory'
+    !-----------------------------------------------------------------------
+
+    ! Nothing to do for now
+
+  end subroutine InitHistory
+
+  !-----------------------------------------------------------------------
+  subroutine InitCold(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Perform cold-start initialization for infiltration_excess_runoff_type
+    !
+    ! !ARGUMENTS:
+    class(infiltration_excess_runoff_type), intent(inout) :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'InitCold'
+    !-----------------------------------------------------------------------
+
+    ! TODO(wjs, 2017-08-14) We'll read qinmax_method from namelist.
+    if (use_vichydro) then
+       this%qinmax_method = QINMAX_METHOD_VIC
+    else
+       this%qinmax_method = QINMAX_METHOD_HKSAT
+    end if
+
+  end subroutine InitCold
+
+  ! ========================================================================
+  ! Science routines
+  ! ========================================================================
+
+  !-----------------------------------------------------------------------
+  subroutine InfiltrationExcessRunoff(this, bounds, num_hydrologyc, filter_hydrologyc, &
+       soilhydrology_inst, soilstate_inst, surf_runoff_sat_inst, waterflux_inst, waterstate_inst)
+    !
+    ! !DESCRIPTION:
+    ! Calculate surface runoff due to infiltration excess
+    !
+    ! !ARGUMENTS:
+    class(infiltration_excess_runoff_type) , intent(inout) :: this
+    type(bounds_type)                      , intent(in)    :: bounds               
+    integer                                , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
+    integer                                , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
+    type(soilhydrology_type)               , intent(in)    :: soilhydrology_inst
+    type(soilstate_type)                   , intent(in)    :: soilstate_inst
+    type(surf_runoff_sat_type)             , intent(in)    :: surf_runoff_sat_inst
+    type(waterflux_type)                   , intent(in)    :: waterflux_inst
+    type(waterstate_type)                  , intent(in)    :: waterstate_inst
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: fc, c
+    real(r8) :: qinmax_on_unsaturated_area(bounds%begc:bounds%endc) ! maximum infiltration capacity on the unsaturated fraction of the column (mm H2O /s)
+
+    character(len=*), parameter :: subname = 'InfiltrationExcessRunoff'
+    !-----------------------------------------------------------------------
+
+    associate( &
+         qinmax           =>    this%qinmax_col                     , & ! Output: [real(r8) (:)   ]  maximum infiltration capacity (mm H2O /s)
+         qflx_infl_excess =>    this%qflx_infl_excess_col           , & ! Output: [real(r8) (:)   ]  infiltration excess runoff (mm H2O /s)
+
+         fsat             =>    surf_runoff_sat_inst%fsat_col       , & ! Input:  [real(r8) (:)   ]  fractional area with water table at surface       
+
+         qflx_in_soil     =>    waterflux_inst%qflx_in_soil_col     , & ! Input:  [real(r8) (:)   ]  surface input to soil (mm/s)
+
+         frac_h2osfc      =>    waterstate_inst%frac_h2osfc_col       & ! Input:  [real(r8) (:)   ]  fraction of ground covered by surface water (0 to 1)
+          )
+
+    select case (this%qinmax_method)
+    case (QINMAX_METHOD_HKSAT)
+       call this%ComputeQinmaxHksat(bounds, num_hydrologyc, filter_hydrologyc, &
+            soilhydrology_inst, soilstate_inst, &
+            qinmax_on_unsaturated_area = qinmax_on_unsaturated_area(bounds%begc:bounds%endc))
+    case (QINMAX_METHOD_VIC)
+       call this%ComputeQinmaxVic(bounds, num_hydrologyc, filter_hydrologyc, &
+            soilhydrology_inst, &
+            fsat = fsat(bounds%begc:bounds%endc), &
+            qflx_in_soil = qflx_in_soil(bounds%begc:bounds%endc), &
+            qinmax_on_unsaturated_area = qinmax_on_unsaturated_area(bounds%begc:bounds%endc))
+    case default
+       write(iulog,*) subname//' ERROR: Unrecognized qinmax_method: ', this%qinmax_method
+       call endrun(subname//' ERROR: Unrecognized qinmax_method')
+    end select
+
+    do fc = 1, num_hydrologyc
+       c = filter_hydrologyc(fc)
+       qinmax(c) = (1._r8 - fsat(c)) * qinmax_on_unsaturated_area(c)
+       qflx_infl_excess(c) = max(0._r8, &
+            (qflx_in_soil(c) - (1.0_r8 - frac_h2osfc(c))*qinmax(c)))
+    end do
+
+    end associate
+
+  end subroutine InfiltrationExcessRunoff
+
+  !-----------------------------------------------------------------------
+  subroutine ComputeQinmaxHksat(bounds, num_hydrologyc, filter_hydrologyc, &
+       soilhydrology_inst, soilstate_inst, &
+       qinmax_on_unsaturated_area)
+    !
+    ! !DESCRIPTION:
+    ! Compute qinmax using a parameterization based on hksat
+    !
+    ! This is the CLM default parameterization
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+    integer, intent(in) :: num_hydrologyc       ! number of column soil points in column filter
+    integer, intent(in) :: filter_hydrologyc(:) ! column filter for soil points
+    type(soilhydrology_type) , intent(in) :: soilhydrology_inst
+    type(soilstate_type), intent(in) :: soilstate_inst
+    real(r8), intent(inout) :: qinmax_on_unsaturated_area( bounds%begc: ) ! maximum infiltration capacity on the unsaturated fraction of the column (mm H2O /s)
+    !
+    ! !LOCAL VARIABLES:
+    integer :: fc, c
+
+    character(len=*), parameter :: subname = 'ComputeQinmaxHksat'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(qinmax_on_unsaturated_area) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
+
+    associate( &
+         icefrac          =>    soilhydrology_inst%icefrac_col      , & ! Input:  [real(r8) (:,:) ]  fraction of ice
+
+         hksat            =>    soilstate_inst%hksat_col              & ! Input:  [real(r8) (:,:) ]  hydraulic conductivity at saturation (mm H2O /s)
+         )
+
+    do fc = 1, num_hydrologyc
+       c = filter_hydrologyc(fc)
+       qinmax_on_unsaturated_area(c) = minval(10._r8**(-e_ice*(icefrac(c,1:3)))*hksat(c,1:3))
+    end do
+
+    end associate
+
+  end subroutine ComputeQinmaxHksat
+
+  !-----------------------------------------------------------------------
+  subroutine ComputeQinmaxVic(bounds, num_hydrologyc, filter_hydrologyc, &
+       soilhydrology_inst, &
+       fsat, qflx_in_soil, qinmax_on_unsaturated_area)
+    !
+    ! !DESCRIPTION:
+    ! Compute qinmax using the VIC parameterization
+    !
+    ! Citation: Wood et al. 1992, "A land-surface hydrology parameterization with subgrid
+    ! variability for general circulation models", JGR 97(D3), 2717-2728.
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+    integer, intent(in) :: num_hydrologyc       ! number of column soil points in column filter
+    integer, intent(in) :: filter_hydrologyc(:) ! column filter for soil points
+    type(soilhydrology_type) , intent(in) :: soilhydrology_inst
+    real(r8) , intent(in)    :: fsat( bounds%begc: )                       ! fractional area with water table at surface
+    real(r8) , intent(in)    :: qflx_in_soil( bounds%begc: )               ! surface input to soil (mm/s)
+    real(r8) , intent(inout) :: qinmax_on_unsaturated_area( bounds%begc: ) ! maximum infiltration capacity on the unsaturated fraction of the column (mm H2O /s)
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: fc, c
+    real(r8) :: dtime       ! land model time step (sec)
+    real(r8) :: top_icefrac ! ice fraction in top VIC layers
+    real(r8) :: max_infil   ! max infiltration capacity in VIC (mm)
+    real(r8) :: i_0         ! average soil moisture in top VIC layers (mm)
+    real(r8) :: rsurf_vic   ! VIC surface runoff
+    real(r8) :: basis       ! variable soil moisture holding capacity in top VIC layers for runoff calculation
+
+    character(len=*), parameter :: subname = 'ComputeQinmaxVic'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(fsat) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(qflx_in_soil) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(qinmax_on_unsaturated_area) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
+
+    associate( &
+          top_max_moist    =>    soilhydrology_inst%top_max_moist_col, & ! Input:  [real(r8) (:)   ]  maximum soil moisture in top VIC layers
+          top_moist        =>    soilhydrology_inst%top_moist_col    , & ! Input:  [real(r8) (:)   ]  soil moisture in top VIC layers
+          top_ice          =>    soilhydrology_inst%top_ice_col      , & ! Input:  [real(r8) (:)   ]  ice len in top VIC layers
+          b_infil          =>    soilhydrology_inst%b_infil_col        & ! Input:  [real(r8) (:)   ]  VIC b infiltration parameter
+          )
+
+    dtime = get_step_size()
+
+    do fc = 1, num_hydrologyc
+       c = filter_hydrologyc(fc)
+       top_icefrac = min(1._r8,top_ice(c)/top_max_moist(c))
+       max_infil = (1._r8+b_infil(c)) * top_max_moist(c)
+       i_0 = max_infil * (1._r8 - (1._r8 - fsat(c))**(1._r8/b_infil(c)))
+       if(qflx_in_soil(c) <= 0._r8) then
+          rsurf_vic = 0._r8
+       else if(max_infil <= 0._r8) then
+          rsurf_vic = qflx_in_soil(c)
+       else if((i_0 + qflx_in_soil(c)*dtime) > max_infil) then             !(Eq.(3a) Wood et al. 1992)
+          rsurf_vic = (qflx_in_soil(c)*dtime - top_max_moist(c) + top_moist(c))/dtime
+       else                                                                !(Eq.(3b) Wood et al. 1992)
+          basis = 1._r8 - (i_0 + qflx_in_soil(c)*dtime)/max_infil
+          rsurf_vic = (qflx_in_soil(c)*dtime - top_max_moist(c) + top_moist(c)    &
+               + top_max_moist(c) * basis**(1._r8 + b_infil(c)))/dtime
+       end if
+       rsurf_vic = min(qflx_in_soil(c), rsurf_vic)
+       qinmax_on_unsaturated_area(c) = (1._r8 - fsat(c)) * 10._r8**(-e_ice*top_icefrac)*(qflx_in_soil(c) - rsurf_vic)
+    end do
+
+    end associate
+
+  end subroutine ComputeQinmaxVic
+
+end module InfiltrationExcessRunoffMod

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -132,6 +132,7 @@ contains
     ! !LOCAL VARIABLES:
     integer :: j, fc, c
     real(r8) :: vol_ice(bounds%begc:bounds%endc,1:nlevsoi) !partial volume of ice lens in layer
+    real(r8) :: icefrac_orig ! original formulation for icefrac
 
     character(len=*), parameter :: subname = 'SetFracIce'
     !-----------------------------------------------------------------------
@@ -157,13 +158,12 @@ contains
           ! fractional impermeability
 
           vol_ice(c,j) = min(watsat(c,j), h2osoi_ice(c,j)/(dz(c,j)*denice))
-          if (origflag == 1) then
-             icefrac(c,j) = min(1._r8,h2osoi_ice(c,j)/(h2osoi_ice(c,j)+h2osoi_liq(c,j)))
-          else
-             icefrac(c,j) = min(1._r8,vol_ice(c,j)/watsat(c,j))
-          endif
+          icefrac(c,j) = min(1._r8,vol_ice(c,j)/watsat(c,j))
 
-          fracice(c,j) = max(0._r8,exp(-3._r8*(1._r8-icefrac(c,j)))- exp(-3._r8))/(1.0_r8-exp(-3._r8))
+          ! fracice is only used in code with origflag == 1. For this calculation, we use
+          ! the version of icefrac that was used in this original hydrology code.
+          icefrac_orig = min(1._r8,h2osoi_ice(c,j)/(h2osoi_ice(c,j)+h2osoi_liq(c,j)))
+          fracice(c,j) = max(0._r8,exp(-3._r8*(1._r8-icefrac_orig))- exp(-3._r8))/(1.0_r8-exp(-3._r8))
        end do
     end do
 

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -165,7 +165,12 @@ contains
 
           ! fracice is only used in code with origflag == 1. For this calculation, we use
           ! the version of icefrac that was used in this original hydrology code.
-          icefrac_orig = min(1._r8,h2osoi_ice(c,j)/(h2osoi_ice(c,j)+h2osoi_liq(c,j)))
+          if (h2osoi_ice(c,j) == 0._r8) then
+             ! Avoid possible divide by zero (in case h2osoi_liq(c,j) is also 0)
+             icefrac_orig = 0._r8
+          else
+             icefrac_orig = min(1._r8,h2osoi_ice(c,j)/(h2osoi_ice(c,j)+h2osoi_liq(c,j)))
+          end if
           fracice(c,j) = max(0._r8,exp(-3._r8*(1._r8-icefrac_orig))- exp(-3._r8))/(1.0_r8-exp(-3._r8))
        end do
     end do

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -244,6 +244,10 @@ contains
            qflx_in_soil(c) = qflx_in_soil(c) - (1.0_r8 - fsno - frac_h2osfc(c))*qflx_evap(c)
            qflx_top_soil_to_h2osfc(c) =  qflx_top_soil_to_h2osfc(c)  - frac_h2osfc(c) * qflx_ev_h2osfc(c)
 
+        else
+           ! FIXME(wjs, 2017-08-15) Rather than this kludge, instead set qflx_in_soil and
+           ! qflx_top_soil_to_h2osfc to reasonable values for other landunits
+           qflx_in_soil(c) = 0._r8
         end if
      end do
 

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -17,6 +17,7 @@ module SoilHydrologyMod
   use landunit_varcon   , only : istsoil, istcrop
   use clm_time_manager  , only : get_step_size
   use EnergyFluxType    , only : energyflux_type
+  use InfiltrationExcessRunoffMod, only : infiltration_excess_runoff_type
   use SoilHydrologyType , only : soilhydrology_type  
   use SoilStateType     , only : soilstate_type
   use SurfRunoffSatMod  , only : surf_runoff_sat_type
@@ -253,8 +254,9 @@ contains
 
    !-----------------------------------------------------------------------
    subroutine Infiltration(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
-        energyflux_inst, soilhydrology_inst, soilstate_inst, surf_runoff_sat_inst, &
-        temperature_inst, waterflux_inst, waterstate_inst)
+        infiltration_excess_runoff_inst, &
+        energyflux_inst, soilhydrology_inst, surf_runoff_sat_inst, &
+        waterflux_inst, waterstate_inst)
      !
      ! !DESCRIPTION:
      ! Calculate infiltration into surface soil layer (minus the evaporation)
@@ -270,54 +272,31 @@ contains
      integer                  , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
      integer                  , intent(in)    :: num_urbanc           ! number of column urban points in column filter
      integer                  , intent(in)    :: filter_urbanc(:)     ! column filter for urban points
-     type(energyflux_type)    , intent(in)    :: energyflux_inst 
+     type(infiltration_excess_runoff_type), intent(in) :: infiltration_excess_runoff_inst
+     type(energyflux_type)    , intent(in)    :: energyflux_inst
      type(soilhydrology_type) , intent(in)    :: soilhydrology_inst
-     type(soilstate_type)     , intent(in)    :: soilstate_inst
      type(surf_runoff_sat_type), intent(in)   :: surf_runoff_sat_inst
-     type(temperature_type)   , intent(in)    :: temperature_inst
      type(waterstate_type)    , intent(inout) :: waterstate_inst
      type(waterflux_type)     , intent(inout) :: waterflux_inst
      !
      ! !LOCAL VARIABLES:
      integer  :: c,l,fc                                     ! indices
      real(r8) :: dtime                                      ! land model time step (sec)
-     real(r8) :: s1,su,v                                    ! variable to calculate qinmax
-     real(r8) :: qinmax                                     ! maximum infiltration capacity (mm/s)
-     real(r8) :: alpha_evap(bounds%begc:bounds%endc)        ! fraction of total evap from h2osfc
      real(r8) :: qflx_h2osfc_drain(bounds%begc:bounds%endc) ! bottom drainage from h2osfc
      real(r8) :: qflx_in_h2osfc(bounds%begc:bounds%endc)    ! net surface input to h2osfc
-     real(r8) :: qflx_infl_excess(bounds%begc:bounds%endc)  ! infiltration excess runoff -> h2osfc
      real(r8) :: frac_infclust                              ! fraction of submerged area that is connected
      real(r8) :: k_wet                                      ! linear reservoir coefficient for h2osfc
-     real(r8) :: fac                                        ! soil wetness of surface layer
-     real(r8) :: psit                                       ! negative potential of soil
-     real(r8) :: hr                                         ! relative humidity
-     real(r8) :: wx                                         ! partial volume of ice and water of surface layer
-     real(r8) :: z_avg
-     real(r8) :: rho_avg
-     real(r8) :: fmelt
-     real(r8) :: f_sno
-     real(r8) :: imped
-     real(r8) :: d
-     real(r8) :: h2osoi_vol                                 
-     real(r8) :: basis                                      ! temporary, variable soil moisture holding capacity 
-     ! in top VIC layers for runoff calculation
-     real(r8) :: rsurf_vic                                  ! temp VIC surface runoff
-     real(r8) :: i_0(bounds%begc:bounds%endc)               ! average soil moisture in top VIC layers (mm)
-     real(r8) :: max_infil(bounds%begc:bounds%endc)         ! max infiltration capacity in VIC (mm)
-     real(r8) :: top_icefrac                                ! temporary, ice fraction in top VIC layers
      !-----------------------------------------------------------------------
 
      associate(                                                        & 
           snl              =>    col%snl                             , & ! Input:  [integer  (:)   ]  minus number of snow layers                        
-          dz               =>    col%dz                              , & ! Input:  [real(r8) (:,:) ]  layer depth (m)                                 
 
-          t_soisno         =>    temperature_inst%t_soisno_col       , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)                       
+          qflx_infl_excess =>    infiltration_excess_runoff_inst%qflx_infl_excess_col , & ! Input:  [real(r8) (:)] infiltration excess runoff (mm H2O /s)
+          qinmax           =>    infiltration_excess_runoff_inst%qinmax_col , & ! Input:  [real(r8) (:)] maximum infiltration capacity (mm H2O /s)
 
           frac_h2osfc      =>    waterstate_inst%frac_h2osfc_col     , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by surface water (0 to 1)
-          frac_h2osfc_nosnow  => waterstate_inst%frac_h2osfc_nosnow_col,    & ! Output: [real(r8) (:)   ] col fractional area with surface water greater than zero (if no snow present)
+          frac_h2osfc_nosnow  => waterstate_inst%frac_h2osfc_nosnow_col,    & ! Input: [real(r8) (:)   ] col fractional area with surface water greater than zero (if no snow present)
           frac_sno         =>    waterstate_inst%frac_sno_eff_col    , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)       
-          h2osoi_ice       =>    waterstate_inst%h2osoi_ice_col      , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)                                
           h2osfc           =>    waterstate_inst%h2osfc_col          , & ! Output: [real(r8) (:)   ]  surface water (mm)                                
 
           qflx_in_soil     =>    waterflux_inst%qflx_in_soil_col     , & ! Input:  [real(r8) (:)   ]  surface input to soil (mm/s)
@@ -329,25 +308,10 @@ contains
           qflx_h2osfc_surf =>    waterflux_inst%qflx_h2osfc_surf_col , & ! Output: [real(r8) (:)   ]  surface water runoff (mm H2O /s)                       
           qflx_infl        =>    waterflux_inst%qflx_infl_col        , & ! Output: [real(r8) (:)   ] infiltration (mm H2O /s)                           
 
-          smpmin           =>    soilstate_inst%smpmin_col           , & ! Input:  [real(r8) (:)   ]  restriction for min of soil potential (mm)        
-          sucsat           =>    soilstate_inst%sucsat_col           , & ! Input:  [real(r8) (:,:) ]  minimum soil suction (mm)                       
-          watsat           =>    soilstate_inst%watsat_col           , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)  
-          bsw              =>    soilstate_inst%bsw_col              , & ! Input:  [real(r8) (:,:) ]  Clapp and Hornberger "b"                        
-          hksat            =>    soilstate_inst%hksat_col            , & ! Input:  [real(r8) (:,:) ]  hydraulic conductivity at saturation (mm H2O /s)
-
           qflx_sat_surf    =>  surf_runoff_sat_inst%qflx_sat_surf_col, & ! Input:  [real(r8) (:)   ]  surface runoff due to saturated surface (mm H2O /s)                        
-          fsat             =>    surf_runoff_sat_inst%fsat_col       , & ! Input:  [real(r8) (:)   ]  fractional area with water table at surface       
 
           h2osfc_thresh    =>    soilhydrology_inst%h2osfc_thresh_col, & ! Input:  [real(r8) (:)   ]  level at which h2osfc "percolates"                
-          zwt              =>    soilhydrology_inst%zwt_col          , & ! Input:  [real(r8) (:)   ]  water table depth (m)                             
-          zwt_perched      =>    soilhydrology_inst%zwt_perched_col  , & ! Input:  [real(r8) (:)   ]  perched water table depth (m)                     
-          b_infil          =>    soilhydrology_inst%b_infil_col      , & ! Input:  [real(r8) (:)   ]  VIC b infiltration parameter                       
-          frost_table      =>    soilhydrology_inst%frost_table_col  , & ! Input:  [real(r8) (:)   ]  frost table depth (m)                             
-          top_moist        =>    soilhydrology_inst%top_moist_col    , & ! Input:  [real(r8) (:)   ]  soil moisture in top VIC layers
-          top_max_moist    =>    soilhydrology_inst%top_max_moist_col, & ! Input:  [real(r8) (:)   ]  maximum soil moisture in top VIC layers
-          top_ice          =>    soilhydrology_inst%top_ice_col      , & ! Input:  [real(r8) (:)   ]  ice len in top VIC layers
-          h2osfcflag       =>    soilhydrology_inst%h2osfcflag       , & ! Input:  logical
-          icefrac          =>    soilhydrology_inst%icefrac_col        & ! Input:  [real(r8) (:,:) ]  fraction of ice
+          h2osfcflag       =>    soilhydrology_inst%h2osfcflag         & ! Input:  logical
           )
 
        dtime = get_step_size()
@@ -357,29 +321,6 @@ contains
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
           if (lun%itype(col%landunit(c)) == istsoil .or. lun%itype(col%landunit(c))==istcrop) then
-
-             !3. determine maximum infiltration rate
-             if (use_vichydro) then
-                top_icefrac = min(1._r8,top_ice(c)/top_max_moist(c))
-                max_infil(c) = (1._r8+b_infil(c)) * top_max_moist(c)
-                i_0(c) = max_infil(c) * (1._r8 - (1._r8 - fsat(c))**(1._r8/b_infil(c)))
-                if(qflx_in_soil(c) <= 0._r8) then
-                   rsurf_vic = 0._r8
-                else if(max_infil(c) <= 0._r8) then
-                   rsurf_vic = qflx_in_soil(c)
-                else if((i_0(c) + qflx_in_soil(c)*dtime) > max_infil(c)) then             !(Eq.(3a) Wood et al. 1992)
-                   rsurf_vic = (qflx_in_soil(c)*dtime - top_max_moist(c) + top_moist(c))/dtime
-                else                                                                      !(Eq.(3b) Wood et al. 1992)
-                   basis = 1._r8 - (i_0(c) + qflx_in_soil(c)*dtime)/max_infil(c)
-                   rsurf_vic = (qflx_in_soil(c)*dtime - top_max_moist(c) + top_moist(c)    &
-                        + top_max_moist(c) * basis**(1._r8 + b_infil(c)))/dtime
-                end if
-                rsurf_vic = min(qflx_in_soil(c), rsurf_vic)
-                qinmax = (1._r8 - fsat(c)) * 10._r8**(-e_ice*top_icefrac)*(qflx_in_soil(c) - rsurf_vic)
-             else
-                qinmax=(1._r8 - fsat(c)) * minval(10._r8**(-e_ice*(icefrac(c,1:3)))*hksat(c,1:3))
-             end if
-             qflx_infl_excess(c) = max(0._r8,qflx_in_soil(c) -  (1.0_r8 - frac_h2osfc(c))*qinmax)
 
              !4. soil infiltration and h2osfc "run-on"
              qflx_infl(c) = qflx_in_soil(c) - qflx_infl_excess(c)
@@ -427,7 +368,7 @@ contains
                 h2osfc(c) = 0.0
                 qflx_h2osfc_drain(c)= 0._r8
              else
-                qflx_h2osfc_drain(c)=min(frac_h2osfc(c)*qinmax,h2osfc(c)/dtime)
+                qflx_h2osfc_drain(c)=min(frac_h2osfc(c)*qinmax(c),h2osfc(c)/dtime)
              endif
 
              if(h2osfcflag==0) then 

--- a/src/biogeophys/SurfRunoffSatMod.F90
+++ b/src/biogeophys/SurfRunoffSatMod.F90
@@ -331,6 +331,9 @@ contains
     ! !DESCRIPTION:
     ! Compute fsat using the VIC-based parameterization
     !
+    ! Citation: Wood et al. 1992, "A land-surface hydrology parameterization with subgrid
+    ! variability for general circulation models", JGR 97(D3), 2717-2728.
+    !
     ! !ARGUMENTS:
     type(bounds_type), intent(in) :: bounds
     integer, intent(in) :: num_hydrologyc       ! number of column soil points in column filter

--- a/src/biogeophys/WaterfluxType.F90
+++ b/src/biogeophys/WaterfluxType.F90
@@ -80,6 +80,8 @@ module WaterfluxType
      real(r8), pointer :: qflx_drain_col           (:)   ! col sub-surface runoff (mm H2O /s)
      real(r8), pointer :: qflx_rain_plus_snomelt_col(:)  ! col rain plus snow melt falling on the soil (mm/s)
      real(r8), pointer :: qflx_top_soil_col        (:)   ! col net water input into soil from top (mm/s)
+     real(r8), pointer :: qflx_in_soil_col         (:)   ! col surface input to soil (mm/s)
+     real(r8), pointer :: qflx_top_soil_to_h2osfc_col(:) ! col portion of qflx_top_soil going to h2osfc, minus evaporation (mm/s)
      real(r8), pointer :: qflx_h2osfc_to_ice_col   (:)   ! col conversion of h2osfc to ice
      real(r8), pointer :: qflx_snow_h2osfc_col     (:)   ! col snow falling on surface water
      real(r8), pointer :: qflx_drain_perched_col   (:)   ! col sub-surface runoff from perched wt (mm H2O /s)
@@ -222,6 +224,8 @@ contains
     allocate(this%qflx_drain_col           (begc:endc))              ; this%qflx_drain_col           (:)   = nan
     allocate(this%qflx_rain_plus_snomelt_col(begc:endc))             ; this%qflx_rain_plus_snomelt_col(:)  = nan
     allocate(this%qflx_top_soil_col        (begc:endc))              ; this%qflx_top_soil_col        (:)   = nan
+    allocate(this%qflx_in_soil_col         (begc:endc))              ; this%qflx_in_soil_col         (:)   = nan
+    allocate(this%qflx_top_soil_to_h2osfc_col(begc:endc))            ; this%qflx_top_soil_to_h2osfc_col(:) = nan
     allocate(this%qflx_h2osfc_to_ice_col   (begc:endc))              ; this%qflx_h2osfc_to_ice_col   (:)   = nan
     allocate(this%qflx_infl_excess_surf_col(begc:endc))              ; this%qflx_infl_excess_surf_col(:)   = nan
     allocate(this%qflx_h2osfc_surf_col     (begc:endc))              ; this%qflx_h2osfc_surf_col     (:)   = nan

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -697,6 +697,7 @@ contains
             clm_fates,                                                         &
             atm2lnd_inst, soilstate_inst, energyflux_inst, temperature_inst,   &
             waterflux_inst, waterstate_inst, soilhydrology_inst, surf_runoff_sat_inst, &
+            infiltration_excess_runoff_inst, &
             aerosol_inst, canopystate_inst, soil_water_retention_curve)
 
        ! The following needs to be done after HydrologyNoDrainage (because it needs

--- a/src/main/clm_instMod.F90
+++ b/src/main/clm_instMod.F90
@@ -44,6 +44,7 @@ module clm_instMod
   use EnergyFluxType                  , only : energyflux_type
   use FrictionVelocityMod             , only : frictionvel_type
   use GlacierSurfaceMassBalanceMod    , only : glacier_smb_type
+  use InfiltrationExcessRunoffMod     , only : infiltration_excess_runoff_type
   use IrrigationMod                   , only : irrigation_type
   use LakeStateType                   , only : lakestate_type
   use OzoneBaseMod                    , only : ozone_base_type
@@ -95,6 +96,7 @@ module clm_instMod
   type(energyflux_type)                   :: energyflux_inst
   type(frictionvel_type)                  :: frictionvel_inst
   type(glacier_smb_type)                  :: glacier_smb_inst
+  type(infiltration_excess_runoff_type)   :: infiltration_excess_runoff_inst
   type(irrigation_type)                   :: irrigation_inst
   type(lakestate_type)                    :: lakestate_inst
   class(ozone_base_type), allocatable     :: ozone_inst
@@ -311,6 +313,7 @@ contains
     call SoilHydrologyInitTimeConst(bounds, soilhydrology_inst) ! sets time constant properties
 
     call surf_runoff_sat_inst%Init(bounds)
+    call infiltration_excess_runoff_inst%Init(bounds)
 
     call solarabs_inst%Init(bounds)
 


### PR DESCRIPTION
**NOTE: This PR was originally created in the temporary CTSM repository by @billsacks, Aug 21, 2017, where it was NCAR/clm-ctsm#2. I am moving over most of the comments from there: both my own and those of @martynpclark . I am not bothering to move some minor comments on earlier commits that I addressed in later commits.**

**Original comment from @billsacks Aug 21, 2017**

Separate out the first 3 steps of subroutine Infiltration into more modular
homes. The biggest piece of this is to introduce a new
InfiltrationExcessRunoffMod.F90; this will be where alternative
parameterizations of infiltration excess runoff can be put.