### PR TITLE
Add routine to find indices of max k values in data

### DIFF
--- a/src/utils/array_utils.F90.in
+++ b/src/utils/array_utils.F90.in
@@ -5,8 +5,8 @@ module array_utils
   ! This module contains routines for working with arrays.
   !
   ! NOTE(wjs, 2015-10-21) These routines could be moved to csm_share. However, I'm not
-  ! sure if these routines will stick around for long, since they are just here to work
-  ! around the fact that we don't specify -Mallocatable=03 with pgi (which in turn is
+  ! sure if some of these routines will stick around for long, since they are just here to
+  ! work around the fact that we don't specify -Mallocatable=03 with pgi (which in turn is
   ! because that flag led to bugs with pgi14).
   !
   ! !USES:
@@ -19,8 +19,9 @@ module array_utils
 
   ! Public routines
 
-  public :: transpose_wrapper ! wrap the intrinsic transpose function, first allocating the destination array
-  public :: pack_wrapper      ! wrap the intrinsic pack function, first allocating the destination array
+  public :: find_k_max_indices ! returns the indices of the maximum k values in data, in sorted order
+  public :: transpose_wrapper  ! wrap the intrinsic transpose function, first allocating the destination array
+  public :: pack_wrapper       ! wrap the intrinsic pack function, first allocating the destination array
 
   interface transpose_wrapper
      !TYPE int,double
@@ -28,6 +29,59 @@ module array_utils
   end interface transpose_wrapper
 
 contains
+
+  !-----------------------------------------------------------------------
+  subroutine find_k_max_indices(data, lb, k, max_indices)
+    !
+    ! !DESCRIPTION:
+    ! Returns the indices of the maximum k values in data, in sorted order (so the first
+    ! index will be the largest, the second index will be the second largest, etc.)
+    !
+    ! The output array (max_indices) is allocated here
+    !
+    ! This is O(n*k) (where n is the size of the input array)
+    !
+    ! !ARGUMENTS:
+    integer  , intent(in)               :: lb ! lower bound of data array
+    real(r8) , intent(in)               :: data(lb:)
+    integer  , intent(in)               :: k  ! number of max indices to find
+    integer  , allocatable, intent(out) :: max_indices(:)
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: max_vals(k)
+    integer :: i, j
+    integer :: insertion_location
+
+    character(len=*), parameter :: subname = 'find_k_max_indices'
+    !-----------------------------------------------------------------------
+
+    allocate(max_indices(k))
+    max_indices(:) = lb - 1
+    max_vals(:) = -huge(1._r8)
+
+    do i = lbound(data,1), ubound(data,1)
+       insertion_location = -1
+       do j = 1, k
+          if (data(i) > max_vals(j)) then
+             insertion_location = j
+             exit
+          end if
+       end do
+
+       if (insertion_location > 0) then
+          ! Shift lower values right by one (note that the k'th value will be dropped)
+          do j = k-1, insertion_location, -1
+             max_indices(j+1) = max_indices(j)
+             max_vals(j+1) = max_vals(j)
+          end do
+
+          max_indices(insertion_location) = i
+          max_vals(insertion_location) = data(i)
+       end if
+    end do
+
+  end subroutine find_k_max_indices
+
 
   !-----------------------------------------------------------------------
   !TYPE int,double

--- a/src/utils/array_utils.F90.in
+++ b/src/utils/array_utils.F90.in
@@ -12,6 +12,7 @@ module array_utils
   ! !USES:
 
   use shr_kind_mod, only : r8 => shr_kind_r8, i4=>shr_kind_i4
+  use abortutils  , only : endrun
 
   implicit none
   private
@@ -55,11 +56,18 @@ contains
     character(len=*), parameter :: subname = 'find_k_max_indices'
     !-----------------------------------------------------------------------
 
+    if (k < 1 .or. k > size(data)) then
+       call endrun(subname//': must have 1 <= k <= size(data)')
+    end if
+
     allocate(max_indices(k))
     max_indices(:) = lb - 1
     max_vals(:) = -huge(1._r8)
 
     do i = lbound(data,1), ubound(data,1)
+       ! Determine where (if anywhere) data(i) should go in max_vals, relative to the
+       ! values we've seen so far. Note that max_vals will be arranged in sorted order,
+       ! with the largest value first.
        insertion_location = -1
        do j = 1, k
           if (data(i) > max_vals(j)) then

--- a/src/utils/test/CMakeLists.txt
+++ b/src/utils/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(array_utils_test)
 add_subdirectory(clm_time_manager_test)
 add_subdirectory(annual_flux_dribbler_test)
 add_subdirectory(numerics_test)

--- a/src/utils/test/array_utils_test/CMakeLists.txt
+++ b/src/utils/test/array_utils_test/CMakeLists.txt
@@ -1,0 +1,10 @@
+set (pfunit_sources
+  test_find_k_max_indices.pf)
+
+set (extra_sources
+  )
+
+create_pFUnit_test(array_utils test_array_utils_exe
+  "${pfunit_sources}" "${extra_sources}")
+
+target_link_libraries(test_array_utils_exe clm csm_share esmf_wrf_timemgr)

--- a/src/utils/test/array_utils_test/test_find_k_max_indices.pf
+++ b/src/utils/test/array_utils_test/test_find_k_max_indices.pf
@@ -1,0 +1,114 @@
+module test_find_k_max_indices
+
+  ! Tests of array_utils: find_k_max_indices
+
+  use pfunit_mod
+  use array_utils
+  use shr_kind_mod , only : r8 => shr_kind_r8
+
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: TestFindKMax
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type TestFindKMax
+
+  real(r8), parameter :: tol = 1.e-13_r8
+
+contains
+
+  subroutine setUp(this)
+    class(TestFindKMax), intent(inout) :: this
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(TestFindKMax), intent(inout) :: this
+  end subroutine tearDown
+
+  @Test
+  subroutine alreadyInOrder(this)
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [5._r8, 4._r8, 3._r8, 2._r8], &
+         lb = 1, &
+         k = 3, &
+         max_indices = max_indices)
+
+    @assertEqual([1,2,3], max_indices)
+  end subroutine alreadyInOrder
+
+  @Test
+  subroutine reversed(this)
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [2._r8, 3._r8, 4._r8, 5._r8], &
+         lb = 1, &
+         k = 3, &
+         max_indices = max_indices)
+
+    @assertEqual([4,3,2], max_indices)
+  end subroutine reversed
+
+  @Test
+  subroutine insertAtLast(this)
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [5._r8, 4._r8, 2._r8, 3._r8], &
+         lb = 1, &
+         k = 3, &
+         max_indices = max_indices)
+
+    @assertEqual([1,2,4], max_indices)
+  end subroutine insertAtLast
+
+  @Test
+  subroutine insertAtFirst(this)
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [5._r8, 4._r8, 3._r8, 6._r8], &
+         lb = 1, &
+         k = 3, &
+         max_indices = max_indices)
+
+    @assertEqual([4,1,2], max_indices)
+  end subroutine insertAtFirst
+
+  @Test
+  subroutine insertAtMiddle(this)
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [5._r8, 3._r8, 2._r8, 4._r8], &
+         lb = 1, &
+         k = 3, &
+         max_indices = max_indices)
+
+    @assertEqual([1,4,2], max_indices)
+  end subroutine insertAtMiddle
+
+  @Test
+  subroutine lbNot1(this)
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [2._r8, 3._r8, 4._r8, 5._r8], &
+         lb = 2, &
+         k = 3, &
+         max_indices = max_indices)
+
+    @assertEqual([5,4,3], max_indices)
+  end subroutine lbNot1
+
+end module test_find_k_max_indices

--- a/src/utils/test/array_utils_test/test_find_k_max_indices.pf
+++ b/src/utils/test/array_utils_test/test_find_k_max_indices.pf
@@ -5,6 +5,7 @@ module test_find_k_max_indices
   use pfunit_mod
   use array_utils
   use shr_kind_mod , only : r8 => shr_kind_r8
+  use unittestUtils, only : endrun_msg
 
   implicit none
 
@@ -57,6 +58,8 @@ contains
 
   @Test
   subroutine insertAtLast(this)
+    ! Make sure we have a test that covers inserting the new element at the end of the
+    ! max_vals array
     class(TestFindKMax), intent(inout) :: this
     integer, allocatable :: max_indices(:)
 
@@ -71,6 +74,8 @@ contains
 
   @Test
   subroutine insertAtFirst(this)
+    ! Make sure we have a test that covers inserting the new element at the start of the
+    ! max_vals array
     class(TestFindKMax), intent(inout) :: this
     integer, allocatable :: max_indices(:)
 
@@ -85,6 +90,8 @@ contains
 
   @Test
   subroutine insertAtMiddle(this)
+    ! Make sure we have a test that covers inserting the new element in the middle of the
+    ! max_vals array
     class(TestFindKMax), intent(inout) :: this
     integer, allocatable :: max_indices(:)
 
@@ -99,6 +106,7 @@ contains
 
   @Test
   subroutine lbNot1(this)
+    ! Test with lower bound different from 1
     class(TestFindKMax), intent(inout) :: this
     integer, allocatable :: max_indices(:)
 
@@ -110,5 +118,84 @@ contains
 
     @assertEqual([5,4,3], max_indices)
   end subroutine lbNot1
+
+  @Test
+  subroutine k0_raisesException(this)
+    class (TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+    character(len=:), allocatable :: expected_msg
+
+    call find_k_max_indices( &
+         data = [2._r8, 3._r8, 4._r8, 5._r8], &
+         lb = 1, &
+         k = 0, &
+         max_indices = max_indices)
+
+    expected_msg = endrun_msg( &
+         'find_k_max_indices: must have 1 <= k <= size(data)')
+    @assertExceptionRaised(expected_msg)
+  end subroutine k0_raisesException
+
+  @Test
+  subroutine kBig_raisesException(this)
+    class (TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+    character(len=:), allocatable :: expected_msg
+
+    call find_k_max_indices( &
+         data = [2._r8, 3._r8, 4._r8, 5._r8], &
+         lb = 1, &
+         k = 5, &
+         max_indices = max_indices)
+
+    expected_msg = endrun_msg( &
+         'find_k_max_indices: must have 1 <= k <= size(data)')
+    @assertExceptionRaised(expected_msg)
+  end subroutine kBig_raisesException
+
+  @Test
+  subroutine kEquals1(this)
+    ! Test the edge case k=1
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [2._r8, 3._r8, 4._r8, 1._r8], &
+         lb = 1, &
+         k = 1, &
+         max_indices = max_indices)
+
+    @assertEqual([3], max_indices)
+  end subroutine kEquals1
+
+  @Test
+  subroutine reversed_kEqualsN(this)
+    ! Test the edge case k=n
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [2._r8, 3._r8, 4._r8, 5._r8], &
+         lb = 1, &
+         k = 4, &
+         max_indices = max_indices)
+
+    @assertEqual([4,3,2,1], max_indices)
+  end subroutine reversed_kEqualsN
+
+  @Test
+  subroutine nEquals1(this)
+    ! Test the edge case n = k = 1
+    class(TestFindKMax), intent(inout) :: this
+    integer, allocatable :: max_indices(:)
+
+    call find_k_max_indices( &
+         data = [2._r8], &
+         lb = 1, &
+         k = 1, &
+         max_indices = max_indices)
+
+    @assertEqual([1], max_indices)
+  end subroutine nEquals1
 
 end module test_find_k_max_indices


### PR DESCRIPTION
### Description of changes

Add routine to find indices of max k values in data

This could be useful for ESCOMP/ctsm#457

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
Just ran unit tests