### PR TITLE
Avoid allocating memory for zero-weight natveg patches and urban

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1569,6 +1569,7 @@ sub process_namelist_inline_logic {
   setup_logic_dynamic_roots($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_params_file($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_create_crop_landunit($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
+  setup_logic_subgrid($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_fertilizer($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_grainproduct($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_soilstate($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
@@ -2069,6 +2070,18 @@ sub setup_logic_create_crop_landunit {
     }
   }
 }
+
+#-------------------------------------------------------------------------------
+
+sub setup_logic_subgrid {
+   my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
+
+   my $var = 'run_all_urban';
+   if ($physv->as_long() >= $physv->as_long("clm4_5")) {
+      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var);
+   }
+}
+
 #-------------------------------------------------------------------------------
 
 sub setup_logic_cnfire {

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -1113,6 +1113,7 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <create_crop_landunit     use_fates=".false.">.true.</create_crop_landunit>
 <create_crop_landunit     use_fates=".true." >.false.</create_crop_landunit>
 
+<run_all_urban>.false.</run_all_urban>
 
 <!-- =========================================  -->
 <!-- Performance issues                         -->

--- a/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -92,6 +92,14 @@ over-productive.
 If TRUE, separate the vegetated landunit into a crop landunit and a natural vegetation landunit
 </entry>
 
+<entry id="run_all_urban" type="logical" category="clm_physics"
+       group="clm_inparm" valid_values="" >
+If TRUE, run all urban landunits everywhere where we have valid urban data.
+This forces memory to be allocated and calculations to be run even for 0-weight urban points.
+This has a substantial impact on memory use and performance, and should only be used
+if you're interested in potential urban behavior globally.
+</entry>
+
 <entry id="all_active" type="logical" category="clm_physics"
        group="clm_inparm" valid_values="" >
 If TRUE, make ALL pfts, columns and landunits active, even those with 0 weight.

--- a/cime_config/testdefs/testmods_dirs/clm/allActive/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/allActive/user_nl_clm
@@ -8,3 +8,8 @@
 ! .true., so we set CLM_FORCE_COLDSTART=on for this (in shell_commands)
 
 all_active = .true.
+
+! Also run urban landunits everywhere possible; while a bit different
+! from all_active, this is a related idea, so we test it as part of the
+! same test mod.
+run_all_urban = .true.

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -130,6 +130,9 @@ module clm_varctl
   ! Other subgrid logic
   !----------------------------------------------------------
 
+  ! true => allocate and run urban landunits everywhere where we have valid urban data
+  logical, public :: run_all_urban = .false.
+
   ! true => make ALL patches, cols & landunits active (even if weight is 0)
   logical, public :: all_active = .false.          
 

--- a/src/main/clm_varsur.F90
+++ b/src/main/clm_varsur.F90
@@ -20,7 +20,7 @@ module clm_instur
   logical , pointer :: urban_valid(:)
 
   ! for natural veg landunit, weight of each patch on the landunit (adds to 1.0 on the
-  ! landunit for all all grid cells, even! those without any natural pft)
+  ! landunit for all grid cells, even those without any natural pft)
   ! (second dimension goes natpft_lb:natpft_ub)
   real(r8), pointer :: wt_nat_patch(:,:)   
 

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -195,7 +195,7 @@ contains
          clump_pproc, wrtdia, &
          create_crop_landunit, nsegspc, co2_ppmv, override_nsrest, &
          albice, soil_layerstruct, subgridflag, &
-         irrigate, all_active
+         irrigate, run_all_urban, all_active
 
     ! vertical soil mixing variables
     namelist /clm_inparm/  &
@@ -600,6 +600,7 @@ contains
     call mpi_bcast(create_crop_landunit, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     ! Other subgrid logic
+    call mpi_bcast(run_all_urban, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast(all_active, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     ! max number of plant functional types in naturally vegetated landunit

--- a/src/main/initGridCellsMod.F90
+++ b/src/main/initGridCellsMod.F90
@@ -527,13 +527,13 @@ contains
        call endrun(msg=errMsg(sourcefile, __LINE__))
     end select
 
-    wtlunit2gcell = wt_lunit(gi, ltype)
-
-    n = ltype - isturb_MIN + 1
-    wtlunit_roof = urbinp%wtlunit_roof(gi,n)
-    wtroad_perv  = urbinp%wtroad_perv(gi,n)
-
     if (npatches > 0) then
+
+       wtlunit2gcell = wt_lunit(gi, ltype)
+
+       n = ltype - isturb_MIN + 1
+       wtlunit_roof = urbinp%wtlunit_roof(gi,n)
+       wtroad_perv  = urbinp%wtroad_perv(gi,n)
 
        call add_landunit(li=li, gi=gi, ltype=ltype, wtgcell=wtlunit2gcell)
 

--- a/src/main/initGridCellsMod.F90
+++ b/src/main/initGridCellsMod.F90
@@ -222,7 +222,7 @@ contains
     !
     ! !USES
     use clm_instur, only : wt_lunit, wt_nat_patch
-    use subgridMod, only : subgrid_get_info_natveg
+    use subgridMod, only : subgrid_get_info_natveg, natveg_patch_exists
     use clm_varpar, only : numpft, maxpatch_pft, natpft_lb, natpft_ub
     !
     ! !ARGUMENTS:
@@ -237,7 +237,9 @@ contains
     integer  :: npatches                         ! number of patches in landunit
     integer  :: ncols
     integer  :: nlunits
-    integer  :: pitype                           ! patch itype
+    integer  :: npatches_added                   ! number of patches actually added
+    integer  :: ncols_added                      ! number of columns actually added
+    integer  :: nlunits_added                    ! number of landunits actually added
     real(r8) :: wtlunit2gcell                    ! landunit weight in gridcell
     !------------------------------------------------------------------------
 
@@ -247,16 +249,29 @@ contains
           npatches=npatches, ncols=ncols, nlunits=nlunits)
     wtlunit2gcell = wt_lunit(gi, ltype)
 
-    if (npatches > 0) then
+    nlunits_added = 0
+    ncols_added = 0
+    npatches_added = 0
+
+    if (nlunits > 0) then
        call add_landunit(li=li, gi=gi, ltype=ltype, wtgcell=wtlunit2gcell)
+       nlunits_added = nlunits_added + 1
        
        ! Assume one column on the landunit
        call add_column(ci=ci, li=li, ctype=1, wtlunit=1.0_r8)
+       ncols_added = ncols_added + 1
 
        do m = natpft_lb,natpft_ub
-          call add_patch(pi=pi, ci=ci, ptype=m, wtcol=wt_nat_patch(gi,m))
+          if (natveg_patch_exists(gi, m)) then
+             call add_patch(pi=pi, ci=ci, ptype=m, wtcol=wt_nat_patch(gi,m))
+             npatches_added = npatches_added + 1
+          end if
        end do
     end if
+
+    SHR_ASSERT(nlunits_added == nlunits, errMsg(sourcefile, __LINE__))
+    SHR_ASSERT(ncols_added == ncols, errMsg(sourcefile, __LINE__))
+    SHR_ASSERT(npatches_added == npatches, errMsg(sourcefile, __LINE__))
 
   end subroutine set_landunit_veg_compete
   
@@ -431,6 +446,9 @@ contains
     integer  :: npatches                         ! number of pfts in landunit
     integer  :: ncols
     integer  :: nlunits
+    integer  :: npatches_added                   ! number of patches actually added
+    integer  :: ncols_added                      ! number of columns actually added
+    integer  :: nlunits_added                    ! number of landunits actually added
     real(r8) :: wtlunit2gcell                    ! landunit weight in gridcell
     !------------------------------------------------------------------------
 
@@ -439,6 +457,10 @@ contains
     call subgrid_get_info_crop(gi, &
          npatches=npatches, ncols=ncols, nlunits=nlunits)
     wtlunit2gcell = wt_lunit(gi, ltype)
+
+    nlunits_added = 0
+    ncols_added = 0
+    npatches_added = 0
 
     if (nlunits > 0) then
 
@@ -455,6 +477,7 @@ contains
        end if
 
        call add_landunit(li=li, gi=gi, ltype=my_ltype, wtgcell=wtlunit2gcell)
+       nlunits_added = nlunits_added + 1
        
        ! Set column and patch properties for this landunit 
        ! (each column has its own pft)
@@ -462,12 +485,18 @@ contains
        do cft = cft_lb, cft_ub
           if (crop_patch_exists(gi, cft)) then
              call add_column(ci=ci, li=li, ctype=((istcrop*100) + cft), wtlunit=wt_cft(gi,cft))
+             ncols_added = ncols_added + 1
              call add_patch(pi=pi, ci=ci, ptype=cft, wtcol=1.0_r8)
+             npatches_added = npatches_added + 1
           end if
        end do
 
     end if
-       
+
+    SHR_ASSERT(nlunits_added == nlunits, errMsg(sourcefile, __LINE__))
+    SHR_ASSERT(ncols_added == ncols, errMsg(sourcefile, __LINE__))
+    SHR_ASSERT(npatches_added == npatches, errMsg(sourcefile, __LINE__))
+
   end subroutine set_landunit_crop_noncompete
 
   !------------------------------------------------------------------------------

--- a/src/main/subgridMod.F90
+++ b/src/main/subgridMod.F90
@@ -16,6 +16,7 @@ module subgridMod
   use abortutils     , only : endrun
   use clm_varctl     , only : iulog
   use clm_instur     , only : wt_lunit, urban_valid, wt_cft
+  use landunit_varcon, only : istcrop, istdlak, istwet, isturb_tbd, isturb_hd, isturb_md
   use glcBehaviorMod , only : glc_behavior_type
   use FatesInterfaceMod, only : fates_maxElementsPerSite
 
@@ -205,7 +206,7 @@ contains
     character(len=*), parameter :: subname = 'subgrid_get_info_urban_tbd'
     !-----------------------------------------------------------------------
 
-    call subgrid_get_info_urban(gi, npatches, ncols, nlunits)
+    call subgrid_get_info_urban(gi, isturb_tbd, npatches, ncols, nlunits)
 
   end subroutine subgrid_get_info_urban_tbd
 
@@ -226,7 +227,7 @@ contains
     character(len=*), parameter :: subname = 'subgrid_get_info_urban_hd'
     !-----------------------------------------------------------------------
 
-    call subgrid_get_info_urban(gi, npatches, ncols, nlunits)
+    call subgrid_get_info_urban(gi, isturb_hd, npatches, ncols, nlunits)
 
   end subroutine subgrid_get_info_urban_hd
 
@@ -247,12 +248,12 @@ contains
     character(len=*), parameter :: subname = 'subgrid_get_info_urban_md'
     !-----------------------------------------------------------------------
 
-    call subgrid_get_info_urban(gi, npatches, ncols, nlunits)
+    call subgrid_get_info_urban(gi, isturb_md, npatches, ncols, nlunits)
 
   end subroutine subgrid_get_info_urban_md
 
   !-----------------------------------------------------------------------
-  subroutine subgrid_get_info_urban(gi, npatches, ncols, nlunits)
+  subroutine subgrid_get_info_urban(gi, ltype, npatches, ncols, nlunits)
     !
     ! !DESCRIPTION:
     ! Obtain properties for one of the urban landunits in this grid cell
@@ -261,24 +262,46 @@ contains
     !
     ! !USES
     use clm_varpar, only : maxpatch_urb
+    use clm_varctl, only : run_all_urban
     !
     ! !ARGUMENTS:
     integer, intent(in)  :: gi        ! grid cell index
+    integer, intent(in)  :: ltype     ! landunit type (isturb_tbd, etc.)
     integer, intent(out) :: npatches  ! number of urban patches in this grid cell, for one urban landunit
     integer, intent(out) :: ncols     ! number of urban columns in this grid cell, for one urban landunit
     integer, intent(out) :: nlunits   ! number of urban landunits in this grid cell, for one urban landunit
     !
     ! !LOCAL VARIABLES:
+    logical :: this_landunit_exists
 
     character(len=*), parameter :: subname = 'subgrid_get_info_urban'
     !-----------------------------------------------------------------------
 
-    ! To support dynamic landunits, we have all urban landunits in every grid cell that
-    ! has valid urban parameters, because they might need to come into existence even if
-    ! their weight is 0 at the start of the run. And for simplicity, we always allocate
-    ! space for ALL columns on the urban landunits.
+    ! In general, only allocate memory for urban landunits that have non-zero weight.
+    !
+    ! However, if run_all_urban is .true., then allocate memory for all urban landunits in
+    ! every grid cell that has valid urban parameters. (This is useful if you want to
+    ! know urban behavior for all potential urban areas, or - in the future - to support
+    ! transient urban areas via dynamic landunits.)
+    !
+    ! In either case, for simplicity, we always allocate space for all columns on any
+    ! allocated urban landunits.
 
-    if (urban_valid(gi)) then
+    if (run_all_urban) then
+       if (urban_valid(gi)) then
+          this_landunit_exists = .true.
+       else
+          this_landunit_exists = .false.
+       end if
+    else
+       if (wt_lunit(gi, ltype) > 0.0_r8) then
+          this_landunit_exists = .true.
+       else
+          this_landunit_exists = .false.
+       end if
+    end if
+
+    if (this_landunit_exists) then
        npatches = maxpatch_urb
        ncols = npatches
        nlunits = 1
@@ -288,6 +311,7 @@ contains
        nlunits = 0
     end if
 
+
   end subroutine subgrid_get_info_urban
 
   !-----------------------------------------------------------------------
@@ -295,9 +319,6 @@ contains
     !
     ! !DESCRIPTION:
     ! Obtain properties for lake landunit in this grid cell
-    !
-    ! !USES:
-    use landunit_varcon, only : istdlak
     !
     ! !ARGUMENTS:
     integer, intent(in)  :: gi        ! grid cell index
@@ -330,9 +351,6 @@ contains
     !
     ! !DESCRIPTION:
     ! Obtain properties for wetland landunit in this grid cell
-    !
-    ! !USES:
-    use landunit_varcon, only : istwet
     !
     ! !ARGUMENTS:
     integer, intent(in)  :: gi        ! grid cell index
@@ -436,7 +454,6 @@ contains
     use clm_varpar           , only : cft_lb, cft_ub
     use clm_varctl           , only : create_crop_landunit
     use pftconmod            , only : pftcon
-    use landunit_varcon      , only : istcrop
     use dynSubgridControlMod , only : get_do_transient_crops
     !
     ! !ARGUMENTS:

--- a/src/main/subgridMod.F90
+++ b/src/main/subgridMod.F90
@@ -15,7 +15,7 @@ module subgridMod
   use spmdMod        , only : masterproc
   use abortutils     , only : endrun
   use clm_varctl     , only : iulog
-  use clm_instur     , only : wt_lunit, urban_valid, wt_cft
+  use clm_instur     , only : wt_lunit, wt_nat_patch, urban_valid, wt_cft
   use landunit_varcon, only : istcrop, istdlak, istwet, isturb_tbd, isturb_hd, isturb_md
   use glcBehaviorMod , only : glc_behavior_type
   use FatesInterfaceMod, only : fates_maxElementsPerSite
@@ -29,6 +29,7 @@ module subgridMod
 
   ! Routines to get info for each landunit:
   public :: subgrid_get_info_natveg
+  public :: natveg_patch_exists ! returns true if the given natural veg patch should be created in memory
   public :: subgrid_get_info_cohort
   public :: subgrid_get_info_urban_tbd
   public :: subgrid_get_info_urban_hd
@@ -128,7 +129,7 @@ contains
     ! Obtain properties for natural vegetated landunit in this grid cell
     !
     ! !USES
-    use clm_varpar, only : natpft_size
+    use clm_varpar, only : natpft_lb, natpft_ub
     !
     ! !ARGUMENTS:
     integer, intent(in)  :: gi        ! grid cell index
@@ -137,22 +138,81 @@ contains
     integer, intent(out) :: nlunits   ! number of nat veg landunits in this grid cell
     !
     ! !LOCAL VARIABLES:
+    integer :: pft  ! plant functional type index
 
     character(len=*), parameter :: subname = 'subgrid_get_info_natveg'
     !-----------------------------------------------------------------------
 
-    ! To support dynamic landunits, we have a naturally vegetated landunit in every grid
-    ! cell, because it might need to come into existence even if its weight is 0 at the
-    ! start of the run. And to support transient patches or dynamic vegetation, we always
-    ! allocate space for ALL patches on this landunit.
+    npatches = 0
 
-    npatches = natpft_size
+    do pft = natpft_lb, natpft_ub
+       if (natveg_patch_exists(gi, pft)) then
+          npatches = npatches + 1
+       end if
+    end do
 
-    ! Assume that the vegetated landunit has one column
-    nlunits = 1
-    ncols = 1
+    if (npatches > 0) then
+       ! Assume that the vegetated landunit has one column
+       ncols = 1
+       nlunits = 1
+    else
+       ! As noted in natveg_patch_exists, we expect a naturally vegetated landunit in
+       ! every grid cell. This means that npatches should be at least 1 in every grid
+       ! cell. If we find that isn't true, abort.
+       write(iulog,*) 'Expect at least one natural veg patch in every grid cell'
+       write(iulog,*) 'Found 0 for gi = ', gi
+       call endrun(subname//' ERROR: Expect at least one natural veg patch in every grid cell')
+    end if
 
   end subroutine subgrid_get_info_natveg
+
+  !-----------------------------------------------------------------------
+  function natveg_patch_exists(gi, pft) result(exists)
+    !
+    ! !DESCRIPTION:
+    ! Returns true if a patch should be created in memory for the given natural veg PFT
+    ! in this grid cell.
+    !
+    ! !USES:
+    use clm_varpar, only : natpft_lb, natpft_ub
+    use clm_varctl, only : use_cndv, use_fates
+    use dynSubgridControlMod, only : get_do_transient_pfts
+    !
+    ! !ARGUMENTS:
+    logical :: exists  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'natveg_patch_exists'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT(pft >= natpft_lb, errMsg(sourcefile, __LINE__))
+    SHR_ASSERT(pft <= natpft_ub, errMsg(sourcefile, __LINE__))
+
+    if (get_do_transient_pfts() .or. use_cndv .or. use_fates) then
+       ! To support transient PFTS and dynamic vegetation cases, we have all possible PFTs
+       ! in every grid cell, because they might need to come into existence even if their
+       ! weight is 0 at the start of the run. (Similarly for FATES, but there patches do
+       ! not correspond to PFTs.)
+       exists = .true.
+
+    else
+       ! For a non-transient PFT/dynamic-veg run: We still have a naturally vegetated
+       ! landunit in every grid cell, because this is needed to support any aspect of
+       ! dynamic landunits, as well as to provide forcings for a GLC model. So we don't
+       ! take into account the landunit's weight on the gridcell in determining whether to
+       ! allocate memory. However, we only allocate memory for patches that actually exist
+       ! on this landunit. (This will require running init_interp when changing between a
+       ! transient run and a non-transient run.)
+       if (wt_nat_patch(gi, pft) > 0.0_r8) then
+          exists = .true.
+       else
+          exists = .false.
+       end if
+    end if
+
+  end function natveg_patch_exists
+
 
   ! -----------------------------------------------------------------------------
 

--- a/src/main/subgridMod.F90
+++ b/src/main/subgridMod.F90
@@ -180,6 +180,8 @@ contains
     !
     ! !ARGUMENTS:
     logical :: exists  ! function result
+    integer, intent(in) :: gi  ! grid cell index
+    integer, intent(in) :: pft ! plant functional type
     !
     ! !LOCAL VARIABLES:
 

--- a/src/main/subgridWeightsMod.F90
+++ b/src/main/subgridWeightsMod.F90
@@ -301,7 +301,7 @@ contains
     ! Determine whether the given landunit is active
     !
     ! !USES:
-    use landunit_varcon, only : istsoil, istice_mec
+    use landunit_varcon, only : istsoil, istice_mec, isturb_MIN, isturb_MAX
     !
     ! !ARGUMENTS:
     implicit none
@@ -332,6 +332,11 @@ contains
 
        if (lun%itype(l) == istice_mec .and. &
             glc_behavior%has_virtual_columns_grc(g)) then
+          is_active_l = .true.
+       end if
+
+       if ((lun%itype(l) >= isturb_MIN .and. lun%itype(l) <= isturb_MAX) .and. &
+            run_all_urban) then
           is_active_l = .true.
        end if
 

--- a/src/main/subgridWeightsMod.F90
+++ b/src/main/subgridWeightsMod.F90
@@ -92,7 +92,7 @@ module subgridWeightsMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use shr_log_mod  , only : errMsg => shr_log_errMsg
   use abortutils   , only : endrun
-  use clm_varctl   , only : iulog, all_active, use_fates
+  use clm_varctl   , only : iulog, all_active, run_all_urban, use_fates
   use clm_varcon   , only : nameg, namel, namec, namep
   use decompMod    , only : bounds_type
   use GridcellType , only : grc                


### PR DESCRIPTION
We currently allocate memory for all urban columns and all natural veg PFTs, everywhere. In some cases this may still be desired, but in some cases – and particularly non-transient cases – this is a waste of memory and performance without any benefit.

In timing runs of a CONUS test case set up by @barlage , where there were 2 PFTs per gridcell (bare plus grass), only allocating memory for the non-zero-weight points (i.e., 2 natural pfts per gridcell and nothing else) reduced land run time from 56.4 sec to 21.6 sec.

This PR puts in place a more general solution, avoiding allocating memory for zero-weight natural PFTs in non-transient runs, and avoiding allocating memory for zero-weight urban points unless requested with a namelist flag.