### PR TITLE
Protected fates calculation of bare-soil area to not go below 0

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -842,7 +842,15 @@ contains
           ! Set the bareground patch indicator
           patch%is_bareground(col%patchi(c)) = .true.
           npatch = this%fates(nc)%sites(s)%youngest_patch%patchno
-          patch%wt_ed(col%patchi(c)) = 1.0_r8-sum(this%fates(nc)%bc_out(s)%canopy_fraction_pa(1:npatch))
+
+          ! Precision errors on the canopy_fraction_pa sum, even small (e-12)
+          ! do exist, and can create potentially negetive bare-soil fractions
+          ! (ie -1e-12 or smaller). Even though this is effectively zero,
+          ! it can generate weird logic scenarios in the ctsm/elm code, so we
+          ! protext it here with a lower bound of 0.0_r8.
+
+          patch%wt_ed(col%patchi(c)) = max(0.0_r8, &
+               1.0_r8-sum(this%fates(nc)%bc_out(s)%canopy_fraction_pa(1:npatch)))
 
           if(sum(this%fates(nc)%bc_out(s)%canopy_fraction_pa(1:npatch))>1.0_r8)then
              write(iulog,*)'Projected Canopy Area of all FATES patches'


### PR DESCRIPTION

This PR ensures that when FATES passes back area weights to CTSM, the bare-soil patch is not given a negative area.  The precisions on our patch area calculations can stray up to 1e-12, which is small but had made it possible that an nearly-zero negative bare-soil patch area was possible.  This fix simply bounds it at 0.