### PR TITLE
Fates history dimensions: height, age*pft, size*age*pft

### DIFF
--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -23,6 +23,7 @@ module histFileMod
   use EDTypesMod     , only : nclmax
   use EDTypesMod     , only : nlevleaf
   use FatesInterfaceMod , only : nlevsclass, nlevage
+  use FatesInterfaceMod , only : nlevheight
   use EDTypesMod     , only : nfsc, ncwd
   use FatesInterfaceMod , only : numpft_ed => numpft
   use ncdio_pio 
@@ -2060,6 +2061,7 @@ contains
        call ncd_defdim(lnfid, 'fates_levscls', nlevsclass, dimid)
        call ncd_defdim(lnfid, 'fates_levpft', numpft_ed, dimid)
        call ncd_defdim(lnfid, 'fates_levage', nlevage, dimid)
+       call ncd_defdim(lnfid, 'fates_levheight', nlevheight, dimid)
        call ncd_defdim(lnfid, 'fates_levfuel', nfsc, dimid)
        call ncd_defdim(lnfid, 'fates_levcwdsc', ncwd, dimid)
        call ncd_defdim(lnfid, 'fates_levscpf', nlevsclass*numpft_ed, dimid)
@@ -2483,6 +2485,7 @@ contains
     use FatesInterfaceMod, only : fates_hdim_pfmap_levscpf
     use FatesInterfaceMod, only : fates_hdim_scmap_levscpf
     use FatesInterfaceMod, only : fates_hdim_levage
+    use FatesInterfaceMod, only : fates_hdim_levheight
     use FatesInterfaceMod, only : fates_hdim_levpft
     use FatesInterfaceMod, only : fates_hdim_scmap_levscag
     use FatesInterfaceMod, only : fates_hdim_agmap_levscag
@@ -2565,6 +2568,8 @@ contains
                   long_name='FATES size index of the combined pft-size class dimension', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_levage',xtype=tape(t)%ncprec, dim1name='fates_levage', &
                   long_name='FATES patch age (yr)', ncid=nfid(t))
+             call ncd_defvar(varname='fates_levheight',xtype=tape(t)%ncprec, dim1name='fates_levheight', &
+                  long_name='FATES height (m)', ncid=nfid(t))
              call ncd_defvar(varname='fates_levpft',xtype=ncd_int, dim1name='fates_levpft', &
                   long_name='FATES pft number', ncid=nfid(t))
              call ncd_defvar(varname='fates_levfuel',xtype=ncd_int, dim1name='fates_levfuel', &
@@ -2614,6 +2619,7 @@ contains
              call ncd_io(varname='fates_pftmap_levscpf',data=fates_hdim_pfmap_levscpf, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_scmap_levscpf',data=fates_hdim_scmap_levscpf, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_levage',data=fates_hdim_levage, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_levheight',data=fates_hdim_levheight, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_levpft',data=fates_hdim_levpft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_levfuel',data=fates_hdim_levfuel, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_levcwdsc',data=fates_hdim_levcwdsc, ncid=nfid(t), flag='write')
@@ -4783,6 +4789,8 @@ contains
        num2d = numpft_ed
     case ('fates_levage')
        num2d = nlevage
+    case ('fates_levheight')
+       num2d = nlevheight
     case ('fates_levfuel')
        num2d = nfsc
     case ('fates_levcwdsc')

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -2055,6 +2055,8 @@ contains
     
     if(use_fates)then
        call ncd_defdim(lnfid, 'fates_levscag', nlevsclass * nlevage, dimid)
+       call ncd_defdim(lnfid, 'fates_levscagpf', nlevsclass * nlevage * numpft_ed, dimid)
+       call ncd_defdim(lnfid, 'fates_levagepft', nlevage * numpft_ed, dimid)
        call ncd_defdim(lnfid, 'fates_levscls', nlevsclass, dimid)
        call ncd_defdim(lnfid, 'fates_levpft', numpft_ed, dimid)
        call ncd_defdim(lnfid, 'fates_levage', nlevage, dimid)
@@ -2484,6 +2486,11 @@ contains
     use FatesInterfaceMod, only : fates_hdim_levpft
     use FatesInterfaceMod, only : fates_hdim_scmap_levscag
     use FatesInterfaceMod, only : fates_hdim_agmap_levscag
+    use FatesInterfaceMod, only : fates_hdim_scmap_levscagpft
+    use FatesInterfaceMod, only : fates_hdim_agmap_levscagpft
+    use FatesInterfaceMod, only : fates_hdim_pftmap_levscagpft
+    use FatesInterfaceMod, only : fates_hdim_agmap_levagepft
+    use FatesInterfaceMod, only : fates_hdim_pftmap_levagepft
     use FatesInterfaceMod, only : fates_hdim_levfuel
     use FatesInterfaceMod, only : fates_hdim_levcwdsc
     use FatesInterfaceMod, only : fates_hdim_levcan
@@ -2576,6 +2583,17 @@ contains
                   long_name='FATES leaf level of combined canopy x leaf x pft dimension', ncid=nfid(t))
              call ncd_defvar(varname='fates_pftmap_levcnlfpf',xtype=ncd_int, dim1name='fates_levcnlfpf', &
                   long_name='FATES PFT level of combined canopy x leaf x pft dimension', ncid=nfid(t))
+             call ncd_defvar(varname='fates_scmap_levscagpft', xtype=ncd_int, dim1name='fates_levscagpf', &
+                  long_name='FATES size-class map into size x patch age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_agmap_levscagpft', xtype=ncd_int, dim1name='fates_levscagpf', &
+                   long_name='FATES age-class map into size x patch age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_pftmap_levscagpft', xtype=ncd_int, dim1name='fates_levscagpf', &
+                   long_name='FATES pft map into size x patch age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_pftmap_levagepft', xtype=ncd_int, dim1name='fates_levagepft', &
+                   long_name='FATES pft map into patch age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_agmap_levagepft', xtype=ncd_int, dim1name='fates_levagepft', &
+                   long_name='FATES age-class map into patch age x pft', units='-', ncid=nfid(t))
+
           end if
 
 
@@ -2605,6 +2623,11 @@ contains
              call ncd_io(varname='fates_canmap_levcnlfpf',data=fates_hdim_canmap_levcnlfpf, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_lfmap_levcnlfpf',data=fates_hdim_lfmap_levcnlfpf, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_pftmap_levcnlfpf',data=fates_hdim_pftmap_levcnlfpf, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_scmap_levscagpft',data=fates_hdim_scmap_levscagpft, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_agmap_levscagpft',data=fates_hdim_agmap_levscagpft, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_pftmap_levscagpft',data=fates_hdim_pftmap_levscagpft, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_pftmap_levagepft',data=fates_hdim_pftmap_levagepft, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_agmap_levagepft',data=fates_hdim_agmap_levagepft, ncid=nfid(t), flag='write')             
           end if
 
        endif
@@ -4768,6 +4791,10 @@ contains
        num2d = nlevsclass*numpft_ed
     case ('fates_levscag')
        num2d = nlevsclass*nlevage
+    case ('fates_levscagpf')
+       num2d = nlevsclass*nlevage*numpft_ed
+    case ('fates_levagepft')
+       num2d = nlevage*numpft_ed
     case ('fates_levcan')
        num2d = nclmax
     case ('fates_levcnlf')

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1873,6 +1873,7 @@ contains
    use FatesIOVariableKindMod, only : site_r8, site_ground_r8, site_size_pft_r8
    use FatesIOVariableKindMod, only : site_size_r8, site_pft_r8, site_age_r8
    use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
+   use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
    use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
    use FatesIODimensionsMod, only : fates_bounds_type
 
@@ -2112,7 +2113,24 @@ contains
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
                               set_lake=0._r8,set_urb=0._r8)
-           
+        case(site_scagpft_r8)
+           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
+           dim2name = this%fates_hist%dim_bounds(d_index)%name
+           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
+                              type2d=trim(dim2name),                        &
+                              avgflag=trim(vavgflag),long_name=trim(vlong), &
+                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
+                              default=trim(vdefault),                       &
+                              set_lake=0._r8,set_urb=0._r8)
+        case(site_agepft_r8)
+           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
+           dim2name = this%fates_hist%dim_bounds(d_index)%name
+           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
+                              type2d=trim(dim2name),                        &
+                              avgflag=trim(vavgflag),long_name=trim(vlong), &
+                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
+                              default=trim(vdefault),                       &
+                              set_lake=0._r8,set_urb=0._r8)           
 
         case default
            write(iulog,*) 'A FATES iotype was created that was not registerred'
@@ -2358,6 +2376,12 @@ contains
 
    fates%sizeage_class_begin = 1
    fates%sizeage_class_end   = nlevsclass * nlevage
+
+   fates%agepft_class_begin = 1
+   fates%agepft_class_end   = nlevage * numpft_ed
+   
+   fates%sizeagepft_class_begin = 1
+   fates%sizeagepft_class_end   = nlevsclass * nlevage * numpft_ed
    
    fates%fuel_begin = 1
    fates%fuel_end = nfsc

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1875,6 +1875,7 @@ contains
    use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
    use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
+   use FatesIOVariableKindMod, only : site_height_r8
    use FatesIODimensionsMod, only : fates_bounds_type
 
 
@@ -2051,6 +2052,15 @@ contains
                               default=trim(vdefault),                       &
                               set_lake=0._r8,set_urb=0._r8)
         case(site_age_r8)
+           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
+           dim2name = this%fates_hist%dim_bounds(d_index)%name
+           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
+                              type2d=trim(dim2name),                        &
+                              avgflag=trim(vavgflag),long_name=trim(vlong), &
+                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
+                              default=trim(vdefault),                       &
+                              set_lake=0._r8,set_urb=0._r8)
+        case(site_height_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
            call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
@@ -2340,6 +2350,7 @@ contains
 
    use FatesIODimensionsMod, only : fates_bounds_type
    use FatesInterfaceMod, only : nlevsclass, nlevage
+   use FatesInterfaceMod, only : nlevheight
    use EDtypesMod, only : nfsc, ncwd
    use EDtypesMod, only : nlevleaf, nclmax
    use FatesInterfaceMod, only : numpft_ed => numpft
@@ -2373,6 +2384,9 @@ contains
 
    fates%age_class_begin = 1
    fates%age_class_end = nlevage
+
+   fates%height_begin = 1
+   fates%height_end = nlevheight
 
    fates%sizeage_class_begin = 1
    fates%sizeage_class_end   = nlevsclass * nlevage


### PR DESCRIPTION
New dimensions for FATES history output: height, age*pft, size*age*pft.  corresponds to the set of changes in https://github.com/NGEET/fates-clm/pull/30, which align with FATES changes in https://github.com/NGEET/fates/pull/316.

I haven't tested these yet in CTSM; @rgknox could you put through your new FATES-CTSM test regime?