### PR TITLE
Update manage_externals

### DIFF
--- a/manage_externals/manic/checkout.py
+++ b/manage_externals/manic/checkout.py
@@ -279,8 +279,15 @@ The root of the source tree will be referred to as `${SRC_ROOT}` below.
                         help='DEVELOPER: output additional debugging '
                         'information to the screen and log file.')
 
-    parser.add_argument('--no-logging', action='store_true',
-                        help='DEVELOPER: disable logging.')
+    logging_group = parser.add_mutually_exclusive_group()
+
+    logging_group.add_argument('--logging', dest='do_logging',
+                               action='store_true',
+                               help='DEVELOPER: enable logging.')
+    logging_group.add_argument('--no-logging', dest='do_logging',
+                               action='store_false', default=False,
+                               help='DEVELOPER: disable logging '
+                               '(this is the default)')
 
     if args:
         options = parser.parse_args(args)
@@ -305,7 +312,7 @@ def main(args):
     *before* executing the checkout command - i.e., the status that it
     used to determine if it's safe to proceed with the checkout.
     """
-    if not args.no_logging:
+    if args.do_logging:
         logging.basicConfig(filename=LOG_FILE_NAME,
                             format='%(levelname)s : %(asctime)s : %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S',
@@ -320,12 +327,14 @@ def main(args):
 
     root_dir = os.path.abspath(os.getcwd())
     external_data = read_externals_description_file(root_dir, args.externals)
-    external = create_externals_description(external_data, components=args.components)
+    external = create_externals_description(
+        external_data, components=args.components)
 
     for comp in args.components:
         if comp not in external.keys():
-            fatal_error("No component {} found in {}".format(comp, args.externals))
-
+            fatal_error(
+                "No component {} found in {}".format(
+                    comp, args.externals))
 
     source_tree = SourceTree(root_dir, external)
     printlog('Checking status of externals: ', end='')
@@ -357,6 +366,13 @@ The following are two options for how to proceed:
 (2) Alternatively, you do not have to rely on {program_name}. Instead, you
     can manually update out-of-sync externals (labeled with 's' above)
     as described in the configuration file {config_file}.
+
+
+The external repositories labeled with '?' above are not under version
+control using the expected protocol. If you are sure you want to switch
+protocols, and you don't have any work you need to save from this
+directory, then run "rm -rf [directory]" before re-running the
+checkout_externals tool.
 """.format(program_name=program_name, config_file=args.externals)
 
             printlog('-' * 70)

--- a/manage_externals/manic/externals_description.py
+++ b/manage_externals/manic/externals_description.py
@@ -91,16 +91,19 @@ def read_externals_description_file(root_dir, file_name):
     return externals_description
 
 
-def create_externals_description(model_data, model_format='cfg', components=None):
+def create_externals_description(
+        model_data, model_format='cfg', components=None):
     """Create the a externals description object from the provided data
     """
     externals_description = None
     if model_format == 'dict':
-        externals_description = ExternalsDescriptionDict(model_data, components=components)
+        externals_description = ExternalsDescriptionDict(
+            model_data, components=components)
     elif model_format == 'cfg':
         major, _, _ = get_cfg_schema_version(model_data)
         if major == 1:
-            externals_description = ExternalsDescriptionConfigV1(model_data, components=components)
+            externals_description = ExternalsDescriptionConfigV1(
+                model_data, components=components)
         else:
             msg = ('Externals description file has unsupported schema '
                    'version "{0}".'.format(major))

--- a/manage_externals/manic/repository_git.py
+++ b/manage_externals/manic/repository_git.py
@@ -694,7 +694,7 @@ class GitRepository(Repository):
     def _git_clone(url, repo_dir_name, verbosity):
         """Run git clone for the side effect of creating a repository.
         """
-        cmd = ['git', 'clone', url, repo_dir_name]
+        cmd = ['git', 'clone', '--quiet', url, repo_dir_name]
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)
@@ -710,7 +710,7 @@ class GitRepository(Repository):
     def _git_fetch(remote_name):
         """Run the git fetch command to for the side effect of updating the repo
         """
-        cmd = ['git', 'fetch', '--tags', remote_name]
+        cmd = ['git', 'fetch', '--quiet', '--tags', remote_name]
         execute_subprocess(cmd)
 
     @staticmethod
@@ -721,7 +721,7 @@ class GitRepository(Repository):
         form 'origin/my_feature', or 'tag1'.
 
         """
-        cmd = ['git', 'checkout', ref]
+        cmd = ['git', 'checkout', '--quiet', ref]
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)

--- a/manage_externals/manic/repository_svn.py
+++ b/manage_externals/manic/repository_svn.py
@@ -205,7 +205,11 @@ then rerun checkout_externals.
         # pylint: enable=invalid-name
 
         is_dirty = False
-        xml_status = ET.fromstring(svn_output)
+        try:
+            xml_status = ET.fromstring(svn_output)
+        except BaseException:
+            fatal_error(
+                "SVN returned invalid XML message {}".format(svn_output))
         xml_target = xml_status.find('./target')
         entries = xml_target.findall('./entry')
         for entry in entries:
@@ -270,7 +274,7 @@ then rerun checkout_externals.
         """
         Switch branches for in an svn sandbox
         """
-        cmd = ['svn', 'switch', url]
+        cmd = ['svn', 'switch', '--quiet', url]
         if verbosity >= VERBOSITY_VERBOSE:
             printlog('    {0}'.format(' '.join(cmd)))
         execute_subprocess(cmd)


### PR DESCRIPTION
This PR updates the version of manage_externals, pulling in some minor
but nice-to-have changes:

- https://github.com/ESMCI/manage_externals/pull/98: Make more git and
  svn commands quiet

- https://github.com/ESMCI/manage_externals/pull/101: Catch errors from
  svn status --xml

- https://github.com/ESMCI/manage_externals/pull/102: Explain question
  mark

- https://github.com/ESMCI/manage_externals/pull/103: Make no-logging be
  the default

