### PR TITLE
Reorder links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ https://escomp.github.io/ctsm-docs/
 
 For help with how to work with CTSM in git, see
 
-https://github.com/ESCOMP/ctsm/wiki/Recommended-git-setup
+https://github.com/ESCOMP/ctsm/wiki/Getting-started-with-CTSM-in-git
 
 and
 
-https://github.com/ESCOMP/ctsm/wiki/Getting-started-with-CTSM-in-git
+https://github.com/ESCOMP/ctsm/wiki/Recommended-git-setup


### PR DESCRIPTION
I think the "Getting started with ctsm in git" page is more relevant for
most people, so I'm putting that one first.