### PR TITLE
fates-hydro boundary index fix

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2192,7 +2192,7 @@ contains
     
     do s = 1, this%fates(nc)%nsites
        c = this%f2hmap(nc)%fcolumn(s)
-       waterflux_inst%qflx_rootsoi_col(c,:) = this%fates(nc)%bc_out(s)%qflx_soil2root_sisl(:)
+       waterflux_inst%qflx_rootsoi_col(c,1:nlevsoi) = this%fates(nc)%bc_out(s)%qflx_soil2root_sisl(1:nlevsoi)
     end do
     
  end subroutine ComputeRootSoilFlux


### PR DESCRIPTION
This PR fixes a bug in the indexing of the soil to root flux boundary condition from CLM to fates-hydro.  The input array to fates is indexed by soil layers, but the providing array was not the same dimension, thus bounds were needed instead of open indexing, ie "(:)".

Note: fates-hydro is only stub code.  This should have no impact on any code covered by active tests right now.

Collaborators: found and corrected originally by @xuchongang

Expected Changes:  No changes to user environment or workflow. This change also only effects stub code in FATES.  Fates-hydro is still being tested.  No answer changes expected.

Tests: TBD