### PR TITLE
Update max day length (max_dayl) each time step

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.6.6
+hash = a67dceae95567cc7529c4cfed153017f4b65b210
 required = True
 
 [externals_description]

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -2,27 +2,11 @@
 
 <expectedFails>
   <category name="aux_clm">
-    <entry issue="#177"     >FAIL ERP_D_Lm9.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-ciso_monthly RUN</entry>
-    <entry issue="#177"     >FAIL SMS_D_Lm13.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-ciso_monthly RUN</entry>
-    <entry issue="#169"     >FAIL ERP_D_Ld10.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-ciso_decStart SHAREDLIB_BUILD</entry>
+    <entry issue="#169"     >PEND ERP_D_Ld10.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-ciso_decStart SHAREDLIB_BUILD</entry>
     <entry issue="#158"     >FAIL ERS_Lm20_Mmpi-serial.1x1_smallvilleIA.I2000Clm50BgcCropGs.cheyenne_gnu.clm-monthly RUN</entry>
     <entry issue="#158"     >FAIL ERS_Lm20_Mmpi-serial.1x1_smallvilleIA.I2000Clm50BgcCropGs.cheyenne_intel.clm-monthly RUN</entry>
     <entry issue="#339"     >FAIL ERS_D_Ld3.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_gnu.clm-default COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERP_D_P48x1.f10_f10_musgs.IHistClm50Bgc.hobart_nag.clm-decStart COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERP_D.f10_f10_musgs.IHistClm50Bgc.cheyenne_intel.clm-decStart COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERP_Ly3_P72x2.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERP_P36x2_D_Ld5.f10_f10_musgs.IHistClm45Bgc.cheyenne_intel.clm-decStart COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_D_Ld7_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_intel.clm-decStart1851_noinitial COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_intel.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly3_P72x2.f10_f10_musgs.IHistClm50BgcCropG.cheyenne_intel.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly5_P144x1.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly5_P72x1.f10_f10_musgs.IHistClm45BgcCrop.cheyenne_intel.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_intel.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput COMPARE_base_rest</entry>
-    <entry issue="#379"     >FAIL ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput COMPARE_base_rest</entry>
     <entry issue="#384"     >FAIL ERP_D_Ld5.f09_g17.I2000Clm50Vic.cheyenne_intel.clm-vrtlay RUN</entry>
-    <entry issue="mosart/#3">FAIL ERP_Ld5.f10_f10_musgs.I2000Clm50Vic.cheyenne_gnu.clm-decStart COMPARE_base_rest</entry>
-    <entry issue="mosart/#3">FAIL ERP_D.f10_f10_musgs.IHistClm50Bgc.cheyenne_gnu.clm-decStart COMPARE_base_rest</entry>
   </category>
   <category name="fates">
     <entry issue="NGEET/fates#315">FAIL ERP_Ld9.f45_f45_mg37.I2000Clm45Fates.hobart_nag.clm-FatesAllVars COMPARE_base_rest</entry>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -369,7 +369,7 @@
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
-      <option name="wallclock">00:20:00</option>
+      <option name="wallclock">02:30:00</option>
       <option name="comment"  >Want a transient case with isotopes, to test isotopes in the transient landuse and harvest code</option>
     </options>
   </test>
@@ -1316,7 +1316,7 @@
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
-      <option name="wallclock">00:20:00</option>
+      <option name="wallclock">02:30:00</option>
       <option name="comment"  >Want a transient case with isotopes, to test isotopes in the transient landuse and harvest code</option>
     </options>
   </test>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,145 @@
 ===============================================================
+Tag name:  clm5.0.dev012
+Originator(s):  sacks (Bill Sacks)
+Date: Thu May 17 14:13:34 MDT 2018
+One-line Summary: Fixes for variable_year orbital mode
+
+Purpose of changes
+------------------
+
+Fixes for correctness and exact restartability with variable_year
+orbital mode:
+
+(1) Update max day length (max_dayl) each time step, rather than just
+    updating it once in initialization
+
+(2) Update to a cime version that has a fix for datm, which updates the
+    orbital parameters (used for solar zenith angle-based interpolation)
+    each time step, rather than just once in initialization
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+- Fixes #379 (Problems with Hist decStart restart tests due to variable
+  orbital year)
+- Fixes #260 (max daylength doesn't change over time for varying orbital
+  parameters)
+
+CIME Issues fixed (include issue #):
+- ESMCI/cime#2598 (datm doesn't restart properly with variable year orbit)
+
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CLM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: Gave extra time to some tests so they would pass
+
+Code reviewed by: Erik Kluzek
+
+Did you follow the steps in .CLMTrunkChecklist: yes
+
+CLM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  unit-tests (components/clm/src):
+
+    cheyenne - pass
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     cheyenne - not run
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- ok
+    cheyenne_gnu ------ ok
+    hobart_nag -------- ok
+    hobart_pgi -------- ok
+    hobart_intel ------ ok
+
+    ok means tests pass, some baselines fail as expected
+
+    Also verified that this test (reported in #379) now passes:
+    ERS_D_P36x1.f10_f10_musgs.IHistClm50Bgc.cheyenne_intel.clm-decStart
+
+    Also verified that the ctsm code changes alone (without the cime
+    update) have the expected behavior in terms of baseline
+    passes/fails:
+
+    FAIL SMS_D_Ld10.f10_f10_musgs.IHistClm50Bgc.cheyenne_intel.clm-decStart BASELINE
+	Enters the second year
+    PASS SMS_D_Ld1.f10_f10_musgs.IHistClm50Bgc.cheyenne_intel.clm-decStart BASELINE
+	Stays in first year
+    PASS SMS_Lm1.f10_f10_musgs.IHistClm50Bgc.cheyenne_intel.clm-ciso_bombspike1963 BASELINE
+	Stays in first year
+
+CLM tag used for the baseline comparisons: clm5.0.dev011
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: multi-year runs with HIST compsets
+    - what platforms/compilers: all
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+      Not investigated carefully, but expected to be larger than roundoff/same climate
+
+      Bit-for-bit for runs with fixed orbital parameters (non-HIST
+      compsets) and for HIST runs that do not span multiple years.
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff? N/A
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: N/A
+
+   URL for LMWG diagnostics output used to validate new climate: N/A
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+- cime: adds one commit that fixes ESMCI/cime#2598 
+
+Pull Requests that document the changes (include PR ids):
+- #385 (Update max day length (max_dayl) each time step)
+
+===============================================================
+===============================================================
 Tag name:  clm5.0.dev011
 Originator(s):  erik (Erik Kluzek)
 Date: Wed May 16 20:27:39 MDT 2018

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+   clm5.0.dev012    sacks 05/17/2018 Fixes for variable_year orbital mode
    clm5.0.dev011     erik 05/16/2018 1850 ndep update, cism update, PE layouts, turn BFBFLAG for testing
    clm5.0.dev010     erik 05/15/2018 Update cime version to version in cesm2.0.beta10, changes answers for 1850 compsets because of orbit
    clm5.0.dev009    sacks 05/10/2018 New init_interp method

--- a/src/biogeophys/test/Daylength_test/CMakeLists.txt
+++ b/src/biogeophys/test/Daylength_test/CMakeLists.txt
@@ -1,4 +1,8 @@
-create_pFUnit_test(daylength test_daylength_exe
-  "test_daylength.pf" "")
+set (pfunit_sources
+  test_daylength.pf
+  test_compute_max_daylength.pf)
 
-target_link_libraries(test_daylength_exe clm csm_share esmf_wrf_timemgr)
+create_pFUnit_test(Daylength test_Daylength_exe
+  "${pfunit_sources}" "")
+
+target_link_libraries(test_Daylength_exe clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/Daylength_test/test_compute_max_daylength.pf
+++ b/src/biogeophys/test/Daylength_test/test_compute_max_daylength.pf
@@ -1,0 +1,100 @@
+module test_compute_max_daylength
+
+  ! Tests of DaylengthMod: ComputeMaxDaylength
+
+  use pfunit_mod
+  use DaylengthMod, only: ComputeMaxDaylength, daylength
+  use shr_kind_mod , only : r8 => shr_kind_r8
+  use unittestSubgridMod, only : unittest_subgrid_teardown, bounds
+  use unittestSimpleSubgridSetupsMod, only : setup_ncells_single_veg_patch
+  use GridcellType, only : grc
+
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: TestMaxDaylength
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type TestMaxDaylength
+
+  ! Note larger tolerance here than what we typically use:
+  real(r8), parameter :: tol = 1.e-3_r8
+
+contains
+
+  subroutine setUp(this)
+    class(TestMaxDaylength), intent(inout) :: this
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(TestMaxDaylength), intent(inout) :: this
+
+    call unittest_subgrid_teardown
+  end subroutine tearDown
+
+  @Test
+  subroutine computeMaxDaylength_basic(this)
+    ! Basic tests of ComputeMaxDaylength, for both negative and positive latitudes
+    class(TestMaxDaylength), intent(inout) :: this
+    real(r8), parameter :: lat1 = 0.1_r8
+    real(r8), parameter :: lat2 = 0.2_r8
+    real(r8), parameter :: obliquity = 0.3_r8
+    real(r8) :: expected_lat1, expected_lat2
+    real(r8) :: expected(4)
+
+    call setup_ncells_single_veg_patch(ncells=4, pft_type=1)
+    ! Mix of negative and positive latitudes:
+    grc%lat(bounds%begg:bounds%endg) = [-lat1, lat1, -lat2, lat2]
+
+    expected_lat1 = daylength(lat1, obliquity)
+    expected_lat2 = daylength(lat2, obliquity)
+    ! Expected max daylength is the same for lat1 and -lat1
+    expected(:) = [expected_lat1, expected_lat1, expected_lat2, expected_lat2]
+
+    call ComputeMaxDaylength(bounds, &
+         lat = grc%lat(bounds%begg:bounds%endg), &
+         obliquity = obliquity, &
+         max_daylength = grc%max_dayl(bounds%begg:bounds%endg))
+
+    @assertEqual(expected, grc%max_dayl(bounds%begg:bounds%endg), tolerance=tol)
+  end subroutine computeMaxDaylength_basic
+
+  @Test
+  subroutine computeMaxDaylength_equator(this)
+    ! At the equator, max daylength should be 12 hours
+    class(TestMaxDaylength), intent(inout) :: this
+    real(r8), parameter :: twelve_hours = 12._r8 * 60._r8 * 60._r8  ! in seconds
+
+    call setup_ncells_single_veg_patch(ncells=1, pft_type=1)
+    grc%lat(bounds%begg) = 0._r8
+
+    call ComputeMaxDaylength(bounds, &
+         lat = grc%lat(bounds%begg:bounds%endg), &
+         obliquity = 0.3_r8, &
+         max_daylength = grc%max_dayl(bounds%begg:bounds%endg))
+
+    @assertEqual(twelve_hours, grc%max_dayl(bounds%begg), tolerance=tol)
+  end subroutine computeMaxDaylength_equator
+
+  @Test
+  subroutine computeMaxDaylength_nearPoles(this)
+    ! Near the poles, max daylength should be 24 hours
+    class(TestMaxDaylength), intent(inout) :: this
+    real(r8), parameter :: twentyfour_hours = 24._r8 * 60._r8 * 60._r8  ! in seconds
+    real(r8) :: expected(2)
+
+    call setup_ncells_single_veg_patch(ncells=2, pft_type=1)
+    grc%lat(bounds%begg:bounds%endg) = [1.5_r8, -1.5_r8]
+
+    expected(:) = [twentyfour_hours, twentyfour_hours]
+
+    call ComputeMaxDaylength(bounds, &
+         lat = grc%lat(bounds%begg:bounds%endg), &
+         obliquity = 0.3_r8, &
+         max_daylength = grc%max_dayl(bounds%begg:bounds%endg))
+
+    @assertEqual(expected, grc%max_dayl(bounds%begg:bounds%endg), tolerance=tol)
+  end subroutine computeMaxDaylength_nearPoles
+
+end module test_compute_max_daylength

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -16,6 +16,7 @@ module clm_driver
   use clm_time_manager       , only : get_nstep, is_beg_curr_day
   use clm_time_manager       , only : get_prev_date, is_first_step
   use clm_varpar             , only : nlevsno, nlevgrnd
+  use clm_varorb             , only : obliqr
   use spmdMod                , only : masterproc, mpicom
   use decompMod              , only : get_proc_clumps, get_clump_bounds, get_proc_bounds, bounds_type
   use filterMod              , only : filter, filter_inactive_and_active
@@ -398,7 +399,7 @@ contains
 
        call t_startf('drvinit')
 
-       call UpdateDaylength(bounds_clump, declin)
+       call UpdateDaylength(bounds_clump, declin=declin, obliquity=obliqr)
 
        ! Initialze variables needed for new driver time step 
        call clm_drv_init(bounds_clump, &

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -272,7 +272,7 @@ contains
     use clm_time_manager      , only : get_curr_date, get_nstep, advance_timestep 
     use clm_time_manager      , only : timemgr_init, timemgr_restart_io, timemgr_restart, is_restart
     use CIsoAtmTimeseriesMod  , only : C14_init_BombSpike, use_c14_bombspike, C13_init_TimeSeries, use_c13_timeseries
-    use DaylengthMod          , only : InitDaylength, daylength
+    use DaylengthMod          , only : InitDaylength
     use dynSubgridDriverMod   , only : dynSubgrid_init
     use fileutils             , only : getfil
     use initInterpMod         , only : initInterp
@@ -293,7 +293,7 @@ contains
     ! !ARGUMENTS    
     !
     ! !LOCAL VARIABLES:
-    integer               :: c,i,g,j,k,l,p! indices
+    integer               :: c,i,j,k,l,p! indices
     integer               :: yr           ! current year (0, ...)
     integer               :: mon          ! current month (1 -> 12)
     integer               :: day          ! current day (1 -> 31)
@@ -316,7 +316,6 @@ contains
     logical               :: lexist
     integer               :: closelatidx,closelonidx
     real(r8)              :: closelat,closelon
-    real(r8)              :: max_decl      ! temporary, for calculation of max_dayl
     integer               :: begp, endp
     integer               :: begc, endc
     integer               :: begl, endl
@@ -372,17 +371,8 @@ contains
 
     call t_stopf('init_orbd')
     
-    call InitDaylength(bounds_proc, declin=declin, declinm1=declinm1)
+    call InitDaylength(bounds_proc, declin=declin, declinm1=declinm1, obliquity=obliqr)
              
-    ! Initialize maximum daylength, based on latitude and maximum declination
-    ! given by the obliquity use negative value for S. Hem
-
-    do g = bounds_proc%begg,bounds_proc%endg
-       max_decl = obliqr
-       if (grc%lat(g) < 0._r8) max_decl = -max_decl
-       grc%max_dayl(g) = daylength(grc%lat(g), max_decl)
-    end do
-
     ! History file variables
 
     if (use_cn) then


### PR DESCRIPTION
This is needed for max day length to remain correct with time-varying
orbital parameters, which in turn is needed to achieve exact restart
in a run that crosses the year boundary with time-varying orbital
parameters.

Fixes #379
Fixes #260