### PR TITLE
Point to the new ndep historical file for all cases, also update cime…

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.6.10
+tag = cime_cesm2_0_rel_05
 required = True
 
 [externals_description]

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3192,16 +3192,12 @@ sub setup_logic_nitrogen_deposition {
     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'ndepmapalgo', 'phys'=>$nl_flags->{'phys'},
                 'use_cn'=>$nl_flags->{'use_cn'}, 'hgrid'=>$nl_flags->{'res'},
                 'clm_accelerated_spinup'=>$nl_flags->{'clm_accelerated_spinup'} );
-    if ( defined($opts->{'use_case'}) ) {
-       if ( ($nl_flags->{'lnd_tuning_mode'} =~ /clm5_0_cam/) && ($opts->{'use_case'} eq "1850_control") ) {
-          add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'ndep_taxmode', 'phys'=>$nl_flags->{'phys'},
+    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'ndep_taxmode', 'phys'=>$nl_flags->{'phys'},
                       'use_cn'=>$nl_flags->{'use_cn'}, 
                       'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'} );
-          add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'ndep_varlist', 'phys'=>$nl_flags->{'phys'},
+    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'ndep_varlist', 'phys'=>$nl_flags->{'phys'},
                       'use_cn'=>$nl_flags->{'use_cn'}, 
                       'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'} );
-       }
-    }
     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_first_ndep', 'phys'=>$nl_flags->{'phys'},
                 'use_cn'=>$nl_flags->{'use_cn'}, 'sim_year'=>$nl_flags->{'sim_year'},
                 'sim_year_range'=>$nl_flags->{'sim_year_range'});
@@ -3214,9 +3210,9 @@ sub setup_logic_nitrogen_deposition {
                   'sim_year_range'=>$nl_flags->{'sim_year_range'});
     }
     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_fldfilename_ndep', 'phys'=>$nl_flags->{'phys'},
-                'use_cn'=>$nl_flags->{'use_cn'}, 'rcp'=>$nl_flags->{'rcp'},
+                'use_cn'=>$nl_flags->{'use_cn'}, 
                 'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'},
-                'hgrid'=>"1.9x2.5" );
+                'hgrid'=>"0.9x1.25" );
   } else {
     # If bgc is NOT CN/CNDV then make sure none of the ndep settings are set!
     if ( defined($nl->get_value('stream_year_first_ndep')) ||

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -979,17 +979,11 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2100</stream_year_last_ndep>
 
-<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   >lnd/clm2/ndepdata/fndep_clm_hist_simyr1849-2006_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="8.5" >lnd/clm2/ndepdata/fndep_clm_rcp8.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="6"   >lnd/clm2/ndepdata/fndep_clm_rcp6.0_simyr1849-2106_1.9x2.5_c100810.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="4.5" >lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep hgrid="1.9x2.5"   use_cn=".true."   rcp="2.6" >lnd/clm2/ndepdata/fndep_clm_rcp2.6_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep hgrid="0.9x1.25" use_cn=".true." >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
 
-<ndep_taxmode use_cn=".true."                              >extend</ndep_taxmode>
-
-<ndep_varlist use_cn=".true."                              >NDEP_year</ndep_varlist>
-
-<ndepmapalgo use_cn=".true."                               >bilinear</ndepmapalgo>
+<ndep_taxmode            use_cn=".true." >cycle</ndep_taxmode>
+<ndep_varlist            use_cn=".true." >NDEP_month</ndep_varlist>
+<ndepmapalgo             use_cn=".true." >bilinear</ndepmapalgo>
 
 <ndepmapalgo use_cn=".true."   hgrid="1x1_brazil"          >nn</ndepmapalgo>
 <ndepmapalgo use_cn=".true."   hgrid="1x1_mexicocityMEX"   >nn</ndepmapalgo>

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -979,11 +979,26 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="2000-2100" >2100</stream_year_last_ndep>
 
-<stream_fldfilename_ndep hgrid="0.9x1.25" use_cn=".true." >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25" use_cn=".true." >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
 
-<ndep_taxmode            use_cn=".true." >cycle</ndep_taxmode>
-<ndep_varlist            use_cn=".true." >NDEP_month</ndep_varlist>
-<ndepmapalgo             use_cn=".true." >bilinear</ndepmapalgo>
+<!-- Use CMIP5 ndep forcing for CLM4.5 cases -->
+<ndep_taxmode            phys="clm4_5" use_cn=".true.">extend</ndep_taxmode>
+<ndep_varlist            phys="clm4_5" use_cn=".true.">NDEP_year</ndep_varlist>
+<stream_fldfilename_ndep phys="clm4_5" use_cn=".true."
+>lnd/clm2/ndepdata/fndep_clm_hist_simyr1849-2006_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   rcp="8.5"
+>lnd/clm2/ndepdata/fndep_clm_rcp8.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   rcp="6"
+>lnd/clm2/ndepdata/fndep_clm_rcp6.0_simyr1849-2106_1.9x2.5_c100810.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   rcp="4.5"
+>lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   rcp="2.6"
+>lnd/clm2/ndepdata/fndep_clm_rcp2.6_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
+
+<ndep_taxmode phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
+<ndep_varlist phys="clm5_0" use_cn=".true." >NDEP_month</ndep_varlist>
+
+<ndepmapalgo                use_cn=".true." >bilinear</ndepmapalgo>
 
 <ndepmapalgo use_cn=".true."   hgrid="1x1_brazil"          >nn</ndepmapalgo>
 <ndepmapalgo use_cn=".true."   hgrid="1x1_mexicocityMEX"   >nn</ndepmapalgo>

--- a/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
@@ -35,12 +35,14 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm5_0" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2010</stream_year_last_popdens>

--- a/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
@@ -35,7 +35,7 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
 <ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
@@ -35,12 +35,14 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm5_0" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2010</stream_year_last_popdens>

--- a/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
@@ -35,7 +35,7 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
 <ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
@@ -37,7 +37,7 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
 <ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
@@ -37,12 +37,14 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm5_0" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2010</stream_year_last_popdens>

--- a/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
@@ -35,12 +35,14 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm5_0" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2010</stream_year_last_popdens>

--- a/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
@@ -35,7 +35,7 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >1850</model_year_align_ndep>
 <ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -32,11 +32,4 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
-<stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
->lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
- 
-<ndep_taxmode            phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
-
-<ndep_varlist            phys="clm5_0" use_cn=".true." >NDEP_month</ndep_varlist>
-
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -32,10 +32,8 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
-<!-- Use single year ndep file as the new multi-year file has different times that change answers relative to control sims -->
+<!-- Use single year ndep file for CLM50 as the new multi-year file has different times that change answers relative to control sims -->
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
->lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -32,4 +32,10 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
+<!-- Use single year ndep file as the new multi-year file has different times that change answers relative to control sims -->
+<stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
+>lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" use_cn=".true."
+>lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
+
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
+++ b/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
@@ -30,16 +30,18 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cn"   >2000</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_0" bgc="cndv" >2000</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cndv" >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_0" bgc="cndv" >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >2000</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >2000</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >2000</model_year_align_ndep>
+<ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >2000</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2100</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true." >2000</model_year_align_ndep>
+<ndep_taxmode           phys="clm5_0" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2010</stream_year_last_popdens>

--- a/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
+++ b/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
@@ -34,7 +34,7 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >2000</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >2000</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2015</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2100</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true." >2000</model_year_align_ndep>
 <ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -28,12 +28,14 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2005</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true."   >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2005</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
+<ndep_taxmode           phys="clm5_0" use_cn=".true." >extend</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2016</stream_year_last_popdens>

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -28,7 +28,7 @@
 <model_year_align_ndep  phys="clm4_0" bgc="cndv" >1850</model_year_align_ndep>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true."   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2015</stream_year_last_ndep>
+<stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2005</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm4_5" use_cn=".true."   >1850</model_year_align_ndep>
 <ndep_taxmode           phys="clm4_5" use_cn=".true." >extend</ndep_taxmode>
 

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+release-clm5.0.08     erik 09/28/2018 Updated CMIP6 ndep file for historical transient Bgc cases, 1850_control same as before
 release-clm5.0.07     erik 08/08/2018 Bring in some simple fixes from ctsm1.0.dev006 and avoid glacier adjustment at startup from ctsm1.0.dev007
 release-clm5.0.06     erik 08/07/2018 Bring in some simple fixes from ctsm1.0.dev006 and avoid glacier adjustment at startup from ctsm1.0.dev007
 release-clm5.0.05     erik 08/05/2018 Update 1850 ndep file, and last year for transient streams

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,4 +1,100 @@
 ===============================================================
+Tag name:  release-clm5.0.08
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date: Fri Sep 28 14:17:52 MDT 2018
+One-line Summary: Updated CMIP6 ndep file for historical transient Bgc cases, 1850_control same as before
+
+Purpose of this version:
+------------------------
+
+Update the ndep file for transient cases for CLM50 to the CMIP6 version that has identical
+data for 1849-1850 to the previous CMIP6 1850_control (with different mid-month times however), and
+new 3-member ensemble average/5-year smoothing from the WACCM case: b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.00[123].
+The new data is monthly rather than yearly, which means there will be a seasonal cycle to nitrogen deposition
+for transient cases now. The midmonth times/dates are different for the multi-year file from
+the previous file, so answers change when using it for 1850_control cases even though the data is exactly the same.
+Because, of that we are still pointing to the previous 1850 CMIP6 ndep file.
+
+CLM4.5 is still using the previous CMIP5 ndep dataset.
+
+CTSM Master Tag This Corresponds To: ctsm1.0.dev008 (minus ctsm1.0.dev005 and ctsm1.0.dev001)
+
+Summary of changes:
+-------------------
+
+Science changes since: New cmip6 ndep file for transient cases
+
+Software changes since: None
+
+Changes to User Interface since: None
+
+Testing:
+--------
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+
+  regular tests (aux_clm): PASS (limited testing)
+     PASS SMS_D.f09_g16.I1850Clm50BgcSpinup.cheyenne_intel.clm-cplhist			
+     PASS SMS_D_Ld3.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_intel.clm-default			
+     PASS SMS_D_Ly2.1x1_brazil.IHistClm50BgcQianGs.cheyenne_intel.clm-ciso_bombspike1963			
+     PASS SMS_D_Ly2.1x1_numaIA.IHistClm50BgcCropGs.cheyenne_intel.clm-ciso_bombspike1963			
+     PASS SMS_Ld5.f10_f10_musgs.I1850Clm45BgcCrop.cheyenne_intel.clm-crop			
+     PASS SMS_Ld5.f19_g17.IHistClm50Bgc.cheyenne_intel.clm-decStart			
+     PASS SMS_Ld5_D.f09_g16.I1850Clm50BgcCrop.cheyenne_intel.clm-cmip6			
+     PASS SMS_Lm1.f09_g17_gl4.I1850Clm50Bgc.cheyenne_intel.clm-clm50KitchenSink			
+     PASS SMS_Lm1.f19_g17_gl4.I1850Clm50Bgc.cheyenne_intel.clm-clm50dynroots			
+     PASS SMS_Lm1_D.f10_f10_musgs.I2000Clm50BgcCrop.cheyenne_intel.clm-snowlayers_3_monthly			
+     PASS ERP_P36x2_D_Ld5.f10_f10_musgs.IHistClm45BgcCruGs.cheyenne_intel.clm-decStart
+
+    Tests that are different from baseline (as expected)
+     DIFF SMS_D_Ly2.1x1_brazil.IHistClm50BgcQianGs.cheyenne_intel.clm-ciso_bombspike1963
+     DIFF SMS_D_Ly2.1x1_numaIA.IHistClm50BgcCropGs.cheyenne_intel.clm-ciso_bombspike1963
+     DIFF SMS_Ld5.f19_g17.IHistClm50Bgc.cheyenne_intel.clm-decStart
+     DIFF SMS_Lm1_D.f10_f10_musgs.I2000Clm50BgcCrop.cheyenne_intel.clm-snowlayers_3_monthly
+
+
+Summary of Answer changes:
+-------------------------
+
+Baseline version for comparison: release-clm5.0.07
+
+Changes answers relative to baseline: Yes! for CLM4.5/CLM5.0 CN or Bgc transient cases
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: IHist Clm45Bgc* and Clm50Bgc (Bgc or Cn)
+    - what platforms/compilers: All
+    - nature of change: Changes in climate for Nitrogen
+        New nitrogen deposition and change from yearly to monthly
+
+Detailed list of changes:
+------------------------
+
+Externals being used: Update cime
+
+   cism:   release-cesm2.0.04
+   rtm:    release-cesm2.0.00
+   mosart: release-cesm2.0.00
+   cime:   cime_cesm2_0_rel_05
+   FATES:  fates_s1.8.1_a3.0.0
+   PTCLM:  PTCLM2_180611
+
+CTSM Tag versions pulled over from master development branch: None
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+
+   #522 -- Point to the new ndep historical file for all cases, also update cime
+
+===============================================================
+===============================================================
 Tag name:  release-clm5.0.07
 Originator(s):  erik (Erik Kluzek)
 Date:  Wed Aug  8 14:02:04 MDT 2018


### PR DESCRIPTION

### Description of changes

New ndep file for hsitorical 1850-2015 from a three member ensemble of WACCM simulations. @olyson created the ndep file. It's data for 1850 are the same as the previous file in use for 1850 control simulations. So this file will be used for all periods, the 1850 will just cycle over the 1850 data.

### Specific notes

Contributors other than yourself, if any: @olyson 

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? Yes! due to new ndep file

 Clm45-Bgc or Clm50-Bgc, and primarily after 1850

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:  Ran some simple tests, will run full test suite

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
