### PR TITLE
Fix bug in XML for surface dataset for f05 1850 non-crop

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime_cesm2_1_rel_04
+tag = cime_cesm2_1_rel_05
 required = True
 
 [externals_description]

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -755,8 +755,6 @@ lnd/clm2/surfdata_map/surfdata_1x1_mexicocityMEX_16pfts_Irrig_CMIP6_simyr2000_c1
 lnd/clm2/surfdata_map/surfdata_1x1_urbanc_alpha_16pfts_Irrig_CMIP6_simyr2000_c171214.nc</fsurdat>
 
 <!-- for pre-industrial simulations - year 1850 without crop -->
-<fsurdat hgrid="0.47x0.63"  sim_year="1850" use_crop=".false." irrigate=".true.">
-lnd/clm2/surfdata_map/surfdata_0.47x0.63_16pfts_Irrig_CMIP6_simyr1850_c180508.nc</fsurdat>
 <fsurdat hgrid="360x720cru"   sim_year="1850" use_crop=".false." irrigate=".true." >
 lnd/clm2/surfdata_map/surfdata_360x720cru_16pfts_Irrig_CMIP6_simyr1850_c170824.nc</fsurdat>
 <fsurdat hgrid="48x96"        sim_year="1850" use_crop=".false." irrigate=".true.">

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-release-clm5.0.14     erik 11/28/2018 Update cime and fix surface dataset for f05 1850 non-crop case
+release-clm5.0.14     erik 11/29/2018 Update cime and fix surface dataset for f05 1850 non-crop case
 release-clm5.0.13     erik 11/14/2018 Update externals with new CO2/presearo/rtm/mosart, add science_support, change testing
 release-clm5.0.12     erik 11/03/2018 New IC files for clm45/clm50 coupled cases, add 2010 compset
 release-clm5.0.11     erik 10/30/2018 Bring fix for transient Bgc/Sp to release branch (from ctsm1.0.dev013)

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+release-clm5.0.14     erik 11/28/2018 Update cime and fix surface dataset for f05 1850 non-crop case
 release-clm5.0.13     erik 11/14/2018 Update externals with new CO2/presearo/rtm/mosart, add science_support, change testing
 release-clm5.0.12     erik 11/03/2018 New IC files for clm45/clm50 coupled cases, add 2010 compset
 release-clm5.0.11     erik 10/30/2018 Bring fix for transient Bgc/Sp to release branch (from ctsm1.0.dev013)

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,4 +1,98 @@
 ===============================================================
+Tag name:  release-clm5.0.14
+Originator(s):  erik (Erik Kluzek)
+Date:  Wed Nov 28 15:12:36 MST 2018
+One-line Summary: Update cime and fix surface dataset for f05 1850 non-crop case
+
+Purpose of this version:
+------------------------
+
+
+
+CTSM Master Tag This Corresponds To:
+
+Summary of changes:
+-------------------
+
+Issues fixed (include CTSM Issue #): 
+CIME Issues fixed (include issue #): 
+
+Science changes since: release-clm5.0.13
+
+Software changes since: release-clm5.0.13
+
+Changes to User Interface since: release-clm5.0.13
+
+Testing:
+--------
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+    hobart --- PASS
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - OK
+    hobart --- OK
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     cheyenne - OK
+     hobart --- OK
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    hobart_nag -------- OK
+    hobart_pgi -------- OK
+    hobart_intel ------ OK
+
+  regular tests (prealpha):
+
+    cheyenne_intel - PASS
+    cheyenne_gnu --- PASS
+    hobart_nag ----- PASS
+
+  regular tests (prebeta):
+
+    cheyenne_intel - PASS
+    cheyenne_gnu --- PASS
+    hobart_nag ----- PASS
+
+Summary of Answer changes:
+-------------------------
+
+Baseline version for comparison: release-clm5.0.13
+
+Changes answers relative to baseline: No (bit-for-bit)
+
+Detailed list of changes:
+------------------------
+
+Externals being used:
+
+   cism:   release-cesm2.0.04
+   rtm:    release-cesm2.0.02
+   mosart: release-cesm2.0.03
+   cime:   cime_cesm2_1_rel_05
+   FATES:  fates_s1.8.1_a3.0.0
+   PTCLM:  PTCLM2_180611
+
+CTSM Tag versions pulled over from master development branch: none
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+
+===============================================================
+===============================================================
 Tag name:  release-clm5.0.13
 Originator(s):  erik (Erik Kluzek)
 Date: Wed Nov 14 11:28:00 MST 2018

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,12 +1,14 @@
 ===============================================================
 Tag name:  release-clm5.0.14
 Originator(s):  erik (Erik Kluzek)
-Date:  Wed Nov 28 15:12:36 MST 2018
+Date: Thu Nov 29 11:46:41 MST 2018
 One-line Summary: Update cime and fix surface dataset for f05 1850 non-crop case
 
 Purpose of this version:
 ------------------------
 
+Update cime to next version being used in cesm2.1.0 release. And fix the XML for f05
+surface dataset for 1850 and non-crop. Test that all six f05 cases work (1850/2000/Hist,crop/non-crop).
 
 
 CTSM Master Tag This Corresponds To:
@@ -14,14 +16,16 @@ CTSM Master Tag This Corresponds To:
 Summary of changes:
 -------------------
 
-Issues fixed (include CTSM Issue #): 
-CIME Issues fixed (include issue #): 
+Issues fixed (include CTSM Issue #): #576
 
 Science changes since: release-clm5.0.13
+   None
 
 Software changes since: release-clm5.0.13
+   Fix XML for f05 1850 non-crop fsurdat file
 
 Changes to User Interface since: release-clm5.0.13
+   cpl auxilary history files names change
 
 Testing:
 --------
@@ -35,12 +39,10 @@ Testing:
   unit-tests (components/clm/src):
 
     cheyenne - PASS
-    hobart --- PASS
 
   tools-tests (components/clm/test/tools):
 
     cheyenne - OK
-    hobart --- OK
 
   PTCLM testing (components/clm/tools/shared/PTCLM/test):
 
@@ -54,6 +56,14 @@ Testing:
     hobart_nag -------- OK
     hobart_pgi -------- OK
     hobart_intel ------ OK
+
+  Also following PASS:
+     SMS.f05_f05_mg17.I1850Clm50BgcCrop.cheyenne_intel.clm-default
+     SMS.f05_f05_mg17.I1850Clm50Sp.cheyenne_intel.clm-default
+     SMS.f05_f05_mg17.I2000Clm50BgcCrop.cheyenne_intel.clm-default
+     SMS.f05_f05_mg17.I2000Clm50Sp.cheyenne_intel.clm-default
+     SMS.f05_f05_mg17.IHistClm50BgcCrop.cheyenne_intel.clm-default
+     SMS.f05_f05_mg17.IHistClm50Sp.cheyenne_intel.clm-default
 
   regular tests (prealpha):
 
@@ -88,8 +98,9 @@ Externals being used:
 
 CTSM Tag versions pulled over from master development branch: none
 
-Pull Requests that document the changes (include PR ids):
+Pull Requests that document the changes (include PR ids): #579
 (https://github.com/ESCOMP/ctsm/pull)
+   #579 -- Fix bug in XML for surface dataset for f05 1850 non-crop
 
 ===============================================================
 ===============================================================


### PR DESCRIPTION
### Description of changes

Fix a bug in the XML for finding the surface dataset for f05 at 1850 and non-crop. Also update to latest cesm2.1.0 version of cime. This fix important for SDYN mode in CAM.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): #576

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
 Standard aux_clm testing on cheyenne and hobart, all PASS as expected...

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
