### PR TITLE
Updated path to fates default parameter file

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.14.0_api.4.0.0
+tag = sci.1.16.1_api.4.1.0
 required = True
 
 [PTCLM]

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_default_2trop.c180905.nc </fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_default_2trop.c180921.nc</fates_paramfile>
 
 
 <!-- ========================================================================================  -->


### PR DESCRIPTION
### Description of changes

This updates the path to the default parameter file for FATES.  This file matches new specifications designed in https://github.com/NGEET/fates/pull/418.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Answers should change in FATES only, and they should only be of scales associated with rounding errors or order of operations.

Any User Interface Changes (namelist or namelist defaults changes)?

New parameter file.

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

fates test suite, non-comparison, cheyenne, intel:   all PASS

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
