### PR TITLE
Addresses bugs with gridcell averaging of FUN variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,18 +58,27 @@ test_driver_*.sh
 # mksurfdata output
 surfdata_*.log
 surfdata_*.namelist
+landuse.timeseries_*.namelist
+landuse.timeseries_*.log
+landuse_timeseries_*.txt
 clm.input_data_list
 clm.input_data_list.previous
+*.stdout.txt.o*
 
 # Tools executables
 tools/mksurfdata_map/mksurfdata_map
 tools/mkprocdata_map/mkprocdata_map
+
+# mksurfdata output files
+tools/mksurfdata_map/surfdata_*.nc
+tools/mksurfdata_map/landuse.timeseries_*.nc
 
 # mkmapdata output files
 tools/mkmapdata/PET*.RegridWeightGen.Log
 tools/mkmapdata/regrid.*.out
 tools/mkmapdata/regrid.*.err
 tools/mkmapdata/regrid.o*
+tools/mkmapdata/map*.nc
 
 # build output
 *.o

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -32,8 +32,8 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
-<stream_fldfilename_ndep phys="clm5_0" use_cn=".true." lnd_tuning_mode="clm5_0_cam6.0"
->lnd/clm2/ndepdata/fndep_clm_hist_simyr1850_0.9x1.25_CMIP6alpha02_c180426.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
+>lnd/clm2/ndepdata/fndep_clm_hist_simyr1850_0.9x1.25_CMIP6_c180617.nc</stream_fldfilename_ndep>
  
 <ndep_taxmode use_cn=".true." lnd_tuning_mode="clm5_0_cam6.0">cycle</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -35,8 +35,8 @@
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_hist_simyr1850_0.9x1.25_CMIP6_c180617.nc</stream_fldfilename_ndep>
  
-<ndep_taxmode use_cn=".true." lnd_tuning_mode="clm5_0_cam6.0">cycle</ndep_taxmode>
+<ndep_taxmode            phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
 
-<ndep_varlist use_cn=".true." lnd_tuning_mode="clm5_0_cam6.0">NDEP_month</ndep_varlist>
+<ndep_varlist            phys="clm5_0" use_cn=".true." >NDEP_month</ndep_varlist>
 
 </namelist_defaults>

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -397,6 +397,7 @@ contains
 
     call this%InitAllocate ( bounds, carbon_type)
     call this%InitHistory ( bounds, carbon_type )
+    call this%InitCold (bounds )
 
   end subroutine Init
 
@@ -3571,6 +3572,7 @@ contains
             dim1name='pft', &
             long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%leafc_to_litter_fun_patch)
+        ! BACKWARDS_COMPATIBILITY(wrw, 2018-06-28) re. issue #426
         call set_missing_vals_to_constant(this%leafc_to_litter_fun_patch, 0._r8)
     end if
 

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -397,7 +397,6 @@ contains
 
     call this%InitAllocate ( bounds, carbon_type)
     call this%InitHistory ( bounds, carbon_type )
-    call this%InitCold (bounds )
 
   end subroutine Init
 
@@ -1662,12 +1661,10 @@ contains
                avgflag='A', long_name='Total C used by N uptake in FUN',  &
                ptr_patch=this%npp_Nuptake_patch)
 
-    this%npp_growth_patch(begp:endp) = spval
+          this%npp_growth_patch(begp:endp) = spval
           call hist_addfld1d (fname='NPP_GROWTH', units='gC/m^2/s',      &
                avgflag='A', long_name='Total C used for growth in FUN',  &
                ptr_patch=this%npp_growth_patch)
-
-
 
           this%leafc_change_patch(begp:endp) = spval
           call hist_addfld1d (fname='LEAFC_CHANGE', units='gC/m^2/s',     &
@@ -3322,7 +3319,7 @@ contains
     do p = bounds%begp,bounds%endp
        l = patch%landunit(p)
        this%gpp_before_downreg_patch(p)       = 0._r8
-
+       ! WW should these be considered spval or 0?
        if (lun%ifspecial(l)) then
           this%availc_patch(p)                = spval
           this%xsmrpool_recover_patch(p)      = spval
@@ -3574,6 +3571,7 @@ contains
             dim1name='pft', &
             long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%leafc_to_litter_fun_patch)
+        call set_missing_vals_to_constant(this%leafc_to_litter_fun_patch, 0._r8)
     end if
 
   end subroutine RestartBulkOnly

--- a/src/biogeochem/CNVegNitrogenFluxType.F90
+++ b/src/biogeochem/CNVegNitrogenFluxType.F90
@@ -178,6 +178,7 @@ module CNVegNitrogenFluxType
      real(r8), pointer :: ndeploy_patch                             (:)     ! patch total N deployed to growth and storage (gN/m2/s)
      real(r8), pointer :: wood_harvestn_patch                       (:)     ! patch total N losses to wood product pools (gN/m2/s)
      real(r8), pointer :: wood_harvestn_col                         (:)     ! col total N losses to wood product pools (gN/m2/s) (p2c)
+     real(r8), pointer :: litfall_n_patch                           (:)     ! total N passed from plant to litter (gN/m2/s)
 
      ! phenology: litterfall and crop fluxes
      real(r8), pointer :: phenology_n_to_litr_met_n_col             (:,:)   ! col N fluxes associated with phenology (litterfall and crop) to litter metabolic pool (gN/m3/s)
@@ -440,6 +441,8 @@ contains
     allocate(this%dwt_wood_productn_gain_patch (begp:endp))                   ; this%dwt_wood_productn_gain_patch (:)   = nan
     allocate(this%dwt_crop_productn_gain_patch (begp:endp))                   ; this%dwt_crop_productn_gain_patch (:)   = nan
     allocate(this%wood_harvestn_col            (begc:endc))                   ; this%wood_harvestn_col            (:)   = nan
+
+    allocate(this%litfall_n_patch (begp:endp))                                ; this%litfall_n_patch (:)                = nan
 
     allocate(this%dwt_frootn_to_litr_met_n_col (begc:endc,1:nlevdecomp_full)) ; this%dwt_frootn_to_litr_met_n_col (:,:) = nan
     allocate(this%dwt_frootn_to_litr_cel_n_col (begc:endc,1:nlevdecomp_full)) ; this%dwt_frootn_to_litr_cel_n_col (:,:) = nan
@@ -1034,6 +1037,11 @@ contains
          '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
          ptr_patch=this%dwt_conv_nflux_patch, default='inactive')
     
+    this%litfall_n_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LITFALL_N', units='gN/m^2/s', &
+         avgflag='A', long_name='N Flux from vegetation to soil', &
+         ptr_patch=this%litfall_n_patch)
+    
     this%dwt_frootn_to_litr_met_n_col(begc:endc,:) = spval
     call hist_addfld_decomp (fname='DWT_FROOTN_TO_LITR_MET_N', units='gN/m^2/s',  type2d='levdcmp', &
          avgflag='A', long_name='fine root to litter due to landcover change', &
@@ -1267,42 +1275,42 @@ contains
        if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
           this%fert_counter_patch(p)  = 0._r8
        end if
-       if ( use_fun ) then
+       if ( use_fun ) then      !previously set to spval for special land units
           if (lun%ifspecial(l)) then
-             this%plant_ndemand_patch(p)        = spval
-             this%avail_retransn_patch(p)       = spval
-             this%plant_nalloc_patch(p)         = spval
-             this%Npassive_patch(p)             = spval
-             this%Nactive_patch(p)              = spval
-             this%Nnonmyc_patch(p)              = spval
-             this%Nam_patch(p)                  = spval
-             this%Necm_patch(p)                 = spval
+             this%plant_ndemand_patch(p)        = 0._r8
+             this%avail_retransn_patch(p)       = 0._r8
+             this%plant_nalloc_patch(p)         = 0._r8
+             this%Npassive_patch(p)             = 0._r8
+             this%Nactive_patch(p)              = 0._r8
+             this%Nnonmyc_patch(p)              = 0._r8
+             this%Nam_patch(p)                  = 0._r8
+             this%Necm_patch(p)                 = 0._r8
              if (use_nitrif_denitrif) then
-                this%Nactive_no3_patch(p)       = spval
-                this%Nactive_nh4_patch(p)       = spval
-                this%Nnonmyc_no3_patch(p)       = spval
-                this%Nnonmyc_nh4_patch(p)       = spval
-                this%Nam_no3_patch(p)           = spval
-                this%Nam_nh4_patch(p)           = spval
-                this%Necm_no3_patch(p)          = spval
-                this%Necm_nh4_patch(p)          = spval
+                this%Nactive_no3_patch(p)       = 0._r8
+                this%Nactive_nh4_patch(p)       = 0._r8
+                this%Nnonmyc_no3_patch(p)       = 0._r8
+                this%Nnonmyc_nh4_patch(p)       = 0._r8
+                this%Nam_no3_patch(p)           = 0._r8
+                this%Nam_nh4_patch(p)           = 0._r8
+                this%Necm_no3_patch(p)          = 0._r8
+                this%Necm_nh4_patch(p)          = 0._r8
              end if
-             this%Nfix_patch(p)                      = spval
-             this%Nretrans_patch(p)             = spval
-             this%Nretrans_org_patch(p)         = spval
-             this%Nretrans_season_patch(p)      = spval
-             this%Nretrans_stress_patch(p)      = spval
-             this%Nuptake_patch(p)              = spval
-             this%sminn_to_plant_fun_patch(p)   = spval
-             this%cost_nfix_patch               = spval
-             this%cost_nactive_patch            = spval
-             this%cost_nretrans_patch           = spval          
-             this%nuptake_npp_fraction_patch    = spval
+             this%Nfix_patch(p)                 = 0._r8
+             this%Nretrans_patch(p)             = 0._r8
+             this%Nretrans_org_patch(p)         = 0._r8
+             this%Nretrans_season_patch(p)      = 0._r8
+             this%Nretrans_stress_patch(p)      = 0._r8
+             this%Nuptake_patch(p)              = 0._r8
+             this%sminn_to_plant_fun_patch(p)   = 0._r8
+             this%cost_nfix_patch               = 0._r8
+             this%cost_nactive_patch            = 0._r8
+             this%cost_nretrans_patch           = 0._r8          
+             this%nuptake_npp_fraction_patch    = 0._r8
                              
              do j = 1, nlevdecomp
-                this%sminn_to_plant_fun_vr_patch(p,j)       = spval
-                this%sminn_to_plant_fun_no3_vr_patch(p,j)   = spval
-                this%sminn_to_plant_fun_nh4_vr_patch(p,j)   = spval
+                this%sminn_to_plant_fun_vr_patch(p,j)       = 0._r8
+                this%sminn_to_plant_fun_no3_vr_patch(p,j)   = 0._r8
+                this%sminn_to_plant_fun_nh4_vr_patch(p,j)   = 0._r8
              end do 
           end if
        end if
@@ -1409,107 +1417,129 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%plant_nalloc_patch) 
 
      if ( use_fun ) then
+!       special land units previously set to spval, not 0
+!       modifications here should correct this 
         call restartvar(ncid=ncid, flag=flag, varname='Nactive', xtype=ncd_double,       &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nactive_patch) 
+        call set_missing_vals_to_constant(this%Nactive_patch, 0._r8)
 !    
         call restartvar(ncid=ncid, flag=flag, varname='Nnonmyc', xtype=ncd_double,       &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nnonmyc_patch)
+        call set_missing_vals_to_constant(this%Nnonmyc_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nam', xtype=ncd_double,           &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nam_patch)
+        call set_missing_vals_to_constant(this%Nam_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Necm', xtype=ncd_double,          &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Necm_patch)
+        call set_missing_vals_to_constant(this%Necm_patch, 0._r8)
  
         if (use_nitrif_denitrif) then
            call restartvar(ncid=ncid, flag=flag, varname='Nactive_no3', xtype=ncd_double,   &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Nactive_no3_patch)
+           call set_missing_vals_to_constant(this%Nactive_no3_patch, 0._r8)
     
            call restartvar(ncid=ncid, flag=flag, varname='Nactive_nh4', xtype=ncd_double,   &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Nactive_nh4_patch)   
+           call set_missing_vals_to_constant(this%Nactive_nh4_patch, 0._r8)
  
            call restartvar(ncid=ncid, flag=flag, varname='Nnonmyc_no3', xtype=ncd_double,    &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Nnonmyc_no3_patch)
+           call set_missing_vals_to_constant(this%Nnonmyc_no3_patch, 0._r8)
  
            call restartvar(ncid=ncid, flag=flag, varname='Nnonmyc_nh4', xtype=ncd_double,    &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Nnonmyc_nh4_patch)
+           call set_missing_vals_to_constant(this%Nnonmyc_nh4_patch, 0._r8)
  
            call restartvar(ncid=ncid, flag=flag, varname='Nam_no3', xtype=ncd_double,         &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Nam_no3_patch)
+           call set_missing_vals_to_constant(this%Nam_no3_patch, 0._r8)
  
            call restartvar(ncid=ncid, flag=flag, varname='Nam_nh4', xtype=ncd_double,         &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Nam_nh4_patch)
+           call set_missing_vals_to_constant(this%Nam_nh4_patch,  0._r8)
  
            call restartvar(ncid=ncid, flag=flag, varname='Necm_no3', xtype=ncd_double,        &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Necm_no3_patch)
+           call set_missing_vals_to_constant(this%Necm_no3_patch, 0._r8)
  
            call restartvar(ncid=ncid, flag=flag, varname='Necm_nh4', xtype=ncd_double,        &
                 dim1name='pft', &
                 long_name='', units='', &
                 interpinic_flag='interp', readvar=readvar, data=this%Necm_nh4_patch)
+           call set_missing_vals_to_constant(this%Necm_nh4_patch, 0._r8)
         end if
 !
         call restartvar(ncid=ncid, flag=flag, varname='Npassive', xtype=ncd_double,      &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Npassive_patch)
+        call set_missing_vals_to_constant(this%Npassive_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nfix', xtype=ncd_double,          &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nfix_patch)
+        call set_missing_vals_to_constant(this%Nfix_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nretrans', xtype=ncd_double,       &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nretrans_patch)
+        call set_missing_vals_to_constant(this%Nretrans_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nretrans_org', xtype=ncd_double,   &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nretrans_org_patch)
+        call set_missing_vals_to_constant(this%Nretrans_org_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nretrans_season', xtype=ncd_double, &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nretrans_season_patch)
+        call set_missing_vals_to_constant(this%Nretrans_season_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nretrans_stress', xtype=ncd_double, &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nretrans_stress_patch)
+        call set_missing_vals_to_constant(this%Nretrans_stress_patch, 0._r8)
  
         call restartvar(ncid=ncid, flag=flag, varname='Nuptake', xtype=ncd_double,            &
              dim1name='pft', &
              long_name='', units='', &
              interpinic_flag='interp', readvar=readvar, data=this%Nuptake_patch)
+        call set_missing_vals_to_constant(this%Nuptake_patch, 0._r8)
 
         call restartvar(ncid=ncid, flag=flag, varname='sminn_to_plant_fun', xtype=ncd_double,            &
              dim1name='pft', &
              long_name='Total soil N uptake of FUN', units='gN/m2/s', &
              interpinic_flag='interp', readvar=readvar, data=this%sminn_to_plant_fun_patch)
+        call set_missing_vals_to_constant(this%sminn_to_plant_fun_patch, 0._r8)
      end if
 
   end subroutine Restart
@@ -1819,6 +1849,49 @@ contains
             this%m_deadcrootn_storage_to_fire_patch(p)  + &
             this%m_deadcrootn_xfer_to_fire_patch(p)     + &
             this%m_retransn_to_fire_patch(p)
+
+       ! total N fluxes from veg to litter
+       this%litfall_n_patch(p) = &
+            this%m_leafn_to_litter_patch(p)     + &
+            this%m_frootn_to_litter_patch(p)     + &
+            this%m_leafn_storage_to_litter_patch(p)     + &
+            this%m_frootn_storage_to_litter_patch(p)     + &
+            this%m_livestemn_storage_to_litter_patch(p)     + &
+            this%m_deadstemn_storage_to_litter_patch(p)     + &
+            this%m_livecrootn_storage_to_litter_patch(p)     + &
+            this%m_deadcrootn_storage_to_litter_patch(p)     + &
+            this%m_leafn_xfer_to_litter_patch(p)     + &
+            this%m_frootn_xfer_to_litter_patch(p)     + &
+            this%m_livestemn_xfer_to_litter_patch(p)     + &
+            this%m_deadstemn_xfer_to_litter_patch(p)     + &
+            this%m_livecrootn_xfer_to_litter_patch(p)     + &
+            this%m_deadcrootn_xfer_to_litter_patch(p)     + &
+            this%m_livestemn_to_litter_patch(p)     + &
+            this%m_deadstemn_to_litter_patch(p)     + &
+            this%m_livecrootn_to_litter_patch(p)     + &
+            this%m_deadcrootn_to_litter_patch(p)     + &
+            this%m_retransn_to_litter_patch(p)     + &
+            this%hrv_leafn_to_litter_patch(p)     + &
+            this%hrv_frootn_to_litter_patch(p)     + &
+            this%hrv_leafn_storage_to_litter_patch(p)     + &
+            this%hrv_frootn_storage_to_litter_patch(p)     + &
+            this%hrv_livestemn_storage_to_litter_patch(p)     + &
+            this%hrv_deadstemn_storage_to_litter_patch(p)     + &
+            this%hrv_livecrootn_storage_to_litter_patch(p)     + &
+            this%hrv_deadcrootn_storage_to_litter_patch(p)     + &
+            this%hrv_leafn_xfer_to_litter_patch(p)     + &
+            this%hrv_frootn_xfer_to_litter_patch(p)     + &
+            this%hrv_livestemn_xfer_to_litter_patch(p)     + &
+            this%hrv_deadstemn_xfer_to_litter_patch(p)     + &
+            this%hrv_livecrootn_xfer_to_litter_patch(p)     + &
+            this%hrv_deadcrootn_xfer_to_litter_patch(p)     + &
+            this%hrv_livestemn_to_litter_patch(p)     + &
+            this%hrv_livecrootn_to_litter_patch(p)     + &
+            this%hrv_deadcrootn_to_litter_patch(p)     + &
+            this%hrv_retransn_to_litter_patch(p)     + &
+            this%livestemn_to_litter_patch(p)     + &
+            this%leafn_to_litter_patch(p)     + &
+            this%frootn_to_litter_patch(p)
 
     end do
 

--- a/src/biogeochem/CNVegNitrogenFluxType.F90
+++ b/src/biogeochem/CNVegNitrogenFluxType.F90
@@ -1417,6 +1417,7 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%plant_nalloc_patch) 
 
      if ( use_fun ) then
+!       set_missing_vals_to_constant for BACKWARDS_COMPATIBILITY(wrw, 2018-06-28) re. issue #426
 !       special land units previously set to spval, not 0
 !       modifications here should correct this 
         call restartvar(ncid=ncid, flag=flag, varname='Nactive', xtype=ncd_double,       &
@@ -1541,6 +1542,7 @@ contains
              interpinic_flag='interp', readvar=readvar, data=this%sminn_to_plant_fun_patch)
         call set_missing_vals_to_constant(this%sminn_to_plant_fun_patch, 0._r8)
      end if
+! End BACKWARDS_COMPATIBILITY(wrw, 2018-06-28) re. issue #426
 
   end subroutine Restart
 

--- a/src/biogeochem/CNVegNitrogenFluxType.F90
+++ b/src/biogeochem/CNVegNitrogenFluxType.F90
@@ -178,8 +178,6 @@ module CNVegNitrogenFluxType
      real(r8), pointer :: ndeploy_patch                             (:)     ! patch total N deployed to growth and storage (gN/m2/s)
      real(r8), pointer :: wood_harvestn_patch                       (:)     ! patch total N losses to wood product pools (gN/m2/s)
      real(r8), pointer :: wood_harvestn_col                         (:)     ! col total N losses to wood product pools (gN/m2/s) (p2c)
-     real(r8), pointer :: litfall_n_patch                           (:)     ! total N passed from plant to litter (gN/m2/s)
-
      ! phenology: litterfall and crop fluxes
      real(r8), pointer :: phenology_n_to_litr_met_n_col             (:,:)   ! col N fluxes associated with phenology (litterfall and crop) to litter metabolic pool (gN/m3/s)
      real(r8), pointer :: phenology_n_to_litr_cel_n_col             (:,:)   ! col N fluxes associated with phenology (litterfall and crop) to litter cellulose pool (gN/m3/s)
@@ -441,8 +439,6 @@ contains
     allocate(this%dwt_wood_productn_gain_patch (begp:endp))                   ; this%dwt_wood_productn_gain_patch (:)   = nan
     allocate(this%dwt_crop_productn_gain_patch (begp:endp))                   ; this%dwt_crop_productn_gain_patch (:)   = nan
     allocate(this%wood_harvestn_col            (begc:endc))                   ; this%wood_harvestn_col            (:)   = nan
-
-    allocate(this%litfall_n_patch (begp:endp))                                ; this%litfall_n_patch (:)                = nan
 
     allocate(this%dwt_frootn_to_litr_met_n_col (begc:endc,1:nlevdecomp_full)) ; this%dwt_frootn_to_litr_met_n_col (:,:) = nan
     allocate(this%dwt_frootn_to_litr_cel_n_col (begc:endc,1:nlevdecomp_full)) ; this%dwt_frootn_to_litr_cel_n_col (:,:) = nan
@@ -1036,11 +1032,6 @@ contains
          '(0 at all times except first timestep of year) ' // &
          '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
          ptr_patch=this%dwt_conv_nflux_patch, default='inactive')
-    
-    this%litfall_n_patch(begp:endp) = spval
-    call hist_addfld1d (fname='LITFALL_N', units='gN/m^2/s', &
-         avgflag='A', long_name='N Flux from vegetation to soil', &
-         ptr_patch=this%litfall_n_patch)
     
     this%dwt_frootn_to_litr_met_n_col(begc:endc,:) = spval
     call hist_addfld_decomp (fname='DWT_FROOTN_TO_LITR_MET_N', units='gN/m^2/s',  type2d='levdcmp', &
@@ -1851,49 +1842,6 @@ contains
             this%m_deadcrootn_storage_to_fire_patch(p)  + &
             this%m_deadcrootn_xfer_to_fire_patch(p)     + &
             this%m_retransn_to_fire_patch(p)
-
-       ! total N fluxes from veg to litter
-       this%litfall_n_patch(p) = &
-            this%m_leafn_to_litter_patch(p)     + &
-            this%m_frootn_to_litter_patch(p)     + &
-            this%m_leafn_storage_to_litter_patch(p)     + &
-            this%m_frootn_storage_to_litter_patch(p)     + &
-            this%m_livestemn_storage_to_litter_patch(p)     + &
-            this%m_deadstemn_storage_to_litter_patch(p)     + &
-            this%m_livecrootn_storage_to_litter_patch(p)     + &
-            this%m_deadcrootn_storage_to_litter_patch(p)     + &
-            this%m_leafn_xfer_to_litter_patch(p)     + &
-            this%m_frootn_xfer_to_litter_patch(p)     + &
-            this%m_livestemn_xfer_to_litter_patch(p)     + &
-            this%m_deadstemn_xfer_to_litter_patch(p)     + &
-            this%m_livecrootn_xfer_to_litter_patch(p)     + &
-            this%m_deadcrootn_xfer_to_litter_patch(p)     + &
-            this%m_livestemn_to_litter_patch(p)     + &
-            this%m_deadstemn_to_litter_patch(p)     + &
-            this%m_livecrootn_to_litter_patch(p)     + &
-            this%m_deadcrootn_to_litter_patch(p)     + &
-            this%m_retransn_to_litter_patch(p)     + &
-            this%hrv_leafn_to_litter_patch(p)     + &
-            this%hrv_frootn_to_litter_patch(p)     + &
-            this%hrv_leafn_storage_to_litter_patch(p)     + &
-            this%hrv_frootn_storage_to_litter_patch(p)     + &
-            this%hrv_livestemn_storage_to_litter_patch(p)     + &
-            this%hrv_deadstemn_storage_to_litter_patch(p)     + &
-            this%hrv_livecrootn_storage_to_litter_patch(p)     + &
-            this%hrv_deadcrootn_storage_to_litter_patch(p)     + &
-            this%hrv_leafn_xfer_to_litter_patch(p)     + &
-            this%hrv_frootn_xfer_to_litter_patch(p)     + &
-            this%hrv_livestemn_xfer_to_litter_patch(p)     + &
-            this%hrv_deadstemn_xfer_to_litter_patch(p)     + &
-            this%hrv_livecrootn_xfer_to_litter_patch(p)     + &
-            this%hrv_deadcrootn_xfer_to_litter_patch(p)     + &
-            this%hrv_livestemn_to_litter_patch(p)     + &
-            this%hrv_livecrootn_to_litter_patch(p)     + &
-            this%hrv_deadcrootn_to_litter_patch(p)     + &
-            this%hrv_retransn_to_litter_patch(p)     + &
-            this%livestemn_to_litter_patch(p)     + &
-            this%leafn_to_litter_patch(p)     + &
-            this%frootn_to_litter_patch(p)
 
     end do
 

--- a/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
@@ -316,23 +316,22 @@ contains
          avgflag='A', long_name='atmospheric N deposition to soil mineral N', &
          ptr_col=this%ndep_to_sminn_col)
 
-    if ( use_fun ) then    ! redundant & confusing to write this out if FUN is on
-      this%nfix_to_sminn_col(begc:endc) = spval
-      call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
-           avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
-           ptr_col=this%nfix_to_sminn_col, default='inactive')
+    if (use_fun) then
+       default = 'inactive'
     else
-      this%nfix_to_sminn_col(begc:endc) = spval
-      call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
-           avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
-           ptr_col=this%nfix_to_sminn_col)
+       default = 'active'
     end if
+    this%nfix_to_sminn_col(begc:endc) = spval
+    call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
+         avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
+         ptr_col=this%nfix_to_sminn_col)
 
     this%ffix_to_sminn_col(begc:endc) = spval
     call hist_addfld1d (fname='FFIX_TO_SMINN', units='gN/m^2/s', &
          avgflag='A', long_name='free living  N fixation to soil mineral N', &
          ptr_col=this%ffix_to_sminn_col)
 
+    default = 'active'
     do l = 1, ndecomp_cascade_transitions
        ! vertically integrated fluxes
        !-- mineralization/immobilization fluxes (none from CWD)

--- a/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
@@ -316,10 +316,17 @@ contains
          avgflag='A', long_name='atmospheric N deposition to soil mineral N', &
          ptr_col=this%ndep_to_sminn_col)
 
-    this%nfix_to_sminn_col(begc:endc) = spval
-    call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
-         avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
-         ptr_col=this%nfix_to_sminn_col)
+    if ( use_fun ) then    ! redundant & confusing to write this out if FUN is on
+      this%nfix_to_sminn_col(begc:endc) = spval
+      call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
+           avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
+           ptr_col=this%nfix_to_sminn_col, default='inactive')
+    else
+      this%nfix_to_sminn_col(begc:endc) = spval
+      call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
+           avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
+           ptr_col=this%nfix_to_sminn_col)
+    end if
 
     this%ffix_to_sminn_col(begc:endc) = spval
     call hist_addfld1d (fname='FFIX_TO_SMINN', units='gN/m^2/s', &

--- a/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
@@ -294,7 +294,7 @@ contains
     integer        :: begc, endc
     character(24)  :: fieldname
     character(100) :: longname
-    character(8)   :: vr_suffix
+    character(8)   :: vr_suffix,default
     real(r8), pointer :: data2dptr(:,:), data1dptr(:) ! temp. pointers for slicing larger arrays
     !------------------------------------------------------------------------
 
@@ -324,14 +324,13 @@ contains
     this%nfix_to_sminn_col(begc:endc) = spval
     call hist_addfld1d (fname='NFIX_TO_SMINN', units='gN/m^2/s', &
          avgflag='A', long_name='symbiotic/asymbiotic N fixation to soil mineral N', &
-         ptr_col=this%nfix_to_sminn_col)
+         ptr_col=this%nfix_to_sminn_col, default=default)
 
     this%ffix_to_sminn_col(begc:endc) = spval
     call hist_addfld1d (fname='FFIX_TO_SMINN', units='gN/m^2/s', &
          avgflag='A', long_name='free living  N fixation to soil mineral N', &
-         ptr_col=this%ffix_to_sminn_col)
+         ptr_col=this%ffix_to_sminn_col, default=default)
 
-    default = 'active'
     do l = 1, ndecomp_cascade_transitions
        ! vertically integrated fluxes
        !-- mineralization/immobilization fluxes (none from CWD)

--- a/test/tools/README
+++ b/test/tools/README
@@ -13,9 +13,7 @@ To use...
 
 on cheyenne
 
-qcmd -- ./test_driver.sh -i >& run.out &
-execgy 
-./test_driver.sh -i >& run.out &
+qcmd -l walltime=06:00:00 -- ./test_driver.sh -i >& run.out &
 
 Intended for use on NCAR machines cheyenne, geyser (DAV) and hobart.
 

--- a/test/tools/TCBCFGtools.sh
+++ b/test/tools/TCBCFGtools.sh
@@ -32,7 +32,11 @@ if [ -f ${CLM_TESTDIR}/${test_name}/TestStatus ]; then
     fi
 fi
 
-cfgdir=`ls -1d ${CLM_ROOT}/tools/${1}*`
+cfgdir=`ls -1d ${CLM_ROOT}/tools/${1}`
+if [ $? -ne 0 ];then
+   cfgdir=`ls -1d ${CIME_ROOT}/tools/mapping/${1}*`
+   echo "use: $cfgdir"
+fi
 blddir=${CLM_TESTDIR}/${test_name}/src
 if [ -d ${blddir} ]; then
     rm -r ${blddir}

--- a/test/tools/input_tests_master
+++ b/test/tools/input_tests_master
@@ -3,10 +3,10 @@
 smc#4 TSMscript_tools.sh mkprocdata_map mkprocdata_map_wrap mkprocdata_ne30_to_f19_I2000^tools__ds
 blc#4 TBLscript_tools.sh mkprocdata_map mkprocdata_map_wrap mkprocdata_ne30_to_f19_I2000^tools__ds
 
-sme14 TSMCFGtools.sh ../../cime/tools/mapping/gen_domain   CFGtools__ds T31.runoptions
-ble14 TBLCFGtools.sh ../../cime/tools/mapping/gen_domain   CFGtools__ds T31.runoptions
-sme@4 TSMCFGtools.sh ../../cime/tools/mapping/gen_domain   CFGtools__ds ne30.runoptions
-ble@4 TBLCFGtools.sh ../../cime/tools/mapping/gen_domain   CFGtools__ds ne30.runoptions
+sme14 TSMCFGtools.sh gen_domain   CFGtools__ds T31.runoptions
+ble14 TBLCFGtools.sh gen_domain   CFGtools__ds T31.runoptions
+sme@4 TSMCFGtools.sh gen_domain   CFGtools__ds ne30.runoptions
+ble@4 TBLCFGtools.sh gen_domain   CFGtools__ds ne30.runoptions
 
 smg54 TSMtools.sh mksurfdata_map   tools__s  namelist
 blg54 TBLtools.sh mksurfdata_map   tools__s  namelist

--- a/test/tools/test_driver.sh
+++ b/test/tools/test_driver.sh
@@ -199,8 +199,8 @@ export P4_GLOBMEMSIZE=500000000
 
 export CESM_MACH="hobart"
 
-limit stacksize unlimited
-limit coredumpsize unlimited
+ulimit -s unlimited
+ulimit -c unlimited
 
 export CESM_COMP="intel"
 export TOOLS_MAKE_STRING="USER_FC=ifort USER_CC=icc "
@@ -211,7 +211,8 @@ export INITMODULES="/usr/share/Modules/init/sh"
 . \$INITMODULES
 module purge
 module load compiler/intel/18.0.3
-module load tool/nco
+module load tool/nco/4.7.5
+tool/netcdf/4.6.1/intel
 
 export NETCDF_DIR=\$NETCDF_PATH
 export INC_NETCDF=\${NETCDF_PATH}/include

--- a/test/tools/test_driver.sh
+++ b/test/tools/test_driver.sh
@@ -210,7 +210,8 @@ export INITMODULES="/usr/share/Modules/init/sh"
 
 . \$INITMODULES
 module purge
-module load compiler/intel/15.0.2.164
+module load compiler/intel/18.0.3
+module load tool/nco
 
 export NETCDF_DIR=\$NETCDF_PATH
 export INC_NETCDF=\${NETCDF_PATH}/include

--- a/tools/mkprocdata_map/src/Makefile.common
+++ b/tools/mkprocdata_map/src/Makefile.common
@@ -190,8 +190,8 @@ ifeq ($(FC),ifort)
      FFLAGS    += -O2
   endif
   ifeq ($(SMP),TRUE)
-    FFLAGS    += -openmp
-    LDFLAGS   += -openmp
+    FFLAGS    += -qopenmp
+    LDFLAGS   += -qopenmp
   endif
 endif
 
@@ -215,7 +215,7 @@ endif
 ifeq ($(CC),icc)
    CFLAGS     += -m64 -g
    ifeq ($(SMP),TRUE)
-     CFLAGS    += -openmp
+     CFLAGS    += -qopenmp
    endif
 endif
 ifeq ($(CC),pgcc)
@@ -307,9 +307,9 @@ ifeq ($(UNAMES),Linux)
        FFLAGS    += -O2
     endif
     ifeq ($(SMP),TRUE)
-      FFLAGS    += -openmp
-      CFLAGS    += -openmp
-      LDFLAGS   += -openmp
+      FFLAGS    += -qopenmp
+      CFLAGS    += -qopenmp
+      LDFLAGS   += -qopenmp
     endif
   endif
   FFLAGS += -c -I$(INC_NETCDF) $(CPPDEF) $(cpp_path)

--- a/tools/mksurfdata_map/Makefile.data
+++ b/tools/mksurfdata_map/Makefile.data
@@ -54,17 +54,22 @@ endif
 
 MKSURFDATA = $(BATCHJOBS) $(PWD)/mksurfdata.pl
 
-STANDARD_RES = 360x720cru,48x96,0.9x1.25,1.9x2.5,10x15,ne30np4
+# f19 and f09 are standard resolutions, f10 is used for testing, f45 is used for FATES
+# ne30np4 is standard resolution for SE dycore in CAM, T31 is for paleo, 360x720cru is for same resolution as forcing data
+STANDARD_RES = 360x720cru,48x96,0.9x1.25,1.9x2.5,10x15,4x5,ne30np4
 
+# ne120np4 is for high resolution SE dycore, ne16 is for testing SE dycore
+# T42 is for SCAM
+# f05 is needed for running full chemistry model
 STANDARD = \
 	global-present \
-	global-present-f45 \
+	global-present-f05 \
 	global-present-ne16np4 \
 	global-present-ne120np4 \
 	global-present-T42 \
 	global-historical \
 	global-historical-ne120np4 \
-	global-transient-f45 \
+	global-transient-f05 \
 	global-transient \
 	global-transient-ne120np4
 
@@ -78,7 +83,7 @@ TROPICS = \
 
 CROP = \
 	crop-global-present \
-	crop-global-present-f45 \
+	crop-global-present-f05 \
 	crop-global-present-ne16np4 \
 	crop-global-present-ne120np4 \
 	crop-numa-present \
@@ -86,9 +91,9 @@ CROP = \
 	crop-smallville \
 	crop-smallville-historical \
 	crop-global-historical \
-	crop-global-historical-f45 \
+	crop-global-historical-f05 \
 	crop-global-historical-ne120np4 \
-	crop-global-transient-f45 \
+	crop-global-transient-f05 \
 	crop-global-transient \
 	crop-global-transient-ne120np4
 
@@ -107,9 +112,10 @@ standard : $(STANDARD)
 global-present : FORCE
 	$(MKSURFDATA) -no-crop -glc_nec 10 -y 2000 -res $(STANDARD_RES) $(BACKGROUND)
 
-global-present-f45 : FORCE
-	$(MKSURFDATA) -no-crop -glc_nec 10 -y 1850,2000 -res 4x5 $(BACKGROUND)
+global-present-f05 : FORCE
+	$(MKSURFDATA) -no-crop -glc_nec 10 -y 1850,2000 -res 0.47x0.63 $(BACKGROUND)
 
+# T42 is needed for SCAM
 global-present-T42 : FORCE
 	$(MKSURFDATA) -no-crop -glc_nec 10 -y 2000 -res 64x128 $(BACKGROUND)
 
@@ -134,8 +140,8 @@ global-transient : FORCE
 global-transient-ne120np4 : FORCE
 	$(MKSURFDATA) -no-crop -no_surfdata -glc_nec 10 -y 1850-2000 -res ne120np4 $(BACKGROUND)
 
-global-transient-f45 : FORCE
-	$(MKSURFDATA) -no-crop -no_surfdata -glc_nec 10 -y 1850-2000 -res 4x5 $(BACKGROUND)
+global-transient-f05 : FORCE
+	$(MKSURFDATA) -no-crop -no_surfdata -glc_nec 10 -y 1850-2000 -res 0.47x0.63 $(BACKGROUND)
 
 #
 # tropics
@@ -171,8 +177,8 @@ crop-global-present : FORCE
 crop-global-present-0.125 : FORCE
 	$(MKSURFDATA) -hirespft -glc_nec 10 -y 2000 -r 0.125x0.125 $(BACKGROUND)
 
-crop-global-present-f45 : FORCE
-	$(MKSURFDATA) -glc_nec 10 -y 1850,2000 -res 4x5 $(BACKGROUND)
+crop-global-present-f05 : FORCE
+	$(MKSURFDATA) -glc_nec 10 -y 1850,2000 -res 0.47x0.63 $(BACKGROUND)
 
 crop-numa-present : FORCE
 	$(MKSURFDATA) -glc_nec 10 -y 2000 -r 1x1_numaIA $(BACKGROUND)
@@ -202,8 +208,8 @@ crop-smallville-historical : FORCE
 crop-global-historical : FORCE
 	$(MKSURFDATA) -glc_nec 10 -y 1850 -res $(STANDARD_RES) $(BACKGROUND)
 
-crop-global-historical-f45 : FORCE
-	$(MKSURFDATA) -glc_nec 10 -y 1850 -r 4x5 $(BACKGROUND)
+crop-global-historical-f05 : FORCE
+	$(MKSURFDATA) -glc_nec 10 -y 1850 -r 0.47x0.63 $(BACKGROUND)
 
 crop-global-historical-ne120np4 : FORCE
 	$(MKSURFDATA) -glc_nec 10 -y 1850 -res ne120np4 $(BACKGROUND)
@@ -214,8 +220,8 @@ crop-global-transient: FORCE
 crop-global-transient-ne120np4 : FORCE
 	$(MKSURFDATA) -no_surfdata -glc_nec 10 -y 1850-2000 -res ne120np4 $(BACKGROUND)
 
-crop-global-transient-f45 : FORCE
-	$(MKSURFDATA) -no_surfdata -glc_nec 10 -y 1850-2000 -res 4x5 $(BACKGROUND)
+crop-global-transient-f05 : FORCE
+	$(MKSURFDATA) -no_surfdata -glc_nec 10 -y 1850-2000 -res 0.47x0.63 $(BACKGROUND)
 #
 # urban
 #

--- a/tools/mksurfdata_map/src/Makefile.common
+++ b/tools/mksurfdata_map/src/Makefile.common
@@ -190,8 +190,8 @@ ifeq ($(FC),ifort)
      FFLAGS    += -O2
   endif
   ifeq ($(SMP),TRUE)
-    FFLAGS    += -openmp
-    LDFLAGS   += -openmp
+    FFLAGS    += -qopenmp
+    LDFLAGS   += -qopenmp
   endif
 endif
 
@@ -215,7 +215,7 @@ endif
 ifeq ($(CC),icc)
    CFLAGS     += -m64 -g
    ifeq ($(SMP),TRUE)
-     CFLAGS    += -openmp
+     CFLAGS    += -qopenmp
    endif
 endif
 ifeq ($(CC),pgcc)
@@ -307,9 +307,9 @@ ifeq ($(UNAMES),Linux)
        FFLAGS    += -O2
     endif
     ifeq ($(SMP),TRUE)
-      FFLAGS    += -openmp
-      CFLAGS    += -openmp
-      LDFLAGS   += -openmp
+      FFLAGS    += -qopenmp
+      CFLAGS    += -qopenmp
+      LDFLAGS   += -qopenmp
     endif
   endif
   FFLAGS += -c -I$(INC_NETCDF) $(CPPDEF) $(cpp_path)

--- a/tools/mksurfdata_map/src/mkpctPftTypeMod.F90
+++ b/tools/mksurfdata_map/src/mkpctPftTypeMod.F90
@@ -46,6 +46,7 @@ module mkpctPftTypeMod
   end type pct_pft_type
 
   ! !PUBLIC MEMBER FUNCTIONS
+  public :: update_max_array ! given an array of pct_pft_type variables update the max_p2l values from pct_p2l
   public :: get_pct_p2l_array ! given an array of pct_pft_type variables, return a 2-d array of pct_p2l
   public :: get_pct_l2g_array ! given an array of pct_pft_type variables, return an array of pct_l2g
 
@@ -409,8 +410,6 @@ contains
     deallocate(pct_p2g, is_small, is_zero)
   end subroutine remove_small_cover
 
-
-
   ! ========================================================================
   ! Private member functions
   ! ========================================================================
@@ -510,6 +509,54 @@ contains
   ! ========================================================================
   ! Module-level routines (not member functions)
   ! ========================================================================
+
+  !-----------------------------------------------------------------------
+  subroutine update_max_array(pct_pft_max_arr,pct_pft_arr)
+    !
+    ! !DESCRIPTION:
+    ! Given an array of pct_pft_type variables, update all the max_p2l variables.
+    !
+    ! Assumes that all elements of pct_pft_max_arr and pct_pft_arr have the same 
+    ! size and lower bound for their pct_p2l array.
+    !
+    ! !ARGUMENTS:
+    ! workaround for gfortran bug (58043): declare this 'type' rather than 'class':
+    type(pct_pft_type), intent(inout) :: pct_pft_max_arr(:)
+    type(pct_pft_type), intent(in) :: pct_pft_arr(:)
+    !
+    ! !LOCAL VARIABLES:
+    integer :: pft_lbound
+    integer :: pft_ubound
+    integer :: arr_index
+    integer :: pft_index
+    
+    character(len=*), parameter :: subname = 'update_max_array'
+    !-----------------------------------------------------------------------
+ 
+       
+    pft_lbound = lbound(pct_pft_arr(1)%pct_p2l, 1)
+    pft_ubound = ubound(pct_pft_arr(1)%pct_p2l, 1)
+
+    do arr_index = 1, size(pct_pft_arr)
+       if (lbound(pct_pft_arr(arr_index)%pct_p2l, 1) /= pft_lbound .or. &
+            ubound(pct_pft_arr(arr_index)%pct_p2l, 1) /= pft_ubound) then
+          write(6,*) subname//' ERROR: all elements of pct_pft_arr must have'
+          write(6,*) 'the same size and lower bound for their pct_p2l array'
+          call abort()
+       end if
+          
+       if (pct_pft_arr(arr_index)%pct_l2g > pct_pft_max_arr(arr_index)%pct_l2g) then
+          pct_pft_max_arr(arr_index)%pct_l2g = pct_pft_arr(arr_index)%pct_l2g
+       end if
+
+       do pft_index = pft_lbound, pft_ubound
+          if (pct_pft_arr(arr_index)%pct_p2l(pft_index) > pct_pft_max_arr(arr_index)%pct_p2l(pft_index)) then
+             pct_pft_max_arr(arr_index)%pct_p2l(pft_index) = pct_pft_arr(arr_index)%pct_p2l(pft_index)
+	  end if
+       end do
+    end do
+
+  end subroutine update_max_array
 
   !-----------------------------------------------------------------------
   function get_pct_p2l_array(pct_pft_arr) result(pct_p2l)

--- a/tools/mksurfdata_map/src/mkpftMod.F90
+++ b/tools/mksurfdata_map/src/mkpftMod.F90
@@ -1008,6 +1008,8 @@ subroutine mkpftAtt( ncid, dynlanduse, xtype )
      call ncd_def_spatial_var(ncid=ncid, varname='PCT_CROP', xtype=xtype, &
           lev1name='time', &
           long_name='total percent crop landunit', units='unitless')
+     call ncd_def_spatial_var(ncid=ncid, varname='PCT_CROP_MAX', xtype=xtype, &
+          long_name='maximum total percent crop landunit during time period', units='unitless')
   end if
 
   ! PCT_NAT_PFT
@@ -1019,6 +1021,9 @@ subroutine mkpftAtt( ncid, dynlanduse, xtype )
      call ncd_def_spatial_var(ncid=ncid, varname='PCT_NAT_PFT', xtype=xtype, &
           lev1name='natpft', lev2name='time', &
           long_name='percent plant functional type on the natural veg landunit (% of landunit)', units='unitless')
+     call ncd_def_spatial_var(ncid=ncid, varname='PCT_NAT_PFT_MAX', xtype=xtype, &
+          lev1name='natpft', &
+          long_name='maximum percent plant functional type during time period (% of landunit)', units='unitless')
   end if
 
   ! PCT_CFT
@@ -1031,6 +1036,9 @@ subroutine mkpftAtt( ncid, dynlanduse, xtype )
         call ncd_def_spatial_var(ncid=ncid, varname='PCT_CFT', xtype=xtype, &
              lev1name='cft', lev2name='time', &
              long_name='percent crop functional type on the crop landunit (% of landunit)', units='unitless')
+        call ncd_def_spatial_var(ncid=ncid, varname='PCT_CFT_MAX', xtype=xtype, &
+             lev1name='cft', &
+             long_name='maximum percent crop functional type during time period (% of landunit)', units='unitless')
      end if
   end if
 

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -15,7 +15,7 @@ program mksurfdat
     use shr_kind_mod       , only : r8 => shr_kind_r8, r4 => shr_kind_r4
     use fileutils          , only : opnfil, getavu
     use mklaiMod           , only : mklai
-    use mkpctPftTypeMod    , only : pct_pft_type, get_pct_p2l_array, get_pct_l2g_array
+    use mkpctPftTypeMod    , only : pct_pft_type, get_pct_p2l_array, get_pct_l2g_array, update_max_array
     use mkpftConstantsMod  , only : natpft_lb, natpft_ub, cft_lb, cft_ub, num_cft
     use mkpftMod           , only : pft_idx, pft_frc, mkpft, mkpftInit, mkpft_parse_oride
     use mksoilMod          , only : soil_sand, soil_clay, mksoiltex, mksoilInit, &
@@ -90,9 +90,11 @@ program mksurfdat
     real(r8), allocatable  :: pctlnd_pft(:)      ! PFT data: % of gridcell for PFTs
     real(r8), allocatable  :: pctlnd_pft_dyn(:)  ! PFT data: % of gridcell for dyn landuse PFTs
     integer , allocatable  :: pftdata_mask(:)    ! mask indicating real or fake land type
-    type(pct_pft_type), allocatable :: pctnatpft(:) ! % of grid cell that is nat veg, and breakdown into PFTs
-    type(pct_pft_type), allocatable :: pctcft(:)    ! % of grid cell that is crop, and breakdown into CFTs
-    type(pct_pft_type), allocatable :: pctcft_saved(:) ! version of pctcft saved from the initial call to mkpft
+    type(pct_pft_type), allocatable :: pctnatpft(:)     ! % of grid cell that is nat veg, and breakdown into PFTs
+    type(pct_pft_type), allocatable :: pctnatpft_max(:) ! % of grid cell maximum PFTs of the time series
+    type(pct_pft_type), allocatable :: pctcft(:)        ! % of grid cell that is crop, and breakdown into CFTs
+    type(pct_pft_type), allocatable :: pctcft_max(:)    ! % of grid cell maximum CFTs of the time series
+    type(pct_pft_type), allocatable :: pctcft_saved(:)  ! version of pctcft saved from the initial call to mkpft
     real(r8), pointer      :: harvest1D(:)       ! harvest 1D data: normalized harvesting
     real(r8), pointer      :: harvest2D(:,:)     ! harvest 1D data: normalized harvesting
     real(r8), allocatable  :: pctgla(:)          ! percent of grid cell that is glacier  
@@ -416,7 +418,9 @@ program mksurfdat
                pctlnd_pft(ns_o)                   , & 
                pftdata_mask(ns_o)                 , & 
                pctnatpft(ns_o)                    , &
+               pctnatpft_max(ns_o)                , &
                pctcft(ns_o)                       , &
+               pctcft_max(ns_o)                   , &
                pctcft_saved(ns_o)                 , &
                pctgla(ns_o)                       , & 
                pctlak(ns_o)                       , & 
@@ -1097,6 +1101,9 @@ program mksurfdat
 
        nfdyn = getavu(); call opnfil (mksrf_fdynuse, nfdyn, 'f')
 
+       pctnatpft_max = pctnatpft
+       pctcft_max = pctcft
+
        ntim = 0
        do 
           ! Read input pft data
@@ -1158,6 +1165,9 @@ program mksurfdat
           call change_landuse(ldomain, dynpft=.true.)
 
           call normalizencheck_landuse(ldomain)
+	  
+          call update_max_array(pctnatpft_max,pctnatpft)
+          call update_max_array(pctcft_max,pctcft)
 
           ! Output time-varying data for current year
 
@@ -1199,6 +1209,17 @@ program mksurfdat
 	  call check_ret(nf_sync(ncid), subname)
 
        end do   ! end of read loop
+
+       call check_ret(nf_inq_varid(ncid, 'PCT_NAT_PFT_MAX', varid), subname)
+       call check_ret(nf_put_var_double(ncid, varid, get_pct_p2l_array(pctnatpft_max)), subname)
+
+       call check_ret(nf_inq_varid(ncid, 'PCT_CROP_MAX', varid), subname)
+       call check_ret(nf_put_var_double(ncid, varid, get_pct_l2g_array(pctcft_max)), subname)
+
+       if (num_cft > 0) then
+          call check_ret(nf_inq_varid(ncid, 'PCT_CFT_MAX', varid), subname)
+          call check_ret(nf_put_var_double(ncid, varid, get_pct_p2l_array(pctcft_max)), subname)
+       end if
 
        call check_ret(nf_close(ncid), subname)
 


### PR DESCRIPTION
Addresses issue #426 where special land units were assigned spval in InitCold for FUN variables.  As @billsacks noted in #431 "BGC variables are all set to 0 for special landunits via the SetValues subroutines in each *Type.F90 module". 

With missing values (instead of zeros), grid cell averaging did not work correctly, initially noticed over lakes where NFIX (patch level variable) > NFIX_TO_SMINN (the column level total).  PFT level output (h1) for NFIX matched grid cell totals (h0) for NFIX_TO_SMINN.

### Description of changes
Most changes in CNVegNitrogenFluxType.F90 including:
* Set these FUN variables to 0 for special land units. (This may be rudundant?)
* Reset spval to 0 in the Restart subroutine, to overwrite existing restart files.

Similar, but less extensive modifications need for CNVegCarbonFluxType.F90
Added conditional to SoilBiogeochemNitrogenFluxType.F90 where NFIX_TO_SMINN
is only on by default if FUN is off, as the variable is redundant with NFIX.

I also noticed there are other spvals defined in InitCold of CNVegCarbonFluxType.F90.  Here, I've only changed FUN related BGC variables, but are others handled consistently?

### Specific notes

Contributors other than yourself, if any:
@olyson, @ekluzek, @billsacks  

CTSM Issues Fixed (include github issue #):
#426 , addresses topics discussed in #431 

Are answers expected to change (and if so in what way)?
No science changes, but values from model diagnostics are different, as special land units will now receive zero values, not spval, and be weighted in grid cell averages accordingly- and consistently with other BGC variables.

Any User Interface Changes (namelist or namelist defaults changes)?
None

Testing performed, if any:
In an older tag, clm4_5_18_r270, I confirmed that special land units received 0 values with changes to InitCold. Separately, modifications to the Restart subroutine overwrote spval for NFIX, making results consistent with NFIX_TO_SMINN.  Tests with other FUN variables were not done, but are handled consistently.

Changes committed here did build correctly, but no simulations were done.