### PR TITLE
fates refactor of 3d arrays in restart - api changes

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1138,12 +1138,23 @@ contains
                         this%fates(nc)%bc_in(s) )
                end do
 
+
                ! ------------------------------------------------------------------------
                ! Update diagnostics of FATES ecosystem structure used in HLM.
                ! ------------------------------------------------------------------------
                call this%wrap_update_hlmfates_dyn(nc,bounds_clump, &
                      waterstate_inst,canopystate_inst,frictionvel_inst)
+
+               ! ------------------------------------------------------------------------
+               ! Update the 3D patch level radiation absorption fractions
+               ! ------------------------------------------------------------------------
+               call this%fates_restart%update_3dpatch_radiation(nc, &
+                                                                this%fates(nc)%nsites, &
+                                                                this%fates(nc)%sites, &
+                                                                this%fates(nc)%bc_out)
+                    
                
+
                ! ------------------------------------------------------------------------
                ! Update history IO fields that depend on ecosystem dynamics
                ! ------------------------------------------------------------------------


### PR DESCRIPTION
### Description of changes

In PR https://github.com/NGEET/fates/pull/428, we refactor fates restarts so that we don't need to save some massive restart variables.  However, we do need to initiate a call early in the restart process that will re-create these arrays (radiation absorbtion fractions).  However, we can't re-use any existing calls through the interface.  

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Fates issue: https://github.com/NGEET/fates/issues/12

Are answers expected to change (and if so in what way)?

hard to say, results should be nigh b4b, but the order of operations will change slightly, so I'm expecting very small round-off errors, but possibly not...

Any User Interface Changes (namelist or namelist defaults changes)?

no

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

Test Output:

All PASS: cheyenne, intel, fates test suite:

/gpfs/fs1/scratch/rgknox/clmed-tests/fates.cheyenne.intel.C46895e9-F3c87f2a-pft-arrays-vf3


**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
