### PR TITLE
Support a %CMIP6DECK compset modifier

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -230,7 +230,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <values match="last">
-      <value compset="_CLM50%[^_]*CMIP6DECK">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
+      <value compset="_CLM50%[^_]*CMIP6DECK[%_]">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
     </values>
     <group>run_component_clm</group>
     <file>env_case.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -13,10 +13,10 @@
   -->
 
   <!-- Descriptions of all the different valid configurations for different model versions -->
-  <description modifier_mode="+">
+  <description modifier_mode="1">
     <desc lnd="CLM40[%SP][%CN][%CNDV][%CN-CROP][%CNDV-CROP]"                                                        >clm4.0:</desc>
-    <desc lnd="CLM45[%SP][%SP-VIC][%CN][%CNDV][%CN-CROP][%CNDV-CROP][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%CMIP6DECK]" >clm4.5:</desc>
-    <desc lnd="CLM50[%SP][%SP-VIC][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%CMIP6DECK]"                              >clm5.0:</desc>
+    <desc lnd="CLM45[%SP][%SP-VIC][%CN][%CNDV][%CN-CROP][%CNDV-CROP][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP]" >clm4.5:</desc>
+    <desc lnd="CLM50[%SP][%SP-VIC][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%BGC-CROP-CMIP6DECK]"         >clm5.0:</desc>
     <desc option="SP"              >Satellite phenology:</desc>
     <desc option="CN"              >CN: Carbon Nitrogen model</desc>
     <desc option="CNDV"            >CNDV: CN with Dynamic Vegetation</desc>
@@ -29,7 +29,7 @@
     <desc option="FATES"           >FATES (Functionally Assembled Terrestrial Ecosystem Simulator) Ecosystem Demography model: (experimental)</desc>
     <desc option="BGCDV"           >BGC (vert. resol. CN and methane) with dynamic vegetation:</desc>
     <desc option="BGCDV-CROP"      >BGC (vert. resol. CN and methane) with dynamic vegetation and prognostic crop:</desc>
-    <desc option="CMIP6DECK"       >With modifications appropriate for CMIP6 DECK experiments:</desc>
+    <desc option="BGC-CROP-CMIP6DECK">BGC (vert. resol. CN and methane) with prognostic crop, with modifications appropriate for CMIP6 DECK experiments:</desc>
   </description>
 
   <entry id="COMP_LND">
@@ -230,11 +230,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <values match="last">
-      <!-- CLM45 and CLM50 are listed separately so that this can't
-           apply to CLM40. Once CLM40 is removed, this can be changed to
-           a single line with a match like "_CLM[^_]*%CMIP6DECK" -->
-      <value compset="_CLM45[^_]*%CMIP6DECK">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
-      <value compset="_CLM50[^_]*%CMIP6DECK">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
+      <value compset="_CLM50%[^_]*CMIP6DECK">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
     </values>
     <group>run_component_clm</group>
     <file>env_case.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -13,10 +13,10 @@
   -->
 
   <!-- Descriptions of all the different valid configurations for different model versions -->
-  <description modifier_mode="1">
+  <description modifier_mode="+">
     <desc lnd="CLM40[%SP][%CN][%CNDV][%CN-CROP][%CNDV-CROP]"                                                        >clm4.0:</desc>
-    <desc lnd="CLM45[%SP][%SP-VIC][%CN][%CNDV][%CN-CROP][%CNDV-CROP][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP]" >clm4.5:</desc>
-    <desc lnd="CLM50[%SP][%SP-VIC][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP]"                              >clm5.0:</desc>
+    <desc lnd="CLM45[%SP][%SP-VIC][%CN][%CNDV][%CN-CROP][%CNDV-CROP][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%CMIP6DECK]" >clm4.5:</desc>
+    <desc lnd="CLM50[%SP][%SP-VIC][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%CMIP6DECK]"                              >clm5.0:</desc>
     <desc option="SP"              >Satellite phenology:</desc>
     <desc option="CN"              >CN: Carbon Nitrogen model</desc>
     <desc option="CNDV"            >CNDV: CN with Dynamic Vegetation</desc>
@@ -29,6 +29,7 @@
     <desc option="FATES"           >FATES (Functionally Assembled Terrestrial Ecosystem Simulator) Ecosystem Demography model: (experimental)</desc>
     <desc option="BGCDV"           >BGC (vert. resol. CN and methane) with dynamic vegetation:</desc>
     <desc option="BGCDV-CROP"      >BGC (vert. resol. CN and methane) with dynamic vegetation and prognostic crop:</desc>
+    <desc option="CMIP6DECK"       >With modifications appropriate for CMIP6 DECK experiments:</desc>
   </description>
 
   <entry id="COMP_LND">
@@ -222,6 +223,22 @@
       A value of on forces the model to spin up from a cold-start
       (arbitrary initial conditions). Setting this value in the xml file will take
       precedence over any settings for finidat in the $CASEROOT/user_clm_clm file.</desc>
+  </entry>
+
+  <entry id="CLM_USER_MODS">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <values match="last">
+      <!-- CLM45 and CLM50 are listed separately so that this can't
+           apply to CLM40. Once CLM40 is removed, this can be changed to
+           a single line with a match like "_CLM[^_]*%CMIP6DECK" -->
+      <value compset="_CLM45[^_]*%CMIP6DECK">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
+      <value compset="_CLM50[^_]*%CMIP6DECK">$SRCROOT/components/clm/cime_config/usermods_dirs/cmip6</value>
+    </values>
+    <group>run_component_clm</group>
+    <file>env_case.xml</file>
+    <desc>User mods to apply to specific compset matches. </desc>
   </entry>
 
   <help>


### PR DESCRIPTION
### Description of changes

This was suggested by @rljacob and supported by @mvertens @jedwards4b
and @bertinia as a mechanism to provide CMIP6-specific compsets.

This allows us to have a compset like this:

```xml
  <compset>
    <alias>B1850CMIP6</alias>
    <lname>1850_CAM60_CLM50%BGC-CROP%CMIP6DECK_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
    <science_support grid="f09_g17_gl4"/>
    <science_support grid="f09_g17"/>
  </compset>
```

I have tentatively chosen the modifier %CMIP6DECK rather than just
%CMIP6, mainly because I imagine we might want some other %CMIP6XXX
modifiers later, and if we had a simple %CMIP6 modifier, it would be
harder to write a correct regular expression that matches %CMIP6XXX
without accidentally matching %CMIP6. For CTSM, my impression is that we
want the same mods for all DECK runs. Other components might want
something different, and they don't necessarily have to use %CMIP6DECK:
they can come up with their own set of modifiers.

Finally, a specific note about the regex match: Elsewhere we use regular
expressions like `"_CLM50%[^_]*BGC"`, but here I have put the "%"
immediately before the modifier, like `"_CLM50[^_]*%CMIP6DECK"`: this
seems slightly more robust.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)?
Allows compsets with %CMIP6DECK modifier

Testing performed, if any:
From a cesm sandbox, created a case using the compset given above; confirmed that user_nl_cpl and user_nl_clm were filled out correctly.
