### PR TITLE
Move changes from release-clm5.0.05 onto master

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -971,7 +971,7 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_ndep>
 
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_ndep>
-<stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2000</stream_year_last_ndep>
+<stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2015</stream_year_last_ndep>
 
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2100</stream_year_last_ndep>
@@ -1064,13 +1064,13 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_popdens>
 
 <stream_year_first_popdens use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_popdens>
-<stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2010</stream_year_last_popdens>
+<stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="1850-2000" >2016</stream_year_last_popdens>
 
 <stream_year_first_popdens use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_popdens>
-<stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2010</stream_year_last_popdens>
+<stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="1850-2100" >2016</stream_year_last_popdens>
 
 <stream_year_first_popdens use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >1850</stream_year_first_popdens>
-<stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2010</stream_year_last_popdens>
+<stream_year_last_popdens  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2016</stream_year_last_popdens>
 
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." >lnd/clm2/firedata/clmforc.Li_2017_HYDEv3.2_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2016_c180202.nc</stream_fldfilename_popdens>
 
@@ -1104,13 +1104,13 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1850-2000" >2010</stream_year_last_urbantv>
+<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1850-2100" >2010</stream_year_last_urbantv>
+<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="2000-2100" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="2000-2100" >2010</stream_year_last_urbantv>
+<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="2000-2100" >2106</stream_year_last_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_0" hgrid="0.9x1.25" >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
 

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -33,7 +33,7 @@
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
->lnd/clm2/ndepdata/fndep_clm_hist_simyr1850_0.9x1.25_CMIP6_c180617.nc</stream_fldfilename_ndep>
+>lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
  
 <ndep_taxmode            phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -2,10 +2,10 @@
 
 <namelist_defaults>
 
-<use_case_desc            >Simulate transient land-use, and aerosol deposition changes from 1850 to 2005</use_case_desc>
-<use_case_desc bgc="cn"   >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2005</use_case_desc>
-<use_case_desc phys="clm4_0" bgc="cndv" >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2005</use_case_desc>
-<use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2005</use_case_desc>
+<use_case_desc            >Simulate transient land-use, and aerosol deposition changes from 1850 to 2015</use_case_desc>
+<use_case_desc bgc="cn"   >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2015</use_case_desc>
+<use_case_desc phys="clm4_0" bgc="cndv" >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2015</use_case_desc>
+<use_case_desc use_cn=".true." >Simulate transient land-use, aerosol deposition, and Nitrogen deposition changes from 1850 to 2015</use_case_desc>
 
 <sim_year>1850</sim_year>
 
@@ -36,15 +36,15 @@
 <model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2010</stream_year_last_popdens>
+<stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2016</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" cnfireson=".true."   >1850</model_year_align_popdens>
 
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true."   >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2010</stream_year_last_popdens>
+<stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2016</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0"  >2005</stream_year_last_urbantv>
+<stream_year_last_urbantv  phys="clm5_0"  >2106</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>
 
 </namelist_defaults>

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -9,6 +9,7 @@
     <entry issue="#442"     >FAIL SMS_D.f10_f10_musgs.I2000Clm50BgcCrop.hobart_pgi.clm-crop RUN</entry>
   </category>
   <category name="fates">
+    <entry issue="NGEET/fates#315">FAIL ERS_Ld60.f45_f45_mg37.I2000Clm45Fates.hobart_nag.clm-Fates COMPARE_base_rest</entry>
     <entry issue="NGEET/fates#315">FAIL ERP_Ld9.f45_f45_mg37.I2000Clm45Fates.hobart_nag.clm-FatesAllVars COMPARE_base_rest</entry>
     <entry issue="NGEET/fates#315">FAIL ERS_Ld60.f45_f45_mg37.I2000Clm45Fates.cheyenne_intel.clm-FatesLogging COMPARE_base_rest</entry>
     <entry issue="NGEET/fates#315">FAIL ERS_Ld60.f45_f45_mg37.I2000Clm45Fates.cheyenne_intel.clm-Fates COMPARE_base_rest</entry>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -950,7 +950,7 @@
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
     <options>
-      <option name="wallclock">01:20:00</option>
+      <option name="wallclock">02:00:00</option>
       <option name="comment"  >tests mid-year restart, with the restart file being written in the middle of the second year</option>
     </options>
   </test>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,109 @@
 ===============================================================
+Tag name:  ctsm1.0.dev008
+Originator(s):  erik (Erik Kluzek)
+Date: Tue Aug 14 10:25:12 MDT 2018
+One-line Summary: Update 1850 ndep file and last year for streams for Historical transient cases
+
+Purpose of changes
+------------------
+
+Bring in changes from release-clm5.0.05. Update to latest Nitrogen Deposition file from simulations with WACCM for 1850.
+Also fix an issue with the last year for historical transient cases.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): 461
+   #461 -- increase last year in streams for transient
+
+Known bugs found since the previous tag (include github issue ID): [If none, remove this line]
+  #478 -- Bare soil g1 should be missing value or zero
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] clm4_5
+
+[ ] clm4_0
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values): Last year extended for transient datasets
+
+Changes to the datasets (e.g., parameter, surface or initial files): New ndep dataset for 1850
+
+Substantial timing or memory changes:
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in .CTSMTrunkChecklist as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): None
+
+Changes to tests or testing: Lengthen some tests
+
+Code reviewed by: self
+
+
+CTSM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (11 show differences for 1850_control and 20thC_transient)
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    hobart_nag -------- OK
+    hobart_pgi -------- OK
+    hobart_intel ------ OK
+
+CTSM tag used for the baseline comparisons: ctsm1.0.dev007
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes!
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: 1850_control or 20thC_transient for Clm50
+    - what platforms/compilers: all
+    - nature of change: similar climate
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+
+    #477 -- Move changes from release-clm5.0.05 onto master
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev007
 Originator(s):  sacks (Bill Sacks)
 Date: Sun Aug  5 21:03:28 MDT 2018

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev008     erik 08/14/2018 Update 1850 ndep file and last year for streams for Historical transient cases
   ctsm1.0.dev007    sacks 08/05/2018 Avoid glacier dynamic landunit adjustments in first time step
   ctsm1.0.dev006    sacks 08/04/2018 Minor bug fixes, cleanup, documentation and enhancements
   ctsm1.0.dev005    sacks 08/03/2018 Rework water data types to accommodate isotopes and other tracers


### PR DESCRIPTION
### Description of changes

Update to use of new 1850 Nitrogen-deposition file as well as correcting year_last for some of the CLM streams. These are the changes that went into release-clm5.0.05 being moved to master.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): #461

Are answers expected to change (and if so in what way)? Yes!

  For 1850 cases with BGC on
  And for post 2005 for IHist cases.

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: testing was done on the release branch
Will be repeated here before this comes to master.
