### PR TITLE
Update version of cime in externals for fates_next_api branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -29,8 +29,8 @@ required = True
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/CESM-Development/cime
-tag = clm4518/n04/cime5.4.0-alpha.03
+repo_url = https://github.com/ESMCI/cime
+tag = ctsm/ctsm1.0/cime5.7.5/n01
 required = True
 
 [externals_description]


### PR DESCRIPTION
### Description of changes

This change updates both the repository and the tag for CIME in the externals file for fates_next_api. This updated version of CIME contains updated machine files for cheyenne which is critical to use driver data in the correct locations.

### Collaborators: 
@ekluzek  @jkshuman  @billsacks 


Are answers expected to change (and if so in what way)?
No

Any User Interface Changes (namelist or namelist defaults changes)?
no (everything cime's to be under the hood)

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

FATES regression suite, all PASS:
/glade/scratch/rgknox/clmed-tests/fates.cheyenne.intel.master-Cff77942-F4ae2e78

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
