### PR TITLE
Make PR template questions less prominent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,16 @@
-### Description of changes:
+### Description of changes
 
-### CTSM Issues Fixed (include github issue #):
+### Specific notes
 
-### Are answers expected to change? (and if so in what way):
+CTSM Issues Fixed (include github issue #):
 
-### Any User Interface Changes (namelist or namelist defaults changes)?:
+Are answers expected to change (and if so in what way)?
 
-### Testing performed:
+Any User Interface Changes (namelist or namelist defaults changes)?
+
+Testing performed:
 (List what testing you did to show your changes worked as expected)
 (This can be manual testing or running of the different test suites)
 
-### NOTE: Be sure to check your Coding style against the standard:
+**NOTE: Be sure to check your Coding style against the standard:**
 https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines


### PR DESCRIPTION
### Description of changes:

Make PR template questions less prominent

I find that, with these big, bold headings, my eye is drawn to the
headings and it's hard to read the important text that the user has
entered him/herself. I find that having the questions in normal text
makes a filled-out PR easier to read.

### CTSM Issues Fixed (include github issue #): None

### Are answers expected to change? (and if so in what way): No

### Any User Interface Changes (namelist or namelist defaults changes)?: None

### Testing performed: None
