### PR TITLE
Allow first history tape to have other than one time point per file

### DIFF
--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -323,9 +323,7 @@ contains
        ! History and restart files
 
        do i = 1, max_tapes
-          if (hist_nhtfrq(i) == 0) then
-             hist_mfilt(i) = 1
-          else if (hist_nhtfrq(i) < 0) then
+          if (hist_nhtfrq(i) < 0) then
              hist_nhtfrq(i) = nint(-hist_nhtfrq(i)*SHR_CONST_CDAY/(24._r8*dtime))
           endif
        end do

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -65,7 +65,7 @@ module histFileMod
   integer, public :: &
        hist_ndens(max_tapes) = 2         ! namelist: output density of netcdf history files
   integer, public :: &
-       hist_mfilt(max_tapes) = (/ 1, (30, ni=2, max_tapes/)        ! namelist: number of time samples per tape
+       hist_mfilt(max_tapes) = (/ 1, (30, ni=2, max_tapes)/)        ! namelist: number of time samples per tape
   logical, public :: &
        hist_dov2xy(max_tapes) = (/.true.,(.true.,ni=2,max_tapes)/) ! namelist: true=> do grid averaging
   integer, public :: &

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -65,7 +65,7 @@ module histFileMod
   integer, public :: &
        hist_ndens(max_tapes) = 2         ! namelist: output density of netcdf history files
   integer, public :: &
-       hist_mfilt(max_tapes) = 30        ! namelist: number of time samples per tape
+       hist_mfilt(max_tapes) = (/ 1, (30, ni=2, max_tapes/)        ! namelist: number of time samples per tape
   logical, public :: &
        hist_dov2xy(max_tapes) = (/.true.,(.true.,ni=2,max_tapes)/) ! namelist: true=> do grid averaging
   integer, public :: &


### PR DESCRIPTION
The current CTSM forces the default one monthly time point per file for the first history tape, even if the user specifies otherwise.  This was pointed out in issue #85 and separately rediscovered at least one other time by me.  This code fixes that and allows the user-specified value of hist_mfilt to occur.  Code change here is based on https://github.com/ESCOMP/ctsm/issues/85#issuecomment-352209370 from @ekluzek.  I confirm that the change does allow specifying other than one time step per file.

