### PR TITLE
Add a bunch of ignore patterns for vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,23 @@ manage_externals.log
 *.swp
 *~
 
+# vim files (from https://github.com/github/gitignore/blob/master/Global/Vim.gitignore)
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+# Session
+Session.vim
+# Temporary
+.netrwhist
+# (removed *~ because it is listed above)
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
 # mac files
 .DS_Store
 


### PR DESCRIPTION
From
https://github.com/github/gitignore/blob/master/Global/Vim.gitignore

Motivated by the fact that a .swp file appeared in a PR. We probably
don't need all of these, but it looks like they should be safe to
include (i.e., I can't imagine a real file having a name like one of
these patterns, given that most of them begin with '.' or '_').

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any: none