### PR TITLE
Add option to dribble XSMRPOOL at crop harvest to atmosphere over a half year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,23 @@ manage_externals.log
 *.swp
 *~
 
+# vim files (from https://github.com/github/gitignore/blob/master/Global/Vim.gitignore)
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+# Session
+Session.vim
+# Temporary
+.netrwhist
+# (removed *~ because it is listed above)
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
 # mac files
 .DS_Store
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime_cesm2_1_rel_05
+tag = cime_cesm2_1_rel_06
 required = True
 
 [externals_description]

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -75,7 +75,7 @@ REQUIRED OPTIONS
                               "-res list" to list valid resolutions.
                               (default: 0.9x1.25)
      -sim_year "year"         Year to simulate for input datasets
-                              (i.e. 1850, 2000, 2010, 1850-2000, 1850-2100)
+                              (i.e. PtVg, 1850, 2000, 2010, 1850-2000, 1850-2100)
                               "-sim_year list" to list valid simulation years
                               (default 2000)
 OPTIONS
@@ -1219,19 +1219,19 @@ sub setup_cmdl_simulation_year {
   }
 
   $nl_flags->{'sim_year_range'} = $defaults->get_value("sim_year_range");
-  $nl_flags->{'sim_year'}       = $val;
+  $nl_flags->{'sim_year'}       = &remove_leading_and_trailing_quotes($val);
   if ( $val =~ /([0-9]+)-([0-9]+)/ ) {
     $nl_flags->{'sim_year'}       = $1;
     $nl_flags->{'sim_year_range'} = $val;
   }
   $val = $nl_flags->{'sim_year'};
   my $group = $definition->get_group_name($var);
-  $nl->set_variable_value($group, $var, $val );
+  $nl->set_variable_value($group, $var, "'$val'" );
   if (  ! $definition->is_valid_value( $var, $val, 'noquotes'=>1 ) ) {
     my @valid_values   = $definition->get_valid_values( $var );
     $log->fatal_error("$var of $val is NOT valid. Valid values are: @valid_values");
   }
-  $nl->set_variable_value($group, $var, $val );
+  $nl->set_variable_value($group, $var, "'$val'" );
   $log->verbose_message("CLM sim_year is $nl_flags->{'sim_year'}");
 
   $var = "sim_year_range";

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1705,6 +1705,10 @@ sub process_namelist_inline_logic {
   ################################################
   setup_logic_century_soilbgcdecompcascade($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
 
+  #############################
+  # namelist group: cngeneral #
+  #############################
+  setup_logic_cngeneral($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
   ####################################
   # namelist group: cnvegcarbonstate #
   ####################################
@@ -3593,6 +3597,31 @@ sub setup_logic_cnvegcarbonstate {
     if ( ! defined($mmnuptake) ) { $mmnuptake = ".false."; }
     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'initial_vegC', 
                 'use_cn' => $nl->get_value('use_cn'), 'mm_nuptake_opt' => $mmnuptake );
+  }
+}
+
+#-------------------------------------------------------------------------------
+
+sub setup_logic_cngeneral {
+  # Must be set after setup_logic_co2_type
+  my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
+
+  if ( $physv->as_long() >= $physv->as_long("clm4_5") && &value_is_true($nl->get_value('use_cn')) ) {
+    if ( &value_is_true($nl->get_value('use_crop')) ) {
+       #add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dribble_crophrv_xsmrpool_2atm', 
+                   #'co2_type' => $nl->get_value('co2_type') );
+    } else {
+      if ( defined($nl->get_value('dribble_crophrv_xsmrpool_2atm')) ) {
+        $log->fatal_error("When CROP is NOT on dribble_crophrv_xsmrpool_2atm can NOT be set\n" );
+      }
+    }
+  } else {
+    if ( defined($nl->get_value('reseed_dead_plants')) ||
+         defined($nl->get_value('dribble_crophrv_xsmrpool_2atm'))   ) {
+             $log->fatal_error("When CN is not on none of the following can be set: ,\n" .
+                  "dribble_crophrv_xsmrpool_2atm nor reseed_dead_plantsr\n" .
+                  "(eg. don't use these options with SP mode).");
+    }
   }
 }
 

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3506,29 +3506,33 @@ sub setup_logic_lai_streams {
   my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
   if ( $physv->as_long() >= $physv->as_long("clm4_5") ) {
-    if ( &value_is_true($nl_flags->{'use_crop'}) && &value_is_true($nl_flags->{'use_lai_streams'}) ) {
+
+    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_lai_streams');
+
+    if ( &value_is_true($nl_flags->{'use_crop'}) && &value_is_true($nl->get_value('use_lai_streams'))  ) {
       $log->fatal_error("turning use_lai_streams on is incompatable with use_crop set to true.");
     }
     if ( $nl_flags->{'bgc_mode'} eq "sp" ) {
 
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_lai_streams');
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'lai_mapalgo',
-                  'hgrid'=>$nl_flags->{'res'} );
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_first_lai',
-                  'sim_year'=>$nl_flags->{'sim_year'},
-                  'sim_year_range'=>$nl_flags->{'sim_year_range'});
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_last_lai',
-                  'sim_year'=>$nl_flags->{'sim_year'},
-                  'sim_year_range'=>$nl_flags->{'sim_year_range'});
-      # Set align year, if first and last years are different
-      if ( $nl->get_value('stream_year_first_lai') !=
-           $nl->get_value('stream_year_last_lai') ) {
-           add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl,
-                       'model_year_align_lai', 'sim_year'=>$nl_flags->{'sim_year'},
-                       'sim_year_range'=>$nl_flags->{'sim_year_range'});
+      if ( &value_is_true($nl->get_value('use_lai_streams')) ) {
+         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'lai_mapalgo',
+                     'hgrid'=>$nl_flags->{'res'} );
+         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_first_lai',
+                     'sim_year'=>$nl_flags->{'sim_year'},
+                     'sim_year_range'=>$nl_flags->{'sim_year_range'});
+         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_year_last_lai',
+                     'sim_year'=>$nl_flags->{'sim_year'},
+                     'sim_year_range'=>$nl_flags->{'sim_year_range'});
+         # Set align year, if first and last years are different
+         if ( $nl->get_value('stream_year_first_lai') !=
+              $nl->get_value('stream_year_last_lai') ) {
+              add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl,
+                          'model_year_align_lai', 'sim_year'=>$nl_flags->{'sim_year'},
+                          'sim_year_range'=>$nl_flags->{'sim_year_range'});
+         }
+         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_fldfilename_lai',
+                     'hgrid'=>"360x720cru" );
       }
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'stream_fldfilename_lai',
-                  'hgrid'=>"360x720cru" );
     } else {
       # If bgc is CN/CNDV then make sure none of the LAI settings are set
       if ( defined($nl->get_value('stream_year_first_lai')) ||

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3608,8 +3608,9 @@ sub setup_logic_cngeneral {
 
   if ( $physv->as_long() >= $physv->as_long("clm4_5") && &value_is_true($nl->get_value('use_cn')) ) {
     if ( &value_is_true($nl->get_value('use_crop')) ) {
-       #add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dribble_crophrv_xsmrpool_2atm', 
-                   #'co2_type' => $nl->get_value('co2_type') );
+       add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dribble_crophrv_xsmrpool_2atm', 
+                   'co2_type' => remove_leading_and_trailing_quotes($nl->get_value('co2_type')), 
+                   'use_crop' => $nl->get_value('use_crop')  );
     } else {
       if ( defined($nl->get_value('dribble_crophrv_xsmrpool_2atm')) ) {
         $log->fatal_error("When CROP is NOT on dribble_crophrv_xsmrpool_2atm can NOT be set\n" );

--- a/bld/namelist_files/createMkSrfEntry.py
+++ b/bld/namelist_files/createMkSrfEntry.py
@@ -7,10 +7,10 @@ class mksrfDataEntry_prog:
    # Class data
    year_start = 2016
    year_end   = 2100
-   ssp_rcp    = "SSP5-8.5"
-   subdir     = "pftcftdynharv.0.25x0.25.SSP5-8.5.simyr2016-2100.c171005"
-   cdate      = 171005
-   desc       = "SSP5RCP85_clm5"
+   ssp_rcp    = "SSP4-6.0"
+   subdir     = "pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217"
+   cdate      = 181217
+   desc       = "SSP4RCP60_clm5"
 
    def parse_cmdline_args( self ):
       "Parse the command line arguments for create data entry list"

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -717,6 +717,9 @@ lnd/clm2/surfdata_map/surfdata_ne30np4_16pfts_Irrig_CMIP6_simyr2000_c170824.nc</
 <fsurdat hgrid="ne16np4"     sim_year="2000" use_crop=".false." irrigate=".true.">
 lnd/clm2/surfdata_map/surfdata_ne16np4_16pfts_Irrig_CMIP6_simyr2000_c170824.nc</fsurdat>
 
+<fsurdat 81003="conus_30_x8"    sim_year="2000" use_crop=".false." irrigate=".true.">
+lnd/clm2/surfdata_map/surfdata_conus_30_x8_16pfts_Irrig_CMIP6_simyr2000_c181003.nc</fsurdat>
+
 <fsurdat hgrid="5x5_amazon"    sim_year="2000" use_crop=".false." irrigate=".true.">
 lnd/clm2/surfdata_map/surfdata_5x5_amazon_16pfts_Irrig_CMIP6_simyr2000_c171214.nc</fsurdat>
 <fsurdat hgrid="1x1_brazil"    sim_year="2000" use_crop=".false." irrigate=".true.">
@@ -750,6 +753,9 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr2000_c170824.nc</fsurd
 lnd/clm2/surfdata_map/surfdata_ne30np4_78pfts_CMIP6_simyr2000_c170824.nc</fsurdat>
 <fsurdat hgrid="ne16np4"     sim_year="2000" use_crop=".true." >
 lnd/clm2/surfdata_map/surfdata_ne16np4_78pfts_CMIP6_simyr2000_c170824.nc</fsurdat>
+
+<fsurdat hgrid="conus_30_x8"     sim_year="2000" use_crop=".true." >
+lnd/clm2/surfdata_map/surfdata_conus_30_x8_78pfts_CMIP6_simyr2000_c181003.nc</fsurdat>
 
 <!-- 100% Urban single-point datasets (only for sim-year=2000) -->
 <fsurdat hgrid="1x1_camdenNJ"        sim_year="2000" use_crop=".false." irrigate=".true.">
@@ -787,6 +793,9 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_16pfts_Irrig_CMIP6_simyr1850_c170824.nc<
 <fsurdat hgrid="ne30np4"      sim_year="1850" use_crop=".false." irrigate=".true.">
 lnd/clm2/surfdata_map/surfdata_ne30np4_16pfts_Irrig_CMIP6_simyr1850_c170824.nc</fsurdat>
 
+<fsurdat hgrid="conus_30_x8"    sim_year="1850" use_crop=".false." irrigate=".true.">
+lnd/clm2/surfdata_map/surfdata_conus_30_x8_16pfts_Irrig_CMIP6_simyr1850_c181003.nc</fsurdat>
+
 <!-- pre-industrial with crop -->
 <fsurdat hgrid="360x720cru"   sim_year="1850" use_crop=".true." >
 lnd/clm2/surfdata_map/surfdata_360x720cru_78pfts_CMIP6_simyr1850_c170824.nc</fsurdat>
@@ -815,6 +824,9 @@ lnd/clm2/surfdata_map/surfdata_1x1_brazil_78pfts_CMIP6_simyr1850_c171214.nc</fsu
 lnd/clm2/surfdata_map/surfdata_ne30np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurdat>
 <fsurdat hgrid="ne120np4"     sim_year="1850" use_crop=".true." >
 lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurdat>
+
+<fsurdat hgrid="conus_30_x8"    sim_year="1850" use_crop=".true." >
+lnd/clm2/surfdata_map/surfdata_conus_30_x8_78pfts_CMIP6_simyr1850_c181003.nc</fsurdat>
 
 <!-- Dynamic PFT surface datasets (relative to {csmdata}) -->
 
@@ -845,6 +857,9 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <flanduse_timeseries hgrid="ne30np4"       sim_year_range="1850-2000"  irrigate=".true."
  use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_16pfts_Irrig_CMIP6_simyr1850-2015_c170824.nc</flanduse_timeseries>
 
+<flanduse_timeseries hgrid="conus_30_x8"   sim_year_range="1850-2000"  irrigate=".true."
+ use_crop=".false."  >lnd/clm2/surfdata_map/landuse.timeseries_conus_30_x8_hist_16pfts_Irrig_CMIP6_simyr1850-2015_c181003.nc</flanduse_timeseries>
+
 <!-- Dynamic PFT surface datasets for crop -->
 
 <flanduse_timeseries hgrid="0.47x0.63"      sim_year_range="1850-2000"
@@ -871,6 +886,9 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
  use_crop=".true."  >lnd/clm2/surfdata_map/landuse.timeseries_ne120np4_hist_78pfts_CMIP6_simyr1850-2015_c170824.nc</flanduse_timeseries>
 <flanduse_timeseries hgrid="ne30np4"       sim_year_range="1850-2000" 
  use_crop=".true."  >lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_78pfts_CMIP6_simyr1850-2015_c170824.nc</flanduse_timeseries>
+
+<flanduse_timeseries hgrid="conus_30_x8"   sim_year_range="1850-2000" 
+ use_crop=".true."  >lnd/clm2/surfdata_map/landuse.timeseries_conus_30_x8_hist_78pfts_CMIP6_simyr1850-2015_c181004.nc</flanduse_timeseries>
 
 <!-- Note that this transient file only goes up to year 1855.
      This is sufficient for testing purposes, but could cause problems if you try to run beyond 1855. -->
@@ -2496,6 +2514,46 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 >lnd/clm2/mappingdata/maps/0.125x0.125/map_5x5min_nomask_to_0.125x0.125_nomask_aave_da_c140702.nc</map>
 
 <!-- mapping files for 0.125x0.125 END -->
+
+<!-- mapping files for conus_30_x8 START added on Mon Jan 14 21:41:02 2019-->
+<!-- Created by lnd/clm/bld/namelist_files/createMapEntry.pl--> 
+
+<map frm_hgrid="5x5min"    frm_lmask="nomask"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_5x5min_nomask_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="GLOBE-Gardner"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_3x3min_GLOBE-Gardner_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="LandScan2004"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_3x3min_LandScan2004_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="10x10min"    frm_lmask="nomask"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_10x10min_nomask_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="0.5x0.5"    frm_lmask="MODIS"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_0.5x0.5_MODIS_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="5x5min"    frm_lmask="ORNL-Soil"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_5x5min_ORNL-Soil_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="0.5x0.5"    frm_lmask="AVHRR"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_0.5x0.5_AVHRR_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="MODIS-wCsp"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_3x3min_MODIS-wCsp_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="1km-merge-10min"    frm_lmask="HYDRO1K-merge-nomask"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_1km-merge-10min_HYDRO1K-merge-nomask_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="360x720cru"    frm_lmask="cruncep"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_360x720cru_cruncep_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="10x10min"    frm_lmask="IGBPmergeICESatGIS"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_10x10min_IGBPmergeICESatGIS_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="GLOBE-Gardner-mergeGIS"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_3x3min_GLOBE-Gardner-mergeGIS_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="0.9x1.25"    frm_lmask="GRDC"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_0.9x1.25_GRDC_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="5x5min"    frm_lmask="ISRIC-WISE"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_5x5min_ISRIC-WISE_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="USGS"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_3x3min_USGS_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="0.25x0.25"    frm_lmask="MODIS"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_0.25x0.25_MODIS_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+<map frm_hgrid="5x5min"    frm_lmask="IGBP-GSDP"  to_hgrid="conus_30_x8"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/conus_30_x8/map_5x5min_IGBP-GSDP_to_conus_30_x8_nomask_aave_da_c181003.nc</map>
+
+<!-- mapping files for conus_30_x8 END -->
 
 <!-- =========================================  -->
 <!-- Defaults for modelio namelist              -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -447,6 +447,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_hydrstress phys="clm4_5"                 >.false.</use_hydrstress>
 <use_hydrstress phys="clm5_0" use_fates=".true." >.false.</use_hydrstress>
 <use_hydrstress phys="clm5_0" use_fates=".false.">.true.</use_hydrstress>
+
+<!-- General CN options -->
+<dribble_crophrv_xsmrpool_2atm co2_type="prognostic" use_crop=".true.">.true.</dribble_crophrv_xsmrpool_2atm>
+<dribble_crophrv_xsmrpool_2atm                       use_crop=".true.">.false.</dribble_crophrv_xsmrpool_2atm>
+
 <!--
 
      Initial condition files to use and or interpolate from

--- a/bld/namelist_files/namelist_defaults_clm4_5_tools.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5_tools.xml
@@ -46,6 +46,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <scripgriddata hgrid="ne16np4"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne16np4_nomask_c110512.nc</scripgriddata>
 <scripgriddata hgrid="ne4np4"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne4np4_nomask_c110808.nc</scripgriddata>
 
+<!-- Refined mesh grids -->
+<scripgriddata hgrid="conus_30_x8" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_conus_30_x8_nomask_c170111.nc</scripgriddata>
+
 <!-- Regular lat/lon grids -->
 <scripgriddata hgrid="0.125x0.125" lmask="nomask"    
    >lnd/clm2/mappingdata/grids/SCRIPgrid_0.125x0.125_nomask_c140702.nc</scripgriddata>
@@ -623,6 +626,2410 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <mksrf_fvegtyp hgrid="0.25x0.25" sim_year="2015" crop="on" >lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.LUH2.histsimyr1850-2015.c170629/mksrf_landuse_histclm50_LUH2_2015.c170629.nc
 </mksrf_fvegtyp>
 
+<!-- Potential Vegetation dataset -->
+<mksrf_fvegtyp hgrid="0.25x0.25" sim_year="PtVg" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.LUH2.simyrPtVg.c181106/mksrf_landuse_potvegclm50_LUH2.c181106.nc
+</mksrf_fvegtyp>
+
+<!-- 
+      Future scenarios 
+-->
+
+<!-- SSP1-RCP 2.6 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-2.6" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP26_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+
+<!-- SSP3-RCP 7.0 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP3-7.0" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2016-2100.c181217/mksrf_landuse_SSP3RCP70_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+<!-- SSP5-RCP 3.4 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-3.4" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP5RCP34_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+
+<!-- SSP2-RCP 4.5 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP2-4.5" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2016-2100.c181217/mksrf_landuse_SSP2RCP45_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+
+<!-- SSP1-RCP 1.9 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP1-1.9" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2016-2100.c181217/mksrf_landuse_SSP1RCP19_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+
+<!-- SSP4-RCP 3.4 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-3.4" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP34_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+
+<!-- SSP4-RCP 6.0 -->
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2016" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2016.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2017" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2017.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2018" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2018.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2019" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2019.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2020" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2020.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2021" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2021.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2022" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2022.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2023" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2023.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2024" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2024.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2025" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2025.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2026" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2026.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2027" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2027.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2028" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2028.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2029" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2029.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2030" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2030.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2031" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2031.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2032" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2032.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2033" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2033.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2034" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2034.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2035" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2035.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2036" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2036.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2037" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2037.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2038" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2038.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2039" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2039.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2040" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2040.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2041" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2041.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2042" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2042.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2043" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2043.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2044" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2044.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2045" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2045.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2046" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2046.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2047" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2047.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2048" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2048.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2049" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2049.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2050" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2050.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2051" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2051.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2052" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2052.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2053" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2053.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2054" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2054.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2055" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2055.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2056" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2056.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2057" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2057.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2058" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2058.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2059" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2059.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2060" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2060.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2061" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2061.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2062" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2062.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2063" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2063.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2064" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2064.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2065" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2065.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2066" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2066.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2067" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2067.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2068" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2068.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2069" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2069.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2070" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2070.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2071" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2071.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2072" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2072.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2073" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2073.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2074" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2074.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2075" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2075.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2076" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2076.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2077" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2077.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2078" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2078.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2079" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2079.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2080" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2080.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2081" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2081.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2082" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2082.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2083" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2083.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2084" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2084.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2085" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2085.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2086" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2086.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2087" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2087.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2088" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2088.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2089" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2089.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2090" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2090.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2091" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2091.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2092" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2092.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2093" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2093.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2094" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2094.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2095" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2095.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2096" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2096.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2097" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2097.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2098" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2098.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2099" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2099.c181217.nc
+</mksrf_fvegtyp>
+
+<mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP4-6.0" sim_year="2100" crop="on"
+>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2016-2100.c181217/mksrf_landuse_SSP4RCP60_clm5_2100.c181217.nc
+</mksrf_fvegtyp>
+
+
+
+<!-- SSP5-RCP 8.5 -->
 <mksrf_fvegtyp hgrid="0.25x0.25" ssp_rcp="SSP5-8.5" sim_year="2016" crop="on"
 >lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-8.5.simyr2016-2100.c171005/mksrf_landuse_SSP5RCP85_clm5_2016.c171005.nc
 </mksrf_fvegtyp>

--- a/bld/namelist_files/namelist_definition_clm4_0.xml
+++ b/bld/namelist_files/namelist_definition_clm4_0.xml
@@ -715,7 +715,7 @@ If TRUE, irrigation will be active (find surface datasets with active irrigation
 If 1, turn on the MEGAN model for BVOC's (Biogenic Volitile Organic Compounds)
 </entry> 
 
-<entry id="sim_year" type="integer" category="default_settings"
+<entry id="sim_year" type="char*4" category="default_settings"
        group="default_settings" valid_values=
 "1000,850,1100,1350,1600,1850,1855,1865,1875,1885,1895,1905,1915,1925,1935,1945,1955,1965,1975,1985,1995,2000,2005,2015,2025,2035,2045,2055,2065,2075,2085,2095,2105">
 Year to simulate and to provide datasets for (such as surface datasets, initial conditions, aerosol-deposition, Nitrogen deposition rates etc.)

--- a/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1969,9 +1969,9 @@ Number of days over which to use exponential relaxation of NPP in N fixation cal
 Flag to reseed any dead plants on startup from reading the initial conditions file
 </entry>
 
-<entry id="harvest_xsmrpool_2atm" type="logical" category="clm_physics"
+<entry id="dribble_crophrv_xsmrpool_2atm" type="logical" category="clm_physics"
        group="cn_general" valid_values="" >
-Harvest the XSMR pool in CN to the atmosphere slowly at an exponential rate
+Harvest the XSMR pool at crop harvest time to the atmosphere slowly at an exponential rate
 </entry>
 
 <!-- C isotope flags    -->

--- a/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1969,6 +1969,11 @@ Number of days over which to use exponential relaxation of NPP in N fixation cal
 Flag to reseed any dead plants on startup from reading the initial conditions file
 </entry>
 
+<entry id="harvest_xsmrpool_2atm" type="logical" category="clm_physics"
+       group="cn_general" valid_values="" >
+Harvest the XSMR pool in CN to the atmosphere slowly at an exponential rate
+</entry>
+
 <!-- C isotope flags    -->
 <entry id="use_c13" type="logical" category="clm_isotope"
        group="clm_inparm" valid_values="" >

--- a/bld/namelist_files/namelist_definition_clm4_5.xml
+++ b/bld/namelist_files/namelist_definition_clm4_5.xml
@@ -1776,7 +1776,7 @@ CLM run type.
 <entry id="res" type="char*30" category="default_settings"
        group="default_settings"  
        valid_values=
-"512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.47x0.63,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.25x0.25,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne16np4,ne30np4,ne60np4,ne120np4,ne240np4,1km-merge-10min">
+"conus_30_x8,512x1024,360x720cru,128x256,64x128,48x96,32x64,8x16,94x192,0.23x0.31,0.47x0.63,0.9x1.25,1.9x2.5,2.5x3.33,4x5,10x15,5x5_amazon,1x1_camdenNJ,1x1_vancouverCAN,1x1_mexicocityMEX,1x1_asphaltjungleNJ,1x1_brazil,1x1_urbanc_alpha,1x1_numaIA,1x1_smallvilleIA,0.1x0.1,0.25x0.25,0.5x0.5,3x3min,5x5min,10x10min,0.33x0.33,0.125x0.125,ne4np4,ne16np4,ne30np4,ne60np4,ne120np4,ne240np4,1km-merge-10min">
 Horizontal resolutions
 Note: 0.1x0.1, 0.25x0.25, 0.5x0.5, 5x5min, 10x10min, 3x3min and 0.33x0.33 are only used for CLM tools
 </entry> 
@@ -1788,9 +1788,9 @@ Representative concentration pathway for future scenarios [radiative forcing at 
 -999.9 means do NOT use a future scenario, just use historical data.
 </entry> 
 
-<entry id="ssp-rcp" type="character*8" category="default_settings"
+<entry id="ssp_rcp" type="character*8" category="default_settings"
        group="default_settings"  
-       valid_values="hist,SSP1-2.6,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-8.5">
+       valid_values="hist,SSP1-2.6,SSP3-7.0,SSP5-3.4,SSP2-4.5,SSP1-1.9,SSP4-3.4,SSP4-6.0,SSP5-8.5">
 Shared Socioeconomic Pathway (SSP) and Representative Concentration Pathway (RCP) combination for future scenarios 
 The form is SSPn-m.m Where n is the SSP number and m.m is RCP radiative forcing at peak or 2100 in W/m^2
 n is just the whole number of the specific SSP scenario. The lower numbers have higher mitigation
@@ -1818,12 +1818,13 @@ to run with a different type of atmospheric forcing.
 If 1, turn on the MEGAN model for BVOC's (Biogenic Volitile Organic Compounds)
 </entry> 
 
-<entry id="sim_year" type="integer" category="default_settings"
+<entry id="sim_year" type="char*4" category="default_settings"
        group="default_settings" valid_values=
-"1000,850,1100,1350,1600,1850,1855,1865,1875,1885,1895,1905,1915,1925,1935,1945,1955,1965,1975,1980,1985,1995,2000,2005,2010,2015,2025,2035,2045,2055,2065,2075,2085,2095,2105">
+"PtVg,1000,850,1100,1350,1600,1850,1855,1865,1875,1885,1895,1905,1915,1925,1935,1945,1955,1965,1975,1980,1985,1995,2000,2005,2010,2015,2025,2035,2045,2055,2065,2075,2085,2095,2105">
 Year to simulate and to provide datasets for (such as surface datasets, initial conditions, aerosol-deposition, Nitrogen deposition rates etc.)
 A sim_year of 1000 corresponds to data used for testing only, NOT corresponding to any real datasets.
-A sim_year greater than 2005 corresponds to rcp scenario data
+A sim_year greater than 2015 corresponds to rcp scenario data
+A sim_year of PtVg refers to the Potential Vegetation dataset, that doesn't include human influences
 Most years are only used for clm_tools and there aren't CLM datasets that correspond to them.
 CLM datasets exist for years: 1000 (for testing), 1850, and 2000
 </entry> 

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -123,9 +123,9 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 946;
+my $ntests = 950;
 if ( defined($opts{'compare'}) ) {
-   $ntests += 597;
+   $ntests += 600;
 }
 plan( tests=>$ntests );
 

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -123,7 +123,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 943;
+my $ntests = 946;
 if ( defined($opts{'compare'}) ) {
    $ntests += 597;
 }
@@ -386,6 +386,21 @@ my %failtest = (
                                      namelst=>"use_crop=.true.",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      conopts=>"-phys clm4_5",
+                                   },
+     "reseed without CN"         =>{ options=>" -envxml_dir . -bgc sp",
+                                     namelst=>"reseed_dead_plants=.true.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     conopts=>"-phys clm5_0",
+                                   },
+     "dribble_crphrv w/o CN"     =>{ options=>" -envxml_dir . -bgc sp",
+                                     namelst=>"dribble_crophrv_xsmrpool_2atm=.true.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     conopts=>"-phys clm5_0",
+                                   },
+     "dribble_crphrv w/o crop"   =>{ options=>" -envxml_dir . -bgc cn -no-crop",
+                                     namelst=>"dribble_crophrv_xsmrpool_2atm=.true.",
+                                     GLC_TWO_WAY_COUPLING=>"FALSE",
+                                     conopts=>"-phys clm5_0",
                                    },
      "CNDV with flanduse_timeseries"         =>{ options=>" -envxml_dir .",
                                      namelst=>"flanduse_timeseries='my_flanduse_timeseries_file.nc'",

--- a/cime_config/testdefs/testmods_dirs/clm/DA_multidrv/user_nl_clm_0001
+++ b/cime_config/testdefs/testmods_dirs/clm/DA_multidrv/user_nl_clm_0001
@@ -10,4 +10,4 @@
  hist_type1d_pertape = ' ',' ',' '
 
  use_init_interp = .true.
- finidat = '/glade/p_old/image/RDA_strawman/CESM_ensembles/CLM/CLM5BGC-Crop/ctsm_2001-01-01-00000/clm5_f09_spinup80.clm2_0001.r.2001-01-01-00000.nc'
+ finidat = '/glade/p/cisl/dares/RDA_strawman/CESM_ensembles/CLM/CLM5BGC-Crop/ctsm_2001-01-01-00000/clm5_f09_spinup80.clm2_0001.r.2001-01-01-00000.nc'

--- a/cime_config/testdefs/testmods_dirs/clm/DA_multidrv/user_nl_clm_0002
+++ b/cime_config/testdefs/testmods_dirs/clm/DA_multidrv/user_nl_clm_0002
@@ -10,4 +10,4 @@
  hist_type1d_pertape = ' ',' ',' '
 
  use_init_interp = .true.
- finidat = '/glade/p_old/image/RDA_strawman/CESM_ensembles/CLM/CLM5BGC-Crop/ctsm_2001-01-01-00000/clm5_f09_spinup80.clm2_0002.r.2001-01-01-00000.nc'
+ finidat = '/glade/p/cisl/dares/RDA_strawman/CESM_ensembles/CLM/CLM5BGC-Crop/ctsm_2001-01-01-00000/clm5_f09_spinup80.clm2_0002.r.2001-01-01-00000.nc'

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+release-clm5.0.16     erik 01/15/2019 PtVg and ssp_rcp future scenario options and Antarctica wetlands fix to mksurfdata, and option to dribble crop harvest XSMRPOOL flux to atmosphere
 release-clm5.0.15    sacks 12/06/2018 Option for rain-to-snow to immediately run off in some regions
 release-clm5.0.14     erik 11/29/2018 Update cime and fix surface dataset for f05 1850 non-crop case
 release-clm5.0.13     erik 11/14/2018 Update externals with new CO2/presearo/rtm/mosart, add science_support, change testing

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,4 +1,103 @@
 ===============================================================
+Tag name:  release-clm5.0.16
+Originator(s):  erik (Erik Kluzek)
+Date: Tue Jan 15 15:13:43 MST 2019
+One-line Summary: PtVg and ssp_rcp future scenario options and Antarctica wetlands fix to mksurfdata, and option to dribble crop harvest XSMRPOOL flux to atmosphere
+
+Purpose of this version:
+------------------------
+
+no-anthro changes on release branch. Update of mksurfdata for Antarctic. Also start adding in newly created SSP-RCP datasets that are easy to add in.
+Also add in new option for dribble_crophrv_xsmrpool_2atm.
+
+CTSM Master Tag This Corresponds To: N/A
+
+Summary of changes:
+-------------------
+
+Issues fixed (include CTSM Issue #): #553 #533 #589 #547 #545
+  #553 -- More robust mksurfdata_map logic for determining where to put wetlands
+  #533 -- Add -no-anthro option to mksurfdata_map
+  #589 -- Existence of content in the lai_streams namelist makes it confusing to users
+  #547 -- Add conus_30_x8 grid as valid option for CTSM and mksurfdata_map
+  #545 -- Antarctica ice shelves are being treated as wetlands rather than glaciers
+
+Science changes since: release-clm5.0.15
+  mksurfdata now properly makes Antarctica teated as glacier rather than wetland
+  Add in option to create all of the SSP-RCP future scenarios in mksurfdata_map
+  Add dribble_crophrv_xsmrpool_2atm, to do slow release of crop harvested XSMRPOOL to atmosphere
+    (only active by default when co2_type="prognostic")
+
+Software changes since: release-clm5.0.15
+  Add no-anthro option for mksurfdata_map
+
+Changes to User Interface since: release-clm5.0.15
+  New namelist option: dribble_crophrv_xsmrpool_2atm
+  Add SSP-RCP future scenarios can be done in mksurfdata_map
+
+Testing:
+--------
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+    hobart --- PASS
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - PASS
+    hobart ---
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     cheyenne - PASS
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    hobart_nag -------- OK
+    hobart_pgi -------- OK
+    hobart_intel ------ OK
+
+Summary of Answer changes:
+-------------------------
+
+Baseline version for comparison: release-clm5.0.15
+
+Changes answers relative to baseline: No bit-for-bit
+
+Detailed list of changes:
+------------------------
+
+Externals being used:
+
+   cism:   release-cesm2.0.04
+   rtm:    release-cesm2.0.02
+   mosart: release-cesm2.0.03
+   cime:   cime_cesm2_1_rel_06
+   FATES:  fates_s1.8.1_a3.0.0
+   PTCLM:  PTCLM2_180611
+
+CTSM Tag versions pulled over from master development branch: N/A
+
+Pull Requests that document the changes (include PR ids):  #567 #561 #564 #616 #610
+(https://github.com/ESCOMP/ctsm/pull)
+
+   #616 -- No anthro options to tools, and all future scenarios in place, plus a few small issue fixes
+   #610 -- Add option to dribble XSMRPOOL at crop harvest to atmosphere over a half year
+   #567 -- ignore patterns for vim
+   #564 -- Update mksurfdata_map to include glaciers outside of pft landmask
+   #561 -- Add list of checks for new surface datasets
+
+===============================================================
+===============================================================
 Tag name:  release-clm5.0.15
 Originator(s):  sacks (Bill Sacks)
 Date: Thu Dec  6 10:14:30 MST 2018

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -146,10 +146,7 @@ contains
          er                      =>    cnveg_carbonflux_inst%er_col                     , & ! Input:  [real(r8) (:) ]  (gC/m2/s) total ecosystem respiration, autotrophic + heterotrophic
          col_fire_closs          =>    cnveg_carbonflux_inst%fire_closs_col             , & ! Input:  [real(r8) (:) ]  (gC/m2/s) total column-level fire C loss
          col_hrv_xsmrpool_to_atm =>    cnveg_carbonflux_inst%hrv_xsmrpool_to_atm_col    , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool harvest mortality 
-!KO
-         col_xsmrpool_loss_to_atm =>   cnveg_carbonflux_inst%xsmrpool_loss_to_atm_col   , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool crop harvest loss to atm
-         col_xsmrpool_loss_store  =>   cnveg_carbonflux_inst%xsmrpool_loss_store_col    , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool crop harvest loss storage
-!KO
+         col_xsmrpool_to_atm     =>   cnveg_carbonflux_inst%xsmrpool_to_atm_col         , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool crop harvest loss to atm
          som_c_leached           =>    soilbiogeochem_carbonflux_inst%som_c_leached_col , & ! Input:  [real(r8) (:) ]  (gC/m2/s) total SOM C loss from vertical transport 
 
          totcolc                 =>    cnveg_carbonstate_inst%totc_col                    & ! Input:  [real(r8) (:) ]  (gC/m2) total column carbon, incl veg and cpool
@@ -170,12 +167,8 @@ contains
 
          ! calculate total column-level outputs
          ! er = ar + hr, col_fire_closs includes patch-level fire losses
-!KO         col_coutputs = er(c) + col_fire_closs(c) + col_hrv_xsmrpool_to_atm(c)
-!KO
          col_coutputs = er(c) + col_fire_closs(c) + col_hrv_xsmrpool_to_atm(c) + &
-              col_xsmrpool_loss_store(c)
-!             col_xsmrpool_loss_to_atm(c) + col_xsmrpool_loss_store(c)
-!KO
+              col_xsmrpool_to_atm(c)
 
          ! Fluxes to product pools are included in column-level outputs: the product
          ! pools are not included in totcolc, so are outside the system with respect to
@@ -219,10 +212,7 @@ contains
          write(iulog,*)'er                       = ',er(c)*dt
          write(iulog,*)'col_fire_closs           = ',col_fire_closs(c)*dt
          write(iulog,*)'col_hrv_xsmrpool_to_atm  = ',col_hrv_xsmrpool_to_atm(c)*dt
-!KO
-         write(iulog,*)'col_xsmrpool_loss_to_atm = ',col_xsmrpool_loss_to_atm(c)*dt
-         write(iulog,*)'col_xsmrpool_loss_store  = ',col_xsmrpool_loss_store(c)*dt
-!KO
+         write(iulog,*)'col_xsmrpool_to_atm      = ',col_xsmrpool_to_atm(c)*dt
          write(iulog,*)'wood_harvestc            = ',wood_harvestc(c)*dt
          write(iulog,*)'grainc_to_cropprodc      = ',grainc_to_cropprodc(c)*dt
          write(iulog,*)'-1*som_c_leached         = ',som_c_leached(c)*dt

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -146,7 +146,10 @@ contains
          er                      =>    cnveg_carbonflux_inst%er_col                     , & ! Input:  [real(r8) (:) ]  (gC/m2/s) total ecosystem respiration, autotrophic + heterotrophic
          col_fire_closs          =>    cnveg_carbonflux_inst%fire_closs_col             , & ! Input:  [real(r8) (:) ]  (gC/m2/s) total column-level fire C loss
          col_hrv_xsmrpool_to_atm =>    cnveg_carbonflux_inst%hrv_xsmrpool_to_atm_col    , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool harvest mortality 
-
+!KO
+         col_xsmrpool_loss_to_atm =>   cnveg_carbonflux_inst%xsmrpool_loss_to_atm_col   , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool crop harvest loss to atm
+         col_xsmrpool_loss_store  =>   cnveg_carbonflux_inst%xsmrpool_loss_store_col    , & ! Input:  [real(r8) (:) ]  (gC/m2/s) excess MR pool crop harvest loss storage
+!KO
          som_c_leached           =>    soilbiogeochem_carbonflux_inst%som_c_leached_col , & ! Input:  [real(r8) (:) ]  (gC/m2/s) total SOM C loss from vertical transport 
 
          totcolc                 =>    cnveg_carbonstate_inst%totc_col                    & ! Input:  [real(r8) (:) ]  (gC/m2) total column carbon, incl veg and cpool
@@ -167,7 +170,12 @@ contains
 
          ! calculate total column-level outputs
          ! er = ar + hr, col_fire_closs includes patch-level fire losses
-         col_coutputs = er(c) + col_fire_closs(c) + col_hrv_xsmrpool_to_atm(c)
+!KO         col_coutputs = er(c) + col_fire_closs(c) + col_hrv_xsmrpool_to_atm(c)
+!KO
+         col_coutputs = er(c) + col_fire_closs(c) + col_hrv_xsmrpool_to_atm(c) + &
+              col_xsmrpool_loss_store(c)
+!             col_xsmrpool_loss_to_atm(c) + col_xsmrpool_loss_store(c)
+!KO
 
          ! Fluxes to product pools are included in column-level outputs: the product
          ! pools are not included in totcolc, so are outside the system with respect to
@@ -211,6 +219,10 @@ contains
          write(iulog,*)'er                       = ',er(c)*dt
          write(iulog,*)'col_fire_closs           = ',col_fire_closs(c)*dt
          write(iulog,*)'col_hrv_xsmrpool_to_atm  = ',col_hrv_xsmrpool_to_atm(c)*dt
+!KO
+         write(iulog,*)'col_xsmrpool_loss_to_atm = ',col_xsmrpool_loss_to_atm(c)*dt
+         write(iulog,*)'col_xsmrpool_loss_store  = ',col_xsmrpool_loss_store(c)*dt
+!KO
          write(iulog,*)'wood_harvestc            = ',wood_harvestc(c)*dt
          write(iulog,*)'grainc_to_cropprodc      = ',grainc_to_cropprodc(c)*dt
          write(iulog,*)'-1*som_c_leached         = ',som_c_leached(c)*dt

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -484,20 +484,28 @@ contains
                ! atmosphere solved many of the crop isotope problems
 
                ! Save xsmrpool, cpool, frootc to loss state variable for dribbling
-               cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) + &
-                                               cs_veg%xsmrpool_patch(p) + &
-                                               cs_veg%cpool_patch(p) + &
-                                               cs_veg%frootc_patch(p)
+               if ( .not. harvest_xsmrpool_2atm ) then
+                  cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%xsmrpool_patch(p)/dt
+                  cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%cpool_patch(p)/dt
+                  cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%frootc_patch(p)/dt
+               else
+                  cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) + &
+                                                  cs_veg%xsmrpool_patch(p) + &
+                                                  cs_veg%cpool_patch(p) + &
+                                                  cs_veg%frootc_patch(p)
+               end if
                cs_veg%xsmrpool_patch(p)        = 0._r8
                cs_veg%cpool_patch(p)           = 0._r8
                cs_veg%frootc_patch(p)          = 0._r8
             end if
 
-            ! calculate flux of xsmrpool loss to atm
-            cf_veg%xsmrpool_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
+            if ( harvest_xsmrpool_2atm ) then
+               ! calculate flux of xsmrpool loss to atm
+               cf_veg%xsmrpool_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
 
-            ! update xsmrpool loss state
-            cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) - cf_veg%xsmrpool_to_atm_patch(p) * dt
+               ! update xsmrpool loss state
+               cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) - cf_veg%xsmrpool_to_atm_patch(p) * dt
+            end if
 
          end if
 

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -142,7 +142,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine CStateUpdate1( num_soilc, filter_soilc, num_soilp, filter_soilp, &
        crop_inst, cnveg_carbonflux_inst, cnveg_carbonstate_inst, &
-       soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
+       soilbiogeochem_carbonflux_inst, dribble_crophrv_xsmrpool_2atm)
     !
     ! !DESCRIPTION:
     ! On the radiation time step, update all the prognostic carbon state
@@ -158,7 +158,7 @@ contains
     type(cnveg_carbonflux_type)          , intent(inout) :: cnveg_carbonflux_inst ! See note below for xsmrpool_to_atm_patch
     type(cnveg_carbonstate_type)         , intent(inout) :: cnveg_carbonstate_inst
     type(soilbiogeochem_carbonflux_type) , intent(inout) :: soilbiogeochem_carbonflux_inst
-    logical                              , intent(in)    :: harvest_xsmrpool_2atm
+    logical                              , intent(in)    :: dribble_crophrv_xsmrpool_2atm
     !
     ! !LOCAL VARIABLES:
     integer  :: c,p,j,k,l ! indices
@@ -484,7 +484,7 @@ contains
                ! atmosphere solved many of the crop isotope problems
 
                ! Save xsmrpool, cpool, frootc to loss state variable for dribbling
-               if ( .not. harvest_xsmrpool_2atm ) then
+               if ( .not. dribble_crophrv_xsmrpool_2atm ) then
                   cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%xsmrpool_patch(p)/dt
                   cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%cpool_patch(p)/dt
                   cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%frootc_patch(p)/dt
@@ -499,7 +499,7 @@ contains
                cs_veg%frootc_patch(p)          = 0._r8
             end if
 
-            if ( harvest_xsmrpool_2atm ) then
+            if ( dribble_crophrv_xsmrpool_2atm ) then
                ! calculate flux of xsmrpool loss to atm
                cf_veg%xsmrpool_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
 

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -191,23 +191,23 @@ contains
 
       ! plant to litter fluxes
       if (.not. use_fates) then    
-      do j = 1,nlevdecomp
-         do fc = 1,num_soilc
-            c = filter_soilc(fc)
-            ! phenology and dynamic land cover fluxes
-            cf_soil%decomp_cpools_sourcesink_col(c,j,i_met_lit) = &
-                 cf_veg%phenology_c_to_litr_met_c_col(c,j) *dt
-            cf_soil%decomp_cpools_sourcesink_col(c,j,i_cel_lit) = &
-                 cf_veg%phenology_c_to_litr_cel_c_col(c,j) *dt
-            cf_soil%decomp_cpools_sourcesink_col(c,j,i_lig_lit) = &
-                 cf_veg%phenology_c_to_litr_lig_c_col(c,j) *dt
-
-            ! NOTE(wjs, 2017-01-02) This used to be set to a non-zero value, but the
-            ! terms have been moved to CStateUpdateDynPatch. I think this is zeroed every
-            ! time step, but to be safe, I'm explicitly setting it to zero here.
-            cf_soil%decomp_cpools_sourcesink_col(c,j,i_cwd) = 0._r8
+         do j = 1,nlevdecomp
+            do fc = 1,num_soilc
+               c = filter_soilc(fc)
+               ! phenology and dynamic land cover fluxes
+               cf_soil%decomp_cpools_sourcesink_col(c,j,i_met_lit) = &
+                    cf_veg%phenology_c_to_litr_met_c_col(c,j) *dt
+               cf_soil%decomp_cpools_sourcesink_col(c,j,i_cel_lit) = &
+                    cf_veg%phenology_c_to_litr_cel_c_col(c,j) *dt
+               cf_soil%decomp_cpools_sourcesink_col(c,j,i_lig_lit) = &
+                    cf_veg%phenology_c_to_litr_lig_c_col(c,j) *dt
+   
+               ! NOTE(wjs, 2017-01-02) This used to be set to a non-zero value, but the
+               ! terms have been moved to CStateUpdateDynPatch. I think this is zeroed every
+               ! time step, but to be safe, I'm explicitly setting it to zero here.
+               cf_soil%decomp_cpools_sourcesink_col(c,j,i_cwd) = 0._r8
+            end do
          end do
-      end do
       else  !use_fates
          ! here add all fates litterfall and CWD breakdown to litter fluxes
          do j = 1,nlevdecomp
@@ -246,270 +246,267 @@ contains
          end if
       end do
 
-    if (.not. use_fates) then    
-      do fp = 1,num_soilp
-         p = filter_soilp(fp)
-         c = patch%column(p)
+      if (.not. use_fates) then    
+        do fp = 1,num_soilp
+           p = filter_soilp(fp)
+           c = patch%column(p)
+  
+           ! phenology: transfer growth fluxes
+           cs_veg%leafc_patch(p)           = cs_veg%leafc_patch(p)       + cf_veg%leafc_xfer_to_leafc_patch(p)*dt
+           cs_veg%leafc_xfer_patch(p)      = cs_veg%leafc_xfer_patch(p)  - cf_veg%leafc_xfer_to_leafc_patch(p)*dt
+           cs_veg%frootc_patch(p)          = cs_veg%frootc_patch(p)      + cf_veg%frootc_xfer_to_frootc_patch(p)*dt
+           cs_veg%frootc_xfer_patch(p)     = cs_veg%frootc_xfer_patch(p) - cf_veg%frootc_xfer_to_frootc_patch(p)*dt
+           if (woody(ivt(p)) == 1._r8) then
+              cs_veg%livestemc_patch(p)       = cs_veg%livestemc_patch(p)       + cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
+              cs_veg%livestemc_xfer_patch(p)  = cs_veg%livestemc_xfer_patch(p)  - cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
+              cs_veg%deadstemc_patch(p)       = cs_veg%deadstemc_patch(p)       + cf_veg%deadstemc_xfer_to_deadstemc_patch(p)*dt
+              cs_veg%deadstemc_xfer_patch(p)  = cs_veg%deadstemc_xfer_patch(p)  - cf_veg%deadstemc_xfer_to_deadstemc_patch(p)*dt
+              cs_veg%livecrootc_patch(p)      = cs_veg%livecrootc_patch(p)      + cf_veg%livecrootc_xfer_to_livecrootc_patch(p)*dt
+              cs_veg%livecrootc_xfer_patch(p) = cs_veg%livecrootc_xfer_patch(p) - cf_veg%livecrootc_xfer_to_livecrootc_patch(p)*dt
+              cs_veg%deadcrootc_patch(p)      = cs_veg%deadcrootc_patch(p)      + cf_veg%deadcrootc_xfer_to_deadcrootc_patch(p)*dt
+              cs_veg%deadcrootc_xfer_patch(p) = cs_veg%deadcrootc_xfer_patch(p) - cf_veg%deadcrootc_xfer_to_deadcrootc_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              ! lines here for consistency; the transfer terms are zero
+              cs_veg%livestemc_patch(p)       = cs_veg%livestemc_patch(p)      + cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
+              cs_veg%livestemc_xfer_patch(p)  = cs_veg%livestemc_xfer_patch(p) - cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
+              cs_veg%grainc_patch(p)          = cs_veg%grainc_patch(p)         + cf_veg%grainc_xfer_to_grainc_patch(p)*dt
+              cs_veg%grainc_xfer_patch(p)     = cs_veg%grainc_xfer_patch(p)    - cf_veg%grainc_xfer_to_grainc_patch(p)*dt
+           end if
 
-         ! phenology: transfer growth fluxes
-         cs_veg%leafc_patch(p)           = cs_veg%leafc_patch(p)       + cf_veg%leafc_xfer_to_leafc_patch(p)*dt
-         cs_veg%leafc_xfer_patch(p)      = cs_veg%leafc_xfer_patch(p)  - cf_veg%leafc_xfer_to_leafc_patch(p)*dt
-         cs_veg%frootc_patch(p)          = cs_veg%frootc_patch(p)      + cf_veg%frootc_xfer_to_frootc_patch(p)*dt
-         cs_veg%frootc_xfer_patch(p)     = cs_veg%frootc_xfer_patch(p) - cf_veg%frootc_xfer_to_frootc_patch(p)*dt
-             if (woody(ivt(p)) == 1._r8) then
-                cs_veg%livestemc_patch(p)       = cs_veg%livestemc_patch(p)       + cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
-                cs_veg%livestemc_xfer_patch(p)  = cs_veg%livestemc_xfer_patch(p)  - cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
-                cs_veg%deadstemc_patch(p)       = cs_veg%deadstemc_patch(p)       + cf_veg%deadstemc_xfer_to_deadstemc_patch(p)*dt
-                cs_veg%deadstemc_xfer_patch(p)  = cs_veg%deadstemc_xfer_patch(p)  - cf_veg%deadstemc_xfer_to_deadstemc_patch(p)*dt
-                cs_veg%livecrootc_patch(p)      = cs_veg%livecrootc_patch(p)      + cf_veg%livecrootc_xfer_to_livecrootc_patch(p)*dt
-                cs_veg%livecrootc_xfer_patch(p) = cs_veg%livecrootc_xfer_patch(p) - cf_veg%livecrootc_xfer_to_livecrootc_patch(p)*dt
-                cs_veg%deadcrootc_patch(p)      = cs_veg%deadcrootc_patch(p)      + cf_veg%deadcrootc_xfer_to_deadcrootc_patch(p)*dt
-                cs_veg%deadcrootc_xfer_patch(p) = cs_veg%deadcrootc_xfer_patch(p) - cf_veg%deadcrootc_xfer_to_deadcrootc_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            ! lines here for consistency; the transfer terms are zero
-            cs_veg%livestemc_patch(p)       = cs_veg%livestemc_patch(p)      + cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
-            cs_veg%livestemc_xfer_patch(p)  = cs_veg%livestemc_xfer_patch(p) - cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
-            cs_veg%grainc_patch(p)          = cs_veg%grainc_patch(p)         + cf_veg%grainc_xfer_to_grainc_patch(p)*dt
-            cs_veg%grainc_xfer_patch(p)     = cs_veg%grainc_xfer_patch(p)    - cf_veg%grainc_xfer_to_grainc_patch(p)*dt
-         end if
-
-         ! phenology: litterfall fluxes
-         cs_veg%leafc_patch(p) = cs_veg%leafc_patch(p) - cf_veg%leafc_to_litter_patch(p)*dt
-         cs_veg%frootc_patch(p) = cs_veg%frootc_patch(p) - cf_veg%frootc_to_litter_patch(p)*dt
+           ! phenology: litterfall fluxes
+           cs_veg%leafc_patch(p) = cs_veg%leafc_patch(p) - cf_veg%leafc_to_litter_patch(p)*dt
+           cs_veg%frootc_patch(p) = cs_veg%frootc_patch(p) - cf_veg%frootc_to_litter_patch(p)*dt
          
-        
-        
-
-         ! livewood turnover fluxes
-         if (woody(ivt(p)) == 1._r8) then
-            cs_veg%livestemc_patch(p)  = cs_veg%livestemc_patch(p)  - cf_veg%livestemc_to_deadstemc_patch(p)*dt
-            cs_veg%deadstemc_patch(p)  = cs_veg%deadstemc_patch(p)  + cf_veg%livestemc_to_deadstemc_patch(p)*dt
-            cs_veg%livecrootc_patch(p) = cs_veg%livecrootc_patch(p) - cf_veg%livecrootc_to_deadcrootc_patch(p)*dt
-            cs_veg%deadcrootc_patch(p) = cs_veg%deadcrootc_patch(p) + cf_veg%livecrootc_to_deadcrootc_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            cs_veg%livestemc_patch(p)  = cs_veg%livestemc_patch(p)  - cf_veg%livestemc_to_litter_patch(p)*dt
-            cs_veg%grainc_patch(p)     = cs_veg%grainc_patch(p) &
-                 - (cf_veg%grainc_to_food_patch(p) + cf_veg%grainc_to_seed_patch(p))*dt
-            cs_veg%cropseedc_deficit_patch(p) = cs_veg%cropseedc_deficit_patch(p) &
-                 - cf_veg%crop_seedc_to_leaf_patch(p) * dt &
-                 + cf_veg%grainc_to_seed_patch(p) * dt
-         end if
+           ! livewood turnover fluxes
+           if (woody(ivt(p)) == 1._r8) then
+              cs_veg%livestemc_patch(p)  = cs_veg%livestemc_patch(p)  - cf_veg%livestemc_to_deadstemc_patch(p)*dt
+              cs_veg%deadstemc_patch(p)  = cs_veg%deadstemc_patch(p)  + cf_veg%livestemc_to_deadstemc_patch(p)*dt
+              cs_veg%livecrootc_patch(p) = cs_veg%livecrootc_patch(p) - cf_veg%livecrootc_to_deadcrootc_patch(p)*dt
+              cs_veg%deadcrootc_patch(p) = cs_veg%deadcrootc_patch(p) + cf_veg%livecrootc_to_deadcrootc_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              cs_veg%livestemc_patch(p)  = cs_veg%livestemc_patch(p)  - cf_veg%livestemc_to_litter_patch(p)*dt
+              cs_veg%grainc_patch(p)     = cs_veg%grainc_patch(p) &
+                   - (cf_veg%grainc_to_food_patch(p) + cf_veg%grainc_to_seed_patch(p))*dt
+              cs_veg%cropseedc_deficit_patch(p) = cs_veg%cropseedc_deficit_patch(p) &
+                   - cf_veg%crop_seedc_to_leaf_patch(p) * dt &
+                   + cf_veg%grainc_to_seed_patch(p) * dt
+           end if
          
-         check_cpool = cs_veg%cpool_patch(p)- cf_veg%psnsun_to_cpool_patch(p)*dt-cf_veg%psnshade_to_cpool_patch(p)*dt
-         cpool_delta  =  cs_veg%cpool_patch(p) 
+           check_cpool = cs_veg%cpool_patch(p)- cf_veg%psnsun_to_cpool_patch(p)*dt-cf_veg%psnshade_to_cpool_patch(p)*dt
+           cpool_delta  =  cs_veg%cpool_patch(p) 
          
-         ! maintenance respiration fluxes from cpool
+           ! maintenance respiration fluxes from cpool
 
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_to_xsmrpool_patch(p)*dt
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%leaf_curmr_patch(p)*dt
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%froot_curmr_patch(p)*dt
-         If (woody(ivt(p)) == 1._r8) then
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livestem_curmr_patch(p)*dt
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livecroot_curmr_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livestem_curmr_patch(p)*dt
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%grain_curmr_patch(p)*dt
-         end if
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_to_xsmrpool_patch(p)*dt
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%leaf_curmr_patch(p)*dt
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%froot_curmr_patch(p)*dt
+           If (woody(ivt(p)) == 1._r8) then
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livestem_curmr_patch(p)*dt
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livecroot_curmr_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livestem_curmr_patch(p)*dt
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%grain_curmr_patch(p)*dt
+           end if
          
          
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) -  cf_veg%cpool_to_resp_patch(p)*dt
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) -  cf_veg%cpool_to_resp_patch(p)*dt
 
-         !RF Add in the carbon spent on uptake respiration. 
-         cs_veg%cpool_patch(p)= cs_veg%cpool_patch(p) - cf_veg%soilc_change_patch(p)*dt
-         
-         ! maintenance respiration fluxes from xsmrpool
-         cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) + cf_veg%cpool_to_xsmrpool_patch(p)*dt
-         cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%leaf_xsmr_patch(p)*dt
-         cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%froot_xsmr_patch(p)*dt
-         if (woody(ivt(p)) == 1._r8) then
-            cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livestem_xsmr_patch(p)*dt
-            cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livecroot_xsmr_patch(p)*dt
-         end if
+           !RF Add in the carbon spent on uptake respiration. 
+           cs_veg%cpool_patch(p)= cs_veg%cpool_patch(p) - cf_veg%soilc_change_patch(p)*dt
+           
+           ! maintenance respiration fluxes from xsmrpool
+           cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) + cf_veg%cpool_to_xsmrpool_patch(p)*dt
+           cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%leaf_xsmr_patch(p)*dt
+           cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%froot_xsmr_patch(p)*dt
+           if (woody(ivt(p)) == 1._r8) then
+              cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livestem_xsmr_patch(p)*dt
+              cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livecroot_xsmr_patch(p)*dt
+           end if
 
-         ! allocation fluxes
-         if (carbon_resp_opt == 1) then
-            cf_veg%cpool_to_leafc_patch(p) = cf_veg%cpool_to_leafc_patch(p) - cf_veg%cpool_to_leafc_resp_patch(p)
-            cf_veg%cpool_to_leafc_storage_patch(p) = cf_veg%cpool_to_leafc_storage_patch(p) - &
-                 cf_veg%cpool_to_leafc_storage_resp_patch(p)
-    	    cf_veg%cpool_to_frootc_patch(p) = cf_veg%cpool_to_frootc_patch(p) - cf_veg%cpool_to_frootc_resp_patch(p)
-            cf_veg%cpool_to_frootc_storage_patch(p) = cf_veg%cpool_to_frootc_storage_patch(p) &
+           ! allocation fluxes
+           if (carbon_resp_opt == 1) then
+              cf_veg%cpool_to_leafc_patch(p) = cf_veg%cpool_to_leafc_patch(p) - cf_veg%cpool_to_leafc_resp_patch(p)
+              cf_veg%cpool_to_leafc_storage_patch(p) = cf_veg%cpool_to_leafc_storage_patch(p) - &
+                   cf_veg%cpool_to_leafc_storage_resp_patch(p)
+              cf_veg%cpool_to_frootc_patch(p) = cf_veg%cpool_to_frootc_patch(p) - cf_veg%cpool_to_frootc_resp_patch(p)
+              cf_veg%cpool_to_frootc_storage_patch(p) = cf_veg%cpool_to_frootc_storage_patch(p) &
                  - cf_veg%cpool_to_frootc_storage_resp_patch(p)
-         end if
-         cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_leafc_patch(p)*dt
-         cs_veg%leafc_patch(p)           = cs_veg%leafc_patch(p)          + cf_veg%cpool_to_leafc_patch(p)*dt
-         cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_leafc_storage_patch(p)*dt
-         cs_veg%leafc_storage_patch(p)   = cs_veg%leafc_storage_patch(p)  + cf_veg%cpool_to_leafc_storage_patch(p)*dt
-         cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_frootc_patch(p)*dt
-         cs_veg%frootc_patch(p)          = cs_veg%frootc_patch(p)         + cf_veg%cpool_to_frootc_patch(p)*dt
-         cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_frootc_storage_patch(p)*dt
+           end if
+           cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_leafc_patch(p)*dt
+           cs_veg%leafc_patch(p)           = cs_veg%leafc_patch(p)          + cf_veg%cpool_to_leafc_patch(p)*dt
+           cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_leafc_storage_patch(p)*dt
+           cs_veg%leafc_storage_patch(p)   = cs_veg%leafc_storage_patch(p)  + cf_veg%cpool_to_leafc_storage_patch(p)*dt
+           cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_frootc_patch(p)*dt
+           cs_veg%frootc_patch(p)          = cs_veg%frootc_patch(p)         + cf_veg%cpool_to_frootc_patch(p)*dt
+           cs_veg%cpool_patch(p)           = cs_veg%cpool_patch(p)          - cf_veg%cpool_to_frootc_storage_patch(p)*dt
 
-         cs_veg%frootc_storage_patch(p)  = cs_veg%frootc_storage_patch(p) + cf_veg%cpool_to_frootc_storage_patch(p)*dt
-         if (woody(ivt(p)) == 1._r8) then
-            if (carbon_resp_opt == 1) then
-               cf_veg%cpool_to_livecrootc_patch(p) = cf_veg%cpool_to_livecrootc_patch(p) - cf_veg%cpool_to_livecrootc_resp_patch(p)
-               cf_veg%cpool_to_livecrootc_storage_patch(p) = cf_veg%cpool_to_livecrootc_storage_patch(p) - &
-                    cf_veg%cpool_to_livecrootc_storage_resp_patch(p)
-    	       cf_veg%cpool_to_livestemc_patch(p) = cf_veg%cpool_to_livestemc_patch(p) - cf_veg%cpool_to_livestemc_resp_patch(p)
-    	       cf_veg%cpool_to_livestemc_storage_patch(p) = cf_veg%cpool_to_livestemc_storage_patch(p) - &
+           cs_veg%frootc_storage_patch(p)  = cs_veg%frootc_storage_patch(p) + cf_veg%cpool_to_frootc_storage_patch(p)*dt
+           if (woody(ivt(p)) == 1._r8) then
+              if (carbon_resp_opt == 1) then
+                 cf_veg%cpool_to_livecrootc_patch(p) = cf_veg%cpool_to_livecrootc_patch(p) - cf_veg%cpool_to_livecrootc_resp_patch(p)
+                 cf_veg%cpool_to_livecrootc_storage_patch(p) = cf_veg%cpool_to_livecrootc_storage_patch(p) - &
+                      cf_veg%cpool_to_livecrootc_storage_resp_patch(p)
+                 cf_veg%cpool_to_livestemc_patch(p) = cf_veg%cpool_to_livestemc_patch(p) - cf_veg%cpool_to_livestemc_resp_patch(p)
+                 cf_veg%cpool_to_livestemc_storage_patch(p) = cf_veg%cpool_to_livestemc_storage_patch(p) - &
                  cf_veg%cpool_to_livestemc_storage_resp_patch(p)
-            end if
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_patch(p)*dt
-            cs_veg%livestemc_patch(p)          = cs_veg%livestemc_patch(p)          + cf_veg%cpool_to_livestemc_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_storage_patch(p)*dt
-            cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p)  + cf_veg%cpool_to_livestemc_storage_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadstemc_patch(p)*dt
-            cs_veg%deadstemc_patch(p)          = cs_veg%deadstemc_patch(p)          + cf_veg%cpool_to_deadstemc_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadstemc_storage_patch(p)*dt
-            cs_veg%deadstemc_storage_patch(p)  = cs_veg%deadstemc_storage_patch(p)  + cf_veg%cpool_to_deadstemc_storage_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livecrootc_patch(p)*dt
-            cs_veg%livecrootc_patch(p)         = cs_veg%livecrootc_patch(p)         + cf_veg%cpool_to_livecrootc_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livecrootc_storage_patch(p)*dt
-            cs_veg%livecrootc_storage_patch(p) = cs_veg%livecrootc_storage_patch(p) + cf_veg%cpool_to_livecrootc_storage_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadcrootc_patch(p)*dt
-            cs_veg%deadcrootc_patch(p)         = cs_veg%deadcrootc_patch(p)         + cf_veg%cpool_to_deadcrootc_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadcrootc_storage_patch(p)*dt
-            cs_veg%deadcrootc_storage_patch(p) = cs_veg%deadcrootc_storage_patch(p) + cf_veg%cpool_to_deadcrootc_storage_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            if (carbon_resp_opt == 1) then
-               cf_veg%cpool_to_livestemc_patch(p) = cf_veg%cpool_to_livestemc_patch(p) - cf_veg%cpool_to_livestemc_resp_patch(p)
-    	       cf_veg%cpool_to_livestemc_storage_patch(p) = cf_veg%cpool_to_livestemc_storage_patch(p) 	- &
+              end if
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_patch(p)*dt
+              cs_veg%livestemc_patch(p)          = cs_veg%livestemc_patch(p)          + cf_veg%cpool_to_livestemc_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_storage_patch(p)*dt
+              cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p)  + cf_veg%cpool_to_livestemc_storage_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadstemc_patch(p)*dt
+              cs_veg%deadstemc_patch(p)          = cs_veg%deadstemc_patch(p)          + cf_veg%cpool_to_deadstemc_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadstemc_storage_patch(p)*dt
+              cs_veg%deadstemc_storage_patch(p)  = cs_veg%deadstemc_storage_patch(p)  + cf_veg%cpool_to_deadstemc_storage_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livecrootc_patch(p)*dt
+              cs_veg%livecrootc_patch(p)         = cs_veg%livecrootc_patch(p)         + cf_veg%cpool_to_livecrootc_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livecrootc_storage_patch(p)*dt
+              cs_veg%livecrootc_storage_patch(p) = cs_veg%livecrootc_storage_patch(p) + cf_veg%cpool_to_livecrootc_storage_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadcrootc_patch(p)*dt
+              cs_veg%deadcrootc_patch(p)         = cs_veg%deadcrootc_patch(p)         + cf_veg%cpool_to_deadcrootc_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_deadcrootc_storage_patch(p)*dt
+              cs_veg%deadcrootc_storage_patch(p) = cs_veg%deadcrootc_storage_patch(p) + cf_veg%cpool_to_deadcrootc_storage_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              if (carbon_resp_opt == 1) then
+                 cf_veg%cpool_to_livestemc_patch(p) = cf_veg%cpool_to_livestemc_patch(p) - cf_veg%cpool_to_livestemc_resp_patch(p)
+                 cf_veg%cpool_to_livestemc_storage_patch(p) = cf_veg%cpool_to_livestemc_storage_patch(p) - &
                  cf_veg%cpool_to_livestemc_storage_resp_patch(p)
-            end if
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_patch(p)*dt
-            cs_veg%livestemc_patch(p)          = cs_veg%livestemc_patch(p)          + cf_veg%cpool_to_livestemc_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_storage_patch(p)*dt
-            cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p)  + cf_veg%cpool_to_livestemc_storage_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_grainc_patch(p)*dt
-            cs_veg%grainc_patch(p)             = cs_veg%grainc_patch(p)             + cf_veg%cpool_to_grainc_patch(p)*dt
-            cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_grainc_storage_patch(p)*dt
-            cs_veg%grainc_storage_patch(p)     = cs_veg%grainc_storage_patch(p)     + cf_veg%cpool_to_grainc_storage_patch(p)*dt
-         end if
+              end if
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_patch(p)*dt
+              cs_veg%livestemc_patch(p)          = cs_veg%livestemc_patch(p)          + cf_veg%cpool_to_livestemc_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_livestemc_storage_patch(p)*dt
+              cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p)  + cf_veg%cpool_to_livestemc_storage_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_grainc_patch(p)*dt
+              cs_veg%grainc_patch(p)             = cs_veg%grainc_patch(p)             + cf_veg%cpool_to_grainc_patch(p)*dt
+              cs_veg%cpool_patch(p)              = cs_veg%cpool_patch(p)              - cf_veg%cpool_to_grainc_storage_patch(p)*dt
+              cs_veg%grainc_storage_patch(p)     = cs_veg%grainc_storage_patch(p)     + cf_veg%cpool_to_grainc_storage_patch(p)*dt
+           end if
 
-         ! growth respiration fluxes for current growth
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_leaf_gr_patch(p)*dt
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_froot_gr_patch(p)*dt
+           ! growth respiration fluxes for current growth
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_leaf_gr_patch(p)*dt
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_froot_gr_patch(p)*dt
 
-         if (woody(ivt(p)) == 1._r8) then
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_gr_patch(p)*dt
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadstem_gr_patch(p)*dt
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livecroot_gr_patch(p)*dt
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadcroot_gr_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_gr_patch(p)*dt
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_grain_gr_patch(p)*dt
-         end if
+           if (woody(ivt(p)) == 1._r8) then
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_gr_patch(p)*dt
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadstem_gr_patch(p)*dt
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livecroot_gr_patch(p)*dt
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadcroot_gr_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_gr_patch(p)*dt
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_grain_gr_patch(p)*dt
+           end if
 
-         ! growth respiration for transfer growth
-         cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_leaf_gr_patch(p)*dt
-         cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_froot_gr_patch(p)*dt
-         if (woody(ivt(p)) == 1._r8) then
-            cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livestem_gr_patch(p)*dt
-            cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_deadstem_gr_patch(p)*dt
-            cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livecroot_gr_patch(p)*dt
-            cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_deadcroot_gr_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livestem_gr_patch(p)*dt
-            cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_grain_gr_patch(p)*dt
-         end if
+           ! growth respiration for transfer growth
+           cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_leaf_gr_patch(p)*dt
+           cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_froot_gr_patch(p)*dt
+           if (woody(ivt(p)) == 1._r8) then
+              cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livestem_gr_patch(p)*dt
+              cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_deadstem_gr_patch(p)*dt
+              cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livecroot_gr_patch(p)*dt
+              cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_deadcroot_gr_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livestem_gr_patch(p)*dt
+              cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_grain_gr_patch(p)*dt
+           end if
 
-         ! growth respiration at time of storage
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_leaf_storage_gr_patch(p)*dt
-         cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_froot_storage_gr_patch(p)*dt
+           ! growth respiration at time of storage
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_leaf_storage_gr_patch(p)*dt
+           cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_froot_storage_gr_patch(p)*dt
 
-         if (woody(ivt(p)) == 1._r8) then
+           if (woody(ivt(p)) == 1._r8) then
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_storage_gr_patch(p)*dt
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadstem_storage_gr_patch(p)*dt
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livecroot_storage_gr_patch(p)*dt
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadcroot_storage_gr_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_storage_gr_patch(p)*dt
- 
-            cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_grain_storage_gr_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_storage_gr_patch(p)*dt
+   
+              cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_grain_storage_gr_patch(p)*dt
 
-         end if
+           end if
 
-         ! growth respiration stored for release during transfer growth
-         cs_veg%cpool_patch(p)         = cs_veg%cpool_patch(p)         - cf_veg%cpool_to_gresp_storage_patch(p)*dt
-         cs_veg%gresp_storage_patch(p) = cs_veg%gresp_storage_patch(p) + cf_veg%cpool_to_gresp_storage_patch(p)*dt
+           ! growth respiration stored for release during transfer growth
+           cs_veg%cpool_patch(p)         = cs_veg%cpool_patch(p)         - cf_veg%cpool_to_gresp_storage_patch(p)*dt
+           cs_veg%gresp_storage_patch(p) = cs_veg%gresp_storage_patch(p) + cf_veg%cpool_to_gresp_storage_patch(p)*dt
 
-         ! move storage pools into transfer pools
-         cs_veg%leafc_storage_patch(p)  = cs_veg%leafc_storage_patch(p)  - cf_veg%leafc_storage_to_xfer_patch(p)*dt
-         cs_veg%leafc_xfer_patch(p)     = cs_veg%leafc_xfer_patch(p)     + cf_veg%leafc_storage_to_xfer_patch(p)*dt
-         cs_veg%frootc_storage_patch(p) = cs_veg%frootc_storage_patch(p) - cf_veg%frootc_storage_to_xfer_patch(p)*dt
-         cs_veg%frootc_xfer_patch(p)    = cs_veg%frootc_xfer_patch(p)    + cf_veg%frootc_storage_to_xfer_patch(p)*dt
-         if (woody(ivt(p)) == 1._r8) then
-            cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p) - cf_veg%livestemc_storage_to_xfer_patch(p)*dt
-            cs_veg%livestemc_xfer_patch(p)     = cs_veg%livestemc_xfer_patch(p)    + cf_veg%livestemc_storage_to_xfer_patch(p)*dt
-            cs_veg%deadstemc_storage_patch(p)  = cs_veg%deadstemc_storage_patch(p) - cf_veg%deadstemc_storage_to_xfer_patch(p)*dt
-            cs_veg%deadstemc_xfer_patch(p)     = cs_veg%deadstemc_xfer_patch(p)    + cf_veg%deadstemc_storage_to_xfer_patch(p)*dt
-            cs_veg%livecrootc_storage_patch(p) = cs_veg%livecrootc_storage_patch(p)- cf_veg%livecrootc_storage_to_xfer_patch(p)*dt
-            cs_veg%livecrootc_xfer_patch(p)    = cs_veg%livecrootc_xfer_patch(p)   + cf_veg%livecrootc_storage_to_xfer_patch(p)*dt
-            cs_veg%deadcrootc_storage_patch(p) = cs_veg%deadcrootc_storage_patch(p)- cf_veg%deadcrootc_storage_to_xfer_patch(p)*dt
-            cs_veg%deadcrootc_xfer_patch(p)    = cs_veg%deadcrootc_xfer_patch(p)   + cf_veg%deadcrootc_storage_to_xfer_patch(p)*dt
-            cs_veg%gresp_storage_patch(p)      = cs_veg%gresp_storage_patch(p)     - cf_veg%gresp_storage_to_xfer_patch(p)*dt
-            cs_veg%gresp_xfer_patch(p)         = cs_veg%gresp_xfer_patch(p)        + cf_veg%gresp_storage_to_xfer_patch(p)*dt
-         end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            ! lines here for consistency; the transfer terms are zero
-            cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p) - cf_veg%livestemc_storage_to_xfer_patch(p)*dt
-            cs_veg%livestemc_xfer_patch(p)     = cs_veg%livestemc_xfer_patch(p)    + cf_veg%livestemc_storage_to_xfer_patch(p)*dt
-            cs_veg%grainc_storage_patch(p)     = cs_veg%grainc_storage_patch(p)    - cf_veg%grainc_storage_to_xfer_patch(p)*dt
-            cs_veg%grainc_xfer_patch(p)        = cs_veg%grainc_xfer_patch(p)       + cf_veg%grainc_storage_to_xfer_patch(p)*dt
-         end if
+           ! move storage pools into transfer pools
+           cs_veg%leafc_storage_patch(p)  = cs_veg%leafc_storage_patch(p)  - cf_veg%leafc_storage_to_xfer_patch(p)*dt
+           cs_veg%leafc_xfer_patch(p)     = cs_veg%leafc_xfer_patch(p)     + cf_veg%leafc_storage_to_xfer_patch(p)*dt
+           cs_veg%frootc_storage_patch(p) = cs_veg%frootc_storage_patch(p) - cf_veg%frootc_storage_to_xfer_patch(p)*dt
+           cs_veg%frootc_xfer_patch(p)    = cs_veg%frootc_xfer_patch(p)    + cf_veg%frootc_storage_to_xfer_patch(p)*dt
+           if (woody(ivt(p)) == 1._r8) then
+              cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p) - cf_veg%livestemc_storage_to_xfer_patch(p)*dt
+              cs_veg%livestemc_xfer_patch(p)     = cs_veg%livestemc_xfer_patch(p)    + cf_veg%livestemc_storage_to_xfer_patch(p)*dt
+              cs_veg%deadstemc_storage_patch(p)  = cs_veg%deadstemc_storage_patch(p) - cf_veg%deadstemc_storage_to_xfer_patch(p)*dt
+              cs_veg%deadstemc_xfer_patch(p)     = cs_veg%deadstemc_xfer_patch(p)    + cf_veg%deadstemc_storage_to_xfer_patch(p)*dt
+              cs_veg%livecrootc_storage_patch(p) = cs_veg%livecrootc_storage_patch(p)- cf_veg%livecrootc_storage_to_xfer_patch(p)*dt
+              cs_veg%livecrootc_xfer_patch(p)    = cs_veg%livecrootc_xfer_patch(p)   + cf_veg%livecrootc_storage_to_xfer_patch(p)*dt
+              cs_veg%deadcrootc_storage_patch(p) = cs_veg%deadcrootc_storage_patch(p)- cf_veg%deadcrootc_storage_to_xfer_patch(p)*dt
+              cs_veg%deadcrootc_xfer_patch(p)    = cs_veg%deadcrootc_xfer_patch(p)   + cf_veg%deadcrootc_storage_to_xfer_patch(p)*dt
+              cs_veg%gresp_storage_patch(p)      = cs_veg%gresp_storage_patch(p)     - cf_veg%gresp_storage_to_xfer_patch(p)*dt
+              cs_veg%gresp_xfer_patch(p)         = cs_veg%gresp_xfer_patch(p)        + cf_veg%gresp_storage_to_xfer_patch(p)*dt
+           end if
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              ! lines here for consistency; the transfer terms are zero
+              cs_veg%livestemc_storage_patch(p)  = cs_veg%livestemc_storage_patch(p) - cf_veg%livestemc_storage_to_xfer_patch(p)*dt
+              cs_veg%livestemc_xfer_patch(p)     = cs_veg%livestemc_xfer_patch(p)    + cf_veg%livestemc_storage_to_xfer_patch(p)*dt
+              cs_veg%grainc_storage_patch(p)     = cs_veg%grainc_storage_patch(p)    - cf_veg%grainc_storage_to_xfer_patch(p)*dt
+              cs_veg%grainc_xfer_patch(p)        = cs_veg%grainc_xfer_patch(p)       + cf_veg%grainc_storage_to_xfer_patch(p)*dt
+           end if
 
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
-            cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livestem_xsmr_patch(p)*dt
-            cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%grain_xsmr_patch(p)*dt
-            if (harvdate(p) < 999) then ! beginning at harvest, send to atm
-               ! TODO (mv, 11-02-2014) the following lines are why the cf_veg is
-               ! an intent(inout)
-               ! fluxes should not be updated in this module - not sure where
-               ! this belongs
-               ! DML (06-20-2017) While debugging crop isotope code, found that cpool_patch and frootc_patch 
-               ! could occasionally be very small but nonzero numbers after crop harvest, which persists 
-               ! through to next planting and for reasons that could not 100%
-               ! isolate, caused C12/C13 ratios to occasionally go out of
-               ! bounds. Zeroing out these small pools and putting them into the flux to the
-               ! atmosphere solved many of the crop isotope problems
+           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+              cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livestem_xsmr_patch(p)*dt
+              cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%grain_xsmr_patch(p)*dt
+              if (harvdate(p) < 999) then ! beginning at harvest, send to atm
+                 ! TODO (mv, 11-02-2014) the following lines are why the cf_veg is
+                 ! an intent(inout)
+                 ! fluxes should not be updated in this module - not sure where
+                 ! this belongs
+                 ! DML (06-20-2017) While debugging crop isotope code, found that cpool_patch and frootc_patch 
+                 ! could occasionally be very small but nonzero numbers after crop harvest, which persists 
+                 ! through to next planting and for reasons that could not 100%
+                 ! isolate, caused C12/C13 ratios to occasionally go out of
+                 ! bounds. Zeroing out these small pools and putting them into the flux to the
+                 ! atmosphere solved many of the crop isotope problems
+  
+                 ! Instantly release XSMRPOOL to atmosphere
+                 if ( .not. dribble_crophrv_xsmrpool_2atm ) then
+                    cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%xsmrpool_patch(p)/dt
+                    cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%cpool_patch(p)/dt
+                    cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%frootc_patch(p)/dt
+                 ! Save xsmrpool, cpool, frootc to loss state variable for dribbling
+                 else
+                    cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) + &
+                                                    cs_veg%xsmrpool_patch(p) + &
+                                                    cs_veg%cpool_patch(p) + &
+                                                    cs_veg%frootc_patch(p)
+                 end if
+                 cs_veg%xsmrpool_patch(p)        = 0._r8
+                 cs_veg%cpool_patch(p)           = 0._r8
+                 cs_veg%frootc_patch(p)          = 0._r8
+              end if
 
-               ! Instantly release XSMRPOOL to atmosphere
-               if ( .not. dribble_crophrv_xsmrpool_2atm ) then
-                  cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%xsmrpool_patch(p)/dt
-                  cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%cpool_patch(p)/dt
-                  cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%frootc_patch(p)/dt
-               ! Save xsmrpool, cpool, frootc to loss state variable for dribbling
-               else
-                  cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) + &
-                                                  cs_veg%xsmrpool_patch(p) + &
-                                                  cs_veg%cpool_patch(p) + &
-                                                  cs_veg%frootc_patch(p)
-               end if
-               cs_veg%xsmrpool_patch(p)        = 0._r8
-               cs_veg%cpool_patch(p)           = 0._r8
-               cs_veg%frootc_patch(p)          = 0._r8
-            end if
-
-            ! Slowly release xsmrpool to atmosphere
-            if ( dribble_crophrv_xsmrpool_2atm ) then
-               ! calculate flux of xsmrpool loss to atm
-               cf_veg%xsmrpool_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
-
-               ! update xsmrpool loss state
-               cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) - cf_veg%xsmrpool_to_atm_patch(p) * dt
-            end if
-
-         end if
+              ! Slowly release xsmrpool to atmosphere
+              if ( dribble_crophrv_xsmrpool_2atm ) then
+                 ! calculate flux of xsmrpool loss to atm
+                 cf_veg%xsmrpool_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
+  
+                 ! update xsmrpool loss state
+                 cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) - cf_veg%xsmrpool_to_atm_patch(p) * dt
+              end if
+  
+           end if
 
          
-      end do ! end of patch loop
-    end if
+        end do ! end of patch loop
+      end if   ! end of NOT fates
     
     end associate
   

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -165,9 +165,7 @@ contains
     real(r8) :: dt        ! radiation time step (seconds)
     real(r8) :: check_cpool
     real(r8) :: cpool_delta
-!KO
     real(r8) :: kprod05   ! decay constant for 0.5-year product pool
-!KO
     !-----------------------------------------------------------------------
 
     associate(                                                               & 
@@ -484,28 +482,22 @@ contains
                ! bounds. Zeroing out these small pools and putting them into the flux to the
                ! atmosphere solved many of the crop isotope problems
 
-!KO
-               ! Save xsmrpool to loss state variable for dribbling
-               cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_patch(p)
-!KO
-
-!KO               cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%xsmrpool_patch(p)/dt
+               ! Save xsmrpool, cpool, frootc to loss state variable for dribbling
+               cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) + &
+                                               cs_veg%xsmrpool_patch(p) + &
+                                               cs_veg%cpool_patch(p) + &
+                                               cs_veg%frootc_patch(p)
                cs_veg%xsmrpool_patch(p)        = 0._r8
-               cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%cpool_patch(p)/dt
                cs_veg%cpool_patch(p)           = 0._r8
-               cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cs_veg%frootc_patch(p)/dt
                cs_veg%frootc_patch(p)          = 0._r8
             end if
-!KO
+
             ! calculate flux of xsmrpool loss to atm
-            cf_veg%xsmrpool_loss_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
-            ! add flux to atmosphere
-            cf_veg%xsmrpool_to_atm_patch(p) = cf_veg%xsmrpool_to_atm_patch(p) + cf_veg%xsmrpool_loss_to_atm_patch(p)
-            ! update xsmrpool loss state variable
-            cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) - cf_veg%xsmrpool_loss_to_atm_patch(p) * dt
-            ! convert loss state to flux for balance check
-            cf_veg%xsmrpool_loss_store_patch(p) = cs_veg%xsmrpool_loss_patch(p)/dt
-!KO
+            cf_veg%xsmrpool_to_atm_patch(p) = cs_veg%xsmrpool_loss_patch(p) * kprod05
+
+            ! update xsmrpool loss state
+            cs_veg%xsmrpool_loss_patch(p) = cs_veg%xsmrpool_loss_patch(p) - cf_veg%xsmrpool_to_atm_patch(p) * dt
+
          end if
 
          

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -142,7 +142,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine CStateUpdate1( num_soilc, filter_soilc, num_soilp, filter_soilp, &
        crop_inst, cnveg_carbonflux_inst, cnveg_carbonstate_inst, &
-       soilbiogeochem_carbonflux_inst)
+       soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
     !
     ! !DESCRIPTION:
     ! On the radiation time step, update all the prognostic carbon state
@@ -158,6 +158,7 @@ contains
     type(cnveg_carbonflux_type)          , intent(inout) :: cnveg_carbonflux_inst ! See note below for xsmrpool_to_atm_patch
     type(cnveg_carbonstate_type)         , intent(inout) :: cnveg_carbonstate_inst
     type(soilbiogeochem_carbonflux_type) , intent(inout) :: soilbiogeochem_carbonflux_inst
+    logical                              , intent(in)    :: harvest_xsmrpool_2atm
     !
     ! !LOCAL VARIABLES:
     integer  :: c,p,j,k,l ! indices

--- a/src/biogeochem/CNDriverMod.F90
+++ b/src/biogeochem/CNDriverMod.F90
@@ -92,7 +92,7 @@ contains
        atm2lnd_inst, waterstate_inst, waterflux_inst,                                      &
        canopystate_inst, soilstate_inst, temperature_inst, crop_inst, ch4_inst,            &
        dgvs_inst, photosyns_inst, soilhydrology_inst, energyflux_inst,                     &
-       nutrient_competition_method, cnfire_method, harvest_xsmrpool_2atm)
+       nutrient_competition_method, cnfire_method, dribble_crophrv_xsmrpool_2atm)
     !
     ! !DESCRIPTION:
     ! The core CN code is executed here. Calculates fluxes for maintenance
@@ -179,7 +179,7 @@ contains
     type(energyflux_type)                   , intent(in)    :: energyflux_inst
     class(nutrient_competition_method_type) , intent(inout) :: nutrient_competition_method
     class(cnfire_method_type)               , intent(inout) :: cnfire_method
-    logical                                 , intent(in)    :: harvest_xsmrpool_2atm
+    logical                                 , intent(in)    :: dribble_crophrv_xsmrpool_2atm
     !
     ! !LOCAL VARIABLES:
     real(r8):: cn_decomp_pools(bounds%begc:bounds%endc,1:nlevdecomp,1:ndecomp_pools)
@@ -550,16 +550,16 @@ contains
     ! Update all prognostic carbon state variables (except for gap-phase mortality and fire fluxes)
     call CStateUpdate1( num_soilc, filter_soilc, num_soilp, filter_soilp, &
          crop_inst, cnveg_carbonflux_inst, cnveg_carbonstate_inst, &
-         soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
+         soilbiogeochem_carbonflux_inst, dribble_crophrv_xsmrpool_2atm)
     if ( use_c13 ) then
        call CStateUpdate1(num_soilc, filter_soilc, num_soilp, filter_soilp, &
             crop_inst, c13_cnveg_carbonflux_inst, c13_cnveg_carbonstate_inst, &
-            c13_soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
+            c13_soilbiogeochem_carbonflux_inst, dribble_crophrv_xsmrpool_2atm)
     end if
     if ( use_c14 ) then
        call CStateUpdate1(num_soilc, filter_soilc, num_soilp, filter_soilp, &
             crop_inst, c14_cnveg_carbonflux_inst, c14_cnveg_carbonstate_inst, &
-            c14_soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
+            c14_soilbiogeochem_carbonflux_inst, dribble_crophrv_xsmrpool_2atm)
     end if
 
     ! Update all prognostic nitrogen state variables (except for gap-phase mortality and fire fluxes)

--- a/src/biogeochem/CNDriverMod.F90
+++ b/src/biogeochem/CNDriverMod.F90
@@ -92,7 +92,7 @@ contains
        atm2lnd_inst, waterstate_inst, waterflux_inst,                                      &
        canopystate_inst, soilstate_inst, temperature_inst, crop_inst, ch4_inst,            &
        dgvs_inst, photosyns_inst, soilhydrology_inst, energyflux_inst,                     &
-       nutrient_competition_method, cnfire_method)
+       nutrient_competition_method, cnfire_method, harvest_xsmrpool_2atm)
     !
     ! !DESCRIPTION:
     ! The core CN code is executed here. Calculates fluxes for maintenance
@@ -179,6 +179,7 @@ contains
     type(energyflux_type)                   , intent(in)    :: energyflux_inst
     class(nutrient_competition_method_type) , intent(inout) :: nutrient_competition_method
     class(cnfire_method_type)               , intent(inout) :: cnfire_method
+    logical                                 , intent(in)    :: harvest_xsmrpool_2atm
     !
     ! !LOCAL VARIABLES:
     real(r8):: cn_decomp_pools(bounds%begc:bounds%endc,1:nlevdecomp,1:ndecomp_pools)
@@ -549,16 +550,16 @@ contains
     ! Update all prognostic carbon state variables (except for gap-phase mortality and fire fluxes)
     call CStateUpdate1( num_soilc, filter_soilc, num_soilp, filter_soilp, &
          crop_inst, cnveg_carbonflux_inst, cnveg_carbonstate_inst, &
-         soilbiogeochem_carbonflux_inst)
+         soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
     if ( use_c13 ) then
        call CStateUpdate1(num_soilc, filter_soilc, num_soilp, filter_soilp, &
             crop_inst, c13_cnveg_carbonflux_inst, c13_cnveg_carbonstate_inst, &
-            c13_soilbiogeochem_carbonflux_inst)
+            c13_soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
     end if
     if ( use_c14 ) then
        call CStateUpdate1(num_soilc, filter_soilc, num_soilp, filter_soilp, &
             crop_inst, c14_cnveg_carbonflux_inst, c14_cnveg_carbonstate_inst, &
-            c14_soilbiogeochem_carbonflux_inst)
+            c14_soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm)
     end if
 
     ! Update all prognostic nitrogen state variables (except for gap-phase mortality and fire fluxes)

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -186,6 +186,12 @@ module CNVegCarbonFluxType
 
      ! growth respiration fluxes                               
      real(r8), pointer :: xsmrpool_to_atm_patch                     (:)     ! excess MR pool harvest mortality (gC/m2/s)
+!KO
+     real(r8), pointer :: xsmrpool_loss_to_atm_patch                (:)     ! excess MR pool crop harvest loss to atm (gC/m2/s)
+     real(r8), pointer :: xsmrpool_loss_to_atm_col                  (:)     ! excess MR pool crop harvest loss to atm (gC/m2/s) (p2c)
+     real(r8), pointer :: xsmrpool_loss_store_patch                 (:)     ! excess MR pool crop harvest loss storage (gC/m2/s)
+     real(r8), pointer :: xsmrpool_loss_store_col                   (:)     ! excess MR pool crop harvest loss storage (gC/m2/s) (p2c)
+!KO
      real(r8), pointer :: cpool_leaf_gr_patch                       (:)     ! leaf growth respiration (gC/m2/s)
      real(r8), pointer :: cpool_leaf_storage_gr_patch               (:)     ! leaf growth respiration to storage (gC/m2/s)
      real(r8), pointer :: transfer_leaf_gr_patch                    (:)     ! leaf growth respiration from storage (gC/m2/s)
@@ -601,6 +607,12 @@ contains
     allocate(this%cpool_grain_storage_gr_patch              (begp:endp)) ; this%cpool_grain_storage_gr_patch              (:) = nan
     allocate(this%transfer_grain_gr_patch                   (begp:endp)) ; this%transfer_grain_gr_patch                   (:) = nan
     allocate(this%xsmrpool_to_atm_patch                     (begp:endp)) ; this%xsmrpool_to_atm_patch                     (:) = nan
+!KO
+    allocate(this%xsmrpool_loss_to_atm_patch                (begp:endp)) ; this%xsmrpool_loss_to_atm_patch                (:) = nan
+    allocate(this%xsmrpool_loss_to_atm_col                  (begc:endc)) ; this%xsmrpool_loss_to_atm_col                  (:) = nan 
+    allocate(this%xsmrpool_loss_store_patch                 (begp:endp)) ; this%xsmrpool_loss_store_patch                 (:) = nan
+    allocate(this%xsmrpool_loss_store_col                   (begc:endc)) ; this%xsmrpool_loss_store_col                   (:) = nan
+!KO
     allocate(this%grainc_storage_to_xfer_patch              (begp:endp)) ; this%grainc_storage_to_xfer_patch              (:) = nan
     allocate(this%frootc_alloc_patch                        (begp:endp)) ; this%frootc_alloc_patch                        (:) = nan
     allocate(this%frootc_loss_patch                         (begp:endp)) ; this%frootc_loss_patch                         (:) = nan
@@ -3818,6 +3830,10 @@ contains
        do fi = 1,num_patch
           i = filter_patch(fi)
           this%xsmrpool_to_atm_patch(i)         = value_patch
+!KO
+          this%xsmrpool_loss_to_atm_patch(i)    = value_patch
+          this%xsmrpool_loss_store_patch(i)     = value_patch
+!KO
           this%livestemc_to_litter_patch(i)     = value_patch
           this%grainc_to_food_patch(i)          = value_patch
           this%grainc_to_seed_patch(i)          = value_patch
@@ -3880,6 +3896,7 @@ contains
        this%cwdc_hr_col(i)                   = value_column
        this%cwdc_loss_col(i)                 = value_column
        this%litterc_loss_col(i)              = value_column
+
     end do
 
     do fi = 1,num_patch
@@ -3938,8 +3955,11 @@ contains
        this%fire_closs_col(i)          = value_column 
        this%wood_harvestc_col(i)       = value_column 
        this%hrv_xsmrpool_to_atm_col(i) = value_column
-
        this%nep_col(i)                 = value_column
+!KO
+       this%xsmrpool_loss_to_atm_col(i)= value_column
+       this%xsmrpool_loss_store_col(i) = value_column
+!KO
 
     end do
 
@@ -4400,7 +4420,16 @@ contains
     call p2c(bounds, num_soilc, filter_soilc, &
          this%hrv_xsmrpool_to_atm_patch(bounds%begp:bounds%endp), &
          this%hrv_xsmrpool_to_atm_col(bounds%begc:bounds%endc))
-
+!KO
+    if (use_crop) then
+       call p2c(bounds, num_soilc, filter_soilc, &
+            this%xsmrpool_loss_to_atm_patch(bounds%begp:bounds%endp), &
+            this%xsmrpool_loss_to_atm_col(bounds%begc:bounds%endc))
+       call p2c(bounds, num_soilc, filter_soilc, &
+            this%xsmrpool_loss_store_patch(bounds%begp:bounds%endp), &
+            this%xsmrpool_loss_store_col(bounds%begc:bounds%endc))
+    end if
+!KO
     call p2c(bounds, num_soilc, filter_soilc, &
          this%fire_closs_patch(bounds%begp:bounds%endp), &
          this%fire_closs_p2c_col(bounds%begc:bounds%endc))

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -465,7 +465,7 @@ contains
     allocate(this%hrv_deadcrootc_xfer_to_litter_patch       (begp:endp)) ; this%hrv_deadcrootc_xfer_to_litter_patch       (:) = nan
     allocate(this%hrv_gresp_storage_to_litter_patch         (begp:endp)) ; this%hrv_gresp_storage_to_litter_patch         (:) = nan
     allocate(this%hrv_gresp_xfer_to_litter_patch            (begp:endp)) ; this%hrv_gresp_xfer_to_litter_patch            (:) = nan
-    allocate(this%hrv_xsmrpool_to_atm_patch                 (begp:endp)) ; this%hrv_xsmrpool_to_atm_patch                 (:) = 0.0d00
+    allocate(this%hrv_xsmrpool_to_atm_patch                 (begp:endp)) ; this%hrv_xsmrpool_to_atm_patch                 (:) = 0.0_r8
     allocate(this%m_leafc_to_fire_patch                     (begp:endp)) ; this%m_leafc_to_fire_patch                     (:) = nan
     allocate(this%m_leafc_storage_to_fire_patch             (begp:endp)) ; this%m_leafc_storage_to_fire_patch             (:) = nan
     allocate(this%m_leafc_xfer_to_fire_patch                (begp:endp)) ; this%m_leafc_xfer_to_fire_patch                (:) = nan
@@ -605,9 +605,9 @@ contains
     allocate(this%cpool_grain_gr_patch                      (begp:endp)) ; this%cpool_grain_gr_patch                      (:) = nan
     allocate(this%cpool_grain_storage_gr_patch              (begp:endp)) ; this%cpool_grain_storage_gr_patch              (:) = nan
     allocate(this%transfer_grain_gr_patch                   (begp:endp)) ; this%transfer_grain_gr_patch                   (:) = nan
-    allocate(this%xsmrpool_to_atm_patch                     (begp:endp)) ; this%xsmrpool_to_atm_patch                     (:) = 0.0d00
-    allocate(this%xsmrpool_to_atm_col                       (begc:endc)) ; this%xsmrpool_to_atm_col                       (:) = 0.0d00
-    allocate(this%xsmrpool_to_atm_grc                       (begg:endg)) ; this%xsmrpool_to_atm_grc                       (:) = 0.0d00
+    allocate(this%xsmrpool_to_atm_patch                     (begp:endp)) ; this%xsmrpool_to_atm_patch                     (:) = 0.0_r8
+    allocate(this%xsmrpool_to_atm_col                       (begc:endc)) ; this%xsmrpool_to_atm_col                       (:) = 0.0_r8
+    allocate(this%xsmrpool_to_atm_grc                       (begg:endg)) ; this%xsmrpool_to_atm_grc                       (:) = 0.0_r8
     allocate(this%grainc_storage_to_xfer_patch              (begp:endp)) ; this%grainc_storage_to_xfer_patch              (:) = nan
     allocate(this%frootc_alloc_patch                        (begp:endp)) ; this%frootc_alloc_patch                        (:) = nan
     allocate(this%frootc_loss_patch                         (begp:endp)) ; this%frootc_loss_patch                         (:) = nan
@@ -703,7 +703,7 @@ contains
     allocate(this%fire_closs_p2c_col      (begc:endc)) ; this%fire_closs_p2c_col      (:) = nan
     allocate(this%fire_closs_col          (begc:endc)) ; this%fire_closs_col          (:) = nan
     allocate(this%wood_harvestc_col       (begc:endc)) ; this%wood_harvestc_col       (:) = nan
-    allocate(this%hrv_xsmrpool_to_atm_col (begc:endc)) ; this%hrv_xsmrpool_to_atm_col (:) = 0.0d00
+    allocate(this%hrv_xsmrpool_to_atm_col (begc:endc)) ; this%hrv_xsmrpool_to_atm_col (:) = 0.0_r8
     allocate(this%tempsum_npp_patch       (begp:endp)) ; this%tempsum_npp_patch       (:) = nan
     allocate(this%annsum_npp_patch        (begp:endp)) ; this%annsum_npp_patch        (:) = nan
     allocate(this%tempsum_litfall_patch   (begp:endp)) ; this%tempsum_litfall_patch   (:) = nan

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -369,7 +369,7 @@ module CNVegCarbonFluxType
      ! that are dribbled throughout the year
      type(annual_flux_dribbler_type) :: dwt_conv_cflux_dribbler
      type(annual_flux_dribbler_type) :: hrv_xsmrpool_to_atm_dribbler
-     logical, private  :: harvest_xsmrpool_2atm
+     logical, private  :: dribble_crophrv_xsmrpool_2atm
    contains
 
      procedure , public  :: Init   
@@ -392,14 +392,14 @@ module CNVegCarbonFluxType
 contains
    
   !------------------------------------------------------------------------
-  subroutine Init(this, bounds, carbon_type, harvest_xsmrpool_2atm)
+  subroutine Init(this, bounds, carbon_type, dribble_crophrv_xsmrpool_2atm)
 
     class(cnveg_carbonflux_type) :: this
     type(bounds_type), intent(in) :: bounds  
     character(len=3) , intent(in) :: carbon_type ! one of ['c12', c13','c14']
-    logical          , intent(in) :: harvest_xsmrpool_2atm
+    logical          , intent(in) :: dribble_crophrv_xsmrpool_2atm
 
-    this%harvest_xsmrpool_2atm = harvest_xsmrpool_2atm
+    this%dribble_crophrv_xsmrpool_2atm = dribble_crophrv_xsmrpool_2atm
     call this%InitAllocate ( bounds, carbon_type)
     call this%InitHistory ( bounds, carbon_type )
     call this%InitCold (bounds )
@@ -4128,7 +4128,7 @@ contains
           this%ar_patch(p) =           &
                this%mr_patch(p)      + &
                this%gr_patch(p)
-          if ( .not. this%harvest_xsmrpool_2atm ) this%ar_patch(p) = this%ar_patch(p) + &
+          if ( .not. this%dribble_crophrv_xsmrpool_2atm ) this%ar_patch(p) = this%ar_patch(p) + &
                                              this%xsmrpool_to_atm_patch(p) ! xsmr... is -ve (slevis)
        else         
              this%ar_patch(p) =           &
@@ -4412,7 +4412,7 @@ contains
          this%hrv_xsmrpool_to_atm_patch(bounds%begp:bounds%endp), &
          this%hrv_xsmrpool_to_atm_col(bounds%begc:bounds%endc))
 
-    if (use_crop .and. this%harvest_xsmrpool_2atm) then
+    if (use_crop .and. this%dribble_crophrv_xsmrpool_2atm) then
        call p2c(bounds, num_soilc, filter_soilc, &
             this%xsmrpool_to_atm_patch(bounds%begp:bounds%endp), &
             this%xsmrpool_to_atm_col(bounds%begc:bounds%endc))
@@ -4568,7 +4568,7 @@ contains
        this%nbp_grc(g) = &
             -this%nee_grc(g)        - &
             this%landuseflux_grc(g)
-       if ( this%harvest_xsmrpool_2atm ) this%nbp_grc(g) = this%nbp_grc(g) - this%xsmrpool_to_atm_grc(g)
+       if ( this%dribble_crophrv_xsmrpool_2atm ) this%nbp_grc(g) = this%nbp_grc(g) - this%xsmrpool_to_atm_grc(g)
     end do
 
     ! coarse woody debris C loss

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -391,11 +391,12 @@ module CNVegCarbonFluxType
 contains
    
   !------------------------------------------------------------------------
-  subroutine Init(this, bounds, carbon_type)
+  subroutine Init(this, bounds, carbon_type, harvest_xsmrpool_2atm)
 
     class(cnveg_carbonflux_type) :: this
     type(bounds_type), intent(in) :: bounds  
     character(len=3) , intent(in) :: carbon_type ! one of ['c12', c13','c14']
+    logical          , intent(in) :: harvest_xsmrpool_2atm
 
     call this%InitAllocate ( bounds, carbon_type)
     call this%InitHistory ( bounds, carbon_type )

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -84,7 +84,7 @@ module CNVegCarbonStateType
      real(r8), pointer :: totc_col                 (:) ! (gC/m2) total column carbon, incl veg and cpool
      real(r8), pointer :: totecosysc_col           (:) ! (gC/m2) total ecosystem carbon, incl veg but excl cpool 
 
-     logical, private  :: harvest_xsmrpool_2atm
+     logical, private  :: dribble_crophrv_xsmrpool_2atm
    contains
 
      procedure , public  :: Init   
@@ -117,20 +117,20 @@ contains
 
   !------------------------------------------------------------------------
   subroutine Init(this, bounds, carbon_type, ratio, NLFilename, &
-                  harvest_xsmrpool_2atm, c12_cnveg_carbonstate_inst)
+                  dribble_crophrv_xsmrpool_2atm, c12_cnveg_carbonstate_inst)
 
     class(cnveg_carbonstate_type)                       :: this
     type(bounds_type)            , intent(in)           :: bounds  
     real(r8)                     , intent(in)           :: ratio
     character(len=*)             , intent(in)           :: carbon_type                ! Carbon isotope type C12, C13 or C1
     character(len=*)             , intent(in)           :: NLFilename                 ! Namelist filename
-    logical                      , intent(in)           :: harvest_xsmrpool_2atm
+    logical                      , intent(in)           :: dribble_crophrv_xsmrpool_2atm
     type(cnveg_carbonstate_type) , intent(in), optional :: c12_cnveg_carbonstate_inst ! cnveg_carbonstate for C12 (if C13 or C14)
     !-----------------------------------------------------------------------
 
     this%species = species_from_string(carbon_type)
 
-    this%harvest_xsmrpool_2atm = harvest_xsmrpool_2atm
+    this%dribble_crophrv_xsmrpool_2atm = dribble_crophrv_xsmrpool_2atm
 
     call this%InitAllocate ( bounds)
     call this%InitReadNML  ( NLFilename )

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -84,6 +84,7 @@ module CNVegCarbonStateType
      real(r8), pointer :: totc_col                 (:) ! (gC/m2) total column carbon, incl veg and cpool
      real(r8), pointer :: totecosysc_col           (:) ! (gC/m2) total ecosystem carbon, incl veg but excl cpool 
 
+     logical, private  :: harvest_xsmrpool_2atm
    contains
 
      procedure , public  :: Init   
@@ -128,6 +129,8 @@ contains
     !-----------------------------------------------------------------------
 
     this%species = species_from_string(carbon_type)
+
+    this%harvest_xsmrpool_2atm = harvest_xsmrpool_2atm
 
     call this%InitAllocate ( bounds)
     call this%InitReadNML  ( NLFilename )

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -116,13 +116,14 @@ contains
 
   !------------------------------------------------------------------------
   subroutine Init(this, bounds, carbon_type, ratio, NLFilename, &
-                  c12_cnveg_carbonstate_inst)
+                  harvest_xsmrpool_2atm, c12_cnveg_carbonstate_inst)
 
     class(cnveg_carbonstate_type)                       :: this
     type(bounds_type)            , intent(in)           :: bounds  
     real(r8)                     , intent(in)           :: ratio
     character(len=*)             , intent(in)           :: carbon_type                ! Carbon isotope type C12, C13 or C1
     character(len=*)             , intent(in)           :: NLFilename                 ! Namelist filename
+    logical                      , intent(in)           :: harvest_xsmrpool_2atm
     type(cnveg_carbonstate_type) , intent(in), optional :: c12_cnveg_carbonstate_inst ! cnveg_carbonstate for C12 (if C13 or C14)
     !-----------------------------------------------------------------------
 

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -58,9 +58,7 @@ module CNVegCarbonStateType
      real(r8), pointer :: gresp_xfer_patch         (:) ! (gC/m2) growth respiration transfer
      real(r8), pointer :: cpool_patch              (:) ! (gC/m2) temporary photosynthate C pool
      real(r8), pointer :: xsmrpool_patch           (:) ! (gC/m2) abstract C pool to meet excess MR demand
-!KO
      real(r8), pointer :: xsmrpool_loss_patch      (:) ! (gC/m2) abstract C pool to meet excess MR demand loss
-!KO
      real(r8), pointer :: ctrunc_patch             (:) ! (gC/m2) patch-level sink for C truncation
      real(r8), pointer :: woodc_patch              (:) ! (gC/m2) wood C
      real(r8), pointer :: leafcmax_patch           (:) ! (gC/m2) ann max leaf C
@@ -242,9 +240,7 @@ contains
     allocate(this%gresp_xfer_patch         (begp:endp)) ; this%gresp_xfer_patch         (:) = nan
     allocate(this%cpool_patch              (begp:endp)) ; this%cpool_patch              (:) = nan
     allocate(this%xsmrpool_patch           (begp:endp)) ; this%xsmrpool_patch           (:) = nan
-!KO
     allocate(this%xsmrpool_loss_patch      (begp:endp)) ; this%xsmrpool_loss_patch      (:) = nan
-!KO
     allocate(this%ctrunc_patch             (begp:endp)) ; this%ctrunc_patch             (:) = nan
     allocate(this%dispvegc_patch           (begp:endp)) ; this%dispvegc_patch           (:) = nan
     allocate(this%storvegc_patch           (begp:endp)) ; this%storvegc_patch           (:) = nan
@@ -318,12 +314,11 @@ contains
           call hist_addfld1d (fname='CROPSEEDC_DEFICIT', units='gC/m^2', &
                avgflag='A', long_name='C used for crop seed that needs to be repaid', &
                ptr_patch=this%cropseedc_deficit_patch)
-!KO
+
           this%xsmrpool_loss_patch(begp:endp) = spval
           call hist_addfld1d (fname='XSMRPOOL_LOSS', units='gC/m^2', &
                avgflag='A', long_name='temporary photosynthate C pool loss', &
                ptr_patch=this%xsmrpool_loss_patch)
-!KO
        end if
        
        this%woodc_patch(begp:endp) = spval
@@ -668,12 +663,11 @@ contains
           call hist_addfld1d (fname='C13_CROPSEEDC_DEFICIT', units='gC/m^2', &
                avgflag='A', long_name='C13 C used for crop seed that needs to be repaid', &
                ptr_patch=this%cropseedc_deficit_patch, default='inactive')
-!KO
+
           this%xsmrpool_loss_patch(begp:endp) = spval
           call hist_addfld1d (fname='C13_XSMRPOOL_LOSS', units='gC13/m^2', &
                avgflag='A', long_name='C13 temporary photosynthate C pool loss', &
                ptr_patch=this%xsmrpool_loss_patch, default='inactive')
-!KO
        end if
 
 
@@ -849,12 +843,11 @@ contains
           call hist_addfld1d (fname='C14_CROPSEEDC_DEFICIT', units='gC/m^2', &
                avgflag='A', long_name='C14 C used for crop seed that needs to be repaid', &
                ptr_patch=this%cropseedc_deficit_patch, default='inactive')
-!KO
+
           this%xsmrpool_loss_patch(begp:endp) = spval
           call hist_addfld1d (fname='C14_XSMRPOOL_LOSS', units='gC14/m^2', &
                avgflag='A', long_name='C14 temporary photosynthate C pool loss', &
                ptr_patch=this%xsmrpool_loss_patch, default='inactive')
-!KO
        end if
 
 
@@ -998,9 +991,7 @@ contains
              this%grainc_storage_patch(p) = 0._r8 
              this%grainc_xfer_patch(p)    = 0._r8 
              this%cropseedc_deficit_patch(p)  = 0._r8
-!KO
              this%xsmrpool_loss_patch(p)  = 0._r8 
-!KO
           end if
 
        endif
@@ -1231,11 +1222,11 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='xsmrpool', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_patch) 
-!KO
+
        call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_loss_patch) 
-!KO
+
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%ctrunc_patch) 
@@ -1452,9 +1443,7 @@ contains
                          this%grainc_storage_patch(i) = 0._r8 
                          this%grainc_xfer_patch(i)    = 0._r8 
                          this%cropseedc_deficit_patch(i)  = 0._r8
-!KO
                          this%xsmrpool_loss_patch(i)  = 0._r8 
-!KO
                       end if
 
                       ! calculate totvegc explicitly so that it is available for the isotope 
@@ -1843,7 +1832,7 @@ contains
              endif
           end do
        end if
-!KO
+
        call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss_13', xtype=ncd_double,  &
             dim1name='pft', &
             long_name='', units='', &
@@ -1858,7 +1847,7 @@ contains
              endif
           end do
        end if
-!KO
+
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc_13', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%ctrunc_patch) 
@@ -2148,7 +2137,7 @@ contains
              endif
           end do
        end if
-!KO
+
        call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss_14', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_loss_patch) 
@@ -2160,7 +2149,7 @@ contains
              endif
           end do
        end if
-!KO
+
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc_14', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%ctrunc_patch) 
@@ -2391,9 +2380,7 @@ contains
           this%grainc_storage_patch(i)  = value_patch
           this%grainc_xfer_patch(i)     = value_patch
           this%cropseedc_deficit_patch(i)  = value_patch
-!KO
           this%xsmrpool_loss_patch(i)   = value_patch
-!KO
        end if
     end do
 
@@ -2527,7 +2514,8 @@ contains
             this%ctrunc_patch(p)
 
        if (use_crop) then 
-          this%totc_patch(p) = this%totc_patch(p) + this%cropseedc_deficit_patch(p)
+          this%totc_patch(p) = this%totc_patch(p) + this%cropseedc_deficit_patch(p) + &
+               this%xsmrpool_loss_patch(p)
        end if
 
        ! (WOODC) - wood C
@@ -2774,18 +2762,17 @@ contains
             var = this%grainc_xfer_patch(begp:endp), &
             flux_out_grc_area = conv_cflux(begp:endp))
 
+!KO WHY ARE THERE TWO use_crop's HERE?
        if (use_crop) then
           ! This is a negative pool. So any deficit that we haven't repaid gets sucked out
           ! of the atmosphere.
           call update_patch_state( &
                var = this%cropseedc_deficit_patch(begp:endp), &
                flux_out_grc_area = conv_cflux(begp:endp))
-!KO
-! DO I NEED THIS?
+
           call update_patch_state( &
                var = this%xsmrpool_loss_patch(begp:endp), &
                flux_out_grc_area = conv_cflux(begp:endp))
-!KO
        end if
     end if
 

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -58,6 +58,9 @@ module CNVegCarbonStateType
      real(r8), pointer :: gresp_xfer_patch         (:) ! (gC/m2) growth respiration transfer
      real(r8), pointer :: cpool_patch              (:) ! (gC/m2) temporary photosynthate C pool
      real(r8), pointer :: xsmrpool_patch           (:) ! (gC/m2) abstract C pool to meet excess MR demand
+!KO
+     real(r8), pointer :: xsmrpool_loss_patch      (:) ! (gC/m2) abstract C pool to meet excess MR demand loss
+!KO
      real(r8), pointer :: ctrunc_patch             (:) ! (gC/m2) patch-level sink for C truncation
      real(r8), pointer :: woodc_patch              (:) ! (gC/m2) wood C
      real(r8), pointer :: leafcmax_patch           (:) ! (gC/m2) ann max leaf C
@@ -239,6 +242,9 @@ contains
     allocate(this%gresp_xfer_patch         (begp:endp)) ; this%gresp_xfer_patch         (:) = nan
     allocate(this%cpool_patch              (begp:endp)) ; this%cpool_patch              (:) = nan
     allocate(this%xsmrpool_patch           (begp:endp)) ; this%xsmrpool_patch           (:) = nan
+!KO
+    allocate(this%xsmrpool_loss_patch      (begp:endp)) ; this%xsmrpool_loss_patch      (:) = nan
+!KO
     allocate(this%ctrunc_patch             (begp:endp)) ; this%ctrunc_patch             (:) = nan
     allocate(this%dispvegc_patch           (begp:endp)) ; this%dispvegc_patch           (:) = nan
     allocate(this%storvegc_patch           (begp:endp)) ; this%storvegc_patch           (:) = nan
@@ -312,6 +318,12 @@ contains
           call hist_addfld1d (fname='CROPSEEDC_DEFICIT', units='gC/m^2', &
                avgflag='A', long_name='C used for crop seed that needs to be repaid', &
                ptr_patch=this%cropseedc_deficit_patch)
+!KO
+          this%xsmrpool_loss_patch(begp:endp) = spval
+          call hist_addfld1d (fname='XSMRPOOL_LOSS', units='gC/m^2', &
+               avgflag='A', long_name='temporary photosynthate C pool loss', &
+               ptr_patch=this%xsmrpool_loss_patch)
+!KO
        end if
        
        this%woodc_patch(begp:endp) = spval
@@ -656,6 +668,12 @@ contains
           call hist_addfld1d (fname='C13_CROPSEEDC_DEFICIT', units='gC/m^2', &
                avgflag='A', long_name='C13 C used for crop seed that needs to be repaid', &
                ptr_patch=this%cropseedc_deficit_patch, default='inactive')
+!KO
+          this%xsmrpool_loss_patch(begp:endp) = spval
+          call hist_addfld1d (fname='C13_XSMRPOOL_LOSS', units='gC13/m^2', &
+               avgflag='A', long_name='C13 temporary photosynthate C pool loss', &
+               ptr_patch=this%xsmrpool_loss_patch, default='inactive')
+!KO
        end if
 
 
@@ -831,6 +849,12 @@ contains
           call hist_addfld1d (fname='C14_CROPSEEDC_DEFICIT', units='gC/m^2', &
                avgflag='A', long_name='C14 C used for crop seed that needs to be repaid', &
                ptr_patch=this%cropseedc_deficit_patch, default='inactive')
+!KO
+          this%xsmrpool_loss_patch(begp:endp) = spval
+          call hist_addfld1d (fname='C14_XSMRPOOL_LOSS', units='gC14/m^2', &
+               avgflag='A', long_name='C14 temporary photosynthate C pool loss', &
+               ptr_patch=this%xsmrpool_loss_patch, default='inactive')
+!KO
        end if
 
 
@@ -974,6 +998,9 @@ contains
              this%grainc_storage_patch(p) = 0._r8 
              this%grainc_xfer_patch(p)    = 0._r8 
              this%cropseedc_deficit_patch(p)  = 0._r8
+!KO
+             this%xsmrpool_loss_patch(p)  = 0._r8 
+!KO
           end if
 
        endif
@@ -1204,7 +1231,11 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='xsmrpool', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_patch) 
-
+!KO
+       call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss', xtype=ncd_double,  &
+            dim1name='pft', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_loss_patch) 
+!KO
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%ctrunc_patch) 
@@ -1421,6 +1452,9 @@ contains
                          this%grainc_storage_patch(i) = 0._r8 
                          this%grainc_xfer_patch(i)    = 0._r8 
                          this%cropseedc_deficit_patch(i)  = 0._r8
+!KO
+                         this%xsmrpool_loss_patch(i)  = 0._r8 
+!KO
                       end if
 
                       ! calculate totvegc explicitly so that it is available for the isotope 
@@ -1809,7 +1843,22 @@ contains
              endif
           end do
        end if
-
+!KO
+       call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss_13', xtype=ncd_double,  &
+            dim1name='pft', &
+            long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_loss_patch) 
+       if (flag=='read' .and. .not. readvar) then
+          if ( masterproc ) write(iulog,*) 'initializing this%xsmrpool_loss with atmospheric c13 value'
+          do i = bounds%begp,bounds%endp
+             if (pftcon%c3psn(patch%itype(i)) == 1._r8) then
+                this%xsmrpool_loss_patch(i) = c12_cnveg_carbonstate_inst%xsmrpool_loss_patch(i) * c3_r2
+             else
+                this%xsmrpool_loss_patch(i) = c12_cnveg_carbonstate_inst%xsmrpool_loss_patch(i) * c4_r2
+             endif
+          end do
+       end if
+!KO
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc_13', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%ctrunc_patch) 
@@ -2099,7 +2148,19 @@ contains
              endif
           end do
        end if
-
+!KO
+       call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss_14', xtype=ncd_double,  &
+            dim1name='pft', long_name='', units='', &
+            interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_loss_patch) 
+       if (flag=='read' .and. .not. readvar) then
+          if ( masterproc ) write(iulog,*) 'initializing this%xsmrpool_loss_patch with atmospheric c14 value'
+          do i = bounds%begp,bounds%endp
+             if (this%xsmrpool_loss_patch(i) /= spval .and. .not. isnan(this%xsmrpool_loss_patch(i)) ) then
+                this%xsmrpool_loss_patch(i) = c12_cnveg_carbonstate_inst%xsmrpool_loss_patch(i) * c14ratio
+             endif
+          end do
+       end if
+!KO
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc_14', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%ctrunc_patch) 
@@ -2330,6 +2391,9 @@ contains
           this%grainc_storage_patch(i)  = value_patch
           this%grainc_xfer_patch(i)     = value_patch
           this%cropseedc_deficit_patch(i)  = value_patch
+!KO
+          this%xsmrpool_loss_patch(i)   = value_patch
+!KO
        end if
     end do
 
@@ -2716,6 +2780,12 @@ contains
           call update_patch_state( &
                var = this%cropseedc_deficit_patch(begp:endp), &
                flux_out_grc_area = conv_cflux(begp:endp))
+!KO
+! DO I NEED THIS?
+          call update_patch_state( &
+               var = this%xsmrpool_loss_patch(begp:endp), &
+               flux_out_grc_area = conv_cflux(begp:endp))
+!KO
        end if
     end if
 

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -322,7 +322,7 @@ contains
           this%xsmrpool_loss_patch(begp:endp) = spval
           call hist_addfld1d (fname='XSMRPOOL_LOSS', units='gC/m^2', &
                avgflag='A', long_name='temporary photosynthate C pool loss', &
-               ptr_patch=this%xsmrpool_loss_patch)
+               ptr_patch=this%xsmrpool_loss_patch, default='inactive')
        end if
        
        this%woodc_patch(begp:endp) = spval
@@ -1230,6 +1230,9 @@ contains
        call restartvar(ncid=ncid, flag=flag, varname='xsmrpool_loss', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &
             interpinic_flag='interp', readvar=readvar, data=this%xsmrpool_loss_patch) 
+       if (flag == 'read' .and. (.not. readvar) ) then
+           this%xsmrpool_loss_patch(bounds%begp:bounds%endp) = 0._r8
+       end if
 
        call restartvar(ncid=ncid, flag=flag, varname='pft_ctrunc', xtype=ncd_double,  &
             dim1name='pft', long_name='', units='', &

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -2769,18 +2769,15 @@ contains
             var = this%grainc_xfer_patch(begp:endp), &
             flux_out_grc_area = conv_cflux(begp:endp))
 
-!KO WHY ARE THERE TWO use_crop's HERE?
-       if (use_crop) then
-          ! This is a negative pool. So any deficit that we haven't repaid gets sucked out
-          ! of the atmosphere.
-          call update_patch_state( &
-               var = this%cropseedc_deficit_patch(begp:endp), &
-               flux_out_grc_area = conv_cflux(begp:endp))
+       ! This is a negative pool. So any deficit that we haven't repaid gets sucked out
+       ! of the atmosphere.
+       call update_patch_state( &
+            var = this%cropseedc_deficit_patch(begp:endp), &
+            flux_out_grc_area = conv_cflux(begp:endp))
 
-          call update_patch_state( &
-               var = this%xsmrpool_loss_patch(begp:endp), &
-               flux_out_grc_area = conv_cflux(begp:endp))
-       end if
+       call update_patch_state( &
+            var = this%xsmrpool_loss_patch(begp:endp), &
+            flux_out_grc_area = conv_cflux(begp:endp))
     end if
 
   contains

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -125,7 +125,7 @@ module CNVegetationFacade
 
      ! Control variables
      logical, private :: reseed_dead_plants              ! Flag to indicate if should reseed dead plants when starting up the model
-     logical, private :: harvest_xsmrpool_2atm = .False. ! Flag to indicate if should harvest xsmrpool to the atmosphere
+     logical, private :: dribble_crophrv_xsmrpool_2atm = .False. ! Flag to indicate if should harvest xsmrpool to the atmosphere
 
      ! TODO(wjs, 2016-02-19) Evaluate whether some other variables should be moved in
      ! here. Whether they should be moved in depends on how tightly they are tied in with
@@ -226,23 +226,23 @@ contains
        call this%CNReadNML( NLFilename )    ! MUST be called first as passes down control information to others
 
        call this%cnveg_carbonstate_inst%Init(bounds, carbon_type='c12', ratio=1._r8, &
-                                             NLFilename=NLFilename,  harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm )
+                                             NLFilename=NLFilename,  dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm )
        if (use_c13) then
           call this%c13_cnveg_carbonstate_inst%Init(bounds, carbon_type='c13', ratio=c13ratio, &
-               NLFilename=NLFilename, harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm,        &
+               NLFilename=NLFilename, dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm,        &
                c12_cnveg_carbonstate_inst=this%cnveg_carbonstate_inst)
        end if
        if (use_c14) then
           call this%c14_cnveg_carbonstate_inst%Init(bounds, carbon_type='c14', ratio=c14ratio, &
-               NLFilename=NLFilename, harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm,        &
+               NLFilename=NLFilename, dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm,        &
                c12_cnveg_carbonstate_inst=this%cnveg_carbonstate_inst)
        end if
-       call this%cnveg_carbonflux_inst%Init(bounds, carbon_type='c12', harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm )
+       call this%cnveg_carbonflux_inst%Init(bounds, carbon_type='c12', dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm )
        if (use_c13) then
-          call this%c13_cnveg_carbonflux_inst%Init(bounds, carbon_type='c13', harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm)
+          call this%c13_cnveg_carbonflux_inst%Init(bounds, carbon_type='c13', dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm)
        end if
        if (use_c14) then
-          call this%c14_cnveg_carbonflux_inst%Init(bounds, carbon_type='c14', harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm)
+          call this%c14_cnveg_carbonflux_inst%Init(bounds, carbon_type='c14', dribble_crophrv_xsmrpool_2atm=this%dribble_crophrv_xsmrpool_2atm)
        end if
        call this%cnveg_nitrogenstate_inst%Init(bounds,                   &
             this%cnveg_carbonstate_inst%leafc_patch(begp:endp),          &
@@ -299,11 +299,11 @@ contains
     character(len=*), parameter :: nmlname = 'cn_general'   ! MUST match what is in namelist below
     !-----------------------------------------------------------------------
     logical :: reseed_dead_plants
-    logical :: harvest_xsmrpool_2atm
-    namelist /cn_general/ reseed_dead_plants, harvest_xsmrpool_2atm
+    logical :: dribble_crophrv_xsmrpool_2atm
+    namelist /cn_general/ reseed_dead_plants, dribble_crophrv_xsmrpool_2atm
 
     reseed_dead_plants    = this%reseed_dead_plants
-    harvest_xsmrpool_2atm = this%harvest_xsmrpool_2atm
+    dribble_crophrv_xsmrpool_2atm = this%dribble_crophrv_xsmrpool_2atm
 
     if (masterproc) then
        unitn = getavu()
@@ -322,10 +322,10 @@ contains
     end if
 
     call shr_mpi_bcast (reseed_dead_plants     , mpicom)
-    call shr_mpi_bcast (harvest_xsmrpool_2atm  , mpicom)
+    call shr_mpi_bcast (dribble_crophrv_xsmrpool_2atm  , mpicom)
 
     this%reseed_dead_plants = reseed_dead_plants
-    this%harvest_xsmrpool_2atm = harvest_xsmrpool_2atm
+    this%dribble_crophrv_xsmrpool_2atm = dribble_crophrv_xsmrpool_2atm
 
     if (masterproc) then
        write(iulog,*) ' '
@@ -868,7 +868,7 @@ contains
          atm2lnd_inst, waterstate_inst, waterflux_inst,                           &
          canopystate_inst, soilstate_inst, temperature_inst, crop_inst, ch4_inst, &
          this%dgvs_inst, photosyns_inst, soilhydrology_inst, energyflux_inst,          &
-         nutrient_competition_method, this%cnfire_method, this%harvest_xsmrpool_2atm)
+         nutrient_competition_method, this%cnfire_method, this%dribble_crophrv_xsmrpool_2atm)
 
     ! fire carbon emissions 
     call CNFireEmisUpdate(bounds, num_soilp, filter_soilp, &

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -124,7 +124,8 @@ module CNVegetationFacade
      type(dgvs_type)                :: dgvs_inst
 
      ! Control variables
-     logical, private :: reseed_dead_plants    ! Flag to indicate if should reseed dead plants when starting up the model
+     logical, private :: reseed_dead_plants              ! Flag to indicate if should reseed dead plants when starting up the model
+     logical, private :: harvest_xsmrpool_2atm = .False. ! Flag to indicate if should harvest xsmrpool to the atmosphere
 
      ! TODO(wjs, 2016-02-19) Evaluate whether some other variables should be moved in
      ! here. Whether they should be moved in depends on how tightly they are tied in with
@@ -224,21 +225,24 @@ contains
        ! Read in the general CN namelist
        call this%CNReadNML( NLFilename )    ! MUST be called first as passes down control information to others
 
-       call this%cnveg_carbonstate_inst%Init(bounds, carbon_type='c12', ratio=1._r8, NLFilename=NLFilename)
+       call this%cnveg_carbonstate_inst%Init(bounds, carbon_type='c12', ratio=1._r8, &
+                                             NLFilename=NLFilename,  harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm )
        if (use_c13) then
           call this%c13_cnveg_carbonstate_inst%Init(bounds, carbon_type='c13', ratio=c13ratio, &
-               NLFilename=NLFilename, c12_cnveg_carbonstate_inst=this%cnveg_carbonstate_inst)
+               NLFilename=NLFilename, harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm,        &
+               c12_cnveg_carbonstate_inst=this%cnveg_carbonstate_inst)
        end if
        if (use_c14) then
           call this%c14_cnveg_carbonstate_inst%Init(bounds, carbon_type='c14', ratio=c14ratio, &
-               NLFilename=NLFilename, c12_cnveg_carbonstate_inst=this%cnveg_carbonstate_inst)
+               NLFilename=NLFilename, harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm,        &
+               c12_cnveg_carbonstate_inst=this%cnveg_carbonstate_inst)
        end if
-       call this%cnveg_carbonflux_inst%Init(bounds, carbon_type='c12')
+       call this%cnveg_carbonflux_inst%Init(bounds, carbon_type='c12', harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm )
        if (use_c13) then
-          call this%c13_cnveg_carbonflux_inst%Init(bounds, carbon_type='c13')
+          call this%c13_cnveg_carbonflux_inst%Init(bounds, carbon_type='c13', harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm)
        end if
        if (use_c14) then
-          call this%c14_cnveg_carbonflux_inst%Init(bounds, carbon_type='c14')
+          call this%c14_cnveg_carbonflux_inst%Init(bounds, carbon_type='c14', harvest_xsmrpool_2atm=this%harvest_xsmrpool_2atm)
        end if
        call this%cnveg_nitrogenstate_inst%Init(bounds,                   &
             this%cnveg_carbonstate_inst%leafc_patch(begp:endp),          &
@@ -295,9 +299,11 @@ contains
     character(len=*), parameter :: nmlname = 'cn_general'   ! MUST match what is in namelist below
     !-----------------------------------------------------------------------
     logical :: reseed_dead_plants
-    namelist /cn_general/ reseed_dead_plants
+    logical :: harvest_xsmrpool_2atm
+    namelist /cn_general/ reseed_dead_plants, harvest_xsmrpool_2atm
 
-    reseed_dead_plants = this%reseed_dead_plants
+    reseed_dead_plants    = this%reseed_dead_plants
+    harvest_xsmrpool_2atm = this%harvest_xsmrpool_2atm
 
     if (masterproc) then
        unitn = getavu()
@@ -315,9 +321,11 @@ contains
        call relavu( unitn )
     end if
 
-    call shr_mpi_bcast (reseed_dead_plants      , mpicom)
+    call shr_mpi_bcast (reseed_dead_plants     , mpicom)
+    call shr_mpi_bcast (harvest_xsmrpool_2atm  , mpicom)
 
     this%reseed_dead_plants = reseed_dead_plants
+    this%harvest_xsmrpool_2atm = harvest_xsmrpool_2atm
 
     if (masterproc) then
        write(iulog,*) ' '
@@ -860,7 +868,7 @@ contains
          atm2lnd_inst, waterstate_inst, waterflux_inst,                           &
          canopystate_inst, soilstate_inst, temperature_inst, crop_inst, ch4_inst, &
          this%dgvs_inst, photosyns_inst, soilhydrology_inst, energyflux_inst,          &
-         nutrient_competition_method, this%cnfire_method)
+         nutrient_competition_method, this%cnfire_method, this%harvest_xsmrpool_2atm)
 
     ! fire carbon emissions 
     call CNFireEmisUpdate(bounds, num_soilp, filter_soilp, &

--- a/src/biogeochem/EDBGCDynMod.F90
+++ b/src/biogeochem/EDBGCDynMod.F90
@@ -237,7 +237,7 @@ contains
     ! Update all prognostic carbon state variables (except for gap-phase mortality and fire fluxes)
     call CStateUpdate1( num_soilc, filter_soilc, num_soilp, filter_soilp, &
          crop_inst, cnveg_carbonflux_inst, cnveg_carbonstate_inst, &
-         soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm=.False.)
+         soilbiogeochem_carbonflux_inst, dribble_crophrv_xsmrpool_2atm=.False.)
 
     call t_stopf('BNGCUpdate1')
 

--- a/src/biogeochem/EDBGCDynMod.F90
+++ b/src/biogeochem/EDBGCDynMod.F90
@@ -237,7 +237,7 @@ contains
     ! Update all prognostic carbon state variables (except for gap-phase mortality and fire fluxes)
     call CStateUpdate1( num_soilc, filter_soilc, num_soilp, filter_soilp, &
          crop_inst, cnveg_carbonflux_inst, cnveg_carbonstate_inst, &
-         soilbiogeochem_carbonflux_inst)
+         soilbiogeochem_carbonflux_inst, harvest_xsmrpool_2atm=.False.)
 
     call t_stopf('BNGCUpdate1')
 

--- a/tools/mksurfdata_map/Makefile.data
+++ b/tools/mksurfdata_map/Makefile.data
@@ -58,6 +58,8 @@ MKSURFDATA = $(BATCHJOBS) $(PWD)/mksurfdata.pl
 # ne30np4 is standard resolution for SE dycore in CAM, T31 is for paleo, 360x720cru is for same resolution as forcing data
 STANDARD_RES = 360x720cru,48x96,0.9x1.25,1.9x2.5,10x15,4x5,ne30np4
 
+FUTURE_RES = 0.9x1.25,1.9x2.5,10x15
+
 # ne120np4 is for high resolution SE dycore, ne16 is for testing SE dycore
 # T42 is for SCAM
 # f05 is needed for running full chemistry model
@@ -71,6 +73,7 @@ STANDARD = \
 	global-historical-ne120np4 \
 	global-transient-f05 \
 	global-transient \
+	global-future \
 	global-transient-ne120np4
 
 TROPICS = \
@@ -95,6 +98,7 @@ CROP = \
 	crop-global-historical-ne120np4 \
 	crop-global-transient-f05 \
 	crop-global-transient \
+	crop-global-future \
 	crop-global-transient-ne120np4
 
 all : standard tropics crop urban landuse-timeseries
@@ -142,6 +146,13 @@ global-transient-ne120np4 : FORCE
 
 global-transient-f05 : FORCE
 	$(MKSURFDATA) -no-crop -no_surfdata -glc_nec 10 -y 1850-2000 -res 0.47x0.63 $(BACKGROUND)
+
+#
+# global with future scenarios
+#
+global-future : FORCE
+	$(MKSURFDATA) -no-crop -no_surfdata -glc_nec 10 -y 1850-2100 \
+	-ssp_rcp SSP1-2.6,SSP3-7.0,SSP5-3.4,SSP2-4.5,SSP1-1.9,SSP4-3.4,SSP4-6.0,SSP5-8.5 -res $(FUTURE_RES) $(BACKGROUND)
 
 #
 # tropics
@@ -222,6 +233,15 @@ crop-global-transient-ne120np4 : FORCE
 
 crop-global-transient-f05 : FORCE
 	$(MKSURFDATA) -no_surfdata -glc_nec 10 -y 1850-2000 -res 0.47x0.63 $(BACKGROUND)
+
+#
+# Crop with future scenarios
+#
+crop-global-future : FORCE
+	$(MKSURFDATA) -no_surfdata -glc_nec 10 -y 1850-2100 \
+	-ssp_rcp SSP1-2.6,SSP3-7.0,SSP5-3.4,SSP2-4.5,SSP1-1.9,SSP4-3.4,SSP4-6.0,SSP5-8.5 -res $(FUTURE_RES) $(BACKGROUND)
+
+
 #
 # urban
 #

--- a/tools/mksurfdata_map/README.developers
+++ b/tools/mksurfdata_map/README.developers
@@ -14,6 +14,8 @@ I.  Adding a new raw data file
 
 II. Adding mapping files for a raw data file with a new grid / landmask
 
+III. Checks that should be done when making new surface datasets
+
 ============================================================================
 I. Adding a new raw data file
 ============================================================================
@@ -176,3 +178,50 @@ laid out here.
       directory yourself
 
 
+============================================================================
+III. Checks that should be done when making new surface datasets
+============================================================================
+
+Remaking all surface datasets carries the risk of introducing unintended
+changes, particularly when you are expecting answer changes (so you
+don't notice unintended answer changes that are mixed with the expected
+changes).
+
+Here are some things to check after making a new set of surface
+datasets:
+
+- For at least one global dataset (probably a production resolution
+  rather than a low resolution that is just used for testing): Compare
+  the new dataset against the previous version:
+
+  - Compare header (via ncdump -h) and/or log file: ensure that the same
+    source data were used, except where you expect differences
+
+  - Compare all fields with a tool like cprnc: make sure that the only
+    fields that differ are those you expect to differ
+
+  - Visually compare all fields that differ: make sure differences look
+    reasonable and as expected
+    
+And here are some things to check for when making new landuse.timeseries 
+datasets (which often happens at the same time, and most of the above applies
+as well):
+
+- Compare one of the productive resolution datasets to a previous version.
+
+  - If part of it should be identical (for example the historical period) make
+    sure it is identical as expected (using cprnc make sure the historical period
+    is identical and only the future scenario changes).
+  
+  - If the historical period should be identical, make sure the 1850 surface dataset
+    created is identical to the previous one.
+    
+  - Visually compare all fields/times that differ: make sure differences look
+    reasonable and as expected. Go through at least the first and last time to see
+    that the change in time is as expected. 
+    
+  - Quickly going through the time differences for at least one field that changes
+    can also be useful to see that there isn't a sudden jump for a particular time.
+    
+  - Go through the list of raw PFT files that were used to create the dataset and make
+    sure it appears to be correct (ncdump -v input_pftdata_filename)

--- a/tools/mksurfdata_map/mksurfdata.pl
+++ b/tools/mksurfdata_map/mksurfdata.pl
@@ -267,10 +267,10 @@ sub write_transient_timeseries_file {
       $fh_landuse_timeseries->open( ">$landuse_timeseries_text_file" ) or die "** can't open file: $landuse_timeseries_text_file\n";
       print "Writing out landuse_timeseries text file: $landuse_timeseries_text_file\n";
       for( my $yr = $sim_yr0; $yr <= $sim_yrn; $yr++ ) {
-        my $vegtypyr = `$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resol -options sim_year=$yr,ssp-rcp=${ssp_rcp}${mkcrop} -var mksrf_fvegtyp -namelist clmexp`;
+        my $vegtypyr = `$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resol -options sim_year='$yr',ssp_rcp=${ssp_rcp}${mkcrop} -var mksrf_fvegtyp -namelist clmexp`;
         chomp( $vegtypyr );
         printf $fh_landuse_timeseries $dynpft_format, $vegtypyr, $yr;
-        my $hrvtypyr = `$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resolhrv -options sim_year=$yr,ssp-rcp=${ssp_rcp}${mkcrop} -var mksrf_fvegtyp -namelist clmexp`;
+        my $hrvtypyr = `$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resolhrv -options sim_year='$yr',ssp_rcp=${ssp_rcp}${mkcrop} -var mksrf_fvegtyp -namelist clmexp`;
         chomp( $hrvtypyr );
         printf $fh_landuse_timeseries $dynpft_format, $hrvtypyr, $yr;
         if ( $yr % 100 == 0 ) {
@@ -519,19 +519,19 @@ EOF
        }
      } else {
        # single year.
-       if ( ! $definition->is_valid_value( "sim_year", $sim_year ) ) {
+       if ( ! $definition->is_valid_value( "sim_year", "'$sim_year'" ) ) {
          print "** Invalid simulation year: $sim_year\n";
          usage();
        }
      }
    }
    #
-   # Set ssp-rcp to use
+   # Set ssp_rcp to use
    #
    my @rcpaths = split( ",", $opts{'ssp_rcp'} );
-   # Check that ssp-rcp is valid
+   # Check that ssp_rcp is valid
    foreach my $ssp_rcp ( @rcpaths  ) {
-      if ( ! $definition->is_valid_value( "ssp-rcp", $ssp_rcp ) ) {
+      if ( ! $definition->is_valid_value( "ssp_rcp", $ssp_rcp ) ) {
           print "** Invalid ssp_rcp: $ssp_rcp\n";
           usage();
        }
@@ -697,7 +697,7 @@ EOF
             #
             # Skip if urban unless sim_year=2000
             #
-            if ( $urb_pt && $sim_year != 2000 ) {
+            if ( $urb_pt && $sim_year ne '2000' ) {
                print "For urban -- skip this simulation year = $sim_year\n";
                next SIM_YEAR;
             }
@@ -721,15 +721,15 @@ EOF
                $transient = 1;
             }
             # determine simulation year to use for the surface dataset:
-            my $sim_yr_surfdat = $sim_yr0;
+            my $sim_yr_surfdat = "$sim_yr0";
             
-            my $cmd    = "$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resol -options sim_year=${sim_yr_surfdat}$mkcrop -var mksrf_fvegtyp -namelist clmexp";
+            my $cmd    = "$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resol -options sim_year='${sim_yr_surfdat}'$mkcrop -var mksrf_fvegtyp -namelist clmexp";
             my $vegtyp = `$cmd`;
             chomp( $vegtyp );
             if ( $vegtyp eq "" ) {
                die "** trouble getting vegtyp file with: $cmd\n";
             }
-            my $cmd    = "$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resolhrv -options sim_year=${sim_yr_surfdat}$mkcrop -var mksrf_fvegtyp -namelist clmexp";
+            my $cmd    = "$scrdir/../../bld/queryDefaultNamelist.pl $queryfilopts $resolhrv -options sim_year='${sim_yr_surfdat}'$mkcrop -var mksrf_fvegtyp -namelist clmexp";
             my $hrvtyp = `$cmd`;
             chomp( $hrvtyp );
             if ( $hrvtyp eq "" ) {
@@ -743,8 +743,8 @@ EOF
             if ( $mkcrop ne "" ) {
                $options = "-options $mkcrop";
             }
-            $desc         = sprintf( "%s_%s_%s_simyr%4.4d-%4.4d", $ssp_rcp, $crpdes, $cmip_series, $sim_yr0, $sim_yrn );
-            $desc_surfdat = sprintf( "%s_%s_%s_simyr%4.4d",       $ssp_rcp, $crpdes, $cmip_series, $sim_yr_surfdat  );
+            $desc         = sprintf( "%s_%s_%s_simyr%s-%4.4d", $ssp_rcp, $crpdes, $cmip_series, $sim_yr0, $sim_yrn );
+            $desc_surfdat = sprintf( "%s_%s_%s_simyr%s",       $ssp_rcp, $crpdes, $cmip_series, $sim_yr_surfdat  );
 
             my $fsurdat_fname_base = "";
             my $fsurdat_fname = "";
@@ -781,7 +781,7 @@ EOF
                  $sim_yr_surfdat);
 
             print "CSMDATA is $CSMDATA \n";
-            print "resolution: $res ssp-rcp=$ssp_rcp sim_year = $sim_year\n";
+            print "resolution: $res ssp_rcp=$ssp_rcp sim_year = $sim_year\n";
             print "namelist: $namelist_fname\n";
             
             write_namelist_file(

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -704,16 +704,20 @@ program mksurfdat
 
     do n = 1,ns_o
 
-       ! Assume wetland and/or lake when dataset landmask implies ocean 
+       ! Assume wetland, glacier and/or lake when dataset landmask implies ocean 
        ! (assume medium soil color (15) and loamy texture).
        ! Also set pftdata_mask here
 
        if (pctlnd_pft(n) < 1.e-6_r8) then
           pftdata_mask(n)  = 0
           soicol(n)        = 15
-          pctwet(n)        = 100._r8 - pctlak(n)
+          if (pctgla(n) < 1.e-6_r8) then
+              pctwet(n)    = 100._r8 - pctlak(n)
+              pctgla(n)    = 0._r8
+          else
+              pctwet(n)    = 100._r8 - pctgla(n) - pctlak(n)
+          end if
           pcturb(n)        = 0._r8
-          pctgla(n)        = 0._r8
           call pctnatpft(n)%set_pct_l2g(0._r8)
           call pctcft(n)%set_pct_l2g(0._r8)
           pctsand(n,:)     = 43._r8


### PR DESCRIPTION
### Description of changes

Add an option to dribble the XSMRPOOL at crop harvest to the atmosphere over about a half year.

### Specific notes

Contributors other than yourself, if any: @olyson

CTSM Issues Fixed (include github issue #): #590 #589

Are answers expected to change (and if so in what way)? No
only when option is invoked

Any User Interface Changes (namelist or namelist defaults changes)?
  New option: dribble_crophrv_xsmrpool_2atm
  Also don't give contents of lai_stream namelist unless use_lai_streams is on.

Testing performed, if any: Ran a few tests by hand to show answers don't change when option off
and answers do when turned on. Also compared to make sure @olyson case clm50_release-clm5.0.15_hrv_xsmrpool_to_atm_1deg_GSWP3V1_hist was exact with the option turned on.

@billsacks it's not critical for you to review this. But, if you do, I need it done in the next few days.

