### PR TITLE
Fixes for init_interp

### DIFF
--- a/src/biogeophys/test/TotalWaterAndHeat_test/test_total_water_and_heat.pf
+++ b/src/biogeophys/test/TotalWaterAndHeat_test/test_total_water_and_heat.pf
@@ -30,9 +30,7 @@ contains
   subroutine tearDown(this)
     class(TestTWAH), intent(inout) :: this
 
-    if (unittest_subgrid_needs_teardown) then
-       call unittest_subgrid_teardown()
-    end if
+    call unittest_subgrid_teardown()
   end subroutine tearDown
 
   ! ------------------------------------------------------------------------

--- a/src/init_interp/CMakeLists.txt
+++ b/src/init_interp/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND clm_sources
   initInterpMultilevelInterp.F90
   initInterpMultilevelSnow.F90
   initInterpMultilevelSplit.F90
+  initInterpUtils.F90
   )
 
 sourcelist_to_parent(clm_sources)

--- a/src/init_interp/initInterp.F90
+++ b/src/init_interp/initInterp.F90
@@ -12,6 +12,7 @@ module initInterpMod
   use initInterp2dvar, only: interp_2dvar_type
   use initInterpMultilevelBase, only : interp_multilevel_type
   use initInterpMultilevelContainer, only : interp_multilevel_container_type
+  use initInterpUtils, only: glc_elevclasses_are_same
   use shr_kind_mod   , only: r8 => shr_kind_r8, r4 => shr_kind_r4
   use shr_const_mod  , only: SHR_CONST_PI, SHR_CONST_REARTH
   use shr_sys_mod    , only: shr_sys_flush
@@ -158,7 +159,8 @@ contains
     integer            :: decomp_cascade_state_i, decomp_cascade_state_o 
     integer            :: npftsi, ncolsi, nlunsi, ngrcsi 
     integer            :: npftso, ncolso, nlunso, ngrcso 
-    integer , pointer  :: pftindx(:)     
+    logical            :: glc_elevclasses_same
+    integer , pointer  :: pftindx(:)
     integer , pointer  :: colindx(:)     
     integer , pointer  :: lunindx(:)     
     integer , pointer  :: grcindx(:) 
@@ -213,6 +215,8 @@ contains
     call check_dim_level(ncidi, ncido, dimname='levtot' , must_be_same=.false.)
     call check_dim_level(ncidi, ncido, dimname='levgrnd', must_be_same=.false.)
     call check_dim_level(ncidi, ncido, dimname='numrad' , must_be_same=.true.)
+
+    glc_elevclasses_same = glc_elevclasses_are_same(ncidi, ncido)
 
     ! --------------------------------------------
     ! Determine input file global attributes that are needed 

--- a/src/init_interp/initInterpMindist.F90
+++ b/src/init_interp/initInterpMindist.F90
@@ -9,12 +9,14 @@ module initInterpMindist
   ! involves some awkward dependencies.
   ! ------------------------------------------------------------------------
 
+#include "shr_assert.h"
   use shr_kind_mod   , only: r8 => shr_kind_r8
   use shr_log_mod    , only : errMsg => shr_log_errMsg
   use clm_varctl     , only: iulog
   use abortutils     , only: endrun
   use spmdMod        , only: masterproc
   use clm_varcon     , only: spval, re
+  use glcBehaviorMod , only: glc_behavior_type
 
   implicit none
   private
@@ -96,7 +98,8 @@ contains
   !=======================================================================
 
   subroutine set_mindist(begi, endi, bego, endo, activei, activeo, subgridi, subgrido, &
-       subgrid_special_indices, fill_missing_with_natveg, mindist_index)
+       subgrid_special_indices, glc_behavior, glc_elevclasses_same, &
+       fill_missing_with_natveg, mindist_index)
 
     ! --------------------------------------------------------------------
     ! arguments
@@ -107,6 +110,11 @@ contains
     type(subgrid_type) , intent(in)  :: subgridi
     type(subgrid_type) , intent(in)  :: subgrido
     type(subgrid_special_indices_type), intent(in) :: subgrid_special_indices
+    type(glc_behavior_type), intent(in) :: glc_behavior
+
+    ! True if the number and bounds of glacier elevation classes are the same in the
+    ! input and output; false otherwise.
+    logical            , intent(in)  :: glc_elevclasses_same
 
     ! If false: if an output type cannot be found in the input, code aborts
     ! If true: if an output type cannot be found in the input, fill with closest natural
@@ -124,11 +132,30 @@ contains
     real(r8) :: distmin,dist,hgtdiffmin,hgtdiff    
     integer  :: nsizei, nsizeo
     integer  :: ni,no,nmin,ier,n,noloc
+    logical  :: topoglc_present
     logical  :: closest
+
+    ! Whether each output icemec point has adjustable column type; only valid for icemec
+    ! points, and only valid for subgrid name = pft or column
+    logical  :: icemec_adjustable_type_o(bego:endo)
+
+    ! Whether two glcmec columns/patches must be the same column/patch type to be
+    ! considered the same type. This is only valid for glcmec points, and is only valid
+    ! for subgrid name = 'pft' or 'column'.
+    logical  :: glcmec_must_be_same_type
     ! --------------------------------------------------------------------
+
+    if (associated(subgridi%topoglc) .and. associated(subgrido%topoglc)) then
+       topoglc_present = .true.
+    else
+       topoglc_present = .false.
+    end if
 
     mindist_index(bego:endo) = 0
     distmin = spval
+
+    call set_icemec_adjustable_type(bego=bego, endo=endo, dimname=subgrido%name, &
+         glc_behavior=glc_behavior, icemec_adjustable_type_o=icemec_adjustable_type_o)
 
 !$OMP PARALLEL DO PRIVATE (ni,no,n,nmin,distmin,dx,dy,dist,closest,hgtdiffmin,hgtdiff)
     do no = bego,endo
@@ -141,17 +168,46 @@ contains
        ! later became active; that's undesirable.
        if (activeo(no)) then 
 
+          ! Set glcmec_must_be_same_type. Note that this only matters for glcmec types,
+          ! but we set it for all types for simplicity.
+          if (.not. glc_elevclasses_same) then
+             ! If the number or bounds of the elevation classes differ between input and
+             ! output, then we ignore the column and patch types of glcmec points when
+             ! looking for the same type - instead using closest topographic height as a
+             ! tie-breaker between equidistant columns/patches.
+             glcmec_must_be_same_type = .false.
+          else if (icemec_adjustable_type_o(no)) then
+             ! If glcmec points in this output cell have adjustable type, then we ignore
+             ! the column and patch types of glcmec points when looking for the same
+             ! type: we want to find the closest glcmec point in lat-lon space without
+             ! regards for column/patch type, because the column/patch types may change
+             ! at runtime.
+             glcmec_must_be_same_type = .false.
+          else
+             ! Otherwise, we require the column and patch types to be the same between
+             ! input and output for this glcmec output point, as is the case for most
+             ! other landunits. This is important for a case with interpolation to give
+             ! bit-for-bit answers with a case without interpolation (since glcmec
+             ! topographic heights can change after initialization, so we can't always
+             ! rely on the point with closest topographic height to be the "right" one to
+             ! pick as the source for interpolation).
+             glcmec_must_be_same_type = .true.
+          end if
+
           nmin    = 0
           distmin = spval
           hgtdiffmin = spval
           do ni = begi,endi
              if (activei(ni)) then
-                if (is_sametype(ni, no, subgridi, subgrido, subgrid_special_indices)) then
+                if (is_sametype(ni = ni, no = no, &
+                     subgridi = subgridi, subgrido = subgrido, &
+                     subgrid_special_indices = subgrid_special_indices, &
+                     glcmec_must_be_same_type = glcmec_must_be_same_type)) then
                    dy = abs(subgrido%lat(no)-subgridi%lat(ni))*re
                    dx = abs(subgrido%lon(no)-subgridi%lon(ni))*re * &
                         0.5_r8*(subgrido%coslat(no)+subgridi%coslat(ni))
                    dist = dx*dx + dy*dy
-                   if (associated(subgridi%topoglc) .and. associated(subgrido%topoglc)) then
+                   if (topoglc_present) then
                       hgtdiff = abs(subgridi%topoglc(ni) - subgrido%topoglc(no))
                    end if
                    closest = .false.
@@ -159,18 +215,19 @@ contains
                       closest = .true.
                       distmin = dist
                       nmin = ni
-                      if (associated(subgridi%topoglc) .and. associated(subgrido%topoglc)) then
+                      if (topoglc_present) then
                          hgtdiffmin = hgtdiff
                       end if
                    end if
                    if (.not. closest) then
-                      ! For glc_mec points, we first find the closest point in lat-lon
-                      ! space (above). Then, within that closest point, we find the
-                      ! closest column in topographic space; this second piece is done
-                      ! here. Note that this ordering means that we could choose a column
-                      ! with a very different topographic height from the target column,
-                      ! if it is closer in lat-lon space than any similar-height columns.
-                      if (associated(subgridi%topoglc) .and. associated(subgrido%topoglc)) then
+                      ! In *some* cases: For glc_mec points, we first find the closest
+                      ! point in lat-lon space, without consideration for column or patch
+                      ! type (above). Then, within that closest point, we find the closest
+                      ! column in topographic space; this second piece is done here. Note
+                      ! that this ordering means that we could choose a column with a very
+                      ! different topographic height from the target column, if it is
+                      ! closer in lat-lon space than any similar-height columns.
+                      if (topoglc_present) then
                          hgtdiff = abs(subgridi%topoglc(ni) - subgrido%topoglc(no))
                          if ((dist == distmin) .and. (hgtdiff < hgtdiffmin)) then
                             closest = .true.
@@ -229,6 +286,56 @@ contains
   end subroutine set_mindist
 
   !-----------------------------------------------------------------------
+  subroutine set_icemec_adjustable_type(bego, endo, dimname, glc_behavior, &
+       icemec_adjustable_type_o)
+    !
+    ! !DESCRIPTION:
+    ! Sets the icemec_adjustable_type_o array for each output icemec point
+    !
+    ! This array will be set to true for icemec points that have adjustable column type
+    ! and false for icemec points that do not. The value will be undefined for non-icemec
+    ! points.
+    !
+    ! This can only be called for the output, not the input!
+    !
+    ! The output array is only valid for dimname = pft or column; for others, the output
+    ! values are undefined.
+    !
+    ! This assumes that bego and endo match the bounds that are used elsewhere in the
+    ! model - i.e., for the decomposition within init_interp to match the model's
+    ! decomposition.
+    !
+    ! !ARGUMENTS:
+    integer                 , intent(in)  :: bego    ! beginning index for output points
+    integer                 , intent(in)  :: endo    ! ending index for output points
+    character(len=*)        , intent(in)  :: dimname ! 'pft', 'column', etc.
+    type(glc_behavior_type) , intent(in)  :: glc_behavior
+    logical                 , intent(out) :: icemec_adjustable_type_o( bego: ) ! see documentation above
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'set_icemec_adjustable_type'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(icemec_adjustable_type_o) == (/endo/)), errMsg(sourcefile, __LINE__))
+
+    select case (dimname)
+    case ('pft')
+       call glc_behavior%patches_have_dynamic_type_array(bego, endo, &
+            icemec_adjustable_type_o(bego:endo))
+    case ('column')
+       call glc_behavior%cols_have_dynamic_type_array(bego, endo, &
+            icemec_adjustable_type_o(bego:endo))
+    case ('landunit', 'gridcell')
+       ! Do nothing: icemec_adjustable_type_o will be left undefined
+    case default
+       call endrun(subname//' ERROR: unexpected dimname: '//trim(dimname)//&
+            errMsg(sourcefile, __LINE__))
+    end select
+
+  end subroutine set_icemec_adjustable_type
+
+  !-----------------------------------------------------------------------
   function do_fill_missing_with_natveg(fill_missing_with_natveg, &
        no, subgrido, subgrid_special_indices)
     !
@@ -272,7 +379,8 @@ contains
 
   !=======================================================================
 
-  logical function is_sametype (ni, no, subgridi, subgrido, subgrid_special_indices)
+  logical function is_sametype (ni, no, subgridi, subgrido, subgrid_special_indices, &
+       glcmec_must_be_same_type)
 
     ! --------------------------------------------------------------------
     ! arguments
@@ -281,12 +389,18 @@ contains
     type(subgrid_type), intent(in)  :: subgridi
     type(subgrid_type), intent(in)  :: subgrido
     type(subgrid_special_indices_type), intent(in) :: subgrid_special_indices
+
+    ! Whether two glcmec columns/patches must be the same column/patch type to be
+    ! considered the same type. This is only valid for glcmec points, and is only valid
+    ! for subgrid name = 'pft' or 'column'.
+    logical, intent(in) :: glcmec_must_be_same_type
     ! --------------------------------------------------------------------
 
     is_sametype = .false.
 
     if (trim(subgridi%name) == 'pft' .and. trim(subgrido%name) == 'pft') then
-       if ( subgridi%ltype(ni) == subgrid_special_indices%ilun_landice_multiple_elevation_classes .and. &
+       if ( .not. glcmec_must_be_same_type .and. &
+            subgridi%ltype(ni) == subgrid_special_indices%ilun_landice_multiple_elevation_classes .and. &
             subgrido%ltype(no) == subgrid_special_indices%ilun_landice_multiple_elevation_classes) then
           is_sametype = .true.
        else if (subgrid_special_indices%is_vegetated_landunit(subgrido%ltype(no))) then
@@ -311,7 +425,8 @@ contains
           is_sametype = .true.
        end if
     else if (trim(subgridi%name) == 'column' .and. trim(subgrido%name) == 'column') then
-       if ( subgridi%ltype(ni) == subgrid_special_indices%ilun_landice_multiple_elevation_classes  .and. &
+       if ( .not. glcmec_must_be_same_type .and. &
+            subgridi%ltype(ni) == subgrid_special_indices%ilun_landice_multiple_elevation_classes  .and. &
             subgrido%ltype(no) == subgrid_special_indices%ilun_landice_multiple_elevation_classes ) then
           is_sametype = .true.
        else if (subgridi%ctype(ni) == subgrido%ctype(no) .and. &

--- a/src/init_interp/initInterpUtils.F90
+++ b/src/init_interp/initInterpUtils.F90
@@ -1,0 +1,112 @@
+module initInterpUtils
+
+  ! ------------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! This module contains various utilities used by initInterp
+  !
+  ! !USES:
+
+  use shr_kind_mod , only: r8 => shr_kind_r8
+  use shr_log_mod  , only : errMsg => shr_log_errMsg
+  use ncdio_pio    , only: file_desc_t, ncd_inqdlen, ncd_inqdid, ncd_io
+  use abortutils   , only: endrun
+
+  implicit none
+  private
+  save
+
+  ! Public methods
+
+  public :: glc_elevclasses_are_same  ! Function that determines whether the glacier elevation classes are the same in the input and output files
+
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
+
+contains
+
+  !-----------------------------------------------------------------------
+  logical function glc_elevclasses_are_same(ncidi, ncido)
+    !
+    ! !DESCRIPTION:
+    ! Determines if the glacier elevation classes are the same in ncidi and ncido
+    !
+    ! Returns .true. if they are the same (i.e., same number and bounds of elevation
+    ! classes, within roundoff), false if not.
+    !
+    ! !ARGUMENTS:
+    type(file_desc_t) , intent(inout) :: ncidi
+    type(file_desc_t) , intent(inout) :: ncido
+    !
+    ! !LOCAL VARIABLES:
+    integer :: dimid_dummy
+    logical :: dimexist
+    integer :: glc_nec_input
+    integer :: glc_nec_output
+    logical :: readvar
+    real(r8), pointer :: elevclass_bounds_input(:)
+    real(r8), pointer :: elevclass_bounds_output(:)
+    integer :: elevclass
+
+    real(r8), parameter :: bounds_tol = 1.e-4_r8  ! tolerance for checking equality of elevclass bounds
+
+    character(len=*), parameter :: subname = 'glc_elevclasses_are_same'
+    !-----------------------------------------------------------------------
+
+    ! BACKWARDS_COMPATIBILITY(wjs, 2018-03-19) Old restart files generated from
+    ! configurations with istice rather than istice_mec don't have a 'glc_nec' dimension.
+    ! Users may still be using files generated like that. The value of this function
+    ! should be irrelevant in that case. We can remove this code once we can rely on all
+    ! users' finidat files having been generated from configurations with istice_mec.
+    call ncd_inqdid(ncidi, 'glc_nec', dimid_dummy, dimexist=dimexist)
+    if (.not. dimexist) then
+       glc_elevclasses_are_same = .false.
+       return
+    end if
+
+    call ncd_inqdlen(ncido, dimid_dummy, glc_nec_output, name='glc_nec')
+    call ncd_inqdlen(ncidi, dimid_dummy, glc_nec_input, name='glc_nec')
+
+    if (glc_nec_input == glc_nec_output) then
+       allocate(elevclass_bounds_input(0:glc_nec_input))
+       allocate(elevclass_bounds_output(0:glc_nec_output))
+       call ncd_io(ncid=ncido, varname='glc_elevclass_bounds', &
+            data=elevclass_bounds_output, flag='read', readvar=readvar)
+       if (.not. readvar) then
+          call endrun('glc_elevclass_bounds not found on output file ' // &
+               errMsg(sourcefile, __LINE__))
+       end if
+       call ncd_io(ncid=ncidi, varname='glc_elevclass_bounds', &
+            data=elevclass_bounds_input, flag='read', readvar=readvar)
+       if (.not. readvar) then
+          ! BACKWARDS_COMPATIBILITY(wjs, 2018-03-19) Older restart files don't have this
+          ! variable, but it's safe to assume that any old restart file was generated
+          ! with the current elevation class bounds, as given below. Once we can rely on
+          ! old restart files having the glc_elevclass_bounds variable, we should replace
+          ! this hard-coded setting with a call to endrun, as we have for ncido.
+          if (glc_nec_input == 10) then
+             elevclass_bounds_input = [0._r8, 200._r8, 400._r8, 700._r8, 1000._r8, &
+                  1300._r8, 1600._r8, 2000._r8, 2500._r8, 3000._r8, 10000._r8]
+          else
+             call endrun('glc_elevclass_bounds not found on input file ' // &
+                  errMsg(sourcefile, __LINE__))
+          end if
+       end if
+
+       glc_elevclasses_are_same = .true.
+       do elevclass = 0, glc_nec_input
+          if (abs(elevclass_bounds_input(elevclass) - elevclass_bounds_output(elevclass)) &
+               > bounds_tol) then
+             glc_elevclasses_are_same = .false.
+          end if
+       end do
+
+       deallocate(elevclass_bounds_input)
+       deallocate(elevclass_bounds_output)
+
+    else  ! glc_nec_input /= glc_nec_output
+       glc_elevclasses_are_same = .false.
+    end if
+
+  end function glc_elevclasses_are_same
+
+end module initInterpUtils

--- a/src/init_interp/test/CMakeLists.txt
+++ b/src/init_interp/test/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(initInterpMindist_test)
 add_subdirectory(initInterpMultilevel_test)
+add_subdirectory(initInterpUtils_test)

--- a/src/init_interp/test/initInterpMindist_test/test_init_interp_mindist.pf
+++ b/src/init_interp/test/initInterpMindist_test/test_init_interp_mindist.pf
@@ -6,6 +6,10 @@ module test_init_interp_mindist
   use initInterpMindist
   use shr_kind_mod , only : r8 => shr_kind_r8
   use clm_varcon   , only: spval
+  use unittestSimpleSubgridSetupsMod
+  use unittestSubgridMod
+  use unittestArrayMod, only: grc_array
+  use glcBehaviorMod, only: glc_behavior_type
 
   implicit none
 
@@ -22,13 +26,13 @@ module test_init_interp_mindist
        subgrid_special_indices_type( &
        ipft_not_vegetated = 0, &
        icol_vegetated_or_bare_soil = 10, &
-       ilun_vegetated_or_bare_soil = 20, &
-       ilun_crop = 21, &
-       ilun_landice_multiple_elevation_classes = 22)
+       ilun_vegetated_or_bare_soil = 3, &
+       ilun_crop = 4, &
+       ilun_landice_multiple_elevation_classes = 5)
 
   ! value we can use for a special landunit; note that this just needs to differ from
   ! ilun_vegetated_or_bare_soil and from ilun_crop
-  integer, parameter :: ilun_special = 29
+  integer, parameter :: ilun_special = 6
 
 contains
 
@@ -43,11 +47,13 @@ contains
 
   subroutine tearDown(this)
     class(TestInitInterpMindist), intent(inout) :: this
+
+    call unittest_subgrid_teardown()
   end subroutine tearDown
 
   !-----------------------------------------------------------------------
   function create_subgrid_info(npts, name, lat, lon, &
-       ptype, ctype, ltype, topoglc) &
+       beg, ptype, ctype, ltype, topoglc) &
        result(subgrid_info)
     !
     ! !ARGUMENTS:
@@ -56,15 +62,25 @@ contains
     character(len=*), intent(in) :: name
     real(r8), intent(in) :: lat(:)
     real(r8), intent(in) :: lon(:)
+    integer, intent(in), optional :: beg  ! beginning index; if not provided, assumed to be 1 (should be provided for output, not needed for input)
     integer, intent(in), optional :: ptype(:)
     integer, intent(in), optional :: ctype(:)
     integer, intent(in), optional :: ltype(:)
     real(r8), intent(in), optional :: topoglc(:)
     !
     ! !LOCAL VARIABLES:
+    integer :: l_beg  ! local version of beg
+    integer :: l_end  ! ending index
 
     character(len=*), parameter :: subname = 'create_subgrid_info'
     !-----------------------------------------------------------------------
+
+    if (present(beg)) then
+       l_beg = beg
+    else
+       l_beg = 1
+    end if
+    l_end = l_beg + npts - 1
 
     ! Check array lengths
     @assertEqual(npts, size(lat))
@@ -86,38 +102,69 @@ contains
 
     subgrid_info%name = name
 
-    allocate(subgrid_info%lat(npts))
+    allocate(subgrid_info%lat(l_beg:l_end))
     subgrid_info%lat = lat
-    allocate(subgrid_info%lon(npts))
+    allocate(subgrid_info%lon(l_beg:l_end))
     subgrid_info%lon = lon
-    allocate(subgrid_info%coslat(npts))
+    allocate(subgrid_info%coslat(l_beg:l_end))
     subgrid_info%coslat = cos(subgrid_info%lat)
 
     if (present(ptype)) then
-       allocate(subgrid_info%ptype(npts))
+       allocate(subgrid_info%ptype(l_beg:l_end))
        subgrid_info%ptype = ptype
     end if
     if (present(ctype)) then
-       allocate(subgrid_info%ctype(npts))
+       allocate(subgrid_info%ctype(l_beg:l_end))
        subgrid_info%ctype = ctype
     end if
     if (present(ltype)) then
-       allocate(subgrid_info%ltype(npts))
+       allocate(subgrid_info%ltype(l_beg:l_end))
        subgrid_info%ltype = ltype
     end if
     if (present(topoglc)) then
-       allocate(subgrid_info%topoglc(npts))
+       allocate(subgrid_info%topoglc(l_beg:l_end))
        subgrid_info%topoglc = topoglc
     end if
 
   end function create_subgrid_info
 
+  !-----------------------------------------------------------------------
+  function create_glc_behavior(collapse_to_atm_topo) result(glc_behavior)
+    !
+    ! !DESCRIPTION:
+    ! Creates a glc_behavior instance with the given collapse_to_atm_topo behavior set
+    ! for all grid cells.
+    !
+    ! Must be called *after* setting up the subgrid structure.
+    !
+    ! Note that collapse_to_atm_topo is the only aspect of glc_behavior that is relevant
+    ! for the unit tests in this module.
+    !
+    ! !ARGUMENTS:
+    type(glc_behavior_type) :: glc_behavior  ! function result
+    logical, intent(in) :: collapse_to_atm_topo
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'create_glc_behavior'
+    !-----------------------------------------------------------------------
+
+    call glc_behavior%InitSetDirectly(bounds%begg, bounds%endg, &
+         has_virtual_columns = grc_array(.false.), &
+         collapse_to_atm_topo = grc_array(collapse_to_atm_topo))
+
+  end function create_glc_behavior
 
   subroutine wrap_set_mindist(subgridi, subgrido, mindist_index, activei, activeo, &
-       fill_missing_with_natveg)
+       glc_behavior, glc_elevclasses_same, fill_missing_with_natveg)
     ! Wrap the call to set_mindist.
     !
     ! If activei / activeo are not provided, they are assumed to be .true. for all points.
+    !
+    ! If glc_behavior is not present, it is assumed to have collapse_to_atm_topo false
+    ! for all grid cells.
+    !
+    ! If glc_elevclasses_same is not present, it is assumed to be true.
     !
     ! If fill_missing_with_natveg is not provided, it is assumed to be false
 
@@ -127,18 +174,25 @@ contains
     integer, intent(out) :: mindist_index(:)
     logical, intent(in), optional :: activei(:)
     logical, intent(in), optional :: activeo(:)
+    type(glc_behavior_type), intent(in), optional :: glc_behavior
+    logical, intent(in), optional :: glc_elevclasses_same
     logical, intent(in), optional :: fill_missing_with_natveg
 
     ! Local variables:
     integer :: npts_i, npts_o
+    integer :: bego, endo
     logical, allocatable :: l_activei(:)
     logical, allocatable :: l_activeo(:)
+    type(glc_behavior_type) :: l_glc_behavior
+    logical :: l_glc_elevclasses_same
     logical :: l_fill_missing_with_natveg
 
     !-----------------------------------------------------------------------
 
     npts_i = size(subgridi%lon)
     npts_o = size(subgrido%lon)
+    bego = lbound(subgrido%lon, 1)
+    endo = ubound(subgrido%lon, 1)
 
     @assertEqual(npts_o, size(mindist_index))
 
@@ -158,19 +212,161 @@ contains
        l_activeo = .true.
     end if
 
+    if (present(glc_behavior)) then
+       l_glc_behavior = glc_behavior
+    else
+       l_glc_behavior = create_glc_behavior(collapse_to_atm_topo = .false.)
+    end if
+
+    if (present(glc_elevclasses_same)) then
+       l_glc_elevclasses_same = glc_elevclasses_same
+    else
+       l_glc_elevclasses_same = .true.
+    end if
+
     if (present(fill_missing_with_natveg)) then
        l_fill_missing_with_natveg = fill_missing_with_natveg
     else
        l_fill_missing_with_natveg = .false.
     end if
 
-    call set_mindist(begi = 1, endi = npts_i, bego = 1, endo = npts_o, &
+    call set_mindist(begi = 1, endi = npts_i, bego = bego, endo = endo, &
          activei = l_activei, activeo = l_activeo, subgridi = subgridi, subgrido = subgrido, &
          subgrid_special_indices = subgrid_special_indices, &
+         glc_behavior = l_glc_behavior, &
+         glc_elevclasses_same = l_glc_elevclasses_same, &
          fill_missing_with_natveg = l_fill_missing_with_natveg, &
          mindist_index = mindist_index)
 
   end subroutine wrap_set_mindist
+
+  !-----------------------------------------------------------------------
+  subroutine setup_and_run_glcmec(ptype_o, ctype_o, topoglc_o, &
+       ptype_i, ctype_i, topoglc_i, &
+       collapse_to_atm_topo, glc_elevclasses_same, &
+       mindist_index_p, mindist_index_c, &
+       ltype_diff_i)
+    !
+    ! !DESCRIPTION:
+    ! Does all the work needed to setup and run wrap_set_mindist for a single glcmec
+    ! output point.
+    !
+    ! Gives both the mindist patch and column for that output point.
+    !
+    ! Some assumptions:
+    ! - All input points are from the same gridcell, with the same lat/lon as the output
+    !   point
+    ! - There is one patch for each column
+    !
+    ! !ARGUMENTS:
+    integer, intent(in) :: ptype_o  ! patch type of the output point
+    integer, intent(in) :: ctype_o  ! col type of the output point
+    real(r8), intent(in) :: topoglc_o  ! topographic height of the output point
+    integer, intent(in) :: ptype_i(:)  ! patch type of each input point
+    integer, intent(in) :: ctype_i(:)  ! col type of each input point
+    real(r8), intent(in) :: topoglc_i(:)  ! topographic height of each input point
+    logical, intent(in) :: collapse_to_atm_topo
+    logical, intent(in) :: glc_elevclasses_same
+    integer, intent(out) :: mindist_index_p
+    integer, intent(out) :: mindist_index_c
+
+    ! If present, this gives the difference in ltype from ltype_glcmec for each input
+    ! point. So, for example, if this is an array [-1, 0, 1] then the input ltypes will
+    ! be [ltype_glcmec-1, ltype_glcmec, ltype_glcmec+1]. If absent, all input points have
+    ! type ltype_glcmec.
+    integer, intent(in), optional :: ltype_diff_i(:)
+
+    !
+    ! !LOCAL VARIABLES:
+    integer, parameter :: ltype_glcmec = subgrid_special_indices%ilun_landice_multiple_elevation_classes
+    real(r8), parameter :: my_lat = 31._r8
+    real(r8), parameter :: my_lon = 41._r8
+    integer :: num_i
+    integer, allocatable :: ltype_i(:)
+    real(r8), allocatable :: lat_i(:)
+    real(r8), allocatable :: lon_i(:)
+    type(subgrid_type) :: subgridi_c, subgrido_c, subgridi_p, subgrido_p
+    type(glc_behavior_type) :: glc_behavior
+    integer :: mindist_index_p_arr(1)
+    integer :: mindist_index_c_arr(1)
+
+    character(len=*), parameter :: subname = 'setup_and_run_glcmec'
+    !-----------------------------------------------------------------------
+
+    ! Note that we assume the same number of patches as columns (i.e., one patch per
+    ! column)
+    num_i = size(ptype_i)
+    @assertEqual(num_i, size(ctype_i))
+    @assertEqual(num_i, size(topoglc_i))
+    if (present(ltype_diff_i)) then
+       @assertEqual(num_i, size(ltype_diff_i))
+    end if
+
+    call setup_landunit_ncols(ltype=ltype_glcmec, &
+         ctypes=[ctype_o], &
+         cweights=[1._r8], &
+         ptype=ptype_o)
+
+    subgrido_c = create_subgrid_info( &
+         npts = 1, &
+         beg = bounds%begc, &
+         name = 'column', &
+         ctype = [ctype_o], &
+         ltype = [ltype_glcmec], &
+         lat = [my_lat], &
+         lon = [my_lon], &
+         topoglc = [topoglc_o])
+    subgrido_p = create_subgrid_info( &
+         npts = 1, &
+         beg = bounds%begp, &
+         name = 'pft', &
+         ptype = [ptype_o], &
+         ctype = [ctype_o], &
+         ltype = [ltype_glcmec], &
+         lat = [my_lat], &
+         lon = [my_lon], &
+         topoglc = [topoglc_o])
+
+    allocate(ltype_i(num_i))
+    allocate(lat_i(num_i))
+    allocate(lon_i(num_i))
+    if (present(ltype_diff_i)) then
+       ltype_i(:) = ltype_glcmec + ltype_diff_i(:)
+    else
+       ltype_i(:) = ltype_glcmec
+    end if
+    lat_i(:) = my_lat
+    lon_i(:) = my_lon
+
+    subgridi_c = create_subgrid_info( &
+         npts = num_i, &
+         name = 'column', &
+         ctype = ctype_i, &
+         ltype = ltype_i, &
+         lat = lat_i, &
+         lon = lon_i, &
+         topoglc = topoglc_i)
+    subgridi_p = create_subgrid_info( &
+         npts = num_i, &
+         name = 'pft', &
+         ptype = ptype_i, &
+         ctype = ctype_i, &
+         ltype = ltype_i, &
+         lat = lat_i, &
+         lon = lon_i, &
+         topoglc = topoglc_i)
+
+    glc_behavior = create_glc_behavior(collapse_to_atm_topo)
+
+    call wrap_set_mindist(subgridi_c, subgrido_c, mindist_index_c_arr, &
+         glc_behavior = glc_behavior, glc_elevclasses_same = glc_elevclasses_same)
+    call wrap_set_mindist(subgridi_p, subgrido_p, mindist_index_p_arr, &
+         glc_behavior = glc_behavior, glc_elevclasses_same = glc_elevclasses_same)
+
+    mindist_index_c = mindist_index_c_arr(1)
+    mindist_index_p = mindist_index_p_arr(1)
+
+  end subroutine setup_and_run_glcmec
 
 
   ! ========================================================================
@@ -179,7 +375,7 @@ contains
 
 
   @Test
-  subroutine multiple_types_finds_same_type(this)
+  subroutine multipleTypes_findsSameType(this)
     ! If there are multiple types in the input, all equidistant from the target point,
     ! then make sure we find the point with the same type.
     !
@@ -187,14 +383,19 @@ contains
     class(TestInitInterpMindist), intent(inout) :: this
     type(subgrid_type) :: subgridi, subgrido
     integer, parameter :: my_ctype = 15
-    integer, parameter :: my_ltype = 25
+    integer, parameter :: my_ltype = 8
     real(r8), parameter :: my_lat = 31._r8
     real(r8), parameter :: my_lon = 41._r8
     integer :: i
     integer :: mindist_index(1)
 
+    call setup_landunit_ncols(ltype=my_ltype, &
+         ctypes=[my_ctype], &
+         cweights=[1._r8])
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begc, &
          name = 'column', &
          ctype = [my_ctype], &
          ltype = [my_ltype], &
@@ -214,57 +415,156 @@ contains
 
     @assertEqual(3, mindist_index(1))
 
-  end subroutine multiple_types_finds_same_type
+  end subroutine multipleTypes_findsSameType
 
   @Test
-  subroutine glcmec_finds_closest_height(this)
-    ! If there are multiple glc_mec points that are equidistant in space, pick the one
-    ! with the closest height
+  subroutine glcmec_elevclassesSame_findsSameColType(this)
+    ! When glc elevation classes are the same between input and output: Choose
+    ! column/patch from the same column type, even if it isn't the one with the closest
+    ! topographic height.
     !
-    ! This tests a column-level point
+    ! This tests both column-level and patch-level
     class(TestInitInterpMindist), intent(inout) :: this
-    type(subgrid_type) :: subgridi, subgrido
     integer, parameter :: my_ctype = 15
-    integer, parameter :: my_ltype = subgrid_special_indices%ilun_landice_multiple_elevation_classes
-    real(r8), parameter :: my_lat = 31._r8
-    real(r8), parameter :: my_lon = 41._r8
+    integer, parameter :: my_ptype = 25
     real(r8), parameter :: my_topo = 1000._r8
     integer :: i
-    integer :: mindist_index(1)
+    integer :: mindist_index_c, mindist_index_p
 
-    subgrido = create_subgrid_info( &
-         npts = 1, &
-         name = 'column', &
-         ctype = [my_ctype], &
-         ltype = [my_ltype], &
-         lat = [my_lat], &
-         lon = [my_lon], &
-         topoglc = [my_topo])
+    ! Note that:
+    ! - all input ptypes are the same as output ptype
+    ! - all input ctypes are different, with one of them matching the output ctype
+    ! - the matching input ctype has the most different topographic height
+    call setup_and_run_glcmec( &
+         ptype_o = my_ptype, &
+         ctype_o = my_ctype, &
+         topoglc_o = my_topo, &
+         ptype_i = [my_ptype, my_ptype, my_ptype, my_ptype], &
+         ctype_i = [my_ctype-2, my_ctype-1, my_ctype, my_ctype+1], &
+         topoglc_i = [my_topo - 10._r8, my_topo - 1._r8, my_topo + 100._r8, my_topo], &
+         collapse_to_atm_topo = .false., &
+         glc_elevclasses_same = .true., &
+         mindist_index_p = mindist_index_p, &
+         mindist_index_c = mindist_index_c)
 
-    ! Note that we use a different ctype value for the target point: this should be
-    ! ignored for glcmec
-    subgridi = create_subgrid_info( &
-         npts = 3, &
-         name = 'column', &
-         ctype = [my_ctype, my_ctype-1, my_ctype], &
-         ltype = [my_ltype, my_ltype, my_ltype], &
-         lat = [(my_lat, i=1,3)], &
-         lon = [(my_lon, i=1,3)], &
-         topoglc = [my_topo - 10._r8, my_topo - 1._r8, my_topo + 100._r8])
-
-    call wrap_set_mindist(subgridi, subgrido, mindist_index)
-
-    @assertEqual(2, mindist_index(1))
-
-  end subroutine glcmec_finds_closest_height
+    @assertEqual(3, mindist_index_c)
+    @assertEqual(3, mindist_index_p)
+  end subroutine glcmec_elevclassesSame_findsSameColType
 
   @Test
-  subroutine glcmec_finds_closest_latlon(this)
+  subroutine glcmec_elevclassesSame_findsSamePatchType(this)
+    ! When glc elevation classes are the same between input and output: Choose patch from
+    ! the same patch type, even if it isn't the one with the closest topographic height.
+    !
+    ! This tests just patch-level
+    class(TestInitInterpMindist), intent(inout) :: this
+    integer, parameter :: my_ctype = 15
+    integer, parameter :: my_ptype = 25
+    real(r8), parameter :: my_topo = 1000._r8
+    integer :: i
+    integer :: mindist_index_c, mindist_index_p
+
+    ! Note that:
+    ! - all input ptypes are different, with one of them matching the output ptype
+    ! - all input ctypes are the same as output ctype (this probably shouldn't happen in
+    !   practice, but is useful for testing the code logic)
+    ! - the matching input ptype has the most different topographic height
+    call setup_and_run_glcmec( &
+         ptype_o = my_ptype, &
+         ctype_o = my_ctype, &
+         topoglc_o = my_topo, &
+         ptype_i = [my_ptype-2, my_ptype-1, my_ptype, my_ptype+1], &
+         ctype_i = [my_ctype, my_ctype, my_ctype, my_ctype], &
+         topoglc_i = [my_topo - 10._r8, my_topo - 1._r8, my_topo + 100._r8, my_topo], &
+         collapse_to_atm_topo = .false., &
+         glc_elevclasses_same = .true., &
+         mindist_index_p = mindist_index_p, &
+         mindist_index_c = mindist_index_c)
+
+    ! Note that we don't assert anything about mindist_index_c in this case: the behavior
+    ! of mindist_index_c is not defined, since there are multiple input columns with the
+    ! same type. (We don't expect this situation of having multiple input columns with
+    ! the same type to arise in practice, so we haven't defined the behavior of this
+    ! case.)
+    @assertEqual(3, mindist_index_p)
+  end subroutine glcmec_elevclassesSame_findsSamePatchType
+
+  @Test
+  subroutine glcmec_elevclassesDiffer_findsClosestHeight(this)
+    ! When glc elevation classes differ between input and output: Ignore column and pft
+    ! types; if there are multiple glc_mec points that are equidistant in space, pick the
+    ! one with the closest height
+    !
+    ! This tests both column-level and patch-level
+    class(TestInitInterpMindist), intent(inout) :: this
+    integer, parameter :: my_ctype = 15
+    integer, parameter :: my_ptype = 25
+    real(r8), parameter :: my_topo = 1000._r8
+    integer :: i
+    integer :: mindist_index_c, mindist_index_p
+
+    ! Note that we use different ptype and ctype values for the target point: these should
+    ! be ignored in this case. However, ltype should *not* be ignored (and thus we should
+    ! *not* pick the third point).
+    call setup_and_run_glcmec( &
+         ptype_o = my_ptype, &
+         ctype_o = my_ctype, &
+         topoglc_o = my_topo, &
+         ptype_i = [my_ptype, my_ptype-1, my_ptype, my_ptype], &
+         ctype_i = [my_ctype, my_ctype-1, my_ctype, my_ctype], &
+         ltype_diff_i = [0, 0, -1, 0], &
+         topoglc_i = [my_topo - 10._r8, my_topo - 1._r8, my_topo, my_topo + 100._r8], &
+         collapse_to_atm_topo = .false., &
+         glc_elevclasses_same = .false., &
+         mindist_index_p = mindist_index_p, &
+         mindist_index_c = mindist_index_c)
+
+    @assertEqual(2, mindist_index_c)
+    @assertEqual(2, mindist_index_p)
+  end subroutine glcmec_elevclassesDiffer_findsClosestHeight
+
+  @Test
+  subroutine glcmec_collapseToAtmTopo_findsClosestHeight(this)
+    ! For an output glcmec point with the collapse_to_atm_topo behavior: Ignore column and
+    ! pft types; if there are multiple glc_mec points that are equidistant in space, pick
+    ! the one with the closest height
+    !
+    ! This tests both column-level and patch-level
+    class(TestInitInterpMindist), intent(inout) :: this
+    integer, parameter :: my_ctype = 15
+    integer, parameter :: my_ptype = 25
+    real(r8), parameter :: my_topo = 1000._r8
+    integer :: i
+    integer :: mindist_index_c, mindist_index_p
+
+    ! Note that we use different ptype and ctype values for the target point: these should
+    ! be ignored in this case. However, ltype should *not* be ignored (and thus we should
+    ! *not* pick the third point).
+    call setup_and_run_glcmec( &
+         ptype_o = my_ptype, &
+         ctype_o = my_ctype, &
+         topoglc_o = my_topo, &
+         ptype_i = [my_ptype, my_ptype-1, my_ptype, my_ptype], &
+         ctype_i = [my_ctype, my_ctype-1, my_ctype, my_ctype], &
+         ltype_diff_i = [0, 0, -1, 0], &
+         topoglc_i = [my_topo - 10._r8, my_topo - 1._r8, my_topo, my_topo + 100._r8], &
+         collapse_to_atm_topo = .true., &
+         glc_elevclasses_same = .true., &
+         mindist_index_p = mindist_index_p, &
+         mindist_index_c = mindist_index_c)
+
+    @assertEqual(2, mindist_index_c)
+    @assertEqual(2, mindist_index_p)
+  end subroutine glcmec_collapseToAtmTopo_findsClosestHeight
+
+  @Test
+  subroutine glcmec_elevclassesDiffer_findsClosestLatlon(this)
     ! For glc_mec, if we have some points closer in topographic height, but others closer
     ! in x-y space, pick the closer point in x-y space
 
     class(TestInitInterpMindist), intent(inout) :: this
     type(subgrid_type) :: subgridi, subgrido
+    type(glc_behavior_type) :: glc_behavior
     integer, parameter :: my_ctype = 15
     integer, parameter :: my_ltype = subgrid_special_indices%ilun_landice_multiple_elevation_classes
     real(r8), parameter :: my_lat = 31._r8
@@ -273,8 +573,13 @@ contains
     integer :: i
     integer :: mindist_index(1)
 
+    call setup_landunit_ncols(ltype=my_ltype, &
+         ctypes=[my_ctype], &
+         cweights=[1._r8])
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begc, &
          name = 'column', &
          ctype = [my_ctype], &
          ltype = [my_ltype], &
@@ -291,13 +596,16 @@ contains
          lon = [(my_lon, i=1,3)], &
          topoglc = [my_topo, my_topo - 100._r8, my_topo])
 
-    call wrap_set_mindist(subgridi, subgrido, mindist_index)
+    glc_behavior = create_glc_behavior(collapse_to_atm_topo = .false.)
+
+    call wrap_set_mindist(subgridi, subgrido, mindist_index, &
+         glc_behavior = glc_behavior, glc_elevclasses_same = .false.)
 
     @assertEqual(2, mindist_index(1))
-  end subroutine glcmec_finds_closest_latlon
+  end subroutine glcmec_elevclassesDiffer_findsClosestLatlon
 
   @Test
-  subroutine noncrop_to_crop_patch_variable_uses_correct_pft(this)
+  subroutine noncropToCrop_patchVariable_usesCorrectPft(this)
     ! For interpolation from a non-crop case to a crop case, ensure that a patch-level
     ! variable takes its input from the correct pft. This simulates what happens to the
     ! generic crop type in this case.
@@ -318,8 +626,14 @@ contains
 
     my_ctype = icol_natveg + 1  ! arbitrary; we just want this to differ from icol_natveg
 
+    call setup_landunit_ncols(ltype=ilun_crop, &
+         ctypes=[my_ctype], &
+         cweights=[1._r8], &
+         ptype=my_ptype)
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begp, &
          name = 'pft', &
          ptype = [my_ptype], &
          ctype = [my_ctype], &
@@ -343,10 +657,10 @@ contains
     @assertEqual(2, mindist_index(1))
 
     end associate
-  end subroutine noncrop_to_crop_patch_variable_uses_correct_pft
+  end subroutine noncropToCrop_patchVariable_usesCorrectPft
 
   @Test
-  subroutine crop_to_noncrop_patch_variable_uses_correct_pft(this)
+  subroutine cropToNoncrop_patchVariable_usesCorrectPft(this)
     ! For interpolation from a crop case to a non-crop case, ensure that a patch-level
     ! variable takes its input from the correct pft. This simulates what happens to the
     ! generic crop type in this case.
@@ -365,8 +679,14 @@ contains
          ilun_crop   => subgrid_special_indices%ilun_crop &
          )
 
+    call setup_landunit_ncols(ltype=ilun_natveg, &
+         ctypes=[icol_natveg], &
+         cweights=[1._r8], &
+         ptype=my_ptype)
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begp, &
          name = 'pft', &
          ptype = [my_ptype], &
          ctype = [icol_natveg], &
@@ -392,10 +712,10 @@ contains
     @assertEqual(2, mindist_index(1))
 
     end associate
-  end subroutine crop_to_noncrop_patch_variable_uses_correct_pft
+  end subroutine cropToNoncrop_patchVariable_usesCorrectPft
 
   @Test
-  subroutine noncrop_to_crop_specific_crop_from_natveg(this)
+  subroutine noncropToCrop_specificCropFromNatveg(this)
     ! For interpolation from a non-crop case to a crop case, ensure that crop columns
     ! take their info from the natural veg column in the input.
     class(TestInitInterpMindist), intent(inout) :: this
@@ -414,8 +734,13 @@ contains
 
     my_ctype = icol_natveg + 1  ! arbitrary; we just want this to differ from icol_natveg
 
+    call setup_landunit_ncols(ltype=ilun_crop, &
+         ctypes=[my_ctype], &
+         cweights=[1._r8])
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begc, &
          name = 'column', &
          ctype = [my_ctype], &
          ltype = [ilun_crop], &
@@ -439,10 +764,10 @@ contains
     @assertEqual(2, mindist_index(1))
 
     end associate
-  end subroutine noncrop_to_crop_specific_crop_from_natveg
+  end subroutine noncropToCrop_specificCropFromNatveg
 
   @Test
-  subroutine newveg_uses_baresoil(this)
+  subroutine newveg_usesBaresoil(this)
     ! If there's a new vegetation (patch) type, this should take inputs from the closest
     ! bare soil point.
     !
@@ -463,8 +788,14 @@ contains
          ilun_natveg => subgrid_special_indices%ilun_vegetated_or_bare_soil &
          )
 
+    call setup_landunit_ncols(ltype=ilun_natveg, &
+         ctypes=[icol_natveg], &
+         cweights=[1._r8], &
+         ptype=my_ptype)
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begp, &
          name = 'pft', &
          ptype = [my_ptype], &
          ctype = [icol_natveg], &
@@ -490,10 +821,10 @@ contains
     @assertEqual(2, mindist_index(1))
 
     end associate
-  end subroutine newveg_uses_baresoil
+  end subroutine newveg_usesBaresoil
 
   @Test
-  subroutine baresoil_ignores_special_landunits(this)
+  subroutine baresoil_ignoresSpecialLandunits(this)
     ! This test ensures that, when finding a match for a bare soil patch, we ignore
     ! special landunits. This is important because special landunits also have pft type =
     ! noveg.
@@ -510,8 +841,14 @@ contains
          ilun_veg => subgrid_special_indices%ilun_vegetated_or_bare_soil &
     )
 
+    call setup_landunit_ncols(ltype=ilun_veg, &
+         ctypes=[icol_veg], &
+         cweights=[1._r8], &
+         ptype=ipft_bare)
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begp, &
          name = 'pft', &
          ptype = [ipft_bare], &
          ctype = [icol_veg], &
@@ -536,10 +873,10 @@ contains
     @assertEqual(2, mindist_index(1))
 
     end associate
-  end subroutine baresoil_ignores_special_landunits
+  end subroutine baresoil_ignoresSpecialLandunits
 
   @Test
-  subroutine fill_missing_uses_natveg(this)
+  subroutine fillMissing_usesNatveg(this)
     ! This test ensures that, when using fill_missing_with_natveg, the code finds a point
     ! from the natural veg landunit. This is especially important to check for
     ! patch-level variables, for which special landunits also use the noveg (0) pft type.
@@ -560,8 +897,14 @@ contains
          ilun_veg => subgrid_special_indices%ilun_vegetated_or_bare_soil &
     )
 
+    call setup_landunit_ncols(ltype=my_ltype, &
+         ctypes=[my_ctype], &
+         cweights=[1._r8], &
+         ptype=my_ptype)
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begp, &
          name = 'pft', &
          ptype = [my_ptype], &
          ctype = [my_ctype], &
@@ -586,10 +929,10 @@ contains
     @assertEqual(2, mindist_index(1))
     
     end associate
-  end subroutine fill_missing_uses_natveg
+  end subroutine fillMissing_usesNatveg
 
   @Test
-  subroutine gridcell_finds_closest_latlon(this)
+  subroutine gridcell_findsClosestLatlon(this)
     ! For gridcell-level variables, should find closest gridcell in lat-lon space
     class(TestInitInterpMindist), intent(inout) :: this
     type(subgrid_type) :: subgridi, subgrido
@@ -598,8 +941,11 @@ contains
     real(r8), parameter :: my_lat = 31._r8
     real(r8), parameter :: my_lon = 41._r8
 
+    call setup_single_veg_patch(pft_type=1)
+
     subgrido = create_subgrid_info( &
          npts = 1, &
+         beg = bounds%begg, &
          name = 'gridcell', &
          lat = [my_lat], &
          lon = [my_lon])
@@ -613,6 +959,6 @@ contains
     call wrap_set_mindist(subgridi, subgrido, mindist_index)
 
     @assertEqual(2, mindist_index(1))
-  end subroutine gridcell_finds_closest_latlon
+  end subroutine gridcell_findsClosestLatlon
 
 end module test_init_interp_mindist

--- a/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_snow.pf
+++ b/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_snow.pf
@@ -58,68 +58,13 @@ contains
 
   end function create_interpolator
 
-
   ! ------------------------------------------------------------------------
-  ! Tests: more levels in destination
+  ! Begin tests
   ! ------------------------------------------------------------------------
-
-  @Test
-  subroutine moreDestLevels_noSourceLevels(this)
-    ! No existing snow levels in the source
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    real(r8) :: data_source(3) = [11._r8, 12._r8, 13._r8]
-
-    interpolator = create_interpolator(num_snow_layers_source = 0)
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(1:2) = 0._r8
-    data_dest_expected(3:5) = data_source(:)
-    @assertEqual(data_dest_expected, data_dest)
-  end subroutine moreDestLevels_noSourceLevels
-
-  @Test
-  subroutine moreDestLevels_allSourceLevels(this)
-    ! All source levels have snow present
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    real(r8) :: data_source(3) = [11._r8, 12._r8, 13._r8]
-
-    interpolator = create_interpolator(num_snow_layers_source = size(data_source))
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(1:2) = 0._r8
-    data_dest_expected(3:5) = data_source(:)
-    @assertEqual(data_dest_expected, data_dest)
-  end subroutine moreDestLevels_allSourceLevels
-
-  @Test
-  subroutine moreDestLevels_oneSourceLevel(this)
-    ! One source level has snow present
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    real(r8) :: data_source(3) = [11._r8, 12._r8, 13._r8]
-
-    interpolator = create_interpolator(num_snow_layers_source = 1)
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(1:2) = 0._r8
-    data_dest_expected(3:5) = data_source(:)
-    @assertEqual(data_dest_expected, data_dest)
-  end subroutine moreDestLevels_oneSourceLevel
 
   @Test
   subroutine moreDestLevels_twoSourceLevels(this)
-    ! Two source levels have snow present
+    ! More dest levels than source levels; only some source levels have snow present
     class(TestInitInterpMultilevelSnow), intent(inout) :: this
     type(interp_multilevel_snow_type) :: interpolator
     real(r8) :: data_dest(5) = 1000._r8
@@ -134,10 +79,6 @@ contains
     data_dest_expected(3:5) = data_source(:)
     @assertEqual(data_dest_expected, data_dest)
   end subroutine moreDestLevels_twoSourceLevels
-
-  ! ------------------------------------------------------------------------
-  ! Tests: same number of levels in dest
-  ! ------------------------------------------------------------------------
 
   @Test
   subroutine sameDestLevels(this)
@@ -156,10 +97,6 @@ contains
     @assertEqual(data_dest_expected, data_dest)
   end subroutine sameDestLevels
  
-  ! ------------------------------------------------------------------------
-  ! Tests: fewer levels in dest
-  ! ------------------------------------------------------------------------
-
   @Test
   subroutine fewerDestLevels_moreThanExist(this)
     ! Fewer snow levels in dest than source, but dest has more levels than the number of
@@ -231,81 +168,5 @@ contains
     data_dest_expected(:) = data_source(1:5)
     @assertEqual(data_dest_expected, data_dest)
   end subroutine fewerDestLevels_allExist
-
-  ! FIXME(wjs, 2018-03-16) Remove tests below here
-
-  @Test
-  subroutine fewerDestLevels_noSourceLevels(this)
-    ! No existing snow levels in the source
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    integer  :: i
-    real(r8) :: data_source(7) = [ (i, i=11,17) ]
-
-    interpolator = create_interpolator(num_snow_layers_source = 0)
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(:) = data_source(3:7)
-    @assertEqual(data_dest_expected, data_dest)
-  end subroutine fewerDestLevels_noSourceLevels
-
-  @Test
-  subroutine fewerDestLevels_allSourceLevels(this)
-    ! All source levels have snow present
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    integer  :: i
-    real(r8) :: data_source(7) = [ (i, i=11,17) ]
-
-    interpolator = create_interpolator(num_snow_layers_source = size(data_source))
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(:) = data_source(1:5)
-    @assertEqual(data_dest_expected, data_dest)
-
-  end subroutine fewerDestLevels_allSourceLevels
-
-  @Test
-  subroutine fewerDestLevels_oneSourceLevel(this)
-    ! One source level has snow present
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    integer  :: i
-    real(r8) :: data_source(7) = [ (i, i=11,17) ]
-
-    interpolator = create_interpolator(num_snow_layers_source = 1)
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(:) = data_source(3:7)
-    @assertEqual(data_dest_expected, data_dest)
-  end subroutine fewerDestLevels_oneSourceLevel
-
-  @Test
-  subroutine fewerDestLevels_twoSourceLevels(this)
-    ! Two source levels have snow present
-    class(TestInitInterpMultilevelSnow), intent(inout) :: this
-    type(interp_multilevel_snow_type) :: interpolator
-    real(r8) :: data_dest(5) = 1000._r8
-    real(r8) :: data_dest_expected(5)
-    integer  :: i
-    real(r8) :: data_source(7) = [ (i, i=11,17) ]
-
-    interpolator = create_interpolator(num_snow_layers_source = 2)
-
-    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
-
-    data_dest_expected(:) = data_source(3:7)
-    @assertEqual(data_dest_expected, data_dest)
-  end subroutine fewerDestLevels_twoSourceLevels
-
 
 end module test_init_interp_multilevel_snow

--- a/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_snow.pf
+++ b/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_snow.pf
@@ -64,9 +64,8 @@ contains
   ! ------------------------------------------------------------------------
 
   @Test
-  subroutine moreDestLevels_noSourceLevels_setsDestToZero(this)
-    ! If there are no existing snow levels in the source, dest should be set to 0 for all
-    ! levels
+  subroutine moreDestLevels_noSourceLevels(this)
+    ! No existing snow levels in the source
     class(TestInitInterpMultilevelSnow), intent(inout) :: this
     type(interp_multilevel_snow_type) :: interpolator
     real(r8) :: data_dest(5) = 1000._r8
@@ -77,9 +76,10 @@ contains
 
     call interpolator%interp_multilevel(data_dest, data_source, index_dest)
 
-    data_dest_expected(:) = 0._r8
+    data_dest_expected(1:2) = 0._r8
+    data_dest_expected(3:5) = data_source(:)
     @assertEqual(data_dest_expected, data_dest)
-  end subroutine moreDestLevels_noSourceLevels_setsDestToZero
+  end subroutine moreDestLevels_noSourceLevels
 
   @Test
   subroutine moreDestLevels_allSourceLevels(this)
@@ -112,14 +112,14 @@ contains
 
     call interpolator%interp_multilevel(data_dest, data_source, index_dest)
 
-    data_dest_expected(1:4) = 0._r8
-    data_dest_expected(5) = data_source(3)
+    data_dest_expected(1:2) = 0._r8
+    data_dest_expected(3:5) = data_source(:)
     @assertEqual(data_dest_expected, data_dest)
   end subroutine moreDestLevels_oneSourceLevel
 
   @Test
   subroutine moreDestLevels_twoSourceLevels(this)
-    ! Two source levels has snow present
+    ! Two source levels have snow present
     class(TestInitInterpMultilevelSnow), intent(inout) :: this
     type(interp_multilevel_snow_type) :: interpolator
     real(r8) :: data_dest(5) = 1000._r8
@@ -130,19 +130,113 @@ contains
 
     call interpolator%interp_multilevel(data_dest, data_source, index_dest)
 
-    data_dest_expected(1:3) = 0._r8
-    data_dest_expected(4:5) = data_source(2:3)
+    data_dest_expected(1:2) = 0._r8
+    data_dest_expected(3:5) = data_source(:)
     @assertEqual(data_dest_expected, data_dest)
   end subroutine moreDestLevels_twoSourceLevels
 
   ! ------------------------------------------------------------------------
-  ! Tests: fewer levels in source
+  ! Tests: same number of levels in dest
   ! ------------------------------------------------------------------------
 
   @Test
-  subroutine fewerDestLevels_noSourceLevels_setsDestToZero(this)
-    ! If there are no existing snow levels in the source, dest should be set to 0 for all
-    ! levels
+  subroutine sameDestLevels(this)
+    ! Same number of levels in dest as source; only some source levels have snow present
+    class(TestInitInterpMultilevelSnow), intent(inout) :: this
+    type(interp_multilevel_snow_type) :: interpolator
+    real(r8) :: data_dest(5) = 1000._r8
+    real(r8) :: data_dest_expected(5)
+    integer  :: i
+    real(r8) :: data_source(5) = [ (i, i=11,15) ]
+
+    interpolator = create_interpolator(num_snow_layers_source = 3)
+    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
+
+    data_dest_expected(:) = data_source(:)
+    @assertEqual(data_dest_expected, data_dest)
+  end subroutine sameDestLevels
+ 
+  ! ------------------------------------------------------------------------
+  ! Tests: fewer levels in dest
+  ! ------------------------------------------------------------------------
+
+  @Test
+  subroutine fewerDestLevels_moreThanExist(this)
+    ! Fewer snow levels in dest than source, but dest has more levels than the number of
+    ! existing snow layers in source
+    class(TestInitInterpMultilevelSnow), intent(inout) :: this
+    type(interp_multilevel_snow_type) :: interpolator
+    real(r8) :: data_dest(5) = 1000._r8
+    real(r8) :: data_dest_expected(5)
+    integer  :: i
+    real(r8) :: data_source(9) = [ (i, i=11,19) ]
+
+    interpolator = create_interpolator(num_snow_layers_source = 3)
+    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
+
+    data_dest_expected(:) = data_source(5:9)
+    @assertEqual(data_dest_expected, data_dest)
+  end subroutine fewerDestLevels_moreThanExist
+
+  @Test
+  subroutine fewerDestLevels_sameAsExist(this)
+    ! Fewer snow levels in dest than source; dest has the same number of levels as the
+    ! number of existing snow layers in source
+    class(TestInitInterpMultilevelSnow), intent(inout) :: this
+    type(interp_multilevel_snow_type) :: interpolator
+    real(r8) :: data_dest(5) = 1000._r8
+    real(r8) :: data_dest_expected(5)
+    integer  :: i
+    real(r8) :: data_source(9) = [ (i, i=11,19) ]
+
+    interpolator = create_interpolator(num_snow_layers_source = 5)
+    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
+
+    data_dest_expected(:) = data_source(5:9)
+    @assertEqual(data_dest_expected, data_dest)
+  end subroutine fewerDestLevels_sameAsExist
+
+  @Test
+  subroutine fewerDestLevels_fewerThanExist(this)
+    ! Fewer snow levels in dest than source; dest has fewer levels than the number of
+    ! existing snow layers in source
+    class(TestInitInterpMultilevelSnow), intent(inout) :: this
+    type(interp_multilevel_snow_type) :: interpolator
+    real(r8) :: data_dest(5) = 1000._r8
+    real(r8) :: data_dest_expected(5)
+    integer  :: i
+    real(r8) :: data_source(9) = [ (i, i=11,19) ]
+
+    interpolator = create_interpolator(num_snow_layers_source = 7)
+    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
+
+    ! Note that the top level of source where snow exists is level 3
+    data_dest_expected(:) = data_source(3:7)
+    @assertEqual(data_dest_expected, data_dest)
+  end subroutine fewerDestLevels_fewerThanExist
+
+  @Test
+  subroutine fewerDestLevels_allExist(this)
+    ! Fewer snow levels in dest than source; all snow levels exist in source
+    class(TestInitInterpMultilevelSnow), intent(inout) :: this
+    type(interp_multilevel_snow_type) :: interpolator
+    real(r8) :: data_dest(5) = 1000._r8
+    real(r8) :: data_dest_expected(5)
+    integer  :: i
+    real(r8) :: data_source(9) = [ (i, i=11,19) ]
+
+    interpolator = create_interpolator(num_snow_layers_source = 9)
+    call interpolator%interp_multilevel(data_dest, data_source, index_dest)
+
+    data_dest_expected(:) = data_source(1:5)
+    @assertEqual(data_dest_expected, data_dest)
+  end subroutine fewerDestLevels_allExist
+
+  ! FIXME(wjs, 2018-03-16) Remove tests below here
+
+  @Test
+  subroutine fewerDestLevels_noSourceLevels(this)
+    ! No existing snow levels in the source
     class(TestInitInterpMultilevelSnow), intent(inout) :: this
     type(interp_multilevel_snow_type) :: interpolator
     real(r8) :: data_dest(5) = 1000._r8
@@ -154,9 +248,9 @@ contains
 
     call interpolator%interp_multilevel(data_dest, data_source, index_dest)
 
-    data_dest_expected(:) = 0._r8
+    data_dest_expected(:) = data_source(3:7)
     @assertEqual(data_dest_expected, data_dest)
-  end subroutine fewerDestLevels_noSourceLevels_setsDestToZero
+  end subroutine fewerDestLevels_noSourceLevels
 
   @Test
   subroutine fewerDestLevels_allSourceLevels(this)
@@ -191,8 +285,7 @@ contains
 
     call interpolator%interp_multilevel(data_dest, data_source, index_dest)
 
-    data_dest_expected(1:4) = 0._r8
-    data_dest_expected(5) = data_source(7)
+    data_dest_expected(:) = data_source(3:7)
     @assertEqual(data_dest_expected, data_dest)
   end subroutine fewerDestLevels_oneSourceLevel
 
@@ -210,8 +303,7 @@ contains
 
     call interpolator%interp_multilevel(data_dest, data_source, index_dest)
 
-    data_dest_expected(1:3) = 0._r8
-    data_dest_expected(4:5) = data_source(6:7)
+    data_dest_expected(:) = data_source(3:7)
     @assertEqual(data_dest_expected, data_dest)
   end subroutine fewerDestLevels_twoSourceLevels
 

--- a/src/init_interp/test/initInterpUtils_test/CMakeLists.txt
+++ b/src/init_interp/test/initInterpUtils_test/CMakeLists.txt
@@ -1,0 +1,7 @@
+set (pfunit_sources
+  test_glc_elevclasses_are_same.pf)
+
+create_pFUnit_test(initInterpUtils test_initInterpUtils_exe
+  "${pfunit_sources}" "")
+
+target_link_libraries(test_initInterpUtils_exe clm csm_share)

--- a/src/init_interp/test/initInterpUtils_test/test_glc_elevclasses_are_same.pf
+++ b/src/init_interp/test/initInterpUtils_test/test_glc_elevclasses_are_same.pf
@@ -1,0 +1,103 @@
+module test_glc_elevclasses_are_same
+
+  ! Tests of initInterpUtils: glc_elevclasses_are_same
+
+  use pfunit_mod
+  use initInterpUtils
+  use shr_kind_mod , only : r8 => shr_kind_r8
+  use ncdio_pio, only : file_desc_t, ncd_set_dim, ncd_set_var
+
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: TestGlcECSame
+     type(file_desc_t) :: ncidi  ! input file to use for test
+     type(file_desc_t) :: ncido  ! output file to use for test
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+     procedure :: createFiles
+  end type TestGlcECSame
+
+  real(r8), parameter :: tol = 1.e-13_r8
+
+contains
+
+  subroutine setUp(this)
+    class(TestGlcECSame), intent(inout) :: this
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(TestGlcECSame), intent(inout) :: this
+  end subroutine tearDown
+
+  subroutine createFiles(this, ec_bounds_ncidi, ec_bounds_ncido)
+    ! Creates this%ncidi and this%ncido, filled with correct glc_nec and glc_nec1
+    ! dimensions and glc_elevclass_bounds data.
+    class(TestGlcECSame), intent(inout) :: this
+    real(r8), intent(in) :: ec_bounds_ncidi(:)
+    real(r8), intent(in) :: ec_bounds_ncido(:)
+
+    this%ncidi = file_desc_t()
+    this%ncido = file_desc_t()
+
+    call ncd_set_dim(this%ncidi, 'glc_nec', size(ec_bounds_ncidi)-1)
+    call ncd_set_dim(this%ncidi, 'glc_nec1', size(ec_bounds_ncidi))
+    call ncd_set_var(ncid = this%ncidi, &
+         varname = 'glc_elevclass_bounds', &
+         data = reshape(ec_bounds_ncidi, [size(ec_bounds_ncidi), 1]), &
+         data_shape = [size(ec_bounds_ncidi)])
+
+    call ncd_set_dim(this%ncido, 'glc_nec', size(ec_bounds_ncido)-1)
+    call ncd_set_dim(this%ncido, 'glc_nec1', size(ec_bounds_ncido))
+    call ncd_set_var(ncid = this%ncido, &
+         varname = 'glc_elevclass_bounds', &
+         data = reshape(ec_bounds_ncido, [size(ec_bounds_ncido), 1]), &
+         data_shape = [size(ec_bounds_ncido)])
+  end subroutine createFiles
+
+  @Test
+  subroutine different_num_ec(this)
+    class(TestGlcECSame), intent(inout) :: this
+    logical :: my_result
+
+    call this%createFiles( &
+         ec_bounds_ncidi = [0._r8, 1._r8, 2._r8], &
+         ec_bounds_ncido = [0._r8, 1._r8, 2._r8, 3._r8])
+
+    my_result = glc_elevclasses_are_same(this%ncidi, this%ncido)
+
+    @assertFalse(my_result)
+  end subroutine different_num_ec
+
+  @Test
+  subroutine different_bounds(this)
+    class(TestGlcECSame), intent(inout) :: this
+    logical :: my_result
+
+    call this%createFiles( &
+         ec_bounds_ncidi = [0._r8, 1._r8, 2._r8], &
+         ec_bounds_ncido = [0._r8, 1._r8, 4._r8])
+
+    my_result = glc_elevclasses_are_same(this%ncidi, this%ncido)
+
+    @assertFalse(my_result)
+  end subroutine different_bounds
+
+  @Test
+  subroutine same(this)
+    class(TestGlcECSame), intent(inout) :: this
+    real(r8), parameter :: diff = 1.e-12
+    logical :: my_result
+
+    ! Should be robust to differences within roundoff
+    call this%createFiles( &
+         ec_bounds_ncidi = [0._r8, 1._r8, 2._r8], &
+         ec_bounds_ncido = [0._r8, 1._r8, 2._r8+diff])
+
+    my_result = glc_elevclasses_are_same(this%ncidi, this%ncido)
+
+    @assertTrue(my_result)
+  end subroutine same
+
+end module test_glc_elevclasses_are_same

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -549,7 +549,8 @@ contains
 
        ! Interpolate finidat onto new template file
        call getfil( finidat_interp_source, fnamer,  0 )
-       call initInterp(filei=fnamer, fileo=finidat_interp_dest, bounds=bounds_proc)
+       call initInterp(filei=fnamer, fileo=finidat_interp_dest, bounds=bounds_proc, &
+            glc_behavior=glc_behavior)
 
        ! Read new interpolated conditions file back in
        call restFile_read(bounds_proc, finidat_interp_dest, glc_behavior)

--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -422,7 +422,11 @@ contains
   subroutine ncd_inqdlen(ncid,dimid,len,name)
     !
     ! !DESCRIPTION:
-    ! enddef netcdf file
+    ! Gets the length of the given dimension
+    !
+    ! If 'name' is absent, then 'dimid' is used as an input: the dimension id to inquire.
+    ! If 'name' is present, then it gives the name of the dimension to inquire, and
+    ! 'dimid' is set to the ID associated with this dimension.
     !
     ! !ARGUMENTS:
     class(file_desc_t), intent(inout) :: ncid       ! netcdf file id

--- a/src/main/restFileMod.F90
+++ b/src/main/restFileMod.F90
@@ -529,6 +529,7 @@ contains
     end if
     call ncd_defdim(ncid , 'string_length', 64        ,  dimid)
     call ncd_defdim(ncid , 'glc_nec', maxpatch_glcmec, dimid)
+    call ncd_defdim(ncid , 'glc_nec1', maxpatch_glcmec+1, dimid)
 
     ! Define global attributes
 

--- a/src/main/test/filter_test/test_filter_col.pf
+++ b/src/main/test/filter_test/test_filter_col.pf
@@ -31,9 +31,7 @@ contains
   subroutine tearDown(this)
     class(TestFilterCol), intent(inout) :: this
 
-    if (unittest_subgrid_needs_teardown) then
-       call unittest_subgrid_teardown()
-    end if
+    call unittest_subgrid_teardown()
   end subroutine tearDown
 
   ! ------------------------------------------------------------------------

--- a/src/main/test/glcBehavior_test/test_glcBehavior.pf
+++ b/src/main/test/glcBehavior_test/test_glcBehavior.pf
@@ -8,7 +8,8 @@ module test_glcBehavior
   use unittestSubgridMod
   use unittestSimpleSubgridSetupsMod
   use unittestArrayMod
-  use column_varcon, only : col_itype_to_icemec_class
+  use column_varcon, only : col_itype_to_icemec_class, icemec_class_to_col_itype
+  use landunit_varcon, only : istice_mec
   use glcBehaviorMod, only : glc_behavior_type
   use ColumnType, only : col
   use unittestGlcMec
@@ -245,5 +246,73 @@ contains
 
     @assertEqual(coltype_orig, col%itype(bounds%begc))
   end subroutine update_glc_classes_non_icemec
+
+  @Test
+  subroutine have_dynamic_type(this)
+    ! Tests cols_have_dynamic_type_array and patches_have_dynamic_type_array
+    class(TestGlcBehavior), intent(inout) :: this
+    type(glc_behavior_type) :: glc_behavior
+    logical, allocatable :: has_dynamic_type_col(:)
+    logical, allocatable :: has_dynamic_type_patch(:)
+    logical, allocatable :: has_dynamic_type_col_expected(:)
+    logical, allocatable :: has_dynamic_type_patch_expected(:)
+
+    ! Setup
+
+    call setup_elevation_classes(3, [0._r8, 1._r8, 2._r8, 3._r8])
+
+    ! Create 3 grid cells, all with one landunit of type istice_mec. The first and third
+    ! will have multiple elevation classes; the second will have a single elevation class
+    ! at the atmosphere's topographic height. All columns have 2 patches (which is not
+    ! typical for istice_mec, but tests the code better).
+    call unittest_subgrid_setup_start()
+    call unittest_add_gridcell()
+    call create_landunit_ncols(ltype = istice_mec, lweight = 1._r8, &
+         ctypes = [icemec_class_to_col_itype(1), icemec_class_to_col_itype(2)], &
+         cweights = [0.5_r8, 0.5_r8], &
+         npatches = 2)
+    call unittest_add_gridcell()
+    call create_landunit_ncols(ltype = istice_mec, lweight = 1._r8, &
+         ctypes = [icemec_class_to_col_itype(2)], &
+         cweights = [1._r8], &
+         npatches = 2)
+    call unittest_add_gridcell()
+    call create_landunit_ncols(ltype = istice_mec, lweight = 1._r8, &
+         ctypes = [icemec_class_to_col_itype(1), icemec_class_to_col_itype(2)], &
+         cweights = [0.5_r8, 0.5_r8], &
+         npatches = 2)
+    call unittest_subgrid_setup_end()
+
+    call glc_behavior%InitFromInputs(bounds%begg, bounds%endg, &
+         glacier_region_map = [0, 1, 0], &
+         glacier_region_behavior_str = ['multiple          ', 'single_at_atm_topo'], &
+         glacier_region_melt_behavior_str = ['remains_in_place', 'remains_in_place'], &
+         glacier_region_ice_runoff_behavior_str = ['remains_ice', 'remains_ice'])
+
+    ! Exercise
+
+    has_dynamic_type_col = col_array(.false.)
+    has_dynamic_type_patch = patch_array(.false.)
+    call glc_behavior%cols_have_dynamic_type_array(bounds%begc, bounds%endc, &
+         has_dynamic_type_col)
+    call glc_behavior%patches_have_dynamic_type_array(bounds%begp, bounds%endp, &
+         has_dynamic_type_patch)
+
+    ! Verify
+
+    has_dynamic_type_col_expected = col_array(.false.)
+    has_dynamic_type_patch_expected = patch_array(.false.)
+    has_dynamic_type_col_expected = [ &
+         .false., .false., &
+         .true., &
+         .false., .false.]
+    has_dynamic_type_patch_expected = [ &
+         .false., .false., .false., .false., &
+         .true., .true., &
+         .false., .false., .false., .false.]
+
+    @assertEqual(logical_array_to_int(has_dynamic_type_col_expected), logical_array_to_int(has_dynamic_type_col))
+    @assertEqual(logical_array_to_int(has_dynamic_type_patch_expected), logical_array_to_int(has_dynamic_type_patch))
+  end subroutine have_dynamic_type
 
 end module test_glcBehavior

--- a/src/unit_test_shr/test/unittestArray_test/test_unittestArray.pf
+++ b/src/unit_test_shr/test/unittestArray_test/test_unittestArray.pf
@@ -76,4 +76,11 @@ contains
     @assertIsNan(arr(2))
   end subroutine col_array_uninit
 
+  @Test
+  subroutine test_logical_array_to_int(this)
+    class(TestUnittestArray), intent(inout) :: this
+
+    @assertEqual([1, 0, 1], logical_array_to_int([.true., .false., .true.]))
+  end subroutine test_logical_array_to_int
+
 end module test_unittestArray

--- a/src/unit_test_shr/unittestArrayMod.F90.in
+++ b/src/unit_test_shr/unittestArrayMod.F90.in
@@ -24,6 +24,14 @@ module unittestArrayMod
   ! filled with NaNs.
   public :: col_array
 
+  ! Create a patch-level array filled with a single value; the type of the array is the
+  ! same as the type of the input value. If no value is given, an r8 array is returned,
+  ! filled with NaNs.
+  public :: patch_array
+
+  ! Converts an array of logicals to a same-size array of integers: false => 0, true => 1
+  public :: logical_array_to_int
+
   interface grc_array
      module procedure grc_array_uninit
 
@@ -37,6 +45,13 @@ module unittestArrayMod
      !TYPE logical,int,double
      module procedure col_array_{TYPE}
   end interface col_array
+
+  interface patch_array
+     module procedure patch_array_uninit
+
+     !TYPE logical,int,double
+     module procedure patch_array_{TYPE}
+  end interface patch_array
 
 contains
 
@@ -130,5 +145,76 @@ contains
 
   end function col_array_{TYPE}
 
+
+  !-----------------------------------------------------------------------
+  pure function patch_array_uninit() result(patch_array)
+    !
+    ! !DESCRIPTION:
+    ! Creates a patch-level array of r8 values. All elements are set to NaN.
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    real(r8), allocatable :: patch_array(:)  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'patch_array_uninit'
+    !-----------------------------------------------------------------------
+
+    allocate(patch_array(bounds%begp:bounds%endp))
+    patch_array(:) = nan
+
+  end function patch_array_uninit
+
+
+  !-----------------------------------------------------------------------
+  !TYPE logical,int,double
+  pure function patch_array_{TYPE}(val) result(patch_array)
+    !
+    ! !DESCRIPTION:
+    ! Creates a patch-level array with the same type as val. All elements are set to val.
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    {VTYPE}, allocatable :: patch_array(:) ! function result
+    {VTYPE}, intent(in)  :: val ! all elements in patch_array are set to val
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'patch_array_{TYPE}'
+    !-----------------------------------------------------------------------
+
+    allocate(patch_array(bounds%begp:bounds%endp))
+    patch_array(:) = val
+
+  end function patch_array_{TYPE}
+
+  !-----------------------------------------------------------------------
+  function logical_array_to_int(logical_array) result(int_array)
+    !
+    ! !DESCRIPTION:
+    ! Converts an array of logicals to a same-size array of integers: false => 0, true => 1
+    !
+    ! This can be useful for doing assertions on arrays, since pFUnit doesn't support
+    ! assertions of equality of logical arrays.
+    !
+    ! !ARGUMENTS:
+    logical, intent(in) :: logical_array(:)
+    integer :: int_array(size(logical_array))  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'logical_array_to_int'
+    !-----------------------------------------------------------------------
+
+    where (logical_array)
+       int_array = 1
+    elsewhere
+       int_array = 0
+    end where
+
+  end function logical_array_to_int
 
 end module unittestArrayMod

--- a/src/unit_test_stubs/main/CMakeLists.txt
+++ b/src/unit_test_stubs/main/CMakeLists.txt
@@ -12,6 +12,7 @@ list(APPEND clm_sources "${clm_genf90_sources}")
 list(APPEND clm_sources
   GetGlobalValuesMod_stub.F90
   histFileMod_stub.F90
+  ncdio_dim.F90
   ncdio_pio_fake.F90
   ncdio_var.F90
   )

--- a/src/unit_test_stubs/main/ncdio_dim.F90
+++ b/src/unit_test_stubs/main/ncdio_dim.F90
@@ -1,0 +1,58 @@
+module ncdio_dim
+  ! This module is specific to using the ncdio_pio_fake version of ncdio_pio. This
+  ! provides a derived type for holding a single dimension from a fake netcdf file, and
+  ! associated methods for working with this derived type.
+
+  implicit none
+  private
+  save
+
+  public :: ncdio_dim_type
+
+  integer, parameter, public :: max_name = 256   ! max length for a dimension name
+
+  ! This type store a single dimension in a fake file
+  type :: ncdio_dim_type
+     private
+     character(len=max_name) :: dimname  ! dimension name
+     integer :: dimlen  ! dimension length
+
+   contains
+     procedure :: get_dimname  ! get the dimension name
+     procedure :: get_dimlen   ! get the dimension length
+  end type ncdio_dim_type
+
+  interface ncdio_dim_type
+     module procedure constructor
+  end interface ncdio_dim_type
+
+contains
+
+  !-----------------------------------------------------------------------
+  type(ncdio_dim_type) function constructor(dimname, dimlen)
+    ! Create a new object of type ncdio_dim_type
+
+    character(len=*) , intent(in) :: dimname  ! dimension name
+    integer          , intent(in) :: dimlen   ! dimension length
+
+    constructor%dimname = dimname
+    constructor%dimlen = dimlen
+  end function constructor
+
+  !-----------------------------------------------------------------------
+  character(len=max_name) function get_dimname(this)
+    ! Get the name associated with this dimension
+    class(ncdio_dim_type), intent(in) :: this
+
+    get_dimname = this%dimname
+  end function get_dimname
+
+  !-----------------------------------------------------------------------
+  integer function get_dimlen(this)
+    ! Get the length associated with this dimension
+    class(ncdio_dim_type), intent(in) :: this
+
+    get_dimlen = this%dimlen
+  end function get_dimlen
+
+end module ncdio_dim

--- a/src/unit_test_stubs/main/ncdio_pio_fake.F90.in
+++ b/src/unit_test_stubs/main/ncdio_pio_fake.F90.in
@@ -7,7 +7,9 @@ module ncdio_pio
   ! Currently it just contains 'read' functionality
 
   use shr_kind_mod, only : r8 => shr_kind_r8, i4=>shr_kind_i4
+  use shr_assert_mod , only : shr_assert
   use ncdio_var, only : ncdio_var_type
+  use ncdio_dim, only : ncdio_dim_type
 
   ! !PUBLIC TYPES:
   implicit none
@@ -24,6 +26,9 @@ module ncdio_pio
      ! all of the variables in the file (a linked list would be a more efficient
      ! implementation, but I'm going for simplicity over efficiency here)
      type(ncdio_var_type), allocatable :: vars(:)
+
+     ! all of the dimensions in the file
+     type(ncdio_dim_type), allocatable :: dims(:)
   end type file_desc_t
 
   ! Stub replacement for var_desc_t, to satisfy interfaces that need it
@@ -42,6 +47,7 @@ module ncdio_pio
   public :: ncd_io                ! do fake i/o (currently only set up to read)
   public :: ncd_inqvid            ! inquire on a variable id
   public :: ncd_set_var           ! set data on "file" for one variable
+  public :: ncd_set_dim           ! set a single dimension on a "file"
   public :: ncd_reset_read_times  ! reset the "read_times" sensor variable for a given variable
   public :: ncd_get_read_times    ! get the value of the "read_times" sensor variable for a given variable
   public :: ncd_pio_openfile      ! stub: open file
@@ -117,6 +123,7 @@ contains
     !-----------------------------------------------------------------------
     
     allocate(constructor%vars(0))
+    allocate(constructor%dims(0))
     
   end function constructor
   
@@ -125,8 +132,8 @@ contains
   ! Fakes for the actual ncdio_pio functionality
   ! ======================================================================
 
-  ! DIMS 1,2
   !-----------------------------------------------------------------------
+  ! DIMS 1,2
   subroutine ncd_io_{DIMS}d_double(varname, data, dim1name, flag, ncid, nt, readvar)
     !
     ! !DESCRIPTION:
@@ -149,17 +156,12 @@ contains
 
     character(len=*), parameter :: subname = 'ncd_io_{DIMS}d_double'
     !-----------------------------------------------------------------------
-    
-    if (flag /= 'read') then
-       write(*,*) subname, ' ERROR: currently only the "read" flag is supported'
-       stop
-    end if
 
-    if (.not. present(nt)) then
-       ! nt is optional so code can build, but any code that is actually run in a unit
-       ! test should be providing nt
-       write(*,*) subname, ' ERROR: currently, the nt optional argument must be present'
-    end if
+    call shr_assert(flag == 'read', subname//' ERROR: currently only the "read" flag is supported')
+
+    ! nt is optional so code can build, but any code that is actually run in a unit
+    ! test should be providing nt
+    call shr_assert(present(nt), subname//' ERROR: currently, the nt optional argument must be present')
     
     varindex = ncd_get_variable_index(ncid, varname)
 
@@ -175,6 +177,58 @@ contains
     end if
        
   end subroutine ncd_io_{DIMS}d_double
+
+  !-----------------------------------------------------------------------
+  ! DIMS 1,2
+  subroutine ncd_io_{DIMS}d_double_glob(varname, data, flag, ncid, readvar, nt, posNOTonfile)
+    !
+    ! !DESCRIPTION:
+    ! Fake for the glob (global) form of ncd_io_{DIMS}d_double.
+    !
+    ! If nt isn't provided, it is assumed to be 1. Note that this fake implementation of
+    ! ncdio_pio gives all variables a time dimension. For variables that are not really
+    ! supposed to have a time dimension (as is the case for many global variables), it is
+    ! appropriate to call this routine with nt absent.
+    !
+    ! !ARGUMENTS:
+    character(len=*)   , intent(in)    :: varname      ! variable name
+    real(r8)           , intent(inout) :: data{DIMSTR} ! read-in data (no time dimension)
+    character(len=*)   , intent(in)    :: flag         ! 'read' or 'write' (currently only 'read' is supported)
+    class(file_desc_t) , intent(inout) :: ncid         ! netcdf file id
+    logical, optional  , intent(out)   :: readvar      ! true => variable is on dataset (read only)
+    integer, optional  , intent(in)    :: nt           ! time sample index (if not present, assumed to be 1)
+    logical, optional  , intent(in)    :: posNOTonfile ! position is NOT on this file (ignored)
+    !
+    ! !LOCAL VARIABLES:
+    integer :: l_nt      ! local version of nt
+    integer :: varindex  ! index of variable of interest
+
+    character(len=*), parameter :: subname = 'ncd_io_{DIMS}d_double'
+    !-----------------------------------------------------------------------
+
+    call shr_assert(flag == 'read', subname//' ERROR: currently only the "read" flag is supported')
+
+    if (present(nt)) then
+       l_nt = nt
+    else
+       l_nt = 1
+    end if
+
+    varindex = ncd_get_variable_index(ncid, varname)
+
+    if (varindex /= var_not_found) then
+       call ncid%vars(varindex)%get_data(l_nt, data)
+       if (present(readvar)) then
+          readvar = .true.
+       end if
+    else  ! varindex == var_not_found
+       if (present(readvar)) then
+          readvar = .false.
+       end if
+    end if
+
+  end subroutine ncd_io_{DIMS}d_double_glob
+
 
   !-----------------------------------------------------------------------
   subroutine ncd_inqvid(ncid, name, varid, vardesc, readvar)
@@ -201,6 +255,72 @@ contains
        end if
     end if
   end subroutine ncd_inqvid
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_inqdid(ncid, name, dimid, dimexist)
+    !
+    ! !DESCRIPTION:
+    ! Fake to inquire on a dimension ID
+    !
+    ! Unlike the true implementation, this one never aborts. It is meant to be called
+    ! with dimexist present (in which case the true implementation doesn't abort, either.)
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t),intent(inout) :: ncid   ! netcdf file id
+    character(len=*) , intent(in) :: name      ! dimension name
+    integer          , intent(out):: dimid     ! dimension id
+    logical,optional , intent(out):: dimexist  ! if this dimension exists or not
+
+    dimid = ncd_get_dimension_index(ncid, name)
+
+    if (present(dimexist)) then
+       if (dimid /= var_not_found) then
+          dimexist = .true.
+       else
+          dimexist = .false.
+       end if
+    end if
+
+  end subroutine ncd_inqdid
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_inqdlen(ncid, dimid, len, name)
+    !
+    ! !DESCRIPTION:
+    ! Fake to inquire on a dimension length.
+    !
+    ! Returns -1 if the given dimension isn't found. (This differs from the behavior of
+    ! the true ncd_inqdlen, which I think aborts if the given dimension isn't found.)
+    !
+    ! As in the real implementation: If 'name' is absent, then 'dimid' is used as an
+    ! input: the dimension id to inquire.  If 'name' is present, then it gives the name of
+    ! the dimension to inquire, and 'dimid' is set to the ID associated with this
+    ! dimension.
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t), intent(inout) :: ncid       ! netcdf file id
+    integer           , intent(inout) :: dimid      ! dimension id
+    integer           , intent(out)   :: len        ! dimension len
+    character(len=*), optional, intent(in) :: name  ! dimension name
+    !
+    ! !LOCAL VARIABLES:
+    logical :: dimexist
+    !-----------------------------------------------------------------------
+
+    len = -1
+
+    if (present(name)) then
+       call ncd_inqdid(ncid, name, dimid, dimexist = dimexist)
+       if (.not. dimexist) then
+          return
+       end if
+    end if
+
+    if (dimid >= 1 .and. dimid <= size(ncid%dims)) then
+       len = ncid%dims(dimid)%get_dimlen()
+    end if
+
+  end subroutine ncd_inqdlen
 
   ! ======================================================================
   ! Stubs for the actual ncdio_pio functionality (do nothing)
@@ -297,8 +417,7 @@ contains
 
   !------------------------------------------------------------------------
   !DIMS 0,1,2,3
-  !TYPE int,double
-  subroutine ncd_io_{DIMS}d_{TYPE}_glob(varname, data, flag, ncid, readvar, nt, posNOTonfile) 
+  subroutine ncd_io_{DIMS}d_int_glob(varname, data, flag, ncid, readvar, nt, posNOTonfile)
     !
     ! !DESCRIPTION:
     ! Stub replacement: netcdf I/O of global variable
@@ -307,7 +426,7 @@ contains
     class(file_desc_t),         intent(inout) :: ncid         ! netcdf file id
     character(len=*),           intent(in)    :: flag         ! 'read' or 'write'
     character(len=*),           intent(in)    :: varname      ! variable name
-    {VTYPE}         ,           intent(inout) :: data{DIMSTR} ! raw data
+    integer         ,           intent(inout) :: data{DIMSTR} ! raw data
     logical         , optional, intent(out)   :: readvar      ! was var read?
     integer         , optional, intent(in)    :: nt           ! time sample index
     logical         , optional, intent(in)    :: posNOTonfile ! position is NOT on this file
@@ -316,7 +435,29 @@ contains
        readvar = .false.
     end if
 
-  end subroutine ncd_io_{DIMS}d_{TYPE}_glob
+  end subroutine ncd_io_{DIMS}d_int_glob
+
+  !------------------------------------------------------------------------
+  !DIMS 0,3
+  subroutine ncd_io_{DIMS}d_double_glob(varname, data, flag, ncid, readvar, nt, posNOTonfile)
+    !
+    ! !DESCRIPTION:
+    ! Stub replacement: netcdf I/O of global variable
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t),         intent(inout) :: ncid         ! netcdf file id
+    character(len=*),           intent(in)    :: flag         ! 'read' or 'write'
+    character(len=*),           intent(in)    :: varname      ! variable name
+    real(r8)        ,           intent(inout) :: data{DIMSTR} ! raw data
+    logical         , optional, intent(out)   :: readvar      ! was var read?
+    integer         , optional, intent(in)    :: nt           ! time sample index
+    logical         , optional, intent(in)    :: posNOTonfile ! position is NOT on this file
+
+    if (present(readvar)) then
+       readvar = .false.
+    end if
+
+  end subroutine ncd_io_{DIMS}d_double_glob
 
   !------------------------------------------------------------------------
   !DIMS 0,1,2
@@ -341,26 +482,6 @@ contains
   end subroutine ncd_io_{DIMS}d_{TYPE}_glob
 
   !-----------------------------------------------------------------------
-  subroutine ncd_inqdid(ncid,name,dimid,dimexist)
-    !
-    ! !DESCRIPTION:
-    ! Stub replacement for ncd_inqdid. This does nothing useful, but just satisfies the
-    ! interface.
-    !
-    ! !ARGUMENTS:
-    class(file_desc_t),intent(inout) :: ncid   ! netcdf file id
-    character(len=*) , intent(in) :: name      ! dimension name
-    integer          , intent(out):: dimid     ! dimension id
-    logical,optional , intent(out):: dimexist  ! if this dimension exists or not
-
-    dimid = 0
-    if (present(dimexist)) then
-       dimexist = .false.
-    end if
-
-  end subroutine ncd_inqdid
-
-  !-----------------------------------------------------------------------
   subroutine ncd_inqvdlen(ncid,varname,dimnum,dlen,err_code)
     !
     ! !DESCRIPTION:
@@ -379,23 +500,6 @@ contains
     err_code = 0
 
   end subroutine ncd_inqvdlen
-
-  !-----------------------------------------------------------------------
-  subroutine ncd_inqdlen(ncid,dimid,len,name)
-    !
-    ! !DESCRIPTION:
-    ! Stub replacement for ncd_inqdlen. This does nothing, but just satisfies the
-    ! interface.
-    !
-    ! !ARGUMENTS:
-    class(file_desc_t), intent(inout) :: ncid       ! netcdf file id
-    integer           , intent(inout) :: dimid      ! dimension id
-    integer           , intent(out)   :: len        ! dimension len
-    character(len=*), optional, intent(in) :: name  ! dimension name
-
-    len = 0
-
-  end subroutine ncd_inqdlen
 
   !-----------------------------------------------------------------------
   subroutine ncd_inqfdims(ncid, isgrid2d, ni, nj, ns)
@@ -542,13 +646,13 @@ contains
     ! !LOCAL VARIABLES:
     type(ncdio_var_type) :: newvar  ! the new variable
     type(ncdio_var_type), allocatable :: new_var_list(:)
+
     character(len=*), parameter :: subname = 'ncd_set_var'
     !-----------------------------------------------------------------------
 
     ! If a variable with this name is already on the file, stop with an error message
-    if (ncd_get_variable_index(ncid, varname) /= var_not_found) then
-       write(*,*) subname, ' ERROR: cannot set a variable already on file - ', trim(varname)
-    end if
+    call shr_assert(ncd_get_variable_index(ncid, varname) == var_not_found, &
+         subname//' ERROR: cannot set a variable already on file - '//trim(varname))
     
     newvar = ncdio_var_type(varname, data, data_shape)
 
@@ -558,6 +662,9 @@ contains
     ! the intel compiler v. 13 on yellowstone:
     ! ncid%vars = [ncid%vars, newvar]
     !
+    ! Update: the above also doesn't work with intel v. 15 on hobart or intel v. 17 on
+    ! cheyenne.
+    !
     ! So I'm using an inefficient method, but that's okay for these purposes
     allocate(new_var_list(size(ncid%vars) + 1))
     new_var_list(1:size(ncid%vars)) = ncid%vars(:)
@@ -565,7 +672,41 @@ contains
     call move_alloc(new_var_list, ncid%vars)
 
   end subroutine ncd_set_var
-  
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_set_dim(ncid, dimname, dimlen)
+    !
+    ! !DESCRIPTION:
+    ! Set a single dimension on this netcdf 'file'.
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t) , intent(inout) :: ncid          ! netcdf 'file' into which we should add this dimension
+    character(len=*)   , intent(in)    :: dimname       ! dimension name
+    integer            , intent(in)    :: dimlen        ! dimension length
+    !
+    ! !LOCAL VARIABLES:
+    type(ncdio_dim_type) :: newdim  ! the new dimension
+    type(ncdio_dim_type), allocatable :: new_dim_list(:)
+
+    character(len=*), parameter :: subname = 'ncd_set_dim'
+    !-----------------------------------------------------------------------
+
+    ! If a dimension with this name is already on the file, stop with an error message
+    call shr_assert(ncd_get_dimension_index(ncid, dimname) == var_not_found, &
+       subname//' ERROR: cannot set a dimension already on file - '//trim(dimname))
+
+    newdim = ncdio_dim_type(dimname, dimlen)
+
+    ! Add newdim to the list.
+    !
+    ! See comment in ncd_set_var for why we use this more complex method.
+    allocate(new_dim_list(size(ncid%dims) + 1))
+    new_dim_list(1:size(ncid%dims)) = ncid%dims(:)
+    new_dim_list(size(ncid%dims)+1) = newdim
+    call move_alloc(new_dim_list, ncid%dims)
+
+  end subroutine ncd_set_dim
+
 
   !-----------------------------------------------------------------------
   subroutine ncd_reset_read_times(ncid, varname)
@@ -587,12 +728,9 @@ contains
 
     varindex = ncd_get_variable_index(ncid, varname)
 
-    if (varindex /= var_not_found) then
-       call ncid%vars(varindex)%reset_read_times()
-    else
-       write(*,*) subname, ' ERROR: could not find variable: ', trim(varname)
-       stop
-    end if
+    call shr_assert(varindex /= var_not_found, subname//' ERROR: could not find variable '//trim(varname))
+
+    call ncid%vars(varindex)%reset_read_times()
     
   end subroutine ncd_reset_read_times
 
@@ -618,12 +756,9 @@ contains
     
     varindex = ncd_get_variable_index(ncid, varname)
     
-    if (varindex /= var_not_found) then
-       ncd_get_read_times = ncid%vars(varindex)%get_read_times()
-    else
-       write(*,*) subname, ' ERROR: could not find variable: ', trim(varname)
-       stop
-    end if
+    call shr_assert(varindex /= var_not_found, subname//' ERROR: could not find variable '//trim(varname))
+
+    ncd_get_read_times = ncid%vars(varindex)%get_read_times()
 
   end function ncd_get_read_times
 
@@ -657,5 +792,31 @@ contains
        ncd_get_variable_index = var_not_found
     end if
   end function ncd_get_variable_index
+
+  !-----------------------------------------------------------------------
+  integer function ncd_get_dimension_index(ncid, dimname)
+    ! Return the index of the dimension whose name is 'dimname' in the ncid structure. If
+    ! dimname is not present, return var_not_found
+    class(file_desc_t), intent(in) :: ncid
+    character(len=*), intent(in) :: dimname  ! dimension name to find
+
+    integer :: index
+    logical :: found
+
+    found = .false.
+    index = 0
+    do while((index < size(ncid%dims)) .and. (.not. found))
+       index = index + 1
+       if (ncid%dims(index)%get_dimname() == dimname) then
+          found = .true.
+       end if
+    end do
+
+    if (found) then
+       ncd_get_dimension_index = index
+    else
+       ncd_get_dimension_index = var_not_found
+    end if
+  end function ncd_get_dimension_index
 
 end module ncdio_pio

--- a/src/unit_test_stubs/main/ncdio_var.F90.in
+++ b/src/unit_test_stubs/main/ncdio_var.F90.in
@@ -18,7 +18,7 @@ module ncdio_var
 
   integer, parameter, public :: max_name = 256   ! max length for a variable name
   
-  ! This type stores a single variable in a fake file, for a single time slice.
+  ! This type stores a single variable in a fake file
   type :: ncdio_var_type
      private
      

--- a/src/utils/restUtilMod.F90.in
+++ b/src/utils/restUtilMod.F90.in
@@ -200,7 +200,7 @@ contains
        ncid, flag, varname, xtype, dim1name, dim2name, &
        long_name, units, interpinic_flag, data, readvar, &
        comment, flag_meanings, missing_value, fill_value, &
-       imissing_value, ifill_value, flag_values, nvalid_range )
+       imissing_value, ifill_value, flag_values, nvalid_range, is_spatial )
 
     ! Note that varname can be a colon-delimited list of possible variable names (with no
     ! spaces around the colons). In this case, when flag = 'read', the input file is
@@ -231,16 +231,24 @@ contains
     integer           , intent(in), optional :: ifill_value      ! attribute for int
     integer           , intent(in), optional :: flag_values(:)   ! attribute for int
     integer           , intent(in), optional :: nvalid_range(2)  ! attribute for int
+    logical           , intent(in), optional :: is_spatial       ! is this a spatial variable (with a dimension of gridcell, column, etc.)? If not present, assumed true.
     ! 
     ! Local variables
     character(len=len(varname)) :: primary_varname ! first name in the varname list
     character(len=len(varname)) :: my_varname      ! actual varname to read/write
+    logical          :: l_is_spatial               ! local version of is_spatial
     integer          :: ivalue
     type(var_desc_t) :: vardesc  ! local vardesc
     integer          :: status   ! return error code 
     integer          :: varid
     integer          :: lxtype   ! local external type (in case logical variable)
     !----------------------------------------------------
+
+    if (present(is_spatial)) then
+       l_is_spatial = is_spatial
+    else
+       l_is_spatial = .true.
+    end if
 
     call shr_string_listGetName(varname, 1, primary_varname)
     if (flag == 'read') then
@@ -329,7 +337,7 @@ contains
     else if (flag == 'read' .or. flag == 'write') then
 
 #if ({ITYPE}!=TYPETEXT) 
-       if (.not. present(dim1name)) then
+       if (.not. present(dim1name) .or. .not. l_is_spatial) then
           call ncd_io(varname=trim(my_varname), data=data, &
                ncid=ncid, flag=flag, readvar=readvar)
        else 


### PR DESCRIPTION
This PR fixes two bugs with init_interp that could cause undesirable answer changes (including changing answers when interpolating a file onto an identical configuration):

(1) Fixes #326 - Now we copy as many snow layers as possible, rather than just copying existing snow layers. This is needed in order to get bit-for-bit results in some radiation fluxes. This changes answers for many points, but in what I believe to be a very minor way (though I haven't done a super-careful investigation of the magnitude of the changes).

(2) Fixes #325 - Now, whenever possible, we find glcmec columns/patches of the same type, rather than ignoring column/patch type when looking for the closest glcmec point. This just changes answers for a few grid cells.

The new behavior is covered by unit tests. This PR also expands some unit testing infrastructure to facilitate the addition of some of these unit tests.

I have confirmed that this test passes: `LII_D_Ld9.f09_g16.I1850Clm50SpCru.hobart_intel.clm-default`, when I point to an initial conditions file that I generated from the dev 002 tag (because I wasn't sure if the current default initial conditions file was exactly compatible with the latest master). Before the changes in this PR, that test was failing.

I have not yet run the test suite on these changes.