### PR TITLE
Transient pft issue #538

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2571,9 +2571,6 @@ sub setup_logic_do_transient_crops {
       if (string_is_undef_or_empty($nl->get_value('flanduse_timeseries'))) {
          $cannot_be_true = "$var can only be set to true when running a transient case (flanduse_timeseries non-blank)";
       }
-      elsif (!&value_is_true($nl->get_value('use_crop'))) {
-         $cannot_be_true = "$var can only be set to true when running with use_crop = true";
-      }
       elsif (&value_is_true($nl->get_value('use_fates'))) {
          # In principle, use_fates should be compatible with
          # do_transient_crops. However, this hasn't been tested, so to be safe,

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1885,7 +1885,11 @@ sub setup_logic_irrigate {
   if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
     add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'irrigate',
                 'use_crop'=>$nl_flags->{'use_crop'}, 'use_cndv'=>$nl_flags->{'use_cndv'} );
-    $nl_flags->{'irrigate'} = lc($nl->get_value('irrigate'));
+    if ( &value_is_true($nl->get_value('irrigate') ) ) {
+       $nl_flags->{'irrigate'} = ".true."
+    } else {
+       $nl_flags->{'irrigate'} = ".false."
+    }
   }
 }
 
@@ -2078,6 +2082,9 @@ sub setup_logic_create_crop_landunit {
                 'use_fates'=>$nl_flags->{'use_fates'} );
     if ( &value_is_true($nl_flags->{'use_fates'}) && &value_is_true($nl->get_value($var)) ) {
          $log->fatal_error( "$var is true and yet use_fates is being set, which contradicts that (use_fates requires $var to be .false." );
+    }
+    if ( (! &value_is_true($nl_flags->{'use_fates'})) && (! &value_is_true($nl->get_value($var))) ) {
+         $log->fatal_error( "$var is false which is ONLY allowed when FATES is being used" );
     }
   }
 }
@@ -2596,6 +2603,13 @@ sub setup_logic_do_transient_crops {
          $log->fatal_error($cannot_be_true);
       }
 
+      my $dopft = "do_transient_pfts";
+      # Make sure the value agrees with the do_transient_pft flag
+      if ( (  &value_is_true($nl->get_value($var))) && (! &value_is_true($nl->get_value($dopft))) ||
+           (! &value_is_true($nl->get_value($var))) && (  &value_is_true($nl->get_value($dopft))) ) {
+         $log->fatal_error("$var and $dopft do NOT agree and need to");
+      }
+
    }
 }
 
@@ -3063,9 +3077,12 @@ sub setup_logic_fertilizer {
    my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
    if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
-     $nl_flags->{'use_crop'} = $nl->get_value('use_crop');
      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fertilizer',
      'use_crop'=>$nl_flags->{'use_crop'} );
+     my $use_fert = $nl->get_value('use_fertilizer');
+     if ( (! &value_is_true($nl_flags->{'use_crop'})) && &value_is_true($use_fert) ) {
+       $log->fatal_error("use_ferilizer can NOT be on without prognostic crop\n" );
+     }
   }
 }
 
@@ -3078,9 +3095,11 @@ sub setup_logic_grainproduct {
    my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
    if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
-     $nl_flags->{'use_crop'} = $nl->get_value('use_crop');
      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_grainproduct',
      'use_crop'=>$nl_flags->{'use_crop'}, 'phys'=>$physv->as_string() );
+     if ( (! &value_is_true($nl_flags->{'use_crop'})) && &value_is_true($nl->get_value('use_grainproduct') ) ) {
+       $log->fatal_error("use_grainproduct can NOT be on without prognostic crop\n" );
+     }
   }
 }
 

--- a/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -2225,7 +2225,6 @@ If TRUE, apply transient natural PFTs from flanduse_timeseries file.
        group="dynamic_subgrid" valid_values="" >
 If TRUE, apply transient crops from flanduse_timeseries file.
 (Only valid for transient runs, where there is a flanduse_timeseries file.)
-(Also, only valid for use_crop = true.)
 </entry>
 
 <entry id="do_harvest" type="logical" category="physics"

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -123,7 +123,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 939;
+my $ntests = 943;
 if ( defined($opts{'compare'}) ) {
    $ntests += 597;
 }
@@ -422,12 +422,12 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm4_5",
                                    },
-     "baset_map without crop"    =>{ options=>"-bgc bgc -envxml_dir .",
+     "baset_map without crop"    =>{ options=>"-bgc bgc -envxml_dir . -no-crop",
                                      namelst=>"baset_mapping='constant'",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm5_0",
                                    },
-     "mapvary var w/o varymap"   =>{ options=>"-crop -bgc bgc -envxml_dir .",
+     "mapvary var w/o varymap"   =>{ options=>"-crop -bgc bgc -envxml_dir . -crop",
                                      namelst=>"baset_mapping='constant', baset_latvary_slope=1.0, baset_latvary_intercept=10.0",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm5_0",
@@ -442,8 +442,14 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm4_0 -bgc cn -crop on",
                                   },
-     "-irrigate=T without -crop" =>{ options=>"-bgc cn -irrig .true. -envxml_dir .",
-                                    namelst=>"irrigate=.true.",
+     # This one should fail now, because we don't have non irrigated non-crop datasets
+     "-irrigate=F without -crop" =>{ options=>"-bgc cn -no-crop -envxml_dir .",
+                                    namelst=>"irrigate=.false.",
+                                    GLC_TWO_WAY_COUPLING=>"FALSE",
+                                    conopts=>"-phys clm4_5",
+                                   },
+     "grainproductWOcrop"       =>{ options=>"-bgc cn -no-crop -envxml_dir .",
+                                    namelst=>"use_grainproduct=.true.",
                                     GLC_TWO_WAY_COUPLING=>"FALSE",
                                     conopts=>"-phys clm4_5",
                                    },
@@ -777,6 +783,11 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm5_0",
                                    },
+     "createcropFalse"           =>{ options=>"-bgc bgc -envxml_dir . -no-megan",
+                                     namelst=>"create_crop_landunit=.false.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     conopts=>"-phys clm5_0",
+                                   },
      "useFATESWTransient"        =>{ options=>"-bgc fates -use_case 20thC_transient -envxml_dir . -no-megan -res 10x15",
                                      namelst=>"",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
@@ -834,6 +845,16 @@ my %failtest = (
                                    },
      "elevWOfireemis"            =>{ options=>"-envxml_dir . -no-fire_emis",
                                      namelst=>"fire_emis_elevated=.false.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     conopts=>"-phys clm5_0",
+                                   },
+     "spdotransconflict"          =>{ options=>"-envxml_dir . -bgc sp -use_case 20thC_transient",
+                                     namelst=>"do_transient_pfts=T,do_transient_crops=.false.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     conopts=>"-phys clm5_0",
+                                   },
+     "nocropwfert"                =>{ options=>"-envxml_dir . -bgc sp -no-crop",
+                                     namelst=>"use_fertilizer=T",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm5_0",
                                    },

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,125 @@
 ===============================================================
+Tag name:  ctsm1.0.dev013
+Originator(s):  erik (Erik Kluzek)/slevisconsulting
+Date: Thu Oct 25 16:25:26 MDT 2018
+One-line Summary: Fix the fact that transient Bgc and SP cases had constant crop area in time
+
+Purpose of changes
+------------------
+
+Fix transient non-crop cases that had constant crop area so that crop area will change in time
+(and hence natural veg area will also change corresponding to it).
+
+Also bring in changes to update mksurfdata_map to handle SSP-RCP future scenarios. Right now
+it can handle SSP5-8.5 out of the box. Also add a new test for that.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):  #538
+   #538 -- In transient pft simulations with use_crop=.false., %crop does not advance from 1850 values
+
+Known bugs found since the previous tag (include github issue ID): #545
+   #545 -- Antarctica ice shelves are being treated as wetlands rather than glaciers
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm5_0
+
+[X] clm4_5
+
+[ ] clm4_0
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): A few more namelist checks
+   Added a check to make sure do_transient_pfts was the same as do_transient_crops
+   Don't allow use_fertilizer for non-crop case
+   namelist checks that create_crop_landunit=T except for FATES
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+   New -ssp_rcp option to mksurfdata.pl
+
+Changes made to namelist defaults (e.g., changed parameter values): None
+
+Changes to the datasets (e.g., parameter, surface or initial files): New mksrfpft datasets in XML for SSP5-8.5
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in ../CTSMMasterChecklist as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+   Now, do_transient_pfts and do_transient_crops only work in unison, and hence
+   should be simplified to one logical called do_transient_veg
+
+Changes to tests or testing: Add new SSP5-8.5 mksurf test
+
+Code reviewed by: self, slevisconsulting, billsacks
+
+CTSM testing: regular, tools
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (18 of the transient test namelists are different to baseline as expected)
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - OK (PTCLM tests fail)
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    hobart_nag -------- OK
+    hobart_pgi -------- OK
+    hobart_intel ------ OK
+
+CTSM tag used for the baseline comparisons:  ctsm1.0.dev012
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes!
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: clm4_5/clm5_0 transient simulations without Crop (either Bgc or SP)
+    - what platforms/compilers: All
+    - nature of change: crop areas increase in time and impact simulations
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: dll/clm50_r267_1deg_GSWP3V1_iso_hist_nocrop_transientfix
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids): #546, #540
+(https://github.com/ESCOMP/ctsm/pull)
+
+   #546 -- Add in ability for mksurfdata_map to handle ssp_rcp scenarios and specifically SSP5-8.5
+   $540 -- Transient PFT issue
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev012
 Originator(s):  erik (Erik Kluzek)
 Date: Sat Sep 29 11:49:35 MDT 2018

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev013     erik 10/25/2018 Fix the fact that transient Bgc and SP cases had constant crop area in time
   ctsm1.0.dev012     erik 09/29/2018 Add snow-free fields for snowmip, fix several issues
   ctsm1.0.dev011    sacks 09/12/2018 Add water tracer consistency checks, and other water tracer work
   ctsm1.0.dev010    sacks 08/30/2018 Update cime to cime5.7.3

--- a/src/dyn_subgrid/dynSubgridControlMod.F90
+++ b/src/dyn_subgrid/dynSubgridControlMod.F90
@@ -165,7 +165,7 @@ contains
     dyn_subgrid_control_inst = dyn_subgrid_control_type( &
          flanduse_timeseries = flanduse_timeseries, &
          do_transient_pfts = do_transient_pfts, &
-         do_transient_crops = do_transient_pfts, &
+         do_transient_crops = do_transient_crops, &
          do_harvest = do_harvest, &
          for_testing_allow_non_annual_changes = for_testing_allow_non_annual_changes, &
          for_testing_zero_dynbal_fluxes = for_testing_zero_dynbal_fluxes)

--- a/src/dyn_subgrid/dynSubgridControlMod.F90
+++ b/src/dyn_subgrid/dynSubgridControlMod.F90
@@ -165,7 +165,7 @@ contains
     dyn_subgrid_control_inst = dyn_subgrid_control_type( &
          flanduse_timeseries = flanduse_timeseries, &
          do_transient_pfts = do_transient_pfts, &
-         do_transient_crops = do_transient_crops, &
+         do_transient_crops = do_transient_pfts, &
          do_harvest = do_harvest, &
          for_testing_allow_non_annual_changes = for_testing_allow_non_annual_changes, &
          for_testing_zero_dynbal_fluxes = for_testing_zero_dynbal_fluxes)
@@ -225,10 +225,10 @@ contains
     end if
 
     if (dyn_subgrid_control_inst%do_transient_crops) then
-       if (.not. use_crop) then
-          write(iulog,*) 'ERROR: do_transient_crops can only be true if use_crop is true'
-          call endrun(msg=errMsg(sourcefile, __LINE__))
-       end if
+!      if (.not. use_crop) then
+!         write(iulog,*) 'ERROR: do_transient_crops can only be true if use_crop is true'
+!         call endrun(msg=errMsg(sourcefile, __LINE__))
+!      end if
        if (use_fates) then
           ! NOTE(wjs, 2017-01-13) ED / FATES does not currently have a mechanism for
           ! changing its column areas, with the consequent changes in aboveground biomass

--- a/src/dyn_subgrid/dynSubgridControlMod.F90
+++ b/src/dyn_subgrid/dynSubgridControlMod.F90
@@ -225,10 +225,6 @@ contains
     end if
 
     if (dyn_subgrid_control_inst%do_transient_crops) then
-!      if (.not. use_crop) then
-!         write(iulog,*) 'ERROR: do_transient_crops can only be true if use_crop is true'
-!         call endrun(msg=errMsg(sourcefile, __LINE__))
-!      end if
        if (use_fates) then
           ! NOTE(wjs, 2017-01-13) ED / FATES does not currently have a mechanism for
           ! changing its column areas, with the consequent changes in aboveground biomass

--- a/src/dyn_subgrid/dyncropFileMod.F90
+++ b/src/dyn_subgrid/dyncropFileMod.F90
@@ -191,7 +191,7 @@ contains
           
           col%wtlunit(c) = wtcft_cur(g,m)
           if (use_crop) then
-	     crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
+             crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
           end if
           col_set(c) = .true.
        end if

--- a/src/dyn_subgrid/dyncropFileMod.F90
+++ b/src/dyn_subgrid/dyncropFileMod.F90
@@ -190,7 +190,9 @@ contains
           end if
           
           col%wtlunit(c) = wtcft_cur(g,m)
-	  crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
+          if (use_crop) then
+	     crop_inst%fertnitro_patch(p) = fertcft_cur(g,m)
+          end if
           col_set(c) = .true.
        end if
     end do

--- a/src/dyn_subgrid/dyncropFileMod.F90
+++ b/src/dyn_subgrid/dyncropFileMod.F90
@@ -125,6 +125,7 @@ contains
     use CropType          , only : crop_type
     use landunit_varcon   , only : istcrop
     use clm_varpar        , only : cft_lb, cft_ub
+    use clm_varctl        , only : use_crop
     use surfrdUtilsMod    , only : collapse_crop_types
     use subgridWeightsMod , only : set_landunit_weight
     !
@@ -164,7 +165,9 @@ contains
     allocate(fertcft_cur(bounds%begg:bounds%endg, cft_lb:cft_ub))
     call fertcft%get_current_data(fertcft_cur)
 
-    call collapse_crop_types(wtcft_cur, fertcft_cur, bounds%begg, bounds%endg, verbose = .false.)
+    if (use_crop) then
+       call collapse_crop_types(wtcft_cur, fertcft_cur, bounds%begg, bounds%endg, verbose = .false.)
+    end if
 
     allocate(col_set(bounds%begc:bounds%endc))
     col_set(:) = .false.


### PR DESCRIPTION
### Description of changes
Corrects the baseline for transient crops in transient pft runs

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
#538 

Are answers expected to change (and if so in what way)?
Yes, in transient pft runs

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
Ran standard intel & gnu test-suites to generate baseline-13 from branch trans_pft_issue538 while comparing to baseline-12. Expect same or similar FAILures as between branch collapse2gencrop & baseline-12:
Gnu generated same DIFF FAILures + 2 new TPUTCOMP FAILures
Intel generated same DIFF FAILures, except 1 new RUN FAILure: corrected, retested, and now it’s among same DIFF FAILures

Ran same tests bet. branch collapse2gencrop & baseline-13 hoping for no FAILures:
nohup qcmd -l walltime=06:00:00 -- ./create_test --xml-category aux_clm --xml-machine cheyenne --xml-compiler gnu -r /glade/scratch/slevis/collapse_pfts_cheyenne_gnu --project P93300641 --compare /glade/scratch/slevis/cesm_baselines/ctsm1.0.dev013 --generate /glade/scratch/slevis/cesm_baselines/ctsm1.0.dev014 &
The expected FAILs
nohup qcmd -l walltime=12:00:00 -- ./create_test --xml-category aux_clm --xml-machine cheyenne --xml-compiler intel -r /glade/scratch/slevis/collapse_pfts_cheyenne_intel --project P93300641 --compare /glade/scratch/slevis/cesm_baselines/ctsm1.0.dev013 --generate /glade/scratch/slevis/cesm_baselines/ctsm1.0.dev014 &
The expected FAILs except the test that FAILed 2 steps up and I corrected but didn’t “generate” files when I corrected it… Still need to do this!
