### PR TITLE
Add missing --append flag to decStart xmlchange command

### DIFF
--- a/cime_config/testdefs/testmods_dirs/clm/decStart/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/decStart/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange RUN_STARTDATE=2001-12-30
-./xmlchange CLM_BLDNML_OPTS=-ignore_warnings
+./xmlchange CLM_BLDNML_OPTS=-ignore_warnings --append


### PR DESCRIPTION
Add missing --append flag to decStart xmlchange command

### Specific notes

CTSM Issues Fixed (include github issue #):
Fixes #424 

Are answers expected to change (and if so in what way)?
Answers will change for some tests: decStart and ciso_decStart

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed:
Tested creation of `ERP_D.f10_f10_musgs.IHistClm50Bgc.roo2_gnu.clm-decStart`