### PR TITLE
Set tracer version of Irrigation fluxes

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -108,6 +108,44 @@ CTSM testing:
 
     ok means tests pass, expected baseline failures as noted below
 
+  Additional manual testing:
+
+  - Out of the box, the one-timestep tracer consistency test
+    (SMS_D_Ln1.f10_f10_musgs.I2000Clm50BgcCropGs.hobart_nag.clm-tracer_consistency)
+    passed when the new check was inserted after the irrigation call,
+    even without the changes in this tag. Presumably this is because no
+    irrigation was being done in the first time step of this test. To
+    confirm that the changes here were both necessary and effective, I
+    hacked the code to force irrigation of all types (surface and
+    groundwater) on the first time step (see
+    https://github.com/billsacks/ctsm/commit/d28a03145). I confirmed
+    that this test, with those code hacks, failed before the changes in
+    this tag, and passed with these changes in place.
+
+  - I used a multi-step process to confirm that these changes are only
+    roundoff-level different for groundwater irrigation (because
+    feedbacks in the system result in
+    SMS_D_Ld5.f10_f10_musgs.I2000Clm50BgcCrop.hobart_nag.clm-irrig_alternate
+    looking greater-than-roundoff-level different from the baseline):
+
+    (1) Confirmed that e507fe603 is only roundoff-level different from
+        baseline using cprnc output from this test.
+
+    (2) Confirmed that a4a1a626c is only roundoff-level different from
+        e507fe603. This was the tricky part. I did this by introducing
+        some temporary code that (a) computed some fluxes in both the
+        old and new ways, (b) compared the old and new methods for each
+        point and time step, confirming that they were no more than
+        roundoff-level different, then (c) set the fluxes to the old
+        method. I confirmed that this was bit-for-bit with e507fe603,
+        and the checks for greater-than-roundoff-level differences
+        between the old and new methods were never triggered. (See
+        https://github.com/billsacks/ctsm/commit/7d23e9e and the earlier
+        commits on that branch.)
+
+    (3) Confirmed that remaining changes an the branch are bit-for-bit
+        with a4a1a626c.
+
 CTSM tag used for the baseline comparisons: ctsm1.0.dev021
 
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,162 @@
 ===============================================================
+Tag name:  ctsm1.0.dev022
+Originator(s):  sacks (Bill Sacks)
+Date: Tue Jan  8 11:01:38 MST 2019
+One-line Summary: Set tracer version of irrigation fluxes
+
+Purpose of changes
+------------------
+
+Set tracer version of irrigation fluxes.
+
+This required a substantial rewrite of ApplyIrrigation (now renamed to
+CalcIrrigationFluxes). The problem was that the code was written to
+compute the total irrigation withdrawal from groundwater, then use this
+to compute the application fluxes (drip/sprinkler), then later divide
+this total withdrawal by layer. But for tracer fluxes to be computed
+correctly, we needed to reorder this, so that the per-layer withdrawals
+are determined before determining the application fluxes. This is
+because the application flux needs to know the tracer concentrations of
+the source, which requires knowing which layers the source is drawing
+from. This was made more challenging because of the mix of patch-level
+and column-level variables at play: irrigation demand is patch-level,
+groundwater availability and extraction is column-level, but application
+is back to patch-level.
+
+In a somewhat-related change, I also reworked the passing of information
+between soil hydrology (groundwater availability) and irrigation:
+Previously, there was some near-duplicate code in
+CalcAvailableUnconfinedAquifer (which was called prior to
+ApplyIrrigation) and WithdrawGroundwaterIrrigation (which was called
+after ApplyIrrigation). I have reworked the code to remove this
+duplication, calling the new CalcIrrigWithdrawals in the midst of
+CalcIrrigationFluxes. In doing so, I reconciled an accidental
+discrepancy between the two original routines (see
+https://github.com/escomp/ctsm/issues/595).
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+- Resolves ESCOMP/ctsm#521 (Set tracer versions of fluxes set by
+  ApplyIrrigation)
+- Resolves ESCOMP/ctsm#593 (Generalize groundwater irrigation availability to
+  handle multiple patches per column)
+- Resolves ESCOMP/ctsm#595 (Inconsistency between CalcAvailableUnconfinedAquifer
+  and WithdrawGroundwaterIrrigation)
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] clm4_5
+
+[ ] clm4_0
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by:
+
+- Sean Swenson reviewed the initial parts of the rework of
+  ApplyIrrigation and the passing of information between soil hydrology
+  and irrigation
+
+CTSM testing:
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  tools-tests (test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+     cheyenne - not run
+
+  regular tests (aux_clm):
+
+    cheyenne ---- ok
+    hobart ------ ok
+
+    ok means tests pass, expected baseline failures as noted below
+
+CTSM tag used for the baseline comparisons: ctsm1.0.dev021
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations:
+
+      - Small answer changes when groundwater irrigation is enabled. In
+        principle, could change answers by greater than roundoff due to
+        fix of #595, but I didn't see any answer changes in my 7-month
+        test due to that change. Other than that, just roundoff-level
+        changes.
+
+      - Answer changes when tracers are enabled.
+
+      - Roundoff-level changes in the diagnostic field,
+        QIRRIG_FROM_SURFACE, for many tests
+
+    - what platforms/compilers: all
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+      See notes under "what code configurations" for details.
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff? N/A
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: N/A
+
+   URL for LMWG diagnostics output used to validate new climate: N/A
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/ctsm/pull/600
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev021
 Originator(s):  mvr (Mathew Rothstein,UCAR/CSEG,303-497-1304)
 Date: Wed Dec 26 16:29:06 MST 2018

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev022    sacks 01/08/2019 Set tracer version of irrigation fluxes
   ctsm1.0.dev021      mvr 12/26/2018 Added tracer ratio capability and included it in consistency checks
   ctsm1.0.dev020    sacks 12/03/2018 New options for irrigation and crop fsat
   ctsm1.0.dev019    sacks 11/30/2018 Rework cold start initialization of wa and zwt

--- a/src/biogeophys/CMakeLists.txt
+++ b/src/biogeophys/CMakeLists.txt
@@ -9,12 +9,15 @@ list(APPEND clm_sources
   EnergyFluxType.F90
   GlacierSurfaceMassBalanceMod.F90
   HumanIndexMod.F90
+  InfiltrationExcessRunoffMod.F90
   IrrigationMod.F90
   LakeCon.F90
   QSatMod.F90
   RootBiophysMod.F90
+  SaturatedExcessRunoffMod.F90
   SnowHydrologyMod.F90
   SnowSnicarMod.F90
+  SoilHydrologyMod.F90
   SoilHydrologyType.F90
   SoilStateType.F90
   SoilWaterRetentionCurveMod.F90

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -65,6 +65,7 @@ contains
     type(water_type)               , intent(inout) :: water_inst
     !
     ! !LOCAL VARIABLES:
+    integer :: i  ! tracer index
 
     character(len=*), parameter :: subname = 'IrrigationWithdrawals'
     !-----------------------------------------------------------------------
@@ -77,8 +78,11 @@ contains
 
     ! Remove groundwater irrigation
     if (irrigation_inst%UseGroundwaterIrrigation()) then
-       call WithdrawGroundwaterIrrigation(bounds, num_soilc, &
-            filter_soilc, water_inst%waterfluxbulk_inst, water_inst%waterstatebulk_inst)
+       do i = water_inst%bulk_and_tracers_beg, water_inst%bulk_and_tracers_end
+          call WithdrawGroundwaterIrrigation(bounds, num_soilc, filter_soilc, &
+               water_inst%bulk_and_tracers(i)%waterflux_inst, &
+               water_inst%bulk_and_tracers(i)%waterstate_inst)
+       end do
     end if
 
   end subroutine IrrigationWithdrawals

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -40,7 +40,6 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine IrrigationWithdrawals(bounds, &
-       num_hydrologyc, filter_hydrologyc, &
        num_soilc, filter_soilc, &
        num_soilp, filter_soilp, &
        soilhydrology_inst, soilstate_inst, &
@@ -52,12 +51,10 @@ contains
     !
     ! !USES:
     use SoilHydrologyMod       , only : CalcAvailableUnconfinedAquifer
-    use SoilHydrologyMod       , only : CalcIrrigWithdrawals, WithdrawGroundwaterIrrigation
+    use SoilHydrologyMod       , only : WithdrawGroundwaterIrrigation
     !
     ! !ARGUMENTS:
     type(bounds_type)              , intent(in)    :: bounds
-    integer                        , intent(in)    :: num_hydrologyc       ! number of points in filter_hydrologyc
-    integer                        , intent(in)    :: filter_hydrologyc(:) ! column filter for hydrologically-active points
     integer                        , intent(in)    :: num_soilc            ! number of points in filter_soilc
     integer                        , intent(in)    :: filter_soilc(:)      ! column filter for soil points
     integer                        , intent(in)    :: num_soilp            ! number of points in filter_soilp
@@ -76,8 +73,8 @@ contains
 
     ! Calculate amount of water available for groundwater irrigation
     if (irrigation_inst%UseGroundwaterIrrigation()) then
-       call CalcAvailableUnconfinedAquifer(bounds, num_hydrologyc, &
-            filter_hydrologyc, soilhydrology_inst, soilstate_inst, &
+       call CalcAvailableUnconfinedAquifer(bounds, num_soilc, &
+            filter_soilc, soilhydrology_inst, soilstate_inst, &
             waterdiagnosticbulk_inst)
     end if
 
@@ -90,12 +87,8 @@ contains
 
     ! Remove groundwater irrigation
     if (irrigation_inst%UseGroundwaterIrrigation()) then
-       call CalcIrrigWithdrawals(bounds, num_hydrologyc, &
-            filter_hydrologyc, soilhydrology_inst, soilstate_inst, &
-            waterfluxbulk_inst)
-
-       call WithdrawGroundwaterIrrigation(bounds, num_hydrologyc, &
-            filter_hydrologyc, waterfluxbulk_inst, waterstatebulk_inst)
+       call WithdrawGroundwaterIrrigation(bounds, num_soilc, &
+            filter_soilc, waterfluxbulk_inst, waterstatebulk_inst)
     end if
 
   end subroutine IrrigationWithdrawals

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -52,7 +52,7 @@ contains
     !
     ! !USES:
     use SoilHydrologyMod       , only : CalcAvailableUnconfinedAquifer
-    use SoilHydrologyMod       , only : WithdrawGroundwaterIrrigation
+    use SoilHydrologyMod       , only : CalcIrrigWithdrawals, WithdrawGroundwaterIrrigation
     !
     ! !ARGUMENTS:
     type(bounds_type)              , intent(in)    :: bounds
@@ -89,10 +89,12 @@ contains
 
     ! Remove groundwater irrigation
     if (irrigation_inst%UseGroundwaterIrrigation()) then
-       call WithdrawGroundwaterIrrigation(bounds, num_hydrologyc, &
+       call CalcIrrigWithdrawals(bounds, num_hydrologyc, &
             filter_hydrologyc, soilhydrology_inst, soilstate_inst, &
-            waterstatebulk_inst, &
             waterfluxbulk_inst)
+
+       call WithdrawGroundwaterIrrigation(bounds, num_hydrologyc, &
+            filter_hydrologyc, waterfluxbulk_inst, waterstatebulk_inst)
     end if
 
   end subroutine IrrigationWithdrawals

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -84,6 +84,7 @@ contains
     ! Calculate irrigation flux
     call irrigation_inst%ApplyIrrigation(bounds, num_soilc, &
          filter_soilc, num_soilp, filter_soilp, &
+         soilhydrology_inst, soilstate_inst, &
          waterfluxbulk_inst, &
          available_gw_uncon = waterdiagnosticbulk_inst%available_gw_uncon_col(bounds%begc:bounds%endc))
 

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -44,13 +44,12 @@ contains
        num_soilp, filter_soilp, &
        soilhydrology_inst, soilstate_inst, &
        irrigation_inst, &
-       waterdiagnosticbulk_inst, waterfluxbulk_inst, waterstatebulk_inst)
+       waterfluxbulk_inst, waterstatebulk_inst)
     !
     ! !DESCRIPTION:
     ! Calculates irrigation withdrawal fluxes and withdraws from groundwater
     !
     ! !USES:
-    use SoilHydrologyMod       , only : CalcAvailableUnconfinedAquifer
     use SoilHydrologyMod       , only : WithdrawGroundwaterIrrigation
     !
     ! !ARGUMENTS:
@@ -62,7 +61,6 @@ contains
     type(soilhydrology_type)       , intent(in)    :: soilhydrology_inst
     type(soilstate_type)           , intent(in)    :: soilstate_inst
     type(irrigation_type)          , intent(inout) :: irrigation_inst
-    type(waterdiagnosticbulk_type) , intent(inout) :: waterdiagnosticbulk_inst
     type(waterfluxbulk_type)       , intent(inout) :: waterfluxbulk_inst
     type(waterstatebulk_type)      , intent(inout) :: waterstatebulk_inst
     !
@@ -71,19 +69,11 @@ contains
     character(len=*), parameter :: subname = 'IrrigationWithdrawals'
     !-----------------------------------------------------------------------
 
-    ! Calculate amount of water available for groundwater irrigation
-    if (irrigation_inst%UseGroundwaterIrrigation()) then
-       call CalcAvailableUnconfinedAquifer(bounds, num_soilc, &
-            filter_soilc, soilhydrology_inst, soilstate_inst, &
-            waterdiagnosticbulk_inst)
-    end if
-
     ! Calculate irrigation flux
     call irrigation_inst%ApplyIrrigation(bounds, num_soilc, &
          filter_soilc, num_soilp, filter_soilp, &
          soilhydrology_inst, soilstate_inst, &
-         waterfluxbulk_inst, &
-         available_gw_uncon = waterdiagnosticbulk_inst%available_gw_uncon_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst)
 
     ! Remove groundwater irrigation
     if (irrigation_inst%UseGroundwaterIrrigation()) then

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -33,14 +33,14 @@ Module HydrologyNoDrainageMod
   save
   !
   ! !PUBLIC MEMBER FUNCTIONS:
-  public  :: IrrigationWithdrawals  ! Calculates irrigation withdrawal fluxes and withdraws from groundwater
+  public  :: CalcAndWithdrawIrrigationFluxes  ! Calculates irrigation withdrawal fluxes and withdraws from groundwater
   public  :: HydrologyNoDrainage    ! Calculates soil/snow hydrology without drainage
   !-----------------------------------------------------------------------
 
 contains
 
   !-----------------------------------------------------------------------
-  subroutine IrrigationWithdrawals(bounds, &
+  subroutine CalcAndWithdrawIrrigationFluxes(bounds, &
        num_soilc, filter_soilc, &
        num_soilp, filter_soilp, &
        soilhydrology_inst, soilstate_inst, &
@@ -67,7 +67,7 @@ contains
     ! !LOCAL VARIABLES:
     integer :: i  ! tracer index
 
-    character(len=*), parameter :: subname = 'IrrigationWithdrawals'
+    character(len=*), parameter :: subname = 'CalcAndWithdrawIrrigationFluxes'
     !-----------------------------------------------------------------------
 
     ! Calculate irrigation flux
@@ -85,7 +85,7 @@ contains
        end do
     end if
 
-  end subroutine IrrigationWithdrawals
+  end subroutine CalcAndWithdrawIrrigationFluxes
 
   !-----------------------------------------------------------------------
   subroutine HydrologyNoDrainage(bounds, &

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -71,7 +71,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Calculate irrigation flux
-    call irrigation_inst%ApplyIrrigation(bounds, num_soilc, &
+    call irrigation_inst%CalcIrrigationFluxes(bounds, num_soilc, &
          filter_soilc, num_soilp, filter_soilp, &
          soilhydrology_inst, soilstate_inst, &
          water_inst)

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -19,6 +19,7 @@ Module HydrologyNoDrainageMod
   use SaturatedExcessRunoffMod, only : saturated_excess_runoff_type
   use InfiltrationExcessRunoffMod, only : infiltration_excess_runoff_type
   use IrrigationMod, only : irrigation_type
+  use WaterType , only : water_type
   use WaterFluxBulkType     , only : waterfluxbulk_type
   use WaterStateBulkType    , only : waterstatebulk_type
   use WaterDiagnosticBulkType    , only : waterdiagnosticbulk_type
@@ -44,7 +45,7 @@ contains
        num_soilp, filter_soilp, &
        soilhydrology_inst, soilstate_inst, &
        irrigation_inst, &
-       waterfluxbulk_inst, waterstatebulk_inst)
+       water_inst)
     !
     ! !DESCRIPTION:
     ! Calculates irrigation withdrawal fluxes and withdraws from groundwater
@@ -61,8 +62,7 @@ contains
     type(soilhydrology_type)       , intent(in)    :: soilhydrology_inst
     type(soilstate_type)           , intent(in)    :: soilstate_inst
     type(irrigation_type)          , intent(inout) :: irrigation_inst
-    type(waterfluxbulk_type)       , intent(inout) :: waterfluxbulk_inst
-    type(waterstatebulk_type)      , intent(inout) :: waterstatebulk_inst
+    type(water_type)               , intent(inout) :: water_inst
     !
     ! !LOCAL VARIABLES:
 
@@ -73,12 +73,12 @@ contains
     call irrigation_inst%ApplyIrrigation(bounds, num_soilc, &
          filter_soilc, num_soilp, filter_soilp, &
          soilhydrology_inst, soilstate_inst, &
-         waterfluxbulk_inst)
+         water_inst)
 
     ! Remove groundwater irrigation
     if (irrigation_inst%UseGroundwaterIrrigation()) then
        call WithdrawGroundwaterIrrigation(bounds, num_soilc, &
-            filter_soilc, waterfluxbulk_inst, waterstatebulk_inst)
+            filter_soilc, water_inst%waterfluxbulk_inst, water_inst%waterstatebulk_inst)
     end if
 
   end subroutine IrrigationWithdrawals

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -930,6 +930,10 @@ contains
           qflx_gw_uncon_irrig_patch(p)     = 0._r8
           qflx_gw_con_irrig_patch(p)       = 0._r8
        end if
+    end do
+
+    do fp = 1, num_soilp
+       p = filter_soilp(fp)
 
        ! Set drip/sprinkler irrigation based on irrigation method from input data
        qflx_irrig_drip_patch(p)      = 0._r8

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -52,6 +52,7 @@ module IrrigationMod
   use clm_varcon       , only : isecspday, denh2o, spval, ispval, namep, namec, nameg
   use clm_varpar       , only : nlevsoi, nlevgrnd
   use clm_time_manager , only : get_step_size
+  use SoilHydrologyMod , only : CalcIrrigWithdrawals
   use SoilHydrologyType, only : soilhydrology_type
   use SoilStateType    , only : soilstate_type
   use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
@@ -950,6 +951,10 @@ contains
           end if
           qflx_gw_irrig_withdrawn_col(c) = qflx_gw_uncon_irrig_col(c) + qflx_gw_con_irrig_col(c)
        end do
+
+       call this%WrapCalcIrrigWithdrawals(bounds, num_soilc, filter_soilc, &
+            soilhydrology_inst, soilstate_inst, waterfluxbulk_inst)
+
     else
        do fc = 1, num_soilc
           c = filter_soilc(fc)
@@ -958,9 +963,6 @@ contains
           qflx_gw_irrig_withdrawn_col(c) = 0._r8
        end do
     end if
-
-    call this%WrapCalcIrrigWithdrawals(bounds, num_soilc, filter_soilc, &
-         soilhydrology_inst, soilstate_inst, waterfluxbulk_inst)
 
     do fp = 1, num_soilp
        p = filter_soilp(fp)
@@ -1037,7 +1039,9 @@ contains
     character(len=*), parameter :: subname = 'WrapCalcIrrigWithdrawals'
     !-----------------------------------------------------------------------
 
-    ! FIXME(wjs, 2018-12-13) Need to fill this in
+    call CalcIrrigWithdrawals(bounds, num_soilc, &
+         filter_soilc, soilhydrology_inst, soilstate_inst, &
+         waterfluxbulk_inst)
 
   end subroutine WrapCalcIrrigWithdrawals
 

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -1062,7 +1062,15 @@ contains
     ! !DESCRIPTION:
     ! Set irrigation withdrawals for bulk water
     !
-    ! Also decrements this%n_irrig_steps_left_patch if appropriate
+    ! Sets / updates the following variables:
+    ! - qflx_sfc_irrig_bulk_patch
+    ! - qflx_gw_demand_bulk_patch
+    ! - qflx_gw_demand_bulk_col
+    ! - this%qflx_irrig_demand_patch
+    ! - this%n_irrig_steps_left_patch
+    ! - waterfluxbulk_inst%qflx_sfc_irrig_col
+    ! - waterfluxbulk_inst%qflx_gw_uncon_irrig_lyr_col
+    ! - waterfluxbulk_inst%qflx_gw_con_irrig_col
     !
     ! !ARGUMENTS:
     class(irrigation_type)   , intent(inout) :: this
@@ -1146,6 +1154,11 @@ contains
     ! !DESCRIPTION:
     ! Set irrigation withdrawals for one water tracer
     !
+    ! Sets the following variables:
+    ! - waterflux_tracer_inst%qflx_sfc_irrig_col
+    ! - waterflux_tracer_inst%qflx_gw_con_irrig_col
+    ! - waterflux_tracer_inst%qflx_gw_uncon_irrig_lyr_col
+    !
     ! !ARGUMENTS:
     class(irrigation_type)    , intent(inout) :: this
     type(bounds_type)         , intent(in)    :: bounds
@@ -1208,6 +1221,9 @@ contains
     ! !DESCRIPTION:
     ! Set total irrigation withdrawal flux from the unconfined aquifer, for either bulk
     ! or one water tracer
+    !
+    ! Sets the following variables:
+    ! - waterflux_inst%qflx_gw_uncon_irrig_col
     !
     ! !ARGUMENTS:
     class(irrigation_type)    , intent(inout) :: this

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -932,6 +932,18 @@ contains
        end if
     end do
 
+    call p2c (bounds, num_soilc, filter_soilc, &
+         patcharr = qflx_sfc_irrig_patch(bounds%begp:bounds%endp), &
+         colarr = qflx_sfc_irrig_col(bounds%begc:bounds%endc))
+
+    call p2c (bounds, num_soilc, filter_soilc, &
+         patcharr = qflx_gw_uncon_irrig_patch(bounds%begp:bounds%endp), &
+         colarr = qflx_gw_uncon_irrig_col(bounds%begc:bounds%endc))
+
+    call p2c (bounds, num_soilc, filter_soilc, &
+         patcharr = qflx_gw_con_irrig_patch(bounds%begp:bounds%endp), &
+         colarr = qflx_gw_con_irrig_col(bounds%begc:bounds%endc))
+
     do fp = 1, num_soilp
        p = filter_soilp(fp)
 
@@ -950,18 +962,6 @@ contains
 
     end do
 
-    call p2c (bounds, num_soilc, filter_soilc, &
-         patcharr = qflx_sfc_irrig_patch(bounds%begp:bounds%endp), &
-         colarr = qflx_sfc_irrig_col(bounds%begc:bounds%endc))
-    
-    call p2c (bounds, num_soilc, filter_soilc, &
-         patcharr = qflx_gw_uncon_irrig_patch(bounds%begp:bounds%endp), &
-         colarr = qflx_gw_uncon_irrig_col(bounds%begc:bounds%endc))
-    
-    call p2c (bounds, num_soilc, filter_soilc, &
-         patcharr = qflx_gw_con_irrig_patch(bounds%begp:bounds%endp), &
-         colarr = qflx_gw_con_irrig_col(bounds%begc:bounds%endc))
-    
     call p2c (bounds, num_soilc, filter_soilc, &
          patcharr = qflx_irrig_drip_patch(bounds%begp:bounds%endp), &
          colarr = qflx_irrig_drip_col(bounds%begc:bounds%endc))

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -56,8 +56,8 @@ module IrrigationMod
   use SoilHydrologyType, only : soilhydrology_type
   use SoilStateType    , only : soilstate_type
   use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
-  use WaterFluxBulkType      , only : waterfluxbulk_type
-  use GridcellType     , only : grc                
+  use WaterType        , only : water_type
+  use GridcellType     , only : grc
   use ColumnType       , only : col                
   use PatchType        , only : patch                
   use subgridAveMod    , only : p2c, c2g
@@ -853,12 +853,13 @@ contains
   subroutine ApplyIrrigation(this, bounds, num_soilc, &
        filter_soilc, num_soilp, filter_soilp, &
        soilhydrology_inst, soilstate_inst, &
-       waterfluxbulk_inst)
+       water_inst)
     !
     ! !DESCRIPTION:
     ! Apply the irrigation computed by CalcIrrigationNeeded to qflx_irrig.
     !
-    ! Sets irrigation withdrawal and application fluxes in waterfluxbulk_inst.
+    ! Sets irrigation withdrawal and application fluxes in the waterflux components of
+    ! water_inst.
     !
     ! Should be called once, AND ONLY ONCE, per time step.
     !
@@ -873,9 +874,9 @@ contains
     integer, intent(in) :: num_soilp
     ! patch filter for soil
     integer, intent(in) :: filter_soilp(:)
-    type(soilhydrology_type)   , intent(in)    :: soilhydrology_inst
-    type(soilstate_type)       , intent(in)    :: soilstate_inst
-    type(waterfluxbulk_type)   , intent(inout) :: waterfluxbulk_inst
+    type(soilhydrology_type) , intent(in)    :: soilhydrology_inst
+    type(soilstate_type)     , intent(in)    :: soilstate_inst
+    type(water_type)         , intent(inout) :: water_inst
     !
     ! !LOCAL VARIABLES:
     integer  :: p,fp  ! patch indices
@@ -896,13 +897,14 @@ contains
     ! This should be called exactly once per time step, so that the counter decrease
     ! works correctly.
 
+    ! Note that these associated variables refer to the bulk instance
     associate( &
-         qflx_sfc_irrig_col        => waterfluxbulk_inst%qflx_sfc_irrig_col        , & ! Output: [real(r8) (:)] col irrigation flux (mm H2O/s)
-         qflx_gw_uncon_irrig_lyr_col => waterfluxbulk_inst%qflx_gw_uncon_irrig_lyr_col, & ! Output: [real(r8) (:,:) ] unconfined groundwater irrigation flux, separated by layer (mm H2O/s)
-         qflx_gw_uncon_irrig_col   => waterfluxbulk_inst%qflx_gw_uncon_irrig_col   , & ! Output: [real(r8) (:)] col unconfined groundwater irrigation flux (mm H2O/s)
-         qflx_gw_con_irrig_col     => waterfluxbulk_inst%qflx_gw_con_irrig_col     , & ! Output: [real(r8) (:)] col confined groundwater irrigation flux (mm H2O/s)
-         qflx_irrig_drip_patch     => waterfluxbulk_inst%qflx_irrig_drip_patch     , & ! Output: [real(r8) (:)] patch drip irrigation flux (mm H2O/s)
-         qflx_irrig_sprinkler_patch=> waterfluxbulk_inst%qflx_irrig_sprinkler_patch  & ! Output: [real(r8) (:)] patch sprinkler irrigation flux (mm H2O/s)
+         qflx_sfc_irrig_col          => water_inst%waterfluxbulk_inst%qflx_sfc_irrig_col          , & ! Output: [real(r8) (:)] col irrigation flux (mm H2O/s)
+         qflx_gw_uncon_irrig_lyr_col => water_inst%waterfluxbulk_inst%qflx_gw_uncon_irrig_lyr_col , & ! Output: [real(r8) (:,:) ] unconfined groundwater irrigation flux, separated by layer (mm H2O/s)
+         qflx_gw_uncon_irrig_col     => water_inst%waterfluxbulk_inst%qflx_gw_uncon_irrig_col     , & ! Output: [real(r8) (:)] col unconfined groundwater irrigation flux (mm H2O/s)
+         qflx_gw_con_irrig_col       => water_inst%waterfluxbulk_inst%qflx_gw_con_irrig_col       , & ! Output: [real(r8) (:)] col confined groundwater irrigation flux (mm H2O/s)
+         qflx_irrig_drip_patch       => water_inst%waterfluxbulk_inst%qflx_irrig_drip_patch       , & ! Output: [real(r8) (:)] patch drip irrigation flux (mm H2O/s)
+         qflx_irrig_sprinkler_patch  => water_inst%waterfluxbulk_inst%qflx_irrig_sprinkler_patch    & ! Output: [real(r8) (:)] patch sprinkler irrigation flux (mm H2O/s)
          )
       
     do fp = 1, num_soilp

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -1057,8 +1057,8 @@ contains
     !
     ! Sets the following variables:
     ! - waterflux_tracer_inst%qflx_sfc_irrig_col
-    ! - waterflux_tracer_inst%qflx_gw_con_irrig_col
     ! - waterflux_tracer_inst%qflx_gw_uncon_irrig_lyr_col
+    ! - waterflux_tracer_inst%qflx_gw_con_irrig_col
     !
     ! !ARGUMENTS:
     class(irrigation_type)    , intent(in)    :: this

--- a/src/biogeophys/IrrigationMod.F90
+++ b/src/biogeophys/IrrigationMod.F90
@@ -897,9 +897,7 @@ contains
          qflx_gw_con_irrig_patch   => waterfluxbulk_inst%qflx_gw_con_irrig_patch   , & ! Output: [real(r8) (:)] patch confined groundwater irrigation flux (mm H2O/s)
          qflx_gw_con_irrig_col     => waterfluxbulk_inst%qflx_gw_con_irrig_col     , & ! Output: [real(r8) (:)] col confined groundwater irrigation flux (mm H2O/s)
          qflx_irrig_drip_patch     => waterfluxbulk_inst%qflx_irrig_drip_patch     , & ! Output: [real(r8) (:)] patch drip irrigation flux (mm H2O/s)
-         qflx_irrig_drip_col       => waterfluxbulk_inst%qflx_irrig_drip_col       , & ! Output: [real(r8) (:)] col drip irrigation flux (mm H2O/s)
-         qflx_irrig_sprinkler_patch=> waterfluxbulk_inst%qflx_irrig_sprinkler_patch, & ! Output: [real(r8) (:)] patch sprinkler irrigation flux (mm H2O/s)
-         qflx_irrig_sprinkler_col  => waterfluxbulk_inst%qflx_irrig_sprinkler_col    & ! Output: [real(r8) (:)] col sprinkler irrigation flux (mm H2O/s)
+         qflx_irrig_sprinkler_patch=> waterfluxbulk_inst%qflx_irrig_sprinkler_patch  & ! Output: [real(r8) (:)] patch sprinkler irrigation flux (mm H2O/s)
          )
       
     do fp = 1, num_soilp
@@ -962,14 +960,6 @@ contains
 
     end do
 
-    call p2c (bounds, num_soilc, filter_soilc, &
-         patcharr = qflx_irrig_drip_patch(bounds%begp:bounds%endp), &
-         colarr = qflx_irrig_drip_col(bounds%begc:bounds%endc))
-    
-    call p2c (bounds, num_soilc, filter_soilc, &
-         patcharr = qflx_irrig_sprinkler_patch(bounds%begp:bounds%endp), &
-         colarr = qflx_irrig_sprinkler_col(bounds%begc:bounds%endc))
-    
     end associate
 
   end subroutine ApplyIrrigation

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -50,7 +50,6 @@ module SoilHydrologyMod
   public :: ThetaBasedWaterTable ! Calculate water table from soil moisture state
   public :: LateralFlowPowerLaw  ! Calculate lateral flow based on power law drainage function
   public :: RenewCondensation    ! Misc. corrections
-  public :: CalcAvailableUnconfinedAquifer  ! Calculate water in unconfined aquifer available for groundwater irrigation use
   public :: CalcIrrigWithdrawals ! Calculate irrigation withdrawals from groundwater by layer
   public :: WithdrawGroundwaterIrrigation   ! Remove groundwater irrigation from unconfined and confined aquifers
   
@@ -2493,86 +2492,18 @@ contains
    end subroutine RenewCondensation
 !#8
    !-----------------------------------------------------------------------
-   subroutine CalcAvailableUnconfinedAquifer(bounds, num_soilc, filter_soilc, &
-        soilhydrology_inst, soilstate_inst, waterdiagnosticbulk_inst) 
-     !
-     ! !DESCRIPTION:
-     ! Calculate water in unconfined aquifer (i.e. soil column) that
-     ! is available for groundwater withdrawal.
-     !
-     ! !USES:
-     !
-     ! !ARGUMENTS:
-     type(bounds_type)        , intent(in)         :: bounds  
-     integer                  , intent(in)         :: num_soilc       ! number of column soil points in column filter
-     integer                  , intent(in)         :: filter_soilc(:) ! column filter for soil points
-     type(soilhydrology_type) , intent(in)         :: soilhydrology_inst
-     type(soilstate_type)     , intent(in)         :: soilstate_inst
-     type(waterdiagnosticbulk_type), intent(inout) :: waterdiagnosticbulk_inst
-     !
-     ! !LOCAL VARIABLES:
-     integer  :: jwt(bounds%begc:bounds%endc)            ! index of the soil layer right above the water table (-)
-     integer  :: c,j,fc                                ! indices
-     real(r8) :: s_y
-     real(r8) :: available_water_layer
-     
-     !-----------------------------------------------------------------------
-
-     associate(                                                            & 
-          nbedrock           =>    col%nbedrock                          , & ! Input:  [real(r8) (:,:) ]  depth to bedrock (m)           
-          z                  =>    col%z                                 , & ! Input:  [real(r8) (:,:) ]  layer depth (m)                                 
-          zi                 =>    col%zi                                , & ! Input:  [real(r8) (:,:) ]  interface level below a "z" level (m)           
-          bsw                =>    soilstate_inst%bsw_col                , & ! Input:  [real(r8) (:,:) ] Clapp and Hornberger "b"                        
-          sucsat             =>    soilstate_inst%sucsat_col             , & ! Input:  [real(r8) (:,:) ] minimum soil suction (mm)                       
-          watsat             =>    soilstate_inst%watsat_col             , & ! Input:  [real(r8) (:,:) ] volumetric soil water at saturation (porosity)  
-          zwt                =>    soilhydrology_inst%zwt_col            , & ! Input:  [real(r8) (:)   ]  water table depth (m)
-          available_gw_uncon =>    waterdiagnosticbulk_inst%available_gw_uncon_col  & ! Output: [real(r8) (:)   ]  available water in the unconfined saturated zone (kg/m2)
-          )
-
-       ! calculate amount of water in saturated zone that
-       ! is available for groundwater irrigation
-
-       do fc = 1, num_soilc
-          c = filter_soilc(fc)
-          available_gw_uncon(c) = 0._r8
-
-          jwt(c) = nlevsoi
-          ! allow jwt to equal zero when zwt is in top layer
-          do j = 1,nlevsoi
-             if(zwt(c) <= zi(c,j)) then
-                jwt(c) = j-1
-                exit
-             end if
-          enddo
-          do j = jwt(c)+1, nbedrock(c)
-             s_y = watsat(c,j) &
-                  * ( 1. - (1.+1.e3*zwt(c)/sucsat(c,j))**(-1./bsw(c,j)))
-             s_y=max(s_y,0.02_r8)
-             
-             if (j==jwt(c)+1) then
-                available_water_layer=max(0._r8,(s_y*(zi(c,j) - zwt(c))*1.e3))
-             else
-                available_water_layer=max(0._r8,(s_y*(zi(c,j) - zi(c,j-1))*1.e3))
-             endif
-
-             available_gw_uncon(c) = available_gw_uncon(c) &
-                  + available_water_layer
-          enddo
-       enddo
-
-     end associate
-
-   end subroutine CalcAvailableUnconfinedAquifer
-!#9
-   !-----------------------------------------------------------------------
    subroutine CalcIrrigWithdrawals(bounds, &
         num_soilc, filter_soilc, &
         soilhydrology_inst, soilstate_inst, &
-        waterfluxbulk_inst)
+        qflx_gw_demand, &
+        qflx_gw_uncon_irrig_lyr, &
+        qflx_gw_con_irrig)
      !
      ! !DESCRIPTION:
-     ! Calculate irrigation withdrawals from groundwater by layer
+     ! Calculate irrigation withdrawals from groundwater, given groundwater irrigation demand
+     !
      ! This routine is called when use_groundwater_irrigation = .true.
+     !
      ! It is not compatible with use_aquifer_layer
      !
      ! !ARGUMENTS:
@@ -2581,7 +2512,10 @@ contains
      integer                  , intent(in)    :: filter_soilc(:) ! column filter for soil points
      type(soilhydrology_type) , intent(in)    :: soilhydrology_inst
      type(soilstate_type)     , intent(in)    :: soilstate_inst
-     type(waterfluxbulk_type) , intent(inout) :: waterfluxbulk_inst
+
+     real(r8) , intent(in)    :: qflx_gw_demand( bounds%begc: )              ! groundwater irrigation demand (mm H2O/s)
+     real(r8) , intent(inout) :: qflx_gw_uncon_irrig_lyr( bounds%begc:, 1: ) ! unconfined aquifer groundwater irrigation withdrawal flux, separated by layer (mm H2O/s)
+     real(r8) , intent(inout) :: qflx_gw_con_irrig( bounds%begc: )           ! total confined aquifer groundwater irrigation withdrawal flux (mm H2O/s)
      !
      ! !LOCAL VARIABLES:
      character(len=32) :: subname = 'CalcIrrigWithdrawals'  ! subroutine name
@@ -2589,10 +2523,14 @@ contains
      real(r8) :: dtime                                   ! land model time step (sec)
      integer  :: jwt(bounds%begc:bounds%endc)            ! index of the soil layer right above the water table (-)
      real(r8) :: s_y
-     real(r8) :: irrig_total
-     real(r8) :: available_water_layer
-     real(r8) :: irrig_layer
+     real(r8) :: irrig_demand_remaining  ! mm H2O
+     real(r8) :: available_water_layer   ! mm H2O
+     real(r8) :: irrig_layer             ! mm H2O
      !-----------------------------------------------------------------------
+
+     SHR_ASSERT_ALL((ubound(qflx_gw_demand) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+     SHR_ASSERT_ALL((ubound(qflx_gw_uncon_irrig_lyr) == [bounds%endc, nlevsoi]), errMsg(sourcefile, __LINE__))
+     SHR_ASSERT_ALL((ubound(qflx_gw_con_irrig) == [bounds%endc]), errMsg(sourcefile, __LINE__))
 
      associate(                                                            & 
           nbedrock           =>    col%nbedrock                          , & ! Input:  [real(r8) (:,:) ]  depth to bedrock (m)           
@@ -2603,10 +2541,7 @@ contains
           hksat              =>    soilstate_inst%hksat_col              , & ! Input:  [real(r8) (:,:) ] hydraulic conductivity at saturation (mm H2O /s)
           sucsat             =>    soilstate_inst%sucsat_col             , & ! Input:  [real(r8) (:,:) ] minimum soil suction (mm)                       
           watsat             =>    soilstate_inst%watsat_col             , & ! Input:  [real(r8) (:,:) ] volumetric soil water at saturation (porosity)  
-          zwt                =>    soilhydrology_inst%zwt_col            , & ! Input:  [real(r8) (:)   ] water table depth (m)                             
-
-          qflx_gw_uncon_irrig =>   waterfluxbulk_inst%qflx_gw_uncon_irrig_col, & ! Input:  [real(r8) (:) ] unconfined groundwater irrigation flux (mm H2O /s)
-          qflx_gw_uncon_irrig_lyr => waterfluxbulk_inst%qflx_gw_uncon_irrig_lyr_col  & ! Output: [real(r8) (:,:) ] unconfined groundwater irrigation flux, separated by layer (mm H2O/s)
+          zwt                =>    soilhydrology_inst%zwt_col              & ! Input:  [real(r8) (:)   ] water table depth (m)                             
           )
 
        dtime = get_step_size()
@@ -2622,12 +2557,12 @@ contains
        do fc = 1, num_soilc
           c = filter_soilc(fc)
 
-          irrig_total = qflx_gw_uncon_irrig(c)*dtime
+          irrig_demand_remaining = qflx_gw_demand(c)*dtime
           
           ! should never be negative... but include for completeness
-          if(irrig_total < 0.) then
+          if(irrig_demand_remaining < 0.) then
              
-             call endrun(msg="negative groundwater irrigation!"//errmsg(sourcefile, __LINE__))
+             call endrun(msg="negative groundwater irrigation demand! "//errmsg(sourcefile, __LINE__))
              
           else 
              jwt(c) = nlevsoi
@@ -2650,22 +2585,30 @@ contains
                    available_water_layer=max(0._r8,(s_y*(zi(c,j) - zi(c,j-1))*1.e3))
                 endif
 
-                irrig_layer = min(irrig_total, available_water_layer)
+                irrig_layer = min(irrig_demand_remaining, available_water_layer)
                 qflx_gw_uncon_irrig_lyr(c,j) = irrig_layer / dtime
 
-                irrig_total = irrig_total - irrig_layer
+                irrig_demand_remaining = irrig_demand_remaining - irrig_layer
 
-                if (irrig_total <= 0.) then 
+                if (irrig_demand_remaining <= 0.) then 
                    exit
                 endif
-             enddo
-          endif
+             end do
+
+             if (irrig_demand_remaining > 0._r8) then
+                ! NOTE(wjs, 2018-12-15) Eventually we could limit irrigation from the
+                ! confined aquifer based on water availability there.
+                qflx_gw_con_irrig(c) = irrig_demand_remaining / dtime
+             else
+                qflx_gw_con_irrig(c) = 0._r8
+             end if
+          end if
        end do
 
      end associate
 
    end subroutine CalcIrrigWithdrawals
-
+!#9
    !-----------------------------------------------------------------------
    subroutine WithdrawGroundwaterIrrigation(bounds, &
         num_soilc, filter_soilc, &

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -2493,7 +2493,7 @@ contains
    end subroutine RenewCondensation
 !#8
    !-----------------------------------------------------------------------
-   subroutine CalcAvailableUnconfinedAquifer(bounds, num_hydrologyc, filter_hydrologyc, &
+   subroutine CalcAvailableUnconfinedAquifer(bounds, num_soilc, filter_soilc, &
         soilhydrology_inst, soilstate_inst, waterdiagnosticbulk_inst) 
      !
      ! !DESCRIPTION:
@@ -2504,8 +2504,8 @@ contains
      !
      ! !ARGUMENTS:
      type(bounds_type)        , intent(in)         :: bounds  
-     integer                  , intent(in)         :: num_hydrologyc       ! number of column soil points in column filter
-     integer                  , intent(in)         :: filter_hydrologyc(:) ! column filter for soil points
+     integer                  , intent(in)         :: num_soilc       ! number of column soil points in column filter
+     integer                  , intent(in)         :: filter_soilc(:) ! column filter for soil points
      type(soilhydrology_type) , intent(in)         :: soilhydrology_inst
      type(soilstate_type)     , intent(in)         :: soilstate_inst
      type(waterdiagnosticbulk_type), intent(inout) :: waterdiagnosticbulk_inst
@@ -2532,8 +2532,8 @@ contains
        ! calculate amount of water in saturated zone that
        ! is available for groundwater irrigation
 
-       do fc = 1, num_hydrologyc
-          c = filter_hydrologyc(fc)
+       do fc = 1, num_soilc
+          c = filter_soilc(fc)
           available_gw_uncon(c) = 0._r8
 
           jwt(c) = nlevsoi
@@ -2566,7 +2566,7 @@ contains
 !#9
    !-----------------------------------------------------------------------
    subroutine CalcIrrigWithdrawals(bounds, &
-        num_hydrologyc, filter_hydrologyc, &
+        num_soilc, filter_soilc, &
         soilhydrology_inst, soilstate_inst, &
         waterfluxbulk_inst)
      !
@@ -2577,8 +2577,8 @@ contains
      !
      ! !ARGUMENTS:
      type(bounds_type)        , intent(in)    :: bounds               
-     integer                  , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
-     integer                  , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
+     integer                  , intent(in)    :: num_soilc       ! number of column soil points in column filter
+     integer                  , intent(in)    :: filter_soilc(:) ! column filter for soil points
      type(soilhydrology_type) , intent(in)    :: soilhydrology_inst
      type(soilstate_type)     , intent(in)    :: soilstate_inst
      type(waterfluxbulk_type) , intent(inout) :: waterfluxbulk_inst
@@ -2612,15 +2612,15 @@ contains
        dtime = get_step_size()
 
        do j = 1, nlevsoi
-          do fc = 1, num_hydrologyc
-             c = filter_hydrologyc(fc)
+          do fc = 1, num_soilc
+             c = filter_soilc(fc)
              qflx_gw_uncon_irrig_lyr(c,j) = 0._r8
           end do
        end do
 
        !-- Remove groundwater from unconfined aquifer  -----------
-       do fc = 1, num_hydrologyc
-          c = filter_hydrologyc(fc)
+       do fc = 1, num_soilc
+          c = filter_soilc(fc)
 
           irrig_total = qflx_gw_uncon_irrig(c)*dtime
           
@@ -2668,7 +2668,7 @@ contains
 
    !-----------------------------------------------------------------------
    subroutine WithdrawGroundwaterIrrigation(bounds, &
-        num_hydrologyc, filter_hydrologyc, &
+        num_soilc, filter_soilc, &
         waterfluxbulk_inst, waterstatebulk_inst)
      !
      ! !DESCRIPTION:
@@ -2678,8 +2678,8 @@ contains
      !
      ! !ARGUMENTS:
      type(bounds_type)        , intent(in)    :: bounds               
-     integer                  , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
-     integer                  , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
+     integer                  , intent(in)    :: num_soilc       ! number of column soil points in column filter
+     integer                  , intent(in)    :: filter_soilc(:) ! column filter for soil points
      type(waterfluxbulk_type) , intent(in)    :: waterfluxbulk_inst
      type(waterstatebulk_type), intent(inout) :: waterstatebulk_inst
      !
@@ -2701,16 +2701,16 @@ contains
      dtime = get_step_size()
 
      do j = 1, nlevsoi
-        do fc = 1, num_hydrologyc
-           c = filter_hydrologyc(fc)
+        do fc = 1, num_soilc
+           c = filter_soilc(fc)
            h2osoi_liq(c,j) = h2osoi_liq(c,j) - qflx_gw_uncon_irrig_lyr(c,j) * dtime
         end do
      end do
 
      ! zwt is not being updated, as it will be updated after HydrologyNoDrainage
        
-     do fc = 1, num_hydrologyc
-        c = filter_hydrologyc(fc)
+     do fc = 1, num_soilc
+        c = filter_soilc(fc)
         wa(c) = wa(c) - qflx_gw_con_irrig(c) * dtime
      end do
 

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -22,9 +22,11 @@ module SoilHydrologyMod
   use InfiltrationExcessRunoffMod, only : infiltration_excess_runoff_type
   use SoilHydrologyType , only : soilhydrology_type  
   use SoilStateType     , only : soilstate_type
-  use WaterFluxBulkType     , only : waterfluxbulk_type
-  use WaterStateBulkType    , only : waterstatebulk_type
-  use WaterDiagnosticBulkType    , only : waterdiagnosticbulk_type
+  use WaterFluxType     , only : waterflux_type
+  use WaterFluxBulkType , only : waterfluxbulk_type
+  use WaterStateType    , only : waterstate_type
+  use WaterStateBulkType, only : waterstatebulk_type
+  use WaterDiagnosticBulkType, only : waterdiagnosticbulk_type
   use TemperatureType   , only : temperature_type
   use LandunitType      , only : lun                
   use ColumnType        , only : col                
@@ -2612,7 +2614,7 @@ contains
    !-----------------------------------------------------------------------
    subroutine WithdrawGroundwaterIrrigation(bounds, &
         num_soilc, filter_soilc, &
-        waterfluxbulk_inst, waterstatebulk_inst)
+        waterflux_inst, waterstate_inst)
      !
      ! !DESCRIPTION:
      ! Remove groundwater irrigation from unconfined and confined aquifers
@@ -2620,11 +2622,11 @@ contains
      ! It is not compatible with use_aquifer_layer
      !
      ! !ARGUMENTS:
-     type(bounds_type)        , intent(in)    :: bounds               
-     integer                  , intent(in)    :: num_soilc       ! number of column soil points in column filter
-     integer                  , intent(in)    :: filter_soilc(:) ! column filter for soil points
-     type(waterfluxbulk_type) , intent(in)    :: waterfluxbulk_inst
-     type(waterstatebulk_type), intent(inout) :: waterstatebulk_inst
+     type(bounds_type)      , intent(in)    :: bounds               
+     integer                , intent(in)    :: num_soilc       ! number of column soil points in column filter
+     integer                , intent(in)    :: filter_soilc(:) ! column filter for soil points
+     class(waterflux_type)  , intent(in)    :: waterflux_inst
+     class(waterstate_type) , intent(inout) :: waterstate_inst
      !
      ! !LOCAL VARIABLES:
      integer  :: fc, c, j
@@ -2634,11 +2636,11 @@ contains
      !-----------------------------------------------------------------------
 
      associate( &
-          qflx_gw_uncon_irrig_lyr => waterfluxbulk_inst%qflx_gw_uncon_irrig_lyr_col, & ! Input: [real(r8) (:,:) ] unconfined groundwater irrigation flux, separated by layer (mm H2O/s)
-          qflx_gw_con_irrig  => waterfluxbulk_inst%qflx_gw_con_irrig_col     , & ! Input: [real(r8) (:,:) ] confined groundwater irrigation flux (mm H2O /s)   
+          qflx_gw_uncon_irrig_lyr => waterflux_inst%qflx_gw_uncon_irrig_lyr_col, & ! Input: [real(r8) (:,:) ] unconfined groundwater irrigation flux, separated by layer (mm H2O/s)
+          qflx_gw_con_irrig  => waterflux_inst%qflx_gw_con_irrig_col     , & ! Input: [real(r8) (:,:) ] confined groundwater irrigation flux (mm H2O /s)
 
-          wa                 =>    waterstatebulk_inst%wa_col                , & ! Output: [real(r8) (:)   ] water in the unconfined aquifer (mm)
-          h2osoi_liq         =>    waterstatebulk_inst%h2osoi_liq_col          & ! Output: [real(r8) (:,:) ] liquid water (kg/m2)
+          wa                 =>    waterstate_inst%wa_col                , & ! Output: [real(r8) (:)   ] water in the unconfined aquifer (mm)
+          h2osoi_liq         =>    waterstate_inst%h2osoi_liq_col          & ! Output: [real(r8) (:,:) ] liquid water (kg/m2)
           )
 
      dtime = get_step_size()

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -65,7 +65,6 @@ module WaterDiagnosticBulkType
      real(r8), pointer :: frac_h2osfc_nosnow_col (:)   ! col fractional area with surface water greater than zero (if no snow present)
      real(r8), pointer :: wf_col                 (:)   ! col soil water as frac. of whc for top 0.05 m (0-1) 
      real(r8), pointer :: wf2_col                (:)   ! col soil water as frac. of whc for top 0.17 m (0-1) 
-     real(r8), pointer :: available_gw_uncon_col (:)   ! col available water in the unconfined saturated zone
      real(r8), pointer :: fwet_patch             (:)   ! patch canopy fraction that is wet (0 to 1)
      real(r8), pointer :: fcansno_patch          (:)   ! patch canopy fraction that is snow covered (0 to 1)
      real(r8), pointer :: fdry_patch             (:)   ! patch canopy fraction of foliage that is green and dry [-] (new)
@@ -169,7 +168,6 @@ contains
     allocate(this%frac_h2osfc_nosnow_col (begc:endc))                     ; this%frac_h2osfc_nosnow_col        (:)   = nan 
     allocate(this%wf_col                 (begc:endc))                     ; this%wf_col                 (:)   = nan
     allocate(this%wf2_col                (begc:endc))                     ; this%wf2_col                (:)   = nan
-    allocate(this%available_gw_uncon_col (begc:endc))                     ; this%available_gw_uncon_col (:)   = nan
     allocate(this%fwet_patch             (begp:endp))                     ; this%fwet_patch             (:)   = nan
     allocate(this%fcansno_patch          (begp:endp))                     ; this%fcansno_patch          (:)   = nan
     allocate(this%fdry_patch             (begp:endp))                     ; this%fdry_patch             (:)   = nan
@@ -386,14 +384,6 @@ contains
             ptr_col=this%wf_col, default='inactive')
     end if
 
-    this%available_gw_uncon_col(begc:endc) = spval
-    call hist_addfld1d ( &
-         fname=this%info%fname('GW_AVAILABLE'), &
-         units='kg/m2', &
-         avgflag='A', &
-         long_name=this%info%lname('available water in the unconfined saturated zone'), &
-         ptr_col=this%available_gw_uncon_col, default='inactive')
-    
     this%h2osno_top_col(begc:endc) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('H2OSNO_TOP'), &

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -7,7 +7,7 @@ module WaterFluxType
   !
   ! !USES:
   use shr_kind_mod   , only: r8 => shr_kind_r8
-  use clm_varpar     , only : nlevsno
+  use clm_varpar     , only : nlevsno, nlevsoi
   use clm_varcon     , only : spval
   use decompMod      , only : bounds_type
   use decompMod      , only : BOUNDS_SUBGRID_PATCH, BOUNDS_SUBGRID_COLUMN, BOUNDS_SUBGRID_GRIDCELL

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -94,11 +94,8 @@ module WaterFluxType
      real(r8), pointer :: qflx_liq_dynbal_grc      (:)   ! grc liq dynamic land cover change conversion runoff flux
      real(r8), pointer :: qflx_ice_dynbal_grc      (:)   ! grc ice dynamic land cover change conversion runoff flux
 
-     real(r8), pointer :: qflx_sfc_irrig_patch      (:)   ! patch surface irrigation flux (mm H2O/s) [+]           
      real(r8), pointer :: qflx_sfc_irrig_col        (:)   ! col surface irrigation flux (mm H2O/s) [+]             
-     real(r8), pointer :: qflx_gw_uncon_irrig_patch (:)   ! patch unconfined groundwater irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_gw_uncon_irrig_col   (:)   ! col unconfined groundwater irrigation flux (mm H2O/s)
-     real(r8), pointer :: qflx_gw_con_irrig_patch   (:)   ! patch confined groundwater irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_gw_con_irrig_col     (:)   ! col confined groundwater irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_irrig_drip_patch     (:)   ! patch drip irrigation
      real(r8), pointer :: qflx_irrig_sprinkler_patch(:)   ! patch sprinkler irrigation
@@ -329,23 +326,14 @@ contains
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_GRIDCELL)
 
-    call AllocateVar1d(var = this%qflx_sfc_irrig_patch, name = 'qflx_sfc_irrig_patch', &
-         container = tracer_vars, &
-         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
     call AllocateVar1d(var = this%qflx_sfc_irrig_col, name = 'qflx_sfc_irrig_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
 
-    call AllocateVar1d(var = this%qflx_gw_uncon_irrig_patch, name = 'qflx_gw_uncon_irrig_patch', &
-         container = tracer_vars, &
-         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
     call AllocateVar1d(var = this%qflx_gw_uncon_irrig_col, name = 'qflx_gw_uncon_irrig_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
 
-    call AllocateVar1d(var = this%qflx_gw_con_irrig_patch, name = 'qflx_gw_con_irrig_patch', &
-         container = tracer_vars, &
-         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
     call AllocateVar1d(var = this%qflx_gw_con_irrig_col, name = 'qflx_gw_con_irrig_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
@@ -733,29 +721,29 @@ contains
          long_name=this%info%lname('surface water converted to ice'), &
          ptr_col=this%qflx_h2osfc_to_ice_col, default='inactive')
 
-    this%qflx_sfc_irrig_patch(begp:endp) = spval
+    this%qflx_sfc_irrig_col(begc:endc) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QIRRIG_FROM_SURFACE'), &
          units='mm/s', &
          avgflag='A', &
          long_name=this%info%lname('water added through surface water irrigation'), &
-         ptr_patch=this%qflx_sfc_irrig_patch)
+         ptr_col=this%qflx_sfc_irrig_col)
 
-    this%qflx_gw_uncon_irrig_patch(begp:endp) = spval
+    this%qflx_gw_uncon_irrig_col(begc:endc) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QIRRIG_FROM_GW_UNCONFINED'), &
          units='mm/s', &
          avgflag='A', &
          long_name=this%info%lname('water added through unconfined groundwater irrigation'), &
-         ptr_patch=this%qflx_gw_uncon_irrig_patch)
+         ptr_col=this%qflx_gw_uncon_irrig_col)
 
-    this%qflx_gw_con_irrig_patch(begp:endp) = spval
+    this%qflx_gw_con_irrig_col(begc:endc) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QIRRIG_FROM_GW_CONFINED'), &
          units='mm/s', &
          avgflag='A', &
          long_name=this%info%lname('water added through confined groundwater irrigation'), &
-         ptr_patch=this%qflx_gw_con_irrig_patch)
+         ptr_patch=this%qflx_gw_con_irrig_col)
 
     this%qflx_irrig_drip_patch(begp:endp) = spval
     call hist_addfld1d ( &
@@ -796,11 +784,8 @@ contains
     this%qflx_dew_grnd_patch (bounds%begp:bounds%endp)        = 0.0_r8
     this%qflx_dew_snow_patch (bounds%begp:bounds%endp)        = 0.0_r8
 
-    this%qflx_sfc_irrig_patch (bounds%begp:bounds%endp)       = 0.0_r8
     this%qflx_sfc_irrig_col (bounds%begc:bounds%endc)         = 0.0_r8
-    this%qflx_gw_uncon_irrig_patch (bounds%begp:bounds%endp)  = 0.0_r8
     this%qflx_gw_uncon_irrig_col (bounds%begc:bounds%endc)    = 0.0_r8
-    this%qflx_gw_con_irrig_patch (bounds%begp:bounds%endp)    = 0.0_r8
     this%qflx_gw_con_irrig_col (bounds%begc:bounds%endc)      = 0.0_r8
     this%qflx_irrig_drip_patch (bounds%begp:bounds%endp)      = 0.0_r8
     this%qflx_irrig_sprinkler_patch (bounds%begp:bounds%endp) = 0.0_r8

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -743,7 +743,7 @@ contains
          units='mm/s', &
          avgflag='A', &
          long_name=this%info%lname('water added through confined groundwater irrigation'), &
-         ptr_patch=this%qflx_gw_con_irrig_col)
+         ptr_col=this%qflx_gw_con_irrig_col)
 
     this%qflx_irrig_drip_patch(begp:endp) = spval
     call hist_addfld1d ( &

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -96,6 +96,7 @@ module WaterFluxType
 
      real(r8), pointer :: qflx_sfc_irrig_col        (:)   ! col surface irrigation flux (mm H2O/s) [+]             
      real(r8), pointer :: qflx_gw_uncon_irrig_col   (:)   ! col unconfined groundwater irrigation flux (mm H2O/s)
+     real(r8), pointer :: qflx_gw_uncon_irrig_lyr_col(:,:) ! col unconfined groundwater irrigation flux, separated by layer (mm H2O/s)
      real(r8), pointer :: qflx_gw_con_irrig_col     (:)   ! col confined groundwater irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_irrig_drip_patch     (:)   ! patch drip irrigation
      real(r8), pointer :: qflx_irrig_sprinkler_patch(:)   ! patch sprinkler irrigation
@@ -333,6 +334,11 @@ contains
     call AllocateVar1d(var = this%qflx_gw_uncon_irrig_col, name = 'qflx_gw_uncon_irrig_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
+
+    call AllocateVar2d(var = this%qflx_gw_uncon_irrig_lyr_col, name = 'qflx_gw_uncon_irrig_lyr_col', &
+         container = tracer_vars, &
+         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN, &
+         dim2beg = 1, dim2end = nlevsoi)
 
     call AllocateVar1d(var = this%qflx_gw_con_irrig_col, name = 'qflx_gw_con_irrig_col', &
          container = tracer_vars, &
@@ -786,6 +792,7 @@ contains
 
     this%qflx_sfc_irrig_col (bounds%begc:bounds%endc)         = 0.0_r8
     this%qflx_gw_uncon_irrig_col (bounds%begc:bounds%endc)    = 0.0_r8
+    this%qflx_gw_uncon_irrig_lyr_col(bounds%begc:bounds%endc,:) = 0.0_r8
     this%qflx_gw_con_irrig_col (bounds%begc:bounds%endc)      = 0.0_r8
     this%qflx_irrig_drip_patch (bounds%begp:bounds%endp)      = 0.0_r8
     this%qflx_irrig_sprinkler_patch (bounds%begp:bounds%endp) = 0.0_r8

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -101,9 +101,7 @@ module WaterFluxType
      real(r8), pointer :: qflx_gw_con_irrig_patch   (:)   ! patch confined groundwater irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_gw_con_irrig_col     (:)   ! col confined groundwater irrigation flux (mm H2O/s)
      real(r8), pointer :: qflx_irrig_drip_patch     (:)   ! patch drip irrigation
-     real(r8), pointer :: qflx_irrig_drip_col       (:)   ! col   drip irrigation
      real(r8), pointer :: qflx_irrig_sprinkler_patch(:)   ! patch sprinkler irrigation
-     real(r8), pointer :: qflx_irrig_sprinkler_col  (:)   ! col   sprinkler irrigation
 
      ! Objects that help convert once-per-year dynamic land cover changes into fluxes
      ! that are dribbled throughout the year
@@ -355,16 +353,10 @@ contains
     call AllocateVar1d(var = this%qflx_irrig_drip_patch, name = 'qflx_irrig_drip_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_irrig_drip_col, name = 'qflx_irrig_drip_col', &
-         container = tracer_vars, &
-         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
 
     call AllocateVar1d(var = this%qflx_irrig_sprinkler_patch, name = 'qflx_irrig_sprinkler_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_irrig_sprinkler_col, name = 'qflx_irrig_sprinkler_col', &
-         container = tracer_vars, &
-         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
     
     this%qflx_liq_dynbal_dribbler = annual_flux_dribbler_gridcell( &
          bounds = bounds, &
@@ -811,9 +803,7 @@ contains
     this%qflx_gw_con_irrig_patch (bounds%begp:bounds%endp)    = 0.0_r8
     this%qflx_gw_con_irrig_col (bounds%begc:bounds%endc)      = 0.0_r8
     this%qflx_irrig_drip_patch (bounds%begp:bounds%endp)      = 0.0_r8
-    this%qflx_irrig_drip_col (bounds%begc:bounds%endc)        = 0.0_r8
     this%qflx_irrig_sprinkler_patch (bounds%begp:bounds%endp) = 0.0_r8
-    this%qflx_irrig_sprinkler_col (bounds%begc:bounds%endc)   = 0.0_r8
     
     this%qflx_evap_grnd_col(bounds%begc:bounds%endc) = 0.0_r8
     this%qflx_dew_grnd_col (bounds%begc:bounds%endc) = 0.0_r8

--- a/src/biogeophys/test/Irrigation_test/README
+++ b/src/biogeophys/test/Irrigation_test/README
@@ -52,3 +52,23 @@ test. This is important because, if an assertion fails, a test immediately
 exits. That means that manual teardown is skipped, whereas this automatic
 teardown still happens. This, in turn, is important so that the remaining tests
 can still run properly.
+
+--- Tests of various irrigation sources ---
+
+(2018-12-15) Some notes about the tests of the various irrigation
+sources: surface water (rivers), unconfined aquifer and confined
+aquifer:
+
+In addition to testing the basic logic for these various sources, there
+are two other aspects of the behavior that I wanted to test:
+
+(1) Does it work to have irrigation from a mix of sources?
+
+(2) Does it work to have multiple patches on a single column? (I felt it
+    was important to test this given the complexity of the logic for
+    going back and forth between patch and column-level variables.)
+
+I felt that tests would have been too complex if I tried to cover (1)
+and (2) in a single test. So instead, I have single-patch but
+multi-source tests covering (1), and multi-patch but single-source tests
+covering (2).

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -666,7 +666,7 @@ contains
   end function totalIrrigationApplicationPatch
 
   !-----------------------------------------------------------------------
-  function totalIrrigationWithdrawalCol(this, c) result(total_withdrawal)
+  function totalIrrigationWithdrawalCol(this, use_per_layer_fluxes, c) result(total_withdrawal)
     !
     ! !DESCRIPTION:
     ! Return total irrigation withdrawal for column c
@@ -674,10 +674,15 @@ contains
     ! !ARGUMENTS:
     real(r8), allocatable :: total_withdrawal  ! function result
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in), optional :: c  ! column index (if not present, use bounds%begc)
+    logical, intent(in) :: use_per_layer_fluxes ! if true, use per-layer uncon irrig fluxes rather than the diagnostic sum
+    integer, intent(in), optional :: c ! column index (if not present, use bounds%begc)
+
+    ! if present and true, use per-layer uncon irrig fluxes rather than the diagnostic
+    ! sum (false by default)
     !
     ! !LOCAL VARIABLES:
     integer :: l_c
+    real(r8) :: qflx_gw_uncon_irrig
 
     character(len=*), parameter :: subname = 'totalIrrigationWithdrawalCol'
     !-----------------------------------------------------------------------
@@ -688,9 +693,15 @@ contains
        l_c = bounds%begc
     end if
 
+    if (use_per_layer_fluxes) then
+       qflx_gw_uncon_irrig = sum(this%waterflux%qflx_gw_uncon_irrig_lyr_col(l_c,:))
+    else
+       qflx_gw_uncon_irrig = this%waterflux%qflx_gw_uncon_irrig_col(l_c)
+    end if
+
     total_withdrawal = &
          this%waterflux%qflx_sfc_irrig_col(l_c) + &
-         this%waterflux%qflx_gw_uncon_irrig_col(l_c) + &
+         qflx_gw_uncon_irrig + &
          this%waterflux%qflx_gw_con_irrig_col(l_c)
 
   end function totalIrrigationWithdrawalCol
@@ -735,7 +746,8 @@ contains
     character(len=*), parameter :: subname = 'assertTotalIrrigationEqualsCol'
     !-----------------------------------------------------------------------
 
-    @assertEqual(expected, this%totalIrrigationWithdrawalCol(c), tolerance=tol)
+    @assertEqual(expected, this%totalIrrigationWithdrawalCol(use_per_layer_fluxes=.false., c=c), tolerance=tol)
+    @assertEqual(expected, this%totalIrrigationWithdrawalCol(use_per_layer_fluxes=.true., c=c), tolerance=tol)
 
   end subroutine assertTotalIrrigationEqualsCol
 
@@ -761,8 +773,8 @@ contains
     character(len=*), parameter :: subname = 'assertTotalIrrigationEquals'
     !-----------------------------------------------------------------------
 
-    @assertEqual(expected, this%totalIrrigationWithdrawalCol(c), tolerance=tol)
-    @assertEqual(expected, this%totalIrrigationApplicationPatch(p), tolerance=tol)
+    call this%assertTotalIrrigationEqualsCol(expected, c)
+    call this%assertTotalIrrigationEqualsPatch(expected, p)
 
   end subroutine assertTotalIrrigationEquals
 
@@ -783,8 +795,8 @@ contains
     character(len=*), parameter :: subname = 'assertTotalIrrigationZero'
     !-----------------------------------------------------------------------
 
-    @assertEqual(0._r8, this%totalIrrigationWithdrawalCol(c))
-    @assertEqual(0._r8, this%totalIrrigationApplicationPatch(p))
+    call this%assertTotalIrrigationEqualsCol(0._r8, c)
+    call this%assertTotalIrrigationEqualsPatch(0._r8, p)
 
   end subroutine assertTotalIrrigationZero
 
@@ -805,7 +817,8 @@ contains
     character(len=*), parameter :: subname = 'assertTotalIrrigationGreaterThanZero'
     !-----------------------------------------------------------------------
 
-    @assertLessThan(0._r8, this%totalIrrigationWithdrawalCol(c))
+    @assertLessThan(0._r8, this%totalIrrigationWithdrawalCol(use_per_layer_fluxes=.false., c=c))
+    @assertLessThan(0._r8, this%totalIrrigationWithdrawalCol(use_per_layer_fluxes=.true., c=c))
     @assertLessThan(0._r8, this%totalIrrigationApplicationPatch(p))
 
   end subroutine assertTotalIrrigationGreaterThanZero

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -1627,7 +1627,7 @@ contains
   end subroutine multiple_irrigated_patches_per_column_gwConIrrig
 
   @Test
-  subroutine multiple_irrigated_patches_per_column_gwConIrrigUnmetDemand(this)
+  subroutine multiple_irrigated_patches_per_column_gwConIrrigSomeUnmetDemand(this)
     ! If we have multiple irrigated patches on a column, with multiple irrigated patches
     ! along with one without, make sure the column-level and patch-level fluxes are
     ! computed correctly.
@@ -1676,7 +1676,54 @@ contains
          deficit_irrig2 = total_deficit2, &
          deficit_fraction_met = deficit_fraction_met, &
          expected_fluxvar_col = this%waterflux%qflx_gw_con_irrig_col)
-  end subroutine multiple_irrigated_patches_per_column_gwConIrrigUnmetDemand
+  end subroutine multiple_irrigated_patches_per_column_gwConIrrigSomeUnmetDemand
+
+  @Test
+  subroutine multiple_irrigated_patches_per_column_allDemandUnmet(this)
+    ! If we have multiple irrigated patches on a column, with multiple irrigated patches
+    ! along with one without, make sure the column-level and patch-level fluxes are
+    ! computed correctly.
+    !
+    ! This version has all demand unmet. This tests to make sure we don't have a divide
+    ! by zero or other error in this edge case.
+    class(TestIrrigation), intent(inout) :: this
+    real(r8), parameter :: wt_irrig1 = 0.5_r8
+    real(r8), parameter :: wt_unirrig = 0.2_r8
+    real(r8), parameter :: wt_irrig2 = 0.3_r8
+    real(r8), allocatable :: deficits(:,:)
+    real(r8) :: total_deficit1, total_deficit2
+
+    ! Setup grid
+    call setup_n_veg_patches(pwtcol = [wt_irrig1, wt_unirrig, wt_irrig2], &
+         pft_types = [1, 2, 3])
+    call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
+
+    ! Other setup
+    call this%setupIrrigation( &
+         maxpft = 3, &
+         test_limit_irrigation = .true., &
+         use_groundwater_irrigation = .true.)
+    this%volr = 0._r8
+    call this%irrigation%SetGwFractions( &
+         gw_frac_from_con = 0._r8, &
+         gw_frac_from_uncon = [0._r8])
+    pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
+
+    ! Call irrigation routines
+    call this%calculateAndApplyIrrigation()
+
+    ! Check result
+    call this%computeDeficits(deficits)
+    total_deficit1 = sum(deficits(bounds%begp, 1:nlevsoi))
+    total_deficit2 = sum(deficits(bounds%begp+2, 1:nlevsoi))
+    call this%assertTotalIrrigationEqualsForTwoIrrigPatches( &
+         wt_irrig1 = wt_irrig1, &
+         wt_irrig2 = wt_irrig2, &
+         deficit_irrig1 = total_deficit1, &
+         deficit_irrig2 = total_deficit2, &
+         deficit_fraction_met = 0._r8, &
+         expected_fluxvar_col = this%waterflux%qflx_gw_con_irrig_col)
+  end subroutine multiple_irrigated_patches_per_column_allDemandUnmet
 
   @Test
   subroutine irrigation_only_happens_within_filter(this)

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -17,10 +17,12 @@ module test_irrigation
   use SoilHydrologyType, only : soilhydrology_type
   use SoilStateType, only : soilstate_type
   use WaterFluxBulkType, only : waterfluxbulk_type
+  use WaterType, only : water_type
   use PatchType     , only : patch
   use ColumnType    , only : col
   use GridcellType  , only : grc
   use pftconMod , only : pftcon
+  use unittestWaterTypeFactory, only : unittest_water_type_factory_type
   use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch, setup_n_veg_patches
   use unittestFilterBuilderMod, only : filter_from_range
 
@@ -46,7 +48,10 @@ module test_irrigation
      integer :: numf
      integer, allocatable :: filter(:)
      type(irrigation_test_type) :: irrigation
-     type(waterfluxbulk_type) :: waterflux
+     
+     type(unittest_water_type_factory_type) :: water_factory
+     type(water_type) :: water_inst
+     type(waterfluxbulk_type), pointer :: waterflux ! Convenience pointer to water_inst%waterfluxbulk_inst
 
      ! Irrigation parameters
      type(irrigation_params_type) :: irrigation_params
@@ -212,6 +217,7 @@ contains
 
   subroutine setUp(this)
     class(TestIrrigation), intent(inout) :: this
+    integer, parameter :: irrelevant_nlevsno = 3
 
     ! Setup time manager
     call unittest_timemgr_setup(dtime=dtime)
@@ -228,6 +234,12 @@ contains
     nlevsoi = 4
     nlevgrnd = nlevsoi + 1
 
+    call this%water_factory%init()
+    call this%water_factory%setup_before_subgrid( &
+         my_nlevsoi = nlevsoi, &
+         nlevgrnd_additional = nlevgrnd - nlevsoi, &
+         my_nlevsno = irrelevant_nlevsno)
+
   end subroutine setUp
 
   subroutine tearDown(this)
@@ -235,12 +247,7 @@ contains
 
     call unittest_timemgr_teardown()
     call this%irrigation%Clean()
-    deallocate(this%waterflux%qflx_sfc_irrig_col)
-    deallocate(this%waterflux%qflx_gw_uncon_irrig_col)
-    deallocate(this%waterflux%qflx_gw_uncon_irrig_lyr_col)
-    deallocate(this%waterflux%qflx_gw_con_irrig_col)
-    deallocate(this%waterflux%qflx_irrig_drip_patch)
-    deallocate(this%waterflux%qflx_irrig_sprinkler_patch)
+    call this%water_factory%teardown(this%water_inst)
     call this%teardownEnvironment()
     call unittest_subgrid_teardown()
   end subroutine tearDown
@@ -312,6 +319,7 @@ contains
     real(r8) :: irrig_depth
     real(r8) :: l_irrig_river_volume_threshold
     logical :: l_use_groundwater_irrigation
+    integer, parameter :: irrelevant_snl = 0
     !-----------------------------------------------------------------------
 
     limit_irrigation_if_rof_enabled = .false.
@@ -359,6 +367,9 @@ contains
 
     ! Allocate fluxes output from irrigation routines. Note that, in the production code,
     ! these are initialized to 0 in InitCold.
+    call this%water_factory%setup_after_subgrid(snl = irrelevant_snl)
+    call this%water_factory%create_water_type(this%water_inst)
+    this%waterflux => this%water_inst%waterfluxbulk_inst
     allocate(this%waterflux%qflx_sfc_irrig_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_gw_uncon_irrig_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_gw_uncon_irrig_lyr_col(bounds%begc:bounds%endc,1:nlevsoi), source=0._r8)
@@ -621,7 +632,7 @@ contains
          filter_soilp = apply_filterp, &
          soilhydrology_inst = soilhydrology_inst, &
          soilstate_inst = soilstate_inst, &
-         waterfluxbulk_inst = this%waterflux)
+         water_inst = this%water_inst)
 
   end subroutine calculateAndApplyIrrigation
 

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -66,29 +66,30 @@ module test_irrigation
      ! Wrapper that calls both CalcIrrigationNeeded and ApplyIrrigation
      procedure :: calculateAndApplyIrrigation
 
-     ! Return total irrigation withdrawal for a given patch
-     procedure :: totalIrrigationWithdrawal
-
      ! Return total irrigation application for a given patch
-     procedure :: totalIrrigationApplication
+     procedure :: totalIrrigationApplicationPatch
 
      ! Return total irrigation withdrawal for a given column
      procedure :: totalIrrigationWithdrawalCol
 
      ! Assert that total irrigation withdrawal and application both equal expected for a
      ! given patch
-     procedure :: assertTotalIrrigationEquals
+     procedure :: assertTotalIrrigationEqualsPatch
 
      ! Assert that total irrigation withdrawal and application both equal expected for a
      ! given column
      procedure :: assertTotalIrrigationEqualsCol
 
+     ! Assert that total irrigation withdrawal and application both equal expected for a
+     ! given patch and column
+     procedure :: assertTotalIrrigationEquals
+
      ! Assert that total irrigation withdrawal and application are both exactly zero for a
-     ! given patch
+     ! given patch and column
      procedure :: assertTotalIrrigationZero
 
      ! Assert that total irrigation withdrawal and application are both greater than zero
-     ! for a given patch
+     ! for a given patch and column
      procedure :: assertTotalIrrigationGreaterThanZero
 
      ! For a column with two irrigated patches (begp and begp+2) and one unirrigated
@@ -130,11 +131,8 @@ contains
 
     call unittest_timemgr_teardown()
     call this%irrigation%Clean()
-    deallocate(this%waterflux%qflx_sfc_irrig_patch)
     deallocate(this%waterflux%qflx_sfc_irrig_col)
-    deallocate(this%waterflux%qflx_gw_uncon_irrig_patch)
     deallocate(this%waterflux%qflx_gw_uncon_irrig_col)
-    deallocate(this%waterflux%qflx_gw_con_irrig_patch)
     deallocate(this%waterflux%qflx_gw_con_irrig_col)
     deallocate(this%waterflux%qflx_irrig_drip_patch)
     deallocate(this%waterflux%qflx_irrig_sprinkler_patch)
@@ -252,11 +250,8 @@ contains
 
     ! Allocate fluxes output from irrigation routines. Note that, in the production code,
     ! these are initialized to 0 in InitCold.
-    allocate(this%waterflux%qflx_sfc_irrig_patch(bounds%begp:bounds%endp), source=0._r8)
     allocate(this%waterflux%qflx_sfc_irrig_col(bounds%begc:bounds%endc), source=0._r8)
-    allocate(this%waterflux%qflx_gw_uncon_irrig_patch(bounds%begp:bounds%endp), source=0._r8)
     allocate(this%waterflux%qflx_gw_uncon_irrig_col(bounds%begc:bounds%endc), source=0._r8)
-    allocate(this%waterflux%qflx_gw_con_irrig_patch(bounds%begp:bounds%endp), source=0._r8)
     allocate(this%waterflux%qflx_gw_con_irrig_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_irrig_drip_patch(bounds%begp:bounds%endp), source=0._r8)
     allocate(this%waterflux%qflx_irrig_sprinkler_patch(bounds%begp:bounds%endp), source=0._r8)
@@ -518,30 +513,7 @@ contains
   end subroutine calculateAndApplyIrrigation
 
   !-----------------------------------------------------------------------
-  function totalIrrigationWithdrawal(this, p) result(total_withdrawal)
-    !
-    ! !DESCRIPTION:
-    ! Return total irrigation withdrawal for patch p
-    !
-    ! !ARGUMENTS:
-    real(r8), allocatable :: total_withdrawal  ! function result
-    class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: p  ! patch index
-    !
-    ! !LOCAL VARIABLES:
-
-    character(len=*), parameter :: subname = 'totalIrrigationWithdrawal'
-    !-----------------------------------------------------------------------
-
-    total_withdrawal = &
-         this%waterflux%qflx_sfc_irrig_patch(p) + &
-         this%waterflux%qflx_gw_uncon_irrig_patch(p) + &
-         this%waterflux%qflx_gw_con_irrig_patch(p)
-
-  end function totalIrrigationWithdrawal
-
-  !-----------------------------------------------------------------------
-  function totalIrrigationApplication(this, p) result(total_application)
+  function totalIrrigationApplicationPatch(this, p) result(total_application)
     !
     ! !DESCRIPTION:
     ! Return total irrigation application for patch p
@@ -549,18 +521,25 @@ contains
     ! !ARGUMENTS:
     real(r8), allocatable :: total_application  ! function result
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: p  ! patch index
+    integer, intent(in), optional :: p  ! patch index (if not present, use bounds%begp)
     !
     ! !LOCAL VARIABLES:
+    integer :: l_p
 
-    character(len=*), parameter :: subname = 'totalIrrigationApplication'
+    character(len=*), parameter :: subname = 'totalIrrigationApplicationPatch'
     !-----------------------------------------------------------------------
 
-    total_application = &
-         this%waterflux%qflx_irrig_drip_patch(p) + &
-         this%waterflux%qflx_irrig_sprinkler_patch(p)
+    if (present(p)) then
+       l_p = p
+    else
+       l_p = bounds%begp
+    end if
 
-  end function totalIrrigationApplication
+    total_application = &
+         this%waterflux%qflx_irrig_drip_patch(l_p) + &
+         this%waterflux%qflx_irrig_sprinkler_patch(l_p)
+
+  end function totalIrrigationApplicationPatch
 
   !-----------------------------------------------------------------------
   function totalIrrigationWithdrawalCol(this, c) result(total_withdrawal)
@@ -571,53 +550,61 @@ contains
     ! !ARGUMENTS:
     real(r8), allocatable :: total_withdrawal  ! function result
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: c  ! column index
+    integer, intent(in), optional :: c  ! column index (if not present, use bounds%begc)
     !
     ! !LOCAL VARIABLES:
+    integer :: l_c
 
     character(len=*), parameter :: subname = 'totalIrrigationWithdrawalCol'
     !-----------------------------------------------------------------------
 
+    if (present(c)) then
+       l_c = c
+    else
+       l_c = bounds%begc
+    end if
+
     total_withdrawal = &
-         this%waterflux%qflx_sfc_irrig_col(c) + &
-         this%waterflux%qflx_gw_uncon_irrig_col(c) + &
-         this%waterflux%qflx_gw_con_irrig_col(c)
+         this%waterflux%qflx_sfc_irrig_col(l_c) + &
+         this%waterflux%qflx_gw_uncon_irrig_col(l_c) + &
+         this%waterflux%qflx_gw_con_irrig_col(l_c)
 
   end function totalIrrigationWithdrawalCol
 
   !-----------------------------------------------------------------------
-  subroutine assertTotalIrrigationEquals(this, p, expected)
+  subroutine assertTotalIrrigationEqualsPatch(this, expected, p)
     !
     ! !DESCRIPTION:
-    ! Assert that total irrigation withdrawal and application both equal expected for a
-    ! given patch
+    ! Assert that total irrigation application equals expected for a given patch
+    !
+    ! (Note that there is no patch-level withdrawal flux)
     !
     ! !ARGUMENTS:
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: p  ! patch index
     real(r8), intent(in) :: expected
+    integer, intent(in), optional :: p  ! patch index (if not present, use bounds%begp)
     !
     ! !LOCAL VARIABLES:
 
-    character(len=*), parameter :: subname = 'assertTotalIrrigationEquals'
+    character(len=*), parameter :: subname = 'assertTotalIrrigationEqualsPatch'
     !-----------------------------------------------------------------------
 
-    @assertEqual(expected, this%totalIrrigationWithdrawal(p), tolerance=tol)
-    @assertEqual(expected, this%totalIrrigationApplication(p), tolerance=tol)
+    @assertEqual(expected, this%totalIrrigationApplicationPatch(p), tolerance=tol)
 
-  end subroutine assertTotalIrrigationEquals
+  end subroutine assertTotalIrrigationEqualsPatch
 
   !-----------------------------------------------------------------------
-  subroutine assertTotalIrrigationEqualsCol(this, c, expected)
+  subroutine assertTotalIrrigationEqualsCol(this, expected, c)
     !
     ! !DESCRIPTION:
-    ! Assert that total irrigation withdrawal equals expected for a given column (note
-    ! that there are no col-level application fluxes, so application is not checked here)
+    ! Assert that total irrigation withdrawal equals expected for a given column
+    !
+    ! (Note that there is no column-level application flux)
     !
     ! !ARGUMENTS:
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: c  ! column index
     real(r8), intent(in) :: expected
+    integer, intent(in), optional :: c  ! col index (if not present, use bounds%begc)
     !
     ! !LOCAL VARIABLES:
 
@@ -625,47 +612,77 @@ contains
     !-----------------------------------------------------------------------
 
     @assertEqual(expected, this%totalIrrigationWithdrawalCol(c), tolerance=tol)
+
   end subroutine assertTotalIrrigationEqualsCol
 
   !-----------------------------------------------------------------------
-  subroutine assertTotalIrrigationZero(this, p)
+  subroutine assertTotalIrrigationEquals(this, expected, p, c)
     !
     ! !DESCRIPTION:
-    ! Assert that total irrigation withdrawal and application are both exactly zero for a
-    ! given patch
+    ! Assert that total irrigation withdrawal and application both equal expected for a
+    ! given patch and column
+    !
+    ! It only makes sense to use this routine if you have a single patch on the column,
+    ! so that the expected patch and column fluxes are the same. Otherwise, separately
+    ! call assertTotalIrrigationEqualsPatch and assertTotalIrrigationEqualsCol.
     !
     ! !ARGUMENTS:
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: p  ! patch index
+    real(r8), intent(in) :: expected
+    integer, intent(in), optional :: p  ! patch index (if not present, use bounds%begp)
+    integer, intent(in), optional :: c  ! col index (if not present, use bounds%begc)
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'assertTotalIrrigationEquals'
+    !-----------------------------------------------------------------------
+
+    @assertEqual(expected, this%totalIrrigationWithdrawalCol(c), tolerance=tol)
+    @assertEqual(expected, this%totalIrrigationApplicationPatch(p), tolerance=tol)
+
+  end subroutine assertTotalIrrigationEquals
+
+  !-----------------------------------------------------------------------
+  subroutine assertTotalIrrigationZero(this, p, c)
+    !
+    ! !DESCRIPTION:
+    ! Assert that total irrigation withdrawal and application are both exactly zero for a
+    ! given patch and column
+    !
+    ! !ARGUMENTS:
+    class(TestIrrigation), intent(in) :: this
+    integer, intent(in), optional :: p  ! patch index (if not present, use bounds%begp)
+    integer, intent(in), optional :: c  ! col index (if not present, use bounds%begc)
     !
     ! !LOCAL VARIABLES:
 
     character(len=*), parameter :: subname = 'assertTotalIrrigationZero'
     !-----------------------------------------------------------------------
 
-    @assertEqual(0._r8, this%totalIrrigationWithdrawal(p))
-    @assertEqual(0._r8, this%totalIrrigationApplication(p))
+    @assertEqual(0._r8, this%totalIrrigationWithdrawalCol(c))
+    @assertEqual(0._r8, this%totalIrrigationApplicationPatch(p))
 
   end subroutine assertTotalIrrigationZero
 
   !-----------------------------------------------------------------------
-  subroutine assertTotalIrrigationGreaterThanZero(this, p)
+  subroutine assertTotalIrrigationGreaterThanZero(this, p, c)
     !
     ! !DESCRIPTION:
     ! Assert that total irrigation withdrawal and application are both greater than zero
-    ! for a given patch
+    ! for a given patch and column
     !
     ! !ARGUMENTS:
     class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: p  ! patch index
+    integer, intent(in), optional :: p  ! patch index (if not present, use bounds%begp)
+    integer, intent(in), optional :: c  ! col index (if not present, use bounds%begc)
     !
     ! !LOCAL VARIABLES:
 
     character(len=*), parameter :: subname = 'assertTotalIrrigationGreaterThanZero'
     !-----------------------------------------------------------------------
 
-    @assertLessThan(0._r8, this%totalIrrigationWithdrawal(p))
-    @assertLessThan(0._r8, this%totalIrrigationApplication(p))
+    @assertLessThan(0._r8, this%totalIrrigationWithdrawalCol(c))
+    @assertLessThan(0._r8, this%totalIrrigationApplicationPatch(p))
 
   end subroutine assertTotalIrrigationGreaterThanZero
 
@@ -701,15 +718,18 @@ contains
 
     expected1 = deficit_irrig1 / this%irrigation_params%irrig_length
     expected2 = deficit_irrig2 / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected1)
-    call this%assertTotalIrrigationEquals(bounds%begp+2, expected2)
+    call this%assertTotalIrrigationEqualsPatch(expected1, &
+         p = bounds%begp)
+    call this%assertTotalIrrigationEqualsPatch(expected2, &
+         p = bounds%begp+2)
     if (present(expected_fluxvar_patch)) then
        @assertEqual(expected1, expected_fluxvar_patch(bounds%begp), tolerance=tol)
        @assertEqual(expected2, expected_fluxvar_patch(bounds%begp+2), tolerance=tol)
     end if
     col_total_deficit = deficit_irrig1 * wt_irrig1 + deficit_irrig2 * wt_irrig2
     expected_col_flux = col_total_deficit / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEqualsCol(bounds%begc, expected_col_flux)
+    call this%assertTotalIrrigationEqualsCol(expected_col_flux, &
+         c = bounds%begc)
     if (present(expected_fluxvar_col)) then
        @assertEqual(expected_col_flux, expected_fluxvar_col(bounds%begc), tolerance=tol)
     end if
@@ -742,7 +762,7 @@ contains
     ! Check result
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
 
   end subroutine irrigation_flux_is_correct
 
@@ -764,7 +784,7 @@ contains
     ! Check result
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
     ! Make sure all irrigation comes from drip
     @assertEqual(expected, this%waterflux%qflx_irrig_drip_patch(bounds%begp), tolerance=tol)
 
@@ -788,7 +808,7 @@ contains
     ! Check result
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
     ! Make sure all irrigation comes from sprinkler
     @assertEqual(expected, this%waterflux%qflx_irrig_sprinkler_patch(bounds%begp), tolerance=tol)
 
@@ -807,7 +827,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
   end subroutine no_irrigation_for_wet_soil
 
   @Test
@@ -837,7 +857,7 @@ contains
     ! This first assertion makes sure the test has been set up reasonably - to give a net deficit
     @assertLessThan(0._r8, expected)
     ! Here is the main assertion:
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
   end subroutine surplus_offsets_deficit
 
   @Test
@@ -855,7 +875,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
 
   end subroutine no_irrigation_for_unirrigated_pfts
 
@@ -872,7 +892,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
 
   end subroutine no_irrigation_for_lai0
 
@@ -899,7 +919,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
   end subroutine no_irrigation_for_soil_moisture_above_threshold
 
   @Test
@@ -916,7 +936,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
 
   end subroutine no_irrigation_at_wrong_time
 
@@ -950,9 +970,8 @@ contains
 
     ! Check result
     expected = total_deficit / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
-    ! Make sure that all irrigation comes as surface irrigation (patch and column-level)
-    @assertEqual(expected, this%waterflux%qflx_sfc_irrig_patch(bounds%begp), tolerance=tol)
+    call this%assertTotalIrrigationEquals(expected)
+    ! Make sure that all irrigation comes as surface irrigation
     @assertEqual(expected, this%waterflux%qflx_sfc_irrig_col(bounds%begc), tolerance=tol)
   end subroutine unlimited_irrigation_for_non_limiting_volr
 
@@ -986,9 +1005,8 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
-    ! Make sure that all irrigation comes as surface irrigation (patch and column-level)
-    @assertEqual(expected, this%waterflux%qflx_sfc_irrig_patch(bounds%begp), tolerance=tol)
+    call this%assertTotalIrrigationEquals(expected)
+    ! Make sure that all irrigation comes as surface irrigation
     @assertEqual(expected, this%waterflux%qflx_sfc_irrig_col(bounds%begc), tolerance=tol)
   end subroutine limited_irrigation_for_limiting_volr_no_groundwater
 
@@ -1027,12 +1045,9 @@ contains
     ! Check result
     expected_total = total_deficit / this%irrigation_params%irrig_length
     expected_gw_uncon = expected_total - volr_limited_irrig_rate
-    call this%assertTotalIrrigationEquals(bounds%begp, expected_total)
-    ! Make sure that irrigation is properly divided into surface and groundwater (both
-    ! patch and column-level)
-    @assertEqual(volr_limited_irrig_rate, this%waterflux%qflx_sfc_irrig_patch(bounds%begp), tolerance=tol)
+    call this%assertTotalIrrigationEquals(expected_total)
+    ! Make sure that irrigation is properly divided into surface and groundwater
     @assertEqual(volr_limited_irrig_rate, this%waterflux%qflx_sfc_irrig_col(bounds%begc), tolerance=tol)
-    @assertEqual(expected_gw_uncon, this%waterflux%qflx_gw_uncon_irrig_patch(bounds%begp), tolerance=tol)
     @assertEqual(expected_gw_uncon, this%waterflux%qflx_gw_uncon_irrig_col(bounds%begc), tolerance=tol)
   end subroutine limiting_volr_with_groundwater_uncon
 
@@ -1083,14 +1098,10 @@ contains
     @assertGreaterThan(expected_gw_uncon, 0._r8)
     @assertGreaterThan(expected_gw_con, 0._r8)
     ! Now do the actual assertions on the irrigation routine
-    call this%assertTotalIrrigationEquals(bounds%begp, expected_total)
-    ! Make sure that irrigation is properly divided into surface and groundwater (both
-    ! patch and column-level)
-    @assertEqual(volr_limited_irrig_rate, this%waterflux%qflx_sfc_irrig_patch(bounds%begp), tolerance=tol)
+    call this%assertTotalIrrigationEquals(expected_total)
+    ! Make sure that irrigation is properly divided into surface and groundwater
     @assertEqual(volr_limited_irrig_rate, this%waterflux%qflx_sfc_irrig_col(bounds%begc), tolerance=tol)
-    @assertEqual(expected_gw_uncon, this%waterflux%qflx_gw_uncon_irrig_patch(bounds%begp), tolerance=tol)
     @assertEqual(expected_gw_uncon, this%waterflux%qflx_gw_uncon_irrig_col(bounds%begc), tolerance=tol)
-    @assertEqual(expected_gw_con, this%waterflux%qflx_gw_con_irrig_patch(bounds%begp), tolerance=tol)
     @assertEqual(expected_gw_con, this%waterflux%qflx_gw_con_irrig_col(bounds%begc), tolerance=tol)
   end subroutine limiting_volr_with_groundwater_uncon_and_con
 
@@ -1115,7 +1126,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
 
   end subroutine irrigation_continues_at_same_rate_for_multiple_time_steps
 
@@ -1138,11 +1149,11 @@ contains
        call this%calculateAndApplyIrrigation()
        call advance_timestep()
     end do
-    call this%assertTotalIrrigationGreaterThanZero(bounds%begp)
+    call this%assertTotalIrrigationGreaterThanZero()
 
     ! Ensure that irrigation flux goes to 0 in the following time step
     call this%calculateAndApplyIrrigation()
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
 
   end subroutine irrigation_continues_for_correct_number_of_time_steps
   
@@ -1169,7 +1180,7 @@ contains
        call advance_timestep()
     end do
     ! The following assertion is mainly here to make sure the test is working as intended
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
 
     ! Now reset time, change soil moisture, and make sure that irrigation happens as expected
     call unittest_timemgr_set_curr_date(yr=5, mon=1, day=1, tod=irrig_start+dtime)
@@ -1180,7 +1191,7 @@ contains
     ! Make sure that the test has been set up reasonably - to give a net deficit
     @assertLessThan(0._r8, expected)
     ! Here's the main assertion:
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
 
   end subroutine irrigation_flux_is_correct_on_second_day
     
@@ -1203,7 +1214,7 @@ contains
     call this%computeDeficits(deficits)
     ! Now on to the real assertion
     expected = sum(deficits(bounds%begp,1:nlevirrig)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
   end subroutine irrigation_excludes_deep_layers
 
   @Test
@@ -1224,7 +1235,7 @@ contains
     ! Check result
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:(nlevsoi-1))) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
   end subroutine irrigation_excludes_bedrock_layers
 
   @Test
@@ -1240,7 +1251,7 @@ contains
     call this%calculateAndApplyIrrigation()
 
     ! Check result
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero()
 
   end subroutine no_irrigation_for_frozen_soil
 
@@ -1262,7 +1273,7 @@ contains
     call this%computeDeficits(deficits)
     ! Only include deficit from top layer, since 2nd layer is frozen
     expected = deficits(bounds%begp, 1) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected)
+    call this%assertTotalIrrigationEquals(expected)
 
   end subroutine no_irrigation_below_frozen_soil_layer
 
@@ -1299,9 +1310,13 @@ contains
     ! Check result
     call this%computeDeficits(deficits)
     expected1 = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected1)
+    call this%assertTotalIrrigationEquals(expected1, &
+         p = bounds%begp, &
+         c = bounds%begc)
     expected2 = sum(deficits(bounds%endp,1:nlevsoi)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%endp, expected2)
+    call this%assertTotalIrrigationEquals(expected2, &
+         p = bounds%endp, &
+         c = bounds%endc)
     ! Make sure this test had some power, by ensuring that the two points differ:
     @assertTrue(expected1 /= expected2)
 
@@ -1342,8 +1357,10 @@ contains
     expected_patch_flux = total_deficit / this%irrigation_params%irrig_length
     col_total_deficit = total_deficit * wt_irrig
     expected_col_flux = col_total_deficit / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp+1, expected_patch_flux)
-    call this%assertTotalIrrigationEqualsCol(bounds%begc, expected_col_flux)
+    call this%assertTotalIrrigationEqualsPatch(expected_patch_flux, &
+         p = bounds%begp+1)
+    call this%assertTotalIrrigationEqualsCol(expected_col_flux, &
+         c = bounds%begc)
   end subroutine multiple_patches_per_column
 
   @Test
@@ -1381,7 +1398,6 @@ contains
          wt_irrig2 = wt_irrig2, &
          deficit_irrig1 = total_deficit1, &
          deficit_irrig2 = total_deficit2, &
-         expected_fluxvar_patch = this%waterflux%qflx_sfc_irrig_patch, &
          expected_fluxvar_col = this%waterflux%qflx_sfc_irrig_col)
   end subroutine multiple_irrigated_patches_per_column_sfcIrrig
 
@@ -1425,7 +1441,6 @@ contains
          wt_irrig2 = wt_irrig2, &
          deficit_irrig1 = total_deficit1, &
          deficit_irrig2 = total_deficit2, &
-         expected_fluxvar_patch = this%waterflux%qflx_gw_uncon_irrig_patch, &
          expected_fluxvar_col = this%waterflux%qflx_gw_uncon_irrig_col)
   end subroutine multiple_irrigated_patches_per_column_gwUnconIrrig
 
@@ -1469,7 +1484,6 @@ contains
          wt_irrig2 = wt_irrig2, &
          deficit_irrig1 = total_deficit1, &
          deficit_irrig2 = total_deficit2, &
-         expected_fluxvar_patch = this%waterflux%qflx_gw_con_irrig_patch, &
          expected_fluxvar_col = this%waterflux%qflx_gw_con_irrig_col)
   end subroutine multiple_irrigated_patches_per_column_gwConIrrig
 
@@ -1500,10 +1514,16 @@ contains
 
     ! Check result
     ! Irrigation happens within filter
-    call this%assertTotalIrrigationGreaterThanZero((bounds%begp + 1))
+    call this%assertTotalIrrigationGreaterThanZero( &
+         p = (bounds%begp + 1), &
+         c = (bounds%begc + 1))
     ! Irrigation does NOT happen outside filter
-    call this%assertTotalIrrigationZero(bounds%begp)
-    call this%assertTotalIrrigationZero(bounds%endp)
+    call this%assertTotalIrrigationZero( &
+         p = bounds%begp, &
+         c = bounds%begc)
+    call this%assertTotalIrrigationZero( &
+         p = bounds%endp, &
+         c = bounds%endc)
     
   end subroutine irrigation_only_happens_within_filter
 
@@ -1544,13 +1564,19 @@ contains
     ! Check result
     call this%computeDeficits(deficits)
     ! First patch should have no irrigation, because soil is all frozen
-    call this%assertTotalIrrigationZero(bounds%begp)
+    call this%assertTotalIrrigationZero( &
+         p = bounds%begp, &
+         c = bounds%begc)
     ! Second patch should have irrigation just based on top layer, because 2nd layer is frozen
     expected = deficits(bounds%begp+1, 1) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals((bounds%begp+1), expected)
+    call this%assertTotalIrrigationEquals(expected, &
+         p = (bounds%begp+1), &
+         c = (bounds%begc+1))
     ! Third patch should have irrigation from all layers
     expected = sum(deficits(bounds%endp,1:nlevsoi)) / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%endp, expected)
+    call this%assertTotalIrrigationEquals(expected, &
+         p = bounds%endp, &
+         c = bounds%endc)
 
   end subroutine test_multiple_patches_with_different_frozen_soil
 
@@ -1607,12 +1633,18 @@ contains
 
     ! Check result
     expected1 = total_deficit1*volr_fraction / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals(bounds%begp, expected1)
+    call this%assertTotalIrrigationEquals(expected1, &
+         p = bounds%begp, &
+         c = bounds%begc)
     expected2 = total_deficit2*volr_fraction / this%irrigation_params%irrig_length
-    call this%assertTotalIrrigationEquals((bounds%begp+1), expected2)
+    call this%assertTotalIrrigationEquals(expected2, &
+         p = (bounds%begp+1), &
+         c = (bounds%begc+1))
     ! Check of unirrigated patch isn't central to this test, but we might as well check
     ! it while we're at it:
-    call this%assertTotalIrrigationZero((bounds%begp+2))
+    call this%assertTotalIrrigationZero( &
+         p = (bounds%begp+2), &
+         c = (bounds%begc+2))
   end subroutine volr_limiting_with_multiple_columns
 
 end module test_irrigation

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -75,9 +75,6 @@ module test_irrigation
      ! Return total irrigation withdrawal for a given column
      procedure :: totalIrrigationWithdrawalCol
 
-     ! Return total irrigation application for a given column
-     procedure :: totalIrrigationApplicationCol
-
      ! Assert that total irrigation withdrawal and application both equal expected for a
      ! given patch
      procedure :: assertTotalIrrigationEquals
@@ -140,9 +137,7 @@ contains
     deallocate(this%waterflux%qflx_gw_con_irrig_patch)
     deallocate(this%waterflux%qflx_gw_con_irrig_col)
     deallocate(this%waterflux%qflx_irrig_drip_patch)
-    deallocate(this%waterflux%qflx_irrig_drip_col)
     deallocate(this%waterflux%qflx_irrig_sprinkler_patch)
-    deallocate(this%waterflux%qflx_irrig_sprinkler_col)
     call this%teardownEnvironment()
     call unittest_subgrid_teardown()
   end subroutine tearDown
@@ -264,9 +259,7 @@ contains
     allocate(this%waterflux%qflx_gw_con_irrig_patch(bounds%begp:bounds%endp), source=0._r8)
     allocate(this%waterflux%qflx_gw_con_irrig_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_irrig_drip_patch(bounds%begp:bounds%endp), source=0._r8)
-    allocate(this%waterflux%qflx_irrig_drip_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_irrig_sprinkler_patch(bounds%begp:bounds%endp), source=0._r8)
-    allocate(this%waterflux%qflx_irrig_sprinkler_col(bounds%begc:bounds%endc), source=0._r8)
 
     ! Set inputs to irrigation routines
     allocate(this%elai(bounds%begp:bounds%endp), source=10._r8)
@@ -593,28 +586,6 @@ contains
   end function totalIrrigationWithdrawalCol
 
   !-----------------------------------------------------------------------
-  function totalIrrigationApplicationCol(this, c) result(total_application)
-    !
-    ! !DESCRIPTION:
-    ! Return total irrigation application for column c
-    !
-    ! !ARGUMENTS:
-    real(r8), allocatable :: total_application  ! function result
-    class(TestIrrigation), intent(in) :: this
-    integer, intent(in) :: c  ! column index
-    !
-    ! !LOCAL VARIABLES:
-
-    character(len=*), parameter :: subname = 'totalIrrigationApplicationCol'
-    !-----------------------------------------------------------------------
-
-    total_application = &
-         this%waterflux%qflx_irrig_drip_col(c) + &
-         this%waterflux%qflx_irrig_sprinkler_col(c)
-
-  end function totalIrrigationApplicationCol
-
-  !-----------------------------------------------------------------------
   subroutine assertTotalIrrigationEquals(this, p, expected)
     !
     ! !DESCRIPTION:
@@ -640,8 +611,8 @@ contains
   subroutine assertTotalIrrigationEqualsCol(this, c, expected)
     !
     ! !DESCRIPTION:
-    ! Assert that total irrigation withdrawal and application both equal expected for a
-    ! given column
+    ! Assert that total irrigation withdrawal equals expected for a given column (note
+    ! that there are no col-level application fluxes, so application is not checked here)
     !
     ! !ARGUMENTS:
     class(TestIrrigation), intent(in) :: this
@@ -654,8 +625,6 @@ contains
     !-----------------------------------------------------------------------
 
     @assertEqual(expected, this%totalIrrigationWithdrawalCol(c), tolerance=tol)
-    @assertEqual(expected, this%totalIrrigationApplicationCol(c), tolerance=tol)
-
   end subroutine assertTotalIrrigationEqualsCol
 
   !-----------------------------------------------------------------------
@@ -796,9 +765,8 @@ contains
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
     call this%assertTotalIrrigationEquals(bounds%begp, expected)
-    ! Make sure all irrigation comes from drip (both patch and column-level)
+    ! Make sure all irrigation comes from drip
     @assertEqual(expected, this%waterflux%qflx_irrig_drip_patch(bounds%begp), tolerance=tol)
-    @assertEqual(expected, this%waterflux%qflx_irrig_drip_col(bounds%begc), tolerance=tol)
 
   end subroutine drip
 
@@ -821,9 +789,8 @@ contains
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
     call this%assertTotalIrrigationEquals(bounds%begp, expected)
-    ! Make sure all irrigation comes from sprinkler (both patch and column-level)
+    ! Make sure all irrigation comes from sprinkler
     @assertEqual(expected, this%waterflux%qflx_irrig_sprinkler_patch(bounds%begp), tolerance=tol)
-    @assertEqual(expected, this%waterflux%qflx_irrig_sprinkler_col(bounds%begc), tolerance=tol)
 
   end subroutine sprinkler
 
@@ -1352,6 +1319,7 @@ contains
     real(r8), allocatable :: deficits(:,:)
     real(r8) :: total_deficit
     real(r8) :: col_total_deficit
+    real(r8) :: expected_patch_flux
     real(r8) :: expected_col_flux
 
     ! Setup grid
@@ -1371,8 +1339,10 @@ contains
     ! Note that only the second patch contributes to the average, because it is the only
     ! irrigated patch
     total_deficit = sum(deficits(bounds%begp+1, 1:nlevsoi))
+    expected_patch_flux = total_deficit / this%irrigation_params%irrig_length
     col_total_deficit = total_deficit * wt_irrig
     expected_col_flux = col_total_deficit / this%irrigation_params%irrig_length
+    call this%assertTotalIrrigationEquals(bounds%begp+1, expected_patch_flux)
     call this%assertTotalIrrigationEqualsCol(bounds%begc, expected_col_flux)
   end subroutine multiple_patches_per_column
 

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -18,7 +18,7 @@ module test_irrigation
   use ColumnType    , only : col
   use GridcellType  , only : grc
   use pftconMod , only : pftcon
-  use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch
+  use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch, setup_n_veg_patches
   use unittestFilterBuilderMod, only : filter_from_range
 
   implicit none
@@ -93,6 +93,10 @@ module test_irrigation
      ! Assert that total irrigation withdrawal and application are both greater than zero
      ! for a given patch
      procedure :: assertTotalIrrigationGreaterThanZero
+
+     ! For a column with two irrigated patches (begp and begp+2) and one unirrigated
+     ! patch (begp+1): assert that patch and column-level irrigation are as expected
+     procedure :: assertTotalIrrigationEqualsForTwoIrrigPatches
   end type TestIrrigation
 
   real(r8), parameter :: mm_times_km2_to_m3 = 1.e3_r8
@@ -696,6 +700,54 @@ contains
 
   end subroutine assertTotalIrrigationGreaterThanZero
 
+  !-----------------------------------------------------------------------
+  subroutine assertTotalIrrigationEqualsForTwoIrrigPatches(this, wt_irrig1, wt_irrig2, &
+       deficit_irrig1, deficit_irrig2, &
+       expected_fluxvar_patch, expected_fluxvar_col)
+    !
+    ! !DESCRIPTION:
+    ! For a column with two irrigated patches (begp and begp+2) and one unirrigated patch
+    ! (begp+1): assert that patch and column-level irrigation are as expected.
+    !
+    ! !ARGUMENTS:
+    class(TestIrrigation), intent(in) :: this
+    real(r8), intent(in) :: wt_irrig1  ! patch weight on the column for first irrigated patch (begp)
+    real(r8), intent(in) :: wt_irrig2  ! patch weight on the column for second irrigated patch (begp+2)
+    real(r8), intent(in) :: deficit_irrig1  ! total deficit for first irrigated patch (begp)
+    real(r8), intent(in) :: deficit_irrig2  ! total deficit for second irrigated patch (begp+2)
+
+    ! If present, assert that all of the flux is accounted for by this patch-level flux variable
+    real(r8), intent(in), optional :: expected_fluxvar_patch(bounds%begp:)
+
+    ! If present, assert that all of the flux as accounted for by this col-level flux variable
+    real(r8), intent(in), optional :: expected_fluxvar_col(bounds%begc:)
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: expected1, expected2
+    real(r8) :: col_total_deficit
+    real(r8) :: expected_col_flux
+
+    character(len=*), parameter :: subname = 'assertTotalIrrigationEqualsForTwoIrrigPatches'
+    !-----------------------------------------------------------------------
+
+    expected1 = deficit_irrig1 / this%irrigation_params%irrig_length
+    expected2 = deficit_irrig2 / this%irrigation_params%irrig_length
+    call this%assertTotalIrrigationEquals(bounds%begp, expected1)
+    call this%assertTotalIrrigationEquals(bounds%begp+2, expected2)
+    if (present(expected_fluxvar_patch)) then
+       @assertEqual(expected1, expected_fluxvar_patch(bounds%begp), tolerance=tol)
+       @assertEqual(expected2, expected_fluxvar_patch(bounds%begp+2), tolerance=tol)
+    end if
+    col_total_deficit = deficit_irrig1 * wt_irrig1 + deficit_irrig2 * wt_irrig2
+    expected_col_flux = col_total_deficit / this%irrigation_params%irrig_length
+    call this%assertTotalIrrigationEqualsCol(bounds%begc, expected_col_flux)
+    if (present(expected_fluxvar_col)) then
+       @assertEqual(expected_col_flux, expected_fluxvar_col(bounds%begc), tolerance=tol)
+    end if
+
+  end subroutine assertTotalIrrigationEqualsForTwoIrrigPatches
+
+
 
   ! ========================================================================
   ! Begin actual tests
@@ -1290,9 +1342,9 @@ contains
 
   @Test
   subroutine multiple_patches_per_column(this)
-    ! If we have multiple patches on a column, some with irrigation and some without,
-    ! make sure (a) irrigation still happens, and (b) the column-level average irrigation
-    ! flux is computed correctly
+    ! If we have multiple patches on a column, one with irrigation and some without, make
+    ! sure (a) irrigation still happens, and (b) the column-level average irrigation flux
+    ! is computed correctly
     class(TestIrrigation), intent(inout) :: this
     real(r8), parameter :: wt_unirrig_1 = 0.25_r8
     real(r8), parameter :: wt_irrig = 0.5_r8
@@ -1303,14 +1355,8 @@ contains
     real(r8) :: expected_col_flux
 
     ! Setup grid
-    call unittest_subgrid_setup_start()
-    call unittest_add_gridcell()
-    call unittest_add_landunit(my_gi=gi, ltype=istsoil, wtgcell=1._r8)
-    call unittest_add_column(my_li=li, ctype=1, wtlunit=1._r8)
-    call unittest_add_patch(my_ci=ci, ptype=1, wtcol=wt_unirrig_1)
-    call unittest_add_patch(my_ci=ci, ptype=2, wtcol=wt_irrig)
-    call unittest_add_patch(my_ci=ci, ptype=3, wtcol=wt_unirrig_2)
-    call unittest_subgrid_setup_end()
+    call setup_n_veg_patches(pwtcol = [wt_unirrig_1, wt_irrig, wt_unirrig_2], &
+         pft_types = [1, 2, 3])
     call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
 
     ! Other setup
@@ -1329,6 +1375,133 @@ contains
     expected_col_flux = col_total_deficit / this%irrigation_params%irrig_length
     call this%assertTotalIrrigationEqualsCol(bounds%begc, expected_col_flux)
   end subroutine multiple_patches_per_column
+
+  @Test
+  subroutine multiple_irrigated_patches_per_column_sfcIrrig(this)
+    ! If we have multiple irrigated patches on a column, with multiple irrigated patches
+    ! along with one without, make sure the column-level and patch-level fluxes are
+    ! computed correctly.
+    !
+    ! This version gets all irrigation from surface (river) water
+    class(TestIrrigation), intent(inout) :: this
+    real(r8), parameter :: wt_irrig1 = 0.5_r8
+    real(r8), parameter :: wt_unirrig = 0.2_r8
+    real(r8), parameter :: wt_irrig2 = 0.3_r8
+    real(r8), allocatable :: deficits(:,:)
+    real(r8) :: total_deficit1, total_deficit2
+
+    ! Setup grid
+    call setup_n_veg_patches(pwtcol = [wt_irrig1, wt_unirrig, wt_irrig2], &
+         pft_types = [1, 2, 3])
+    call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
+
+    ! Other setup
+    call this%setupIrrigation(maxpft=3)
+    pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
+
+    ! Call irrigation routines
+    call this%calculateAndApplyIrrigation()
+
+    ! Check result
+    call this%computeDeficits(deficits)
+    total_deficit1 = sum(deficits(bounds%begp, 1:nlevsoi))
+    total_deficit2 = sum(deficits(bounds%begp+2, 1:nlevsoi))
+    call this%assertTotalIrrigationEqualsForTwoIrrigPatches( &
+         wt_irrig1 = wt_irrig1, &
+         wt_irrig2 = wt_irrig2, &
+         deficit_irrig1 = total_deficit1, &
+         deficit_irrig2 = total_deficit2, &
+         expected_fluxvar_patch = this%waterflux%qflx_sfc_irrig_patch, &
+         expected_fluxvar_col = this%waterflux%qflx_sfc_irrig_col)
+  end subroutine multiple_irrigated_patches_per_column_sfcIrrig
+
+  @Test
+  subroutine multiple_irrigated_patches_per_column_gwUnconIrrig(this)
+    ! If we have multiple irrigated patches on a column, with multiple irrigated patches
+    ! along with one without, make sure the column-level and patch-level fluxes are
+    ! computed correctly.
+    !
+    ! This version gets all irrigation from the unconfined aquifer
+    class(TestIrrigation), intent(inout) :: this
+    real(r8), parameter :: wt_irrig1 = 0.5_r8
+    real(r8), parameter :: wt_unirrig = 0.2_r8
+    real(r8), parameter :: wt_irrig2 = 0.3_r8
+    real(r8), allocatable :: deficits(:,:)
+    real(r8) :: total_deficit1, total_deficit2
+
+    ! Setup grid
+    call setup_n_veg_patches(pwtcol = [wt_irrig1, wt_unirrig, wt_irrig2], &
+         pft_types = [1, 2, 3])
+    call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
+
+    ! Other setup
+    call this%setupIrrigation( &
+         maxpft = 3, &
+         test_limit_irrigation = .true., &
+         use_groundwater_irrigation = .true.)
+    this%volr = 0._r8
+    this%available_gw_uncon(bounds%begc) = huge(1._r8)
+    pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
+
+    ! Call irrigation routines
+    call this%calculateAndApplyIrrigation()
+
+    ! Check result
+    call this%computeDeficits(deficits)
+    total_deficit1 = sum(deficits(bounds%begp, 1:nlevsoi))
+    total_deficit2 = sum(deficits(bounds%begp+2, 1:nlevsoi))
+    call this%assertTotalIrrigationEqualsForTwoIrrigPatches( &
+         wt_irrig1 = wt_irrig1, &
+         wt_irrig2 = wt_irrig2, &
+         deficit_irrig1 = total_deficit1, &
+         deficit_irrig2 = total_deficit2, &
+         expected_fluxvar_patch = this%waterflux%qflx_gw_uncon_irrig_patch, &
+         expected_fluxvar_col = this%waterflux%qflx_gw_uncon_irrig_col)
+  end subroutine multiple_irrigated_patches_per_column_gwUnconIrrig
+
+  @Test
+  subroutine multiple_irrigated_patches_per_column_gwConIrrig(this)
+    ! If we have multiple irrigated patches on a column, with multiple irrigated patches
+    ! along with one without, make sure the column-level and patch-level fluxes are
+    ! computed correctly.
+    !
+    ! This version gets all irrigation from the confined aquifer
+    class(TestIrrigation), intent(inout) :: this
+    real(r8), parameter :: wt_irrig1 = 0.5_r8
+    real(r8), parameter :: wt_unirrig = 0.2_r8
+    real(r8), parameter :: wt_irrig2 = 0.3_r8
+    real(r8), allocatable :: deficits(:,:)
+    real(r8) :: total_deficit1, total_deficit2
+
+    ! Setup grid
+    call setup_n_veg_patches(pwtcol = [wt_irrig1, wt_unirrig, wt_irrig2], &
+         pft_types = [1, 2, 3])
+    call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
+
+    ! Other setup
+    call this%setupIrrigation( &
+         maxpft = 3, &
+         test_limit_irrigation = .true., &
+         use_groundwater_irrigation = .true.)
+    this%volr = 0._r8
+    this%available_gw_uncon(bounds%begc) = 0._r8
+    pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
+
+    ! Call irrigation routines
+    call this%calculateAndApplyIrrigation()
+
+    ! Check result
+    call this%computeDeficits(deficits)
+    total_deficit1 = sum(deficits(bounds%begp, 1:nlevsoi))
+    total_deficit2 = sum(deficits(bounds%begp+2, 1:nlevsoi))
+    call this%assertTotalIrrigationEqualsForTwoIrrigPatches( &
+         wt_irrig1 = wt_irrig1, &
+         wt_irrig2 = wt_irrig2, &
+         deficit_irrig1 = total_deficit1, &
+         deficit_irrig2 = total_deficit2, &
+         expected_fluxvar_patch = this%waterflux%qflx_gw_con_irrig_patch, &
+         expected_fluxvar_col = this%waterflux%qflx_gw_con_irrig_col)
+  end subroutine multiple_irrigated_patches_per_column_gwConIrrig
 
   @Test
   subroutine irrigation_only_happens_within_filter(this)

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -33,8 +33,8 @@ module test_irrigation
   integer , parameter :: pft_type = 1  ! pft type in target patch for single-patch tests
 
   type, extends(irrigation_type) :: irrigation_test_type
-     real(r8) :: gw_frac_from_uncon  ! Fraction of groundwater irrigation taken from unconfined aquifer
-     real(r8), allocatable :: gw_frac_from_con(:)  ! Fraction of groundwater irrigation taken from confined aquifer in various layers
+     real(r8) :: gw_frac_from_con  ! Fraction of groundwater irrigation taken from confined aquifer (same for all columns)
+     real(r8), allocatable :: gw_frac_from_uncon(:)  ! Fraction of groundwater irrigation taken from unconfined aquifer in various layers (same for all columns)
    contains
      procedure, public :: InitForTesting    ! Call the main irrigation InitForTesting, and also initialize IrrigationTestType's test-specific data to reasonable values
      procedure, public :: SetGwFractions            ! Set fraction of groundwater from various sources
@@ -59,7 +59,6 @@ module test_irrigation
      real(r8), allocatable :: relsat_wilting_point(:,:)
      real(r8), allocatable :: relsat_target(:,:)
      real(r8), allocatable :: volr(:)
-     real(r8), allocatable :: available_gw_uncon(:)
 
    contains
      procedure :: setUp
@@ -123,7 +122,7 @@ contains
     ! Call the main irrigation's InitForTesting, and also initialize IrrigationTestType's
     ! test-specific data to reasonable values
     !
-    ! Sets all groundwater irrigation to come from unconfined aquifer
+    ! Sets all groundwater irrigation to come from confined aquifer
     !
     ! Assumes nlevsoi has already been set
     class(irrigation_test_type)  , intent(inout) :: this
@@ -140,33 +139,36 @@ contains
          relsat_wilting_point = relsat_wilting_point, &
          relsat_target = relsat_target)
 
-    this%gw_frac_from_uncon = 1._r8
-    allocate(this%gw_frac_from_con(nlevsoi))
-    this%gw_frac_from_con(:) = 0._r8
+    this%gw_frac_from_con = 1._r8
+    allocate(this%gw_frac_from_uncon(nlevsoi))
+    this%gw_frac_from_uncon(:) = 0._r8
   end subroutine InitForTesting
 
-  subroutine SetGwFractions(this, gw_frac_from_uncon, gw_frac_from_con)
+  subroutine SetGwFractions(this, gw_frac_from_con, gw_frac_from_uncon)
     ! Set fraction of groundwater from various sources
     class(irrigation_test_type), intent(inout) :: this
 
-    ! fraction of groundwater taken from unconfined aquifer
-    real(r8), intent(in) :: gw_frac_from_uncon
+    ! fraction of groundwater taken from confined aquifer
+    real(r8), intent(in) :: gw_frac_from_con
 
-    ! fraction of groundwater taken from confined aquifer in various layers; this should
-    ! have at most nlevsoi values; it specifies the fraction of groundwater extracted
-    ! from the top N layers of soil
-    real(r8), intent(in) :: gw_frac_from_con(:)
+    ! fraction of groundwater taken from unconfined aquifer in various layers; this should
+    ! have at most nlevsoi values; it specifies the fraction of groundwater extracted from
+    ! the top N layers of soil
+    real(r8), intent(in) :: gw_frac_from_uncon(:)
 
     ! Error checking on input argument
-    @assertLessThanOrEqual(size(gw_frac_from_con), size(this%gw_frac_from_con))
+    @assertLessThanOrEqual(size(gw_frac_from_uncon), size(this%gw_frac_from_uncon))
 
-    this%gw_frac_from_uncon = gw_frac_from_uncon
-    this%gw_frac_from_con(1:size(gw_frac_from_con)) = gw_frac_from_con(:)
+    this%gw_frac_from_con = gw_frac_from_con
+    this%gw_frac_from_uncon(1:size(gw_frac_from_uncon)) = gw_frac_from_uncon(:)
   end subroutine SetGwFractions
 
   !-----------------------------------------------------------------------
   subroutine WrapCalcIrrigWithdrawals(this, bounds, num_soilc, filter_soilc, &
-       soilhydrology_inst, soilstate_inst, waterfluxbulk_inst)
+       soilhydrology_inst, soilstate_inst, &
+       qflx_gw_demand, &
+       qflx_gw_uncon_irrig_lyr, &
+       qflx_gw_con_irrig)
     !
     ! !DESCRIPTION:
     ! Overrides WrapCalcIrrigWithdrawals for testing
@@ -178,14 +180,28 @@ contains
     integer                  , intent(in)    :: filter_soilc(:) ! column filter for soil
     type(soilhydrology_type) , intent(in)    :: soilhydrology_inst
     type(soilstate_type)     , intent(in)    :: soilstate_inst
-    type(waterfluxbulk_type) , intent(inout) :: waterfluxbulk_inst
+
+    real(r8) , intent(in)    :: qflx_gw_demand( bounds%begc: )              ! groundwater irrigation demand (mm H2O/s)
+    real(r8) , intent(inout) :: qflx_gw_uncon_irrig_lyr( bounds%begc:, 1: ) ! unconfined aquifer groundwater irrigation withdrawal flux, separated by layer (mm H2O/s)
+    real(r8) , intent(inout) :: qflx_gw_con_irrig( bounds%begc: )           ! total confined aquifer groundwater irrigation withdrawal flux (mm H2O/s)
     !
     ! !LOCAL VARIABLES:
+    integer :: j, fc, c
 
     character(len=*), parameter :: subname = 'WrapCalcIrrigWithdrawals'
     !-----------------------------------------------------------------------
 
-    ! FIXME(wjs, 2018-12-14) Need to fill this in
+    do j = 1, nlevsoi
+       do fc = 1, num_soilc
+          c = filter_soilc(fc)
+          qflx_gw_uncon_irrig_lyr(c,j) = qflx_gw_demand(c) * this%gw_frac_from_uncon(j)
+       end do
+    end do
+
+    do fc = 1, num_soilc
+       c = filter_soilc(fc)
+       qflx_gw_con_irrig(c) = qflx_gw_demand(c) * this%gw_frac_from_con
+    end do
 
   end subroutine WrapCalcIrrigWithdrawals
 
@@ -221,6 +237,7 @@ contains
     call this%irrigation%Clean()
     deallocate(this%waterflux%qflx_sfc_irrig_col)
     deallocate(this%waterflux%qflx_gw_uncon_irrig_col)
+    deallocate(this%waterflux%qflx_gw_uncon_irrig_lyr_col)
     deallocate(this%waterflux%qflx_gw_con_irrig_col)
     deallocate(this%waterflux%qflx_irrig_drip_patch)
     deallocate(this%waterflux%qflx_irrig_sprinkler_patch)
@@ -340,6 +357,7 @@ contains
     ! these are initialized to 0 in InitCold.
     allocate(this%waterflux%qflx_sfc_irrig_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_gw_uncon_irrig_col(bounds%begc:bounds%endc), source=0._r8)
+    allocate(this%waterflux%qflx_gw_uncon_irrig_lyr_col(bounds%begc:bounds%endc,1:nlevsoi), source=0._r8)
     allocate(this%waterflux%qflx_gw_con_irrig_col(bounds%begc:bounds%endc), source=0._r8)
     allocate(this%waterflux%qflx_irrig_drip_patch(bounds%begp:bounds%endp), source=0._r8)
     allocate(this%waterflux%qflx_irrig_sprinkler_patch(bounds%begp:bounds%endp), source=0._r8)
@@ -354,9 +372,6 @@ contains
     ! By default, volr will be very limiting... but this should have no effect if
     ! limit_irrigation_if_rof_enabled is false (the default)
     allocate(this%volr(bounds%begg:bounds%endg), source=0._r8)
-    ! By default, available_gw_uncon is very limiting... but this should have no effect
-    ! if use_groundwater_irrigation is false (the default)
-    allocate(this%available_gw_uncon(bounds%begc:bounds%endc), source=0._r8)
 
     do j = 1, nlevsoi
        do c = bounds%begc, bounds%endc
@@ -602,8 +617,7 @@ contains
          filter_soilp = apply_filterp, &
          soilhydrology_inst = soilhydrology_inst, &
          soilstate_inst = soilstate_inst, &
-         waterfluxbulk_inst = this%waterflux, &
-         available_gw_uncon = this%available_gw_uncon)
+         waterfluxbulk_inst = this%waterflux)
 
   end subroutine calculateAndApplyIrrigation
 
@@ -784,6 +798,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine assertTotalIrrigationEqualsForTwoIrrigPatches(this, wt_irrig1, wt_irrig2, &
        deficit_irrig1, deficit_irrig2, &
+       deficit_fraction_met, &
        expected_fluxvar_patch, expected_fluxvar_col)
     !
     ! !DESCRIPTION:
@@ -797,6 +812,9 @@ contains
     real(r8), intent(in) :: deficit_irrig1  ! total deficit for first irrigated patch (begp)
     real(r8), intent(in) :: deficit_irrig2  ! total deficit for second irrigated patch (begp+2)
 
+    ! If present, we only expect to meet this fraction of the deficit
+    real(r8), intent(in), optional :: deficit_fraction_met
+
     ! If present, assert that all of the flux is accounted for by this patch-level flux variable
     real(r8), intent(in), optional :: expected_fluxvar_patch(bounds%begp:)
 
@@ -804,6 +822,7 @@ contains
     real(r8), intent(in), optional :: expected_fluxvar_col(bounds%begc:)
     !
     ! !LOCAL VARIABLES:
+    real(r8) :: l_deficit_fraction_met
     real(r8) :: expected1, expected2
     real(r8) :: col_total_deficit
     real(r8) :: expected_col_flux
@@ -811,8 +830,14 @@ contains
     character(len=*), parameter :: subname = 'assertTotalIrrigationEqualsForTwoIrrigPatches'
     !-----------------------------------------------------------------------
 
-    expected1 = deficit_irrig1 / this%irrigation_params%irrig_length
-    expected2 = deficit_irrig2 / this%irrigation_params%irrig_length
+    if (present(deficit_fraction_met)) then
+       l_deficit_fraction_met = deficit_fraction_met
+    else
+       l_deficit_fraction_met = 1._r8
+    end if
+
+    expected1 = l_deficit_fraction_met * deficit_irrig1 / this%irrigation_params%irrig_length
+    expected2 = l_deficit_fraction_met * deficit_irrig2 / this%irrigation_params%irrig_length
     call this%assertTotalIrrigationEqualsPatch(expected1, &
          p = bounds%begp)
     call this%assertTotalIrrigationEqualsPatch(expected2, &
@@ -822,7 +847,7 @@ contains
        @assertEqual(expected2, expected_fluxvar_patch(bounds%begp+2), tolerance=tol)
     end if
     col_total_deficit = deficit_irrig1 * wt_irrig1 + deficit_irrig2 * wt_irrig2
-    expected_col_flux = col_total_deficit / this%irrigation_params%irrig_length
+    expected_col_flux = l_deficit_fraction_met * col_total_deficit / this%irrigation_params%irrig_length
     call this%assertTotalIrrigationEqualsCol(expected_col_flux, &
          c = bounds%begc)
     if (present(expected_fluxvar_col)) then
@@ -1122,7 +1147,9 @@ contains
     call this%setupIrrigation(test_limit_irrigation=.true., &
          irrig_river_volume_threshold=irrig_river_volume_threshold, &
          use_groundwater_irrigation = .true.)
-    this%available_gw_uncon(bounds%begc) = huge(1._r8)
+    call this%irrigation%SetGwFractions( &
+         gw_frac_from_con = 0._r8, &
+         gw_frac_from_uncon = [0.4_r8, 0.6_r8])
 
     call this%computeDeficits(deficits)
     total_deficit = sum(deficits(bounds%begp,1:nlevsoi))
@@ -1177,10 +1204,11 @@ contains
          volr_diff_from_threshold = -10._r8, &
          volr_limited_irrig_rate = volr_limited_irrig_rate)
 
-    ! Set available_gw_uncon to be 1/4 of the non-river-supplied irrigation
+    call this%irrigation%SetGwFractions( &
+         gw_frac_from_con = 0.75_r8, &
+         gw_frac_from_uncon = [0.1_r8, 0.15_r8])
     expected_total = total_deficit / this%irrigation_params%irrig_length
     expected_gw = expected_total - volr_limited_irrig_rate
-    this%available_gw_uncon(bounds%begc) = expected_gw * dtime / 4._r8
     expected_gw_uncon = expected_gw / 4._r8
     expected_gw_con = expected_gw - expected_gw_uncon
 
@@ -1190,8 +1218,8 @@ contains
     ! Check result
     ! First make sure the test is set up reasonably
     @assertGreaterThan(expected_total, 0._r8)
-    @assertGreaterThan(expected_gw_uncon, 0._r8)
-    @assertGreaterThan(expected_gw_con, 0._r8)
+    @assertGreaterThan(expected_gw, 0._r8)
+    @assertLessThan(expected_gw, expected_total)
     ! Now do the actual assertions on the irrigation routine
     call this%assertTotalIrrigationEquals(expected_total)
     ! Make sure that irrigation is properly divided into surface and groundwater
@@ -1529,7 +1557,9 @@ contains
          test_limit_irrigation = .true., &
          use_groundwater_irrigation = .true.)
     this%volr = 0._r8
-    this%available_gw_uncon(bounds%begc) = huge(1._r8)
+    call this%irrigation%SetGwFractions( &
+         gw_frac_from_con = 0._r8, &
+         gw_frac_from_uncon = [0.6_r8, 0.4_r8])
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
@@ -1576,7 +1606,9 @@ contains
          test_limit_irrigation = .true., &
          use_groundwater_irrigation = .true.)
     this%volr = 0._r8
-    this%available_gw_uncon(bounds%begc) = 0._r8
+    call this%irrigation%SetGwFractions( &
+         gw_frac_from_con = 1._r8, &
+         gw_frac_from_uncon = [0._r8])
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
@@ -1593,6 +1625,58 @@ contains
          deficit_irrig2 = total_deficit2, &
          expected_fluxvar_col = this%waterflux%qflx_gw_con_irrig_col)
   end subroutine multiple_irrigated_patches_per_column_gwConIrrig
+
+  @Test
+  subroutine multiple_irrigated_patches_per_column_gwConIrrigUnmetDemand(this)
+    ! If we have multiple irrigated patches on a column, with multiple irrigated patches
+    ! along with one without, make sure the column-level and patch-level fluxes are
+    ! computed correctly.
+    !
+    ! This version gets all irrigation from the confined aquifer, but some irrigation
+    ! demand remains unmet.
+    !
+    ! NOTE(wjs, 2018-12-12) If we ever allow different patches in a column to have
+    ! different irrigation amounts (e.g., due to some pft-specific parameter), it would
+    ! be good to change this test to leverage that, to make it a stronger test.
+    class(TestIrrigation), intent(inout) :: this
+    real(r8), parameter :: wt_irrig1 = 0.5_r8
+    real(r8), parameter :: wt_unirrig = 0.2_r8
+    real(r8), parameter :: wt_irrig2 = 0.3_r8
+    real(r8), parameter :: deficit_fraction_met = 0.75_r8
+    real(r8), allocatable :: deficits(:,:)
+    real(r8) :: total_deficit1, total_deficit2
+
+    ! Setup grid
+    call setup_n_veg_patches(pwtcol = [wt_irrig1, wt_unirrig, wt_irrig2], &
+         pft_types = [1, 2, 3])
+    call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
+
+    ! Other setup
+    call this%setupIrrigation( &
+         maxpft = 3, &
+         test_limit_irrigation = .true., &
+         use_groundwater_irrigation = .true.)
+    this%volr = 0._r8
+    call this%irrigation%SetGwFractions( &
+         gw_frac_from_con = deficit_fraction_met, &
+         gw_frac_from_uncon = [0._r8])
+    pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
+
+    ! Call irrigation routines
+    call this%calculateAndApplyIrrigation()
+
+    ! Check result
+    call this%computeDeficits(deficits)
+    total_deficit1 = sum(deficits(bounds%begp, 1:nlevsoi))
+    total_deficit2 = sum(deficits(bounds%begp+2, 1:nlevsoi))
+    call this%assertTotalIrrigationEqualsForTwoIrrigPatches( &
+         wt_irrig1 = wt_irrig1, &
+         wt_irrig2 = wt_irrig2, &
+         deficit_irrig1 = total_deficit1, &
+         deficit_irrig2 = total_deficit2, &
+         deficit_fraction_met = deficit_fraction_met, &
+         expected_fluxvar_col = this%waterflux%qflx_gw_con_irrig_col)
+  end subroutine multiple_irrigated_patches_per_column_gwConIrrigUnmetDemand
 
   @Test
   subroutine irrigation_only_happens_within_filter(this)

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -270,7 +270,11 @@ contains
     !
     ! volr is set up to be non-limiting
     !
-    ! Set up to *not* do groundwater irrigation by default
+    ! Set up to have use_groundwater_irrigation true by default, but this won't actually
+    ! trigger any groundwater irrigation by default given the non-limiting volr. (This is
+    ! done so that we still exercise the code block for use_groundwater_irrigation in
+    ! most test cases, making sure it works correctly in these various cases, e.g., when
+    ! we have no irrigation.)
     !
     ! Assumes that nlevgrnd and nlevsoi have been set, and that all necessary subgrid
     ! setup has been completed.
@@ -293,7 +297,7 @@ contains
     ! not given, defaults to 0.1
     real(r8), intent(in), optional :: irrig_river_volume_threshold
 
-    ! Whether to use groundwater irrigation (false by default)
+    ! Whether to use groundwater irrigation (true by default)
     logical, intent(in), optional :: use_groundwater_irrigation
 
     ! Irrigation method (drip by default); just set for the module-level pft_type parameter
@@ -330,7 +334,7 @@ contains
        l_irrig_river_volume_threshold = irrig_river_volume_threshold
     end if
 
-    l_use_groundwater_irrigation = .false.
+    l_use_groundwater_irrigation = .true.
     if (present(use_groundwater_irrigation)) then
        l_use_groundwater_irrigation = use_groundwater_irrigation
     end if
@@ -1073,7 +1077,8 @@ contains
     ! Setup
     call this%setupSinglePatch()
     call this%setupIrrigation(test_limit_irrigation=.true., &
-         irrig_river_volume_threshold=irrig_river_volume_threshold)
+         irrig_river_volume_threshold=irrig_river_volume_threshold, &
+         use_groundwater_irrigation = .false.)
 
     call this%computeDeficits(deficits)
     total_deficit = sum(deficits(bounds%begp,1:nlevsoi))
@@ -1510,7 +1515,10 @@ contains
     call filter_from_range(start=bounds%begp, end=bounds%endp, numf=this%numf, filter=this%filter)
 
     ! Other setup
-    call this%setupIrrigation(maxpft=3)
+    ! Note that use_groundwater_irrigation is true, but with the by-default non-limiting
+    ! volr, we should still have all irrigation from surface water.
+    call this%setupIrrigation(maxpft=3, &
+         use_groundwater_irrigation = .true.)
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -79,8 +79,8 @@ module test_irrigation
      ! Computes irrigation deficit for every patch and level
      procedure :: computeDeficits
 
-     ! Wrapper that calls both CalcIrrigationNeeded and ApplyIrrigation
-     procedure :: calculateAndApplyIrrigation
+     ! Wrapper that calls both CalcIrrigationNeeded and CalcIrrigationFluxes
+     procedure :: calculateIrrigation
 
      ! Return total irrigation application for a given patch
      procedure :: totalIrrigationApplicationPatch
@@ -269,7 +269,7 @@ contains
     !
     ! Values are set up such that there is some irrigation deficit everywhere, and
     ! irrigation would start in the following call to CalcIrrigationNeeded (followed by
-    ! ApplyIrrigation). Values are set the same for every patch/column, and are the same
+    ! CalcIrrigationFluxes). Values are set the same for every patch/column, and are the same
     ! at every level EXCEPT for relsat_wilting_point and relsat_target, which vary
     ! linearly by level and col number.
     !
@@ -573,11 +573,11 @@ contains
   end subroutine computeDeficits
 
   !-----------------------------------------------------------------------
-  subroutine calculateAndApplyIrrigation(this)
+  subroutine calculateIrrigation(this)
     !
     ! !DESCRIPTION:
     ! Call CalculateIrrigationNeeded with the given irrigation parameters. Then call
-    ! ApplyIrrigation.
+    ! CalcIrrigationFluxes.
     !
     ! !USES:
     !
@@ -585,17 +585,17 @@ contains
     class(TestIrrigation), intent(inout) :: this
     !
     ! !LOCAL VARIABLES:
-    integer :: apply_nump
-    integer, allocatable :: apply_filterp(:)
-    integer :: apply_numc
-    integer, allocatable :: apply_filterc(:)
+    integer :: calc_fluxes_nump
+    integer, allocatable :: calc_fluxes_filterp(:)
+    integer :: calc_fluxes_numc
+    integer, allocatable :: calc_fluxes_filterc(:)
 
     ! For the sake of the tests done here, it's currently fine for soilhydrology_inst and
     ! soilstate_inst to be uninitialized
     type(soilhydrology_type) :: soilhydrology_inst
     type(soilstate_type) :: soilstate_inst
 
-    character(len=*), parameter :: subname = 'calculateAndApplyIrrigation'
+    character(len=*), parameter :: subname = 'calculateIrrigation'
     !-----------------------------------------------------------------------
 
     call this%irrigation%CalcIrrigationNeeded(&
@@ -610,31 +610,31 @@ contains
          rof_prognostic = .true.)
 
     ! The expectation is that the filter used in CalcIrrigationNeeded is a subset of the
-    ! filter used in ApplyIrrigation. In order to (a) keep the unit tests simpler, and (b)
-    ! ensure that it works for the ApplyIrrigation filter to have points not in the
-    ! CalcIrrigationNeededFilter, we send ApplyIrrigation a filter that includes all
-    ! points. (The one situation where the ApplyIrrigation filter might include points not
+    ! filter used in CalcIrrigationFluxes. In order to (a) keep the unit tests simpler, and (b)
+    ! ensure that it works for the CalcIrrigationFluxes filter to have points not in the
+    ! CalcIrrigationNeededFilter, we send CalcIrrigationFluxes a filter that includes all
+    ! points. (The one situation where the CalcIrrigationFluxes filter might include points not
     ! in the CalcIrrigationNeeded filter is if a point that was inactive at the time of
-    ! the CalcIrrigationNeeded call has become active for the ApplyIrrigation call; in
+    ! the CalcIrrigationNeeded call has become active for the CalcIrrigationFluxes call; in
     ! this case, if there were still some irrigation time steps left when it had become
-    ! inactive, then ApplyIrrigation might start re-irrigating there. But this behavior
+    ! inactive, then CalcIrrigationFluxes might start re-irrigating there. But this behavior
     ! is probably okay; in any case, it doesn't seem worth testing for.)
     call filter_from_range(start=bounds%begp, end=bounds%endp, &
-         numf=apply_nump, filter=apply_filterp)
+         numf=calc_fluxes_nump, filter=calc_fluxes_filterp)
     call filter_from_range(start=bounds%begc, end=bounds%endc, &
-         numf=apply_numc, filter=apply_filterc)
+         numf=calc_fluxes_numc, filter=calc_fluxes_filterc)
 
-    call this%irrigation%ApplyIrrigation( &
+    call this%irrigation%CalcIrrigationFluxes( &
          bounds = bounds, &
-         num_soilc = apply_numc, &
-         filter_soilc = apply_filterc, &
-         num_soilp = apply_nump, &
-         filter_soilp = apply_filterp, &
+         num_soilc = calc_fluxes_numc, &
+         filter_soilc = calc_fluxes_filterc, &
+         num_soilp = calc_fluxes_nump, &
+         filter_soilp = calc_fluxes_filterp, &
          soilhydrology_inst = soilhydrology_inst, &
          soilstate_inst = soilstate_inst, &
          water_inst = this%water_inst)
 
-  end subroutine calculateAndApplyIrrigation
+  end subroutine calculateIrrigation
 
   !-----------------------------------------------------------------------
   function totalIrrigationApplicationPatch(this, p) result(total_application)
@@ -905,7 +905,7 @@ contains
     call this%setupIrrigation()
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -927,7 +927,7 @@ contains
     call this%setupIrrigation(my_irrig_method = irrig_method_drip)
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -951,7 +951,7 @@ contains
     call this%setupIrrigation(my_irrig_method = irrig_method_sprinkler)
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -972,7 +972,7 @@ contains
     this%h2osoi_liq(:,:) = 1.e15_r8
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationZero()
@@ -997,7 +997,7 @@ contains
     this%h2osoi_liq(bounds%begc,1) = h2osoi_target_layer1 + surplus
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1020,7 +1020,7 @@ contains
     pftcon%irrigated(1:2) = [1.0, 0.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationZero()
@@ -1037,7 +1037,7 @@ contains
     this%elai(bounds%begp) = 0._r8
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationZero()
@@ -1064,7 +1064,7 @@ contains
     end do
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationZero()
@@ -1081,7 +1081,7 @@ contains
     call unittest_timemgr_set_curr_date(yr=5, mon=1, day=1, tod=irrig_start)
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationZero()
@@ -1115,7 +1115,7 @@ contains
          volr_limited_irrig_rate = volr_limited_irrig_rate)
     
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     expected = total_deficit / this%irrigation_params%irrig_length
@@ -1151,7 +1151,7 @@ contains
          volr_limited_irrig_rate = expected)
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationEquals(expected)
@@ -1191,7 +1191,7 @@ contains
          volr_limited_irrig_rate = volr_limited_irrig_rate)
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     expected_total = total_deficit / this%irrigation_params%irrig_length
@@ -1242,7 +1242,7 @@ contains
     expected_gw_con = expected_gw - expected_gw_uncon
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     ! First make sure the test is set up reasonably
@@ -1270,12 +1270,12 @@ contains
     ! Call irrigation routines
     ! First call the routines to get irrigation started. Then increment time, and also
     ! adjust the soil water amount. Irrigation should continue at the original rate.
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
     call advance_timestep()
     this%h2osoi_liq = 100._r8
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationEquals(expected)
@@ -1298,13 +1298,13 @@ contains
     ! Ensure that irrigation flux is still non-zero after the expected number of time
     ! steps
     do time = 1, expected_num_time_steps
-       call this%calculateAndApplyIrrigation()
+       call this%calculateIrrigation()
        call advance_timestep()
     end do
     call this%assertTotalIrrigationGreaterThanZero()
 
     ! Ensure that irrigation flux goes to 0 in the following time step
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
     call this%assertTotalIrrigationZero()
 
   end subroutine irrigation_continues_for_correct_number_of_time_steps
@@ -1328,7 +1328,7 @@ contains
     ! Call irrigation routines for long enough that irrigation should go to 0
     expected_num_time_steps = this%irrigation_params%irrig_length / dtime
     do time = 1, expected_num_time_steps + 1
-       call this%calculateAndApplyIrrigation()
+       call this%calculateIrrigation()
        call advance_timestep()
     end do
     ! The following assertion is mainly here to make sure the test is working as intended
@@ -1337,7 +1337,7 @@ contains
     ! Now reset time, change soil moisture, and make sure that irrigation happens as expected
     call unittest_timemgr_set_curr_date(yr=5, mon=1, day=1, tod=irrig_start+dtime)
     this%h2osoi_liq(:,:) = 100._r8
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
     call this%computeDeficits(deficits)
     expected = sum(deficits(bounds%begp,1:nlevsoi)) / this%irrigation_params%irrig_length
     ! Make sure that the test has been set up reasonably - to give a net deficit
@@ -1360,7 +1360,7 @@ contains
     call this%setupIrrigation(nlevirrig=nlevirrig)
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1382,7 +1382,7 @@ contains
     col%nbedrock(bounds%begc) = nlevsoi - 1
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1400,7 +1400,7 @@ contains
     this%t_soisno(bounds%begc, :) = 272._r8
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%assertTotalIrrigationZero()
@@ -1419,7 +1419,7 @@ contains
     this%t_soisno(bounds%begc, 2) = 272._r8
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1457,7 +1457,7 @@ contains
     call this%setupIrrigation()
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1499,7 +1499,7 @@ contains
     pftcon%irrigated(1:3) = [0.0, 1.0, 0.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1546,7 +1546,7 @@ contains
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1595,7 +1595,7 @@ contains
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1644,7 +1644,7 @@ contains
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1695,7 +1695,7 @@ contains
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1742,7 +1742,7 @@ contains
     pftcon%irrigated(1:3) = [1.0, 0.0, 1.0]
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1780,7 +1780,7 @@ contains
     call this%setupIrrigation()
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     ! Irrigation happens within filter
@@ -1829,7 +1829,7 @@ contains
     this%t_soisno(bounds%begc+1, 2) = 272._r8
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     call this%computeDeficits(deficits)
@@ -1899,7 +1899,7 @@ contains
     this%volr(begg) = gridcell_total_deficit_as_volr * volr_fraction
 
     ! Call irrigation routines
-    call this%calculateAndApplyIrrigation()
+    call this%calculateIrrigation()
 
     ! Check result
     expected1 = total_deficit1*volr_fraction / this%irrigation_params%irrig_length

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -13,6 +13,9 @@ module test_irrigation
   use clm_instur, only : irrig_method
   use clm_varpar, only : nlevsoi, nlevgrnd
   use landunit_varcon, only : istsoil
+  use decompMod, only : bounds_type
+  use SoilHydrologyType, only : soilhydrology_type
+  use SoilStateType, only : soilstate_type
   use WaterFluxBulkType, only : waterfluxbulk_type
   use PatchType     , only : patch
   use ColumnType    , only : col
@@ -29,11 +32,20 @@ module test_irrigation
   integer , parameter :: irrig_start = 21600
   integer , parameter :: pft_type = 1  ! pft type in target patch for single-patch tests
 
+  type, extends(irrigation_type) :: irrigation_test_type
+     real(r8) :: gw_frac_from_uncon  ! Fraction of groundwater irrigation taken from unconfined aquifer
+     real(r8), allocatable :: gw_frac_from_con(:)  ! Fraction of groundwater irrigation taken from confined aquifer in various layers
+   contains
+     procedure, public :: InitForTesting    ! Call the main irrigation InitForTesting, and also initialize IrrigationTestType's test-specific data to reasonable values
+     procedure, public :: SetGwFractions            ! Set fraction of groundwater from various sources
+     procedure, public :: WrapCalcIrrigWithdrawals  ! Override WrapCalcIrrigWithdrawals for testing
+  end type irrigation_test_type
+
   @TestCase
   type, extends(TestCase) :: TestIrrigation
      integer :: numf
      integer, allocatable :: filter(:)
-     type(irrigation_type) :: irrigation
+     type(irrigation_test_type) :: irrigation
      type(waterfluxbulk_type) :: waterflux
 
      ! Irrigation parameters
@@ -101,6 +113,82 @@ module test_irrigation
   real(r8), parameter :: m3_over_km2_to_mm = 1.e-3_r8
 
 contains
+
+  ! ========================================================================
+  ! Methods on irrigation_test_type
+  ! ========================================================================
+
+  subroutine InitForTesting(this, bounds, params, dtime, &
+       relsat_wilting_point, relsat_target)
+    ! Call the main irrigation's InitForTesting, and also initialize IrrigationTestType's
+    ! test-specific data to reasonable values
+    !
+    ! Sets all groundwater irrigation to come from unconfined aquifer
+    !
+    ! Assumes nlevsoi has already been set
+    class(irrigation_test_type)  , intent(inout) :: this
+    type(bounds_type)            , intent(in)    :: bounds
+    type(irrigation_params_type) , intent(in)    :: params
+    integer                      , intent(in)    :: dtime ! model time step (sec)
+    real(r8)                     , intent(in)    :: relsat_wilting_point( bounds%begc: , 1: ) ! relative saturation at which smp = irrig_wilting_point_smp [col, nlevsoi]
+    real(r8)                     , intent(in)    :: relsat_target( bounds%begc: , 1: ) ! relative saturation at which smp = irrig_target_smp [col, nlevsoi]
+
+    call this%irrigation_type%InitForTesting( &
+         bounds = bounds, &
+         params = params, &
+         dtime = dtime, &
+         relsat_wilting_point = relsat_wilting_point, &
+         relsat_target = relsat_target)
+
+    this%gw_frac_from_uncon = 1._r8
+    allocate(this%gw_frac_from_con(nlevsoi))
+    this%gw_frac_from_con(:) = 0._r8
+  end subroutine InitForTesting
+
+  subroutine SetGwFractions(this, gw_frac_from_uncon, gw_frac_from_con)
+    ! Set fraction of groundwater from various sources
+    class(irrigation_test_type), intent(inout) :: this
+
+    ! fraction of groundwater taken from unconfined aquifer
+    real(r8), intent(in) :: gw_frac_from_uncon
+
+    ! fraction of groundwater taken from confined aquifer in various layers; this should
+    ! have at most nlevsoi values; it specifies the fraction of groundwater extracted
+    ! from the top N layers of soil
+    real(r8), intent(in) :: gw_frac_from_con(:)
+
+    ! Error checking on input argument
+    @assertLessThanOrEqual(size(gw_frac_from_con), size(this%gw_frac_from_con))
+
+    this%gw_frac_from_uncon = gw_frac_from_uncon
+    this%gw_frac_from_con(1:size(gw_frac_from_con)) = gw_frac_from_con(:)
+  end subroutine SetGwFractions
+
+  !-----------------------------------------------------------------------
+  subroutine WrapCalcIrrigWithdrawals(this, bounds, num_soilc, filter_soilc, &
+       soilhydrology_inst, soilstate_inst, waterfluxbulk_inst)
+    !
+    ! !DESCRIPTION:
+    ! Overrides WrapCalcIrrigWithdrawals for testing
+    !
+    ! !ARGUMENTS:
+    class(irrigation_test_type), intent(in)  :: this
+    type(bounds_type)        , intent(in)    :: bounds
+    integer                  , intent(in)    :: num_soilc       ! number of points in filter_soilc
+    integer                  , intent(in)    :: filter_soilc(:) ! column filter for soil
+    type(soilhydrology_type) , intent(in)    :: soilhydrology_inst
+    type(soilstate_type)     , intent(in)    :: soilstate_inst
+    type(waterfluxbulk_type) , intent(inout) :: waterfluxbulk_inst
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'WrapCalcIrrigWithdrawals'
+    !-----------------------------------------------------------------------
+
+    ! FIXME(wjs, 2018-12-14) Need to fill this in
+
+  end subroutine WrapCalcIrrigWithdrawals
+
 
   ! ========================================================================
   ! Test helpers
@@ -471,7 +559,12 @@ contains
     integer, allocatable :: apply_filterp(:)
     integer :: apply_numc
     integer, allocatable :: apply_filterc(:)
-    
+
+    ! For the sake of the tests done here, it's currently fine for soilhydrology_inst and
+    ! soilstate_inst to be uninitialized
+    type(soilhydrology_type) :: soilhydrology_inst
+    type(soilstate_type) :: soilstate_inst
+
     character(len=*), parameter :: subname = 'calculateAndApplyIrrigation'
     !-----------------------------------------------------------------------
 
@@ -507,6 +600,8 @@ contains
          filter_soilc = apply_filterc, &
          num_soilp = apply_nump, &
          filter_soilp = apply_filterp, &
+         soilhydrology_inst = soilhydrology_inst, &
+         soilstate_inst = soilstate_inst, &
          waterfluxbulk_inst = this%waterflux, &
          available_gw_uncon = this%available_gw_uncon)
 

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -1370,6 +1370,10 @@ contains
     ! computed correctly.
     !
     ! This version gets all irrigation from surface (river) water
+    !
+    ! NOTE(wjs, 2018-12-12) If we ever allow different patches in a column to have
+    ! different irrigation amounts (e.g., due to some pft-specific parameter), it would
+    ! be good to change this test to leverage that, to make it a stronger test.
     class(TestIrrigation), intent(inout) :: this
     real(r8), parameter :: wt_irrig1 = 0.5_r8
     real(r8), parameter :: wt_unirrig = 0.2_r8
@@ -1408,6 +1412,10 @@ contains
     ! computed correctly.
     !
     ! This version gets all irrigation from the unconfined aquifer
+    !
+    ! NOTE(wjs, 2018-12-12) If we ever allow different patches in a column to have
+    ! different irrigation amounts (e.g., due to some pft-specific parameter), it would
+    ! be good to change this test to leverage that, to make it a stronger test.
     class(TestIrrigation), intent(inout) :: this
     real(r8), parameter :: wt_irrig1 = 0.5_r8
     real(r8), parameter :: wt_unirrig = 0.2_r8
@@ -1451,6 +1459,10 @@ contains
     ! computed correctly.
     !
     ! This version gets all irrigation from the confined aquifer
+    !
+    ! NOTE(wjs, 2018-12-12) If we ever allow different patches in a column to have
+    ! different irrigation amounts (e.g., due to some pft-specific parameter), it would
+    ! be good to change this test to leverage that, to make it a stronger test.
     class(TestIrrigation), intent(inout) :: this
     real(r8), parameter :: wt_irrig1 = 0.5_r8
     real(r8), parameter :: wt_unirrig = 0.2_r8

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -451,7 +451,6 @@ contains
                soilhydrology_inst = soilhydrology_inst, &
                soilstate_inst = soilstate_inst, &
                irrigation_inst = irrigation_inst, &
-               waterdiagnosticbulk_inst = water_inst%waterdiagnosticbulk_inst, &
                waterfluxbulk_inst = water_inst%waterfluxbulk_inst, &
                waterstatebulk_inst = water_inst%waterstatebulk_inst)
 

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -451,8 +451,7 @@ contains
                soilhydrology_inst = soilhydrology_inst, &
                soilstate_inst = soilstate_inst, &
                irrigation_inst = irrigation_inst, &
-               waterfluxbulk_inst = water_inst%waterfluxbulk_inst, &
-               waterstatebulk_inst = water_inst%waterstatebulk_inst)
+               water_inst = water_inst)
 
           call t_stopf('irrigationwithdraw')
 

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -38,7 +38,7 @@ module clm_driver
   use UrbanFluxesMod         , only : UrbanFluxes 
   use LakeFluxesMod          , only : LakeFluxes
   !
-  use HydrologyNoDrainageMod , only : IrrigationWithdrawals, HydrologyNoDrainage ! (formerly Hydrology2Mod)
+  use HydrologyNoDrainageMod , only : CalcAndWithdrawIrrigationFluxes, HydrologyNoDrainage ! (formerly Hydrology2Mod)
   use HydrologyDrainageMod   , only : HydrologyDrainage   ! (formerly Hydrology2Mod)
   use CanopyHydrologyMod     , only : CanopyHydrology     ! (formerly Hydrology1Mod)
   use LakeHydrologyMod       , only : LakeHydrology
@@ -442,7 +442,7 @@ contains
 
           call t_startf('irrigationwithdraw')
 
-          call IrrigationWithdrawals( &
+          call CalcAndWithdrawIrrigationFluxes( &
                bounds = bounds_clump, &
                num_soilc = filter(nc)%num_soilc, &
                filter_soilc = filter(nc)%soilc, &
@@ -462,7 +462,7 @@ contains
           ! every time step
           if (get_nstep() == 0) then
              call t_startf("tracer_consistency_check")
-             call water_inst%TracerConsistencyCheck(bounds_clump, 'after IrrigationWithdrawals')
+             call water_inst%TracerConsistencyCheck(bounds_clump, 'after CalcAndWithdrawIrrigationFluxes')
              call t_stopf("tracer_consistency_check")
           end if
        end if

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -444,8 +444,6 @@ contains
 
           call IrrigationWithdrawals( &
                bounds = bounds_clump, &
-               num_hydrologyc = filter(nc)%num_hydrologyc, &
-               filter_hydrologyc = filter(nc)%hydrologyc, &
                num_soilc = filter(nc)%num_soilc, &
                filter_soilc = filter(nc)%soilc, &
                num_soilp = filter(nc)%num_soilp, &

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -461,6 +461,16 @@ contains
 
        end if
 
+       if (water_inst%DoConsistencyCheck()) then
+          ! BUG(wjs, 2018-09-05, ESCOMP/ctsm#498) Eventually do tracer consistency checks
+          ! every time step
+          if (get_nstep() == 0) then
+             call t_startf("tracer_consistency_check")
+             call water_inst%TracerConsistencyCheck(bounds_clump, 'after IrrigationWithdrawals')
+             call t_stopf("tracer_consistency_check")
+          end if
+       end if
+
        ! ============================================================================
        ! Canopy Hydrology
        ! (1) water storage of intercepted precipitation

--- a/src/unit_test_shr/unittestSimpleSubgridSetupsMod.F90
+++ b/src/unit_test_shr/unittestSimpleSubgridSetupsMod.F90
@@ -21,7 +21,7 @@ module unittestSimpleSubgridSetupsMod
   ! Create a grid that has a single gridcell with a single vegetated patch
   public :: setup_single_veg_patch
 
-  ! Create a grid that has a single gridcell with N vegetated patches
+  ! Create a grid that has a single gridcell with N vegetated patches on one column
   public :: setup_n_veg_patches
 
   ! Create a grid that has a single gridcell with one landunit of a given type with N

--- a/src/unit_test_shr/unittestWaterTypeFactory.F90
+++ b/src/unit_test_shr/unittestWaterTypeFactory.F90
@@ -70,11 +70,18 @@ contains
     class(unittest_water_type_factory_type), intent(inout) :: this
 
     ! For now, set all snl and dz values to the single input
-    integer, intent(in) :: snl
-    real(r8), intent(in) :: dz
+    ! If either of these are absent, then we assume that the relevant col values have
+    ! already been set, and we do nothing here. (e.g., if dz is absent, we assume that
+    ! col%dz has already been set, and don't do anything with col%dz here.)
+    integer, intent(in), optional :: snl
+    real(r8), intent(in), optional :: dz
 
-    col%snl(:) = snl
-    col%dz(:,:) = dz
+    if (present(snl)) then
+       col%snl(:) = snl
+    end if
+    if (present(dz)) then
+       col%dz(:,:) = dz
+    end if
   end subroutine setup_after_subgrid
 
   subroutine create_water_type(this, water_inst, &


### PR DESCRIPTION
### Description of changes

Set tracer version of irrigation fluxes.

This required a substantial rewrite of ApplyIrrigation (now renamed to
CalcIrrigationFluxes). The problem was that the code was written to
compute the total irrigation withdrawal from groundwater, then use this
to compute the application fluxes (drip/sprinkler), then later divide
this total withdrawal by layer. But for tracer fluxes to be computed
correctly, we needed to reorder this, so that the per-layer withdrawals
are determined before determining the application fluxes. This is
because the application flux needs to know the tracer concentrations of
the source, which requires knowing which layers the source is drawing
from. This was made more challenging because of the mix of patch-level
and column-level variables at play: irrigation demand is patch-level,
groundwater availability and extraction is column-level, but application
is back to patch-level.

In a somewhat-related change, I also reworked the passing of information
between soil hydrology (groundwater availability) and irrigation:
Previously, there was some near-duplicate code in
CalcAvailableUnconfinedAquifer (which was called prior to
ApplyIrrigation) and WithdrawGroundwaterIrrigation (which was called
after ApplyIrrigation). I have reworked the code to remove this
duplication, calling the new CalcIrrigWithdrawals in the midst of
CalcIrrigationFluxes. In doing so, I reconciled an accidental
discrepancy between the two original routines (see #595).

### Specific notes

Contributors other than yourself, if any: none, but @swensosc reviewed
the initial parts of the rework of ApplyIrrigation and the passing of
information between soil hydrology and irrigation

CTSM Issues Fixed (include github issue #):
- Resolves #521 (Set tracer versions of fluxes set by ApplyIrrigation)
- Resolves #593 (Generalize groundwater irrigation availability to
  handle multiple patches per column)
- Resolves #595 (Inconsistency between CalcAvailableUnconfinedAquifer
  and WithdrawGroundwaterIrrigation)

Are answers expected to change (and if so in what way)?
- Small answer changes when groundwater irrigation is enabled. In
  principle, could change answers by greater than roundoff due to fix of
  #595, but I didn't see any answer changes in my 7-month test due to
  that change. Other than that, just roundoff-level changes.
- Answer changes when tracers are enabled.
- Roundoff-level changes in the diagnostic field, QIRRIG_FROM_SURFACE,
  for many tests

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
I have run the unit tests and selected system tests so far. I am running
the full aux_clm test suite now.
