### PR TITLE
Add carbon_isotope user-mod directory to turn on c13 and c14

### DIFF
--- a/cime_config/usermods_dirs/carbon_isotopes/user_nl_clm
+++ b/cime_config/usermods_dirs/carbon_isotopes/user_nl_clm
@@ -1,0 +1,4 @@
+use_c13 = .true.
+use_c14 = .true.
+use_c13_timeseries = .true.
+use_c14_bombspike = .true.

--- a/cime_config/usermods_dirs/cmip6/include_user_mods
+++ b/cime_config/usermods_dirs/cmip6/include_user_mods
@@ -1,2 +1,3 @@
 ../cmip6_glaciers
 ../cmip6_output
+../carbon_isotopes


### PR DESCRIPTION
User-mod directory for carbon_isotopes and include it for the cmip6 user-mod

### Description of changes

Add carbon_isotopes user-mod directory to turn on c13 and c14 carbon isotopes.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)?

Yes, just for the cmip6 user-mod test cases

Any User Interface Changes (namelist or namelist defaults changes)? Changes cmip6

Testing performed, if any: none yet
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
