### PR TITLE
Updating default FATES parameter file

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_2trop.c180725.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_default_2trop.c180905.nc </fates_paramfile>
 
 
 <!-- ========================================================================================  -->


### PR DESCRIPTION
### Description of changes

This updates the default path to the FATES default parameter file. This file has been updated to reflect changes in https://github.com/NGEET/fates/pull/414.


### Specific notes

Contributors other than yourself, if any:

See https://github.com/NGEET/fates/pull/414

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)?  This change, synced with https://github.com/NGEET/fates/pull/414, should produce nigh-indistinguishable, yet not B4B results with fates_next_api and FATES/master.

Any User Interface Changes (namelist or namelist defaults changes)? No namelist changes, updates to default fates_parameter file only.

Testing performed, if any:

See https://github.com/NGEET/fates/pull/414 for in depth comparison.  The default file pull was tested on Cheyenne using "fates" test.  ALL PASS

(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
