### PR TITLE
Bring in a working PTCLMmkdata version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ surfdata_*.namelist
 clm.input_data_list
 clm.input_data_list.previous
 
+# Tools executables
+tools/mksurfdata_map/mksurfdata_map
+tools/mkprocdata_map/mkprocdata_map
 
 # build output
 *.o

--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -9,7 +9,7 @@ required = True
 local_path = tools/PTCLM
 protocol = git
 repo_url = https://github.com/ESCOMP/ptclm
-branch = gitupdate
+tag = PTCLM2_180214
 required = True
 
 [externals_description]

--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -9,7 +9,7 @@ required = True
 local_path = tools/PTCLM
 protocol = git
 repo_url = https://github.com/ESCOMP/ptclm
-tag = PTCLM2_171216c
+branch = gitupdate
 required = True
 
 [externals_description]


### PR DESCRIPTION
Bring in a version of PTCLMmkdata that works in the new CTSM git checkout directory structure.