### PR TITLE
Qsnoevapfix

### DIFF
--- a/src/biogeophys/WaterfluxType.F90
+++ b/src/biogeophys/WaterfluxType.F90
@@ -432,7 +432,7 @@ contains
     this%qflx_ev_snow_patch(begp:endp) = spval
     call hist_addfld1d (fname='QSNOEVAP', units='mm/s',  &
          avgflag='A', long_name='evaporation from snow', &
-         ptr_patch=this%qflx_tran_veg_patch, set_lake=0._r8, c2l_scale_type='urbanf')
+         ptr_patch=this%qflx_ev_snow_patch, set_lake=0._r8, c2l_scale_type='urbanf')
 
     this%qflx_snowindunload_patch(begp:endp) = spval
     call hist_addfld1d (fname='QSNO_WINDUNLOAD', units='mm/s',  &


### PR DESCRIPTION
### Description of changes

QSNOEVAP for history was pointing to the wrong internal variable. This corrects it to point to the correct one.

### Specific notes

Contributors other than yourself, if any: @olyson 

CTSM Issues Fixed (include github issue #): #624

Are answers expected to change (and if so in what way)? Yes (just for QSNOEVAP)

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
 Ran SMS_Lm1_D.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_intel.clm-output_crop_highfreq
and made sure only the QSNOEVAP variable changed on history