### PR TITLE
Soil hydrology initialization of time-constant variables moved to SoilHydrologyType.

### DIFF
--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -767,7 +767,7 @@
       <option name="comment"  >test transient PFTs (via HIST) in conjunction with changing glacier area</option>
     </options>
   </test>
-  <test name="ERS_D_Ld10" grid="f10_f10_musgs" compset="IHistClm50SpG" testmods="clm/collapse_pfts_78_to_16_decStart_f10">
+  <test name="ERS_D_Ld10" grid="f10_f10_musgs" compset="IHistClm50Sp" testmods="clm/collapse_pfts_78_to_16_decStart_f10">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -2,7 +2,7 @@
 Tag name:  ctsm1.0.dev027
 Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
 Date: Tue Feb 19 12:57:12 MST 2019
-One-line Summary: Non-constant time initialization for soil hydrology types are moved to /src/biogeophys/SoilHydrologyType.F90. 
+One-line Summary: Non-constant time initialization for soil hydrology types are moved to SoilHydrologyType.F90. 
 
 Purpose of changes
 ------------------

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -46,7 +46,8 @@ Notes of particular relevance for developers: (including Code reviews and testin
 
 Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
 
-Changes to tests or testing: none
+Changes to tests or testing: Updated a test.  The test added in previous tag included decStart with transient glaciers, which would not work. Hence, this test is modified so the compset does not include G.
+Test IHistClm50SpG is updated to IHistClm50Sp.
 
 Code reviewed by:
 Bill Sacks

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,98 @@
 ===============================================================
+Tag name:  ctsm1.0.dev027
+Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
+Date: Tue Feb 19 12:57:12 MST 2019
+One-line Summary: Non-constant time initialization for soil hydrology types are moved to SoilHydrologyType.F
+
+Purpose of changes
+------------------
+
+[Fill this in with details]
+Initalization of time-varying `zwt`, `zwt_perched`, and `frost_table` are moved to `InitCold` in `SoilHydrologyType`.
+
+Previously, `zwt`, `zwt_perched`, and `frost_table` were initialized in `SoilHydrologyInitTimeConstMod`.
+
+Bugs fixed or introduced
+------------------------
+Issues fixed (include CTSM Issue #575)
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+None
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+
+Changes made to namelist defaults (e.g., changed parameter values):
+
+Changes to the datasets (e.g., parameter, surface or initial files):
+
+Substantial timing or memory changes: [For timing changes, can check PFS test(s) in the test suite]
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in ../CTSMMasterChecklist as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+
+Changes to tests or testing:
+
+Code reviewed by:
+Bill Sacks
+Erik Kluzek
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS 
+
+  tools-tests (test/tools):
+
+    cheyenne - PASS
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+     cheyenne - PASS
+
+  regular tests (aux_clm):
+
+    cheyenne OK
+    hobart OK 
+
+CTSM tag used for the baseline comparisons: 
+ctsm1.0.dev026
+
+Answer changes
+-------------
+None
+
+Changes answers relative to baseline:
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/ctsm/pull/631
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev026
 Originator(s):  slevis (Samuel Levis, SLevis Consulting LLC, 303-665-1310)
 Date:  Tue Feb  5 17:08:48 MST 2019

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -2,23 +2,22 @@
 Tag name:  ctsm1.0.dev027
 Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
 Date: Tue Feb 19 12:57:12 MST 2019
-One-line Summary: Non-constant time initialization for soil hydrology types are moved to SoilHydrologyType.F
+One-line Summary: Non-constant time initialization for soil hydrology types are moved to /src/biogeophys/SoilHydrologyType.F90. 
 
 Purpose of changes
 ------------------
 
-[Fill this in with details]
-Initalization of time-varying `zwt`, `zwt_perched`, and `frost_table` are moved to `InitCold` in `SoilHydrologyType`.
+Initalization of time-varying `zwt`, `zwt_perched`, and `frost_table` are moved to `InitCold` in `SoilHydrologyType.F90`.
 
-Previously, `zwt`, `zwt_perched`, and `frost_table` were initialized in `SoilHydrologyInitTimeConstMod`.
+Previously, `zwt`, `zwt_perched`, and `frost_table` were initialized in `SoilHydrologyInitTimeConstMod.F90`, which caused confusions.
 
 Bugs fixed or introduced
 ------------------------
-Issues fixed (include CTSM Issue #575)
+Issues fixed (include CTSM Issue #):
+- Resolves ESCOMP/ctsm#575 ("Some variables initialized in SoilHydrologyInitTimeConstMod are not time-constant")
 
 Significant changes to scientifically-supported configurations
 --------------------------------------------------------------
-None
 
 Does this tag change answers significantly for any of the following physics configurations?
 (Details of any changes will be given in the "Answer changes" section below.)
@@ -32,23 +31,22 @@ Does this tag change answers significantly for any of the following physics conf
 Notes of particular relevance for users
 ---------------------------------------
 
-Caveats for users (e.g., need to interpolate initial conditions):
+Caveats for users (e.g., need to interpolate initial conditions): none
 
-Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
 
-Changes made to namelist defaults (e.g., changed parameter values):
+Changes made to namelist defaults (e.g., changed parameter values): none
 
-Changes to the datasets (e.g., parameter, surface or initial files):
+Changes to the datasets (e.g., parameter, surface or initial files): none
 
-Substantial timing or memory changes: [For timing changes, can check PFS test(s) in the test suite]
+Substantial timing or memory changes: none
 
 Notes of particular relevance for developers: (including Code reviews and testing)
 ---------------------------------------------
-NOTE: Be sure to review the steps in ../CTSMMasterChecklist as well as the coding style in the Developers Guide
 
-Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
 
-Changes to tests or testing:
+Changes to tests or testing: none
 
 Code reviewed by:
 Bill Sacks
@@ -56,33 +54,34 @@ Erik Kluzek
 
 CTSM testing:
 
- [PASS means all tests PASS and OK means tests PASS other than expected fails.]
 
   build-namelist tests:
 
-    cheyenne - PASS 
+    cheyenne - not run 
 
   tools-tests (test/tools):
 
-    cheyenne - PASS
+    cheyenne - not run
 
   PTCLM testing (tools/shared/PTCLM/test):
 
-     cheyenne - PASS
+     cheyenne - not run
 
   regular tests (aux_clm):
 
-    cheyenne OK
-    hobart OK 
+    cheyenne ---- ok
+    hobart ------ ok
+
+    ok means tests pass, except for the expected failures.
 
 CTSM tag used for the baseline comparisons: 
 ctsm1.0.dev026
 
 Answer changes
 -------------
-None
 
-Changes answers relative to baseline:
+Changes answers relative to baseline: no
+
 
 Detailed list of changes
 ------------------------
@@ -90,7 +89,10 @@ Detailed list of changes
 List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
 
 Pull Requests that document the changes (include PR ids):
+PR #631 Soil hydrology initialization of time-constant variables moved to SoilHydrologyType
 https://github.com/ESCOMP/ctsm/pull/631
+
+
 ===============================================================
 ===============================================================
 Tag name:  ctsm1.0.dev026

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev027   negins 02/19/2019 non-constant time init for soil hydrology types are moved to SoilHydrologyType.F
+  ctsm1.0.dev027   negins 02/19/2019 non-constant time init for soil hydrology types are moved to SoilHydrologyType.F90
   ctsm1.0.dev026   slevis 02/05/2019 Collapse unmanaged PFTs to the N most dominant
   ctsm1.0.dev025    sacks 01/23/2019 History fields for vertically-resolved sums of soil C and N, and minor fixes
   ctsm1.0.dev024   slevis 01/14/2019 Remove unnecessary restart variables

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev027   negins 02/19/2019 non-constant time init for soil hydrology types are moved to SoilHydrologyType.F
   ctsm1.0.dev026   slevis 02/05/2019 Collapse unmanaged PFTs to the N most dominant
   ctsm1.0.dev025    sacks 01/23/2019 History fields for vertically-resolved sums of soil C and N, and minor fixes
   ctsm1.0.dev024   slevis 01/14/2019 Remove unnecessary restart variables

--- a/src/biogeophys/SoilHydrologyType.F90
+++ b/src/biogeophys/SoilHydrologyType.F90
@@ -9,6 +9,8 @@ Module SoilHydrologyType
   use clm_varctl            , only : iulog
   use LandunitType          , only : lun                
   use ColumnType            , only : col                
+  use WaterStateBulkType    , only : waterstatebulk_type
+  use column_varcon         , only : icol_shadewall, icol_road_perv, icol_road_imperv, icol_roof, icol_sunwall
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -74,16 +76,18 @@ Module SoilHydrologyType
 contains
   
   !------------------------------------------------------------------------
-  subroutine Init(this, bounds, NLFilename)
+  subroutine Init(this, bounds, NLFilename, waterstatebulk_inst, use_aquifer_layer)
 
     class(soilhydrology_type) :: this
     type(bounds_type), intent(in)    :: bounds  
     character(len=*), intent(in) :: NLFilename
+    type(waterstatebulk_type) , intent(inout) :: waterstatebulk_inst
+    logical                  , intent(in)    :: use_aquifer_layer ! whether an aquifer layer is used in this run
 
     call this%ReadNL(NLFilename)
     call this%InitAllocate(bounds) 
     call this%InitHistory(bounds)
-    call this%InitCold(bounds)
+    call this%InitCold(bounds, waterstatebulk_inst, use_aquifer_layer)
 
   end subroutine Init
 
@@ -192,24 +196,80 @@ contains
   end subroutine InitHistory
 
   !-----------------------------------------------------------------------
-  subroutine InitCold(this, bounds)
+  subroutine InitCold(this, bounds, waterstatebulk_inst, &
+      use_aquifer_layer)
     !
     ! !USES:
     !
     ! !ARGUMENTS:
-    class(soilhydrology_type) :: this
-    type(bounds_type) , intent(in)    :: bounds
+    class(soilhydrology_type)                 :: this
+    type(bounds_type)         , intent(in)    :: bounds
+    type(waterstatebulk_type) , intent(inout) :: waterstatebulk_inst
+    logical                   , intent(in)    :: use_aquifer_layer ! whether an aquifer layer is used in this run
+    
     ! !LOCAL VARIABLES:
-    integer :: c ! indices
-
+    integer            :: c,l
     !-----------------------------------------------------------------------
-
-    ! Nothing for now
-
     ! needs to be initialized to spval to avoid problems when 
     ! averaging for the accum field
     do c = bounds%begc, bounds%endc
        this%num_substeps_col(c) = spval
+    end do
+
+    !-----------------------------------------------------------------------
+    ! Initialize frost table
+    !-----------------------------------------------------------------------
+
+    this%zwt_col(bounds%begc:bounds%endc) = 0._r8
+
+    do c = bounds%begc,bounds%endc
+       l = col%landunit(c)
+       if (.not. lun%lakpoi(l)) then  !not lake
+          if (lun%urbpoi(l)) then
+             if (col%itype(c) == icol_road_perv) then
+                if (use_aquifer_layer) then
+                   ! NOTE(wjs, 2018-11-27) There is no fundamental reason why zwt should
+                   ! be initialized differently based on use_aquifer_layer, but we (Bill
+                   ! Sacks and Sean Swenson) are changing the cold start initialization of
+                   ! wa_col when use_aquifer_layer is .false., and so need to come up with
+                   ! a different cold start initialization of zwt in that case, but we
+                   ! don't want to risk messing up the use_aquifer_layer = .true.  case,
+                   ! so we're keeping that as it was before.
+    
+                   ! Note that the following hard-coded constants (on the next line)
+                   ! seem implicitly related to the initial value of wa_col
+                   this%zwt_col(c) = (25._r8 + col%zi(c,nlevsoi)) - waterstatebulk_inst%wa_col(c)/0.2_r8 /1000._r8  ! One meter below soil column
+                else
+                   this%zwt_col(c) = col%zi(c,col%nbedrock(c))
+                end if
+             else
+                this%zwt_col(c) = spval
+             end if
+             ! initialize frost_table, zwt_perched
+             this%zwt_perched_col(c) = spval
+             this%frost_table_col(c) = spval
+          else
+             if (use_aquifer_layer) then
+                ! NOTE(wjs, 2018-11-27) There is no fundamental reason why zwt should
+                ! be initialized differently based on use_aquifer_layer, but we (Bill
+                ! Sacks and Sean Swenson) are changing the cold start initialization of
+                ! wa_col when use_aquifer_layer is .false., and so need to come up with
+                ! a different cold start initialization of zwt in that case, but we
+                ! don't want to risk messing up the use_aquifer_layer = .true.  case,
+                ! so we're keeping that as it was before.
+    
+                ! Note that the following hard-coded constants (on the next line) seem
+                ! implicitly related to the initial value of wa_col
+                this%zwt_col(c) = (25._r8 + col%zi(c,nlevsoi)) - waterstatebulk_inst%wa_col(c)/0.2_r8 /1000._r8
+             else
+                this%zwt_col(c) = col%zi(c,col%nbedrock(c))
+             end if
+    
+             ! initialize frost_table, zwt_perched to bottom of soil column
+             this%zwt_perched_col(c) = col%zi(c,nlevsoi)
+             this%frost_table_col(c) = col%zi(c,nlevsoi)
+          end if
+       end if
     end do
 
   end subroutine InitCold

--- a/src/main/clm_instMod.F90
+++ b/src/main/clm_instMod.F90
@@ -304,9 +304,9 @@ contains
 
     call photosyns_inst%Init(bounds)
 
-    call soilhydrology_inst%Init(bounds, nlfilename)
-    call SoilHydrologyInitTimeConst(bounds, soilhydrology_inst, water_inst%waterstatebulk_inst, &
+    call soilhydrology_inst%Init(bounds, nlfilename, water_inst%waterstatebulk_inst, &
          use_aquifer_layer = use_aquifer_layer())
+    call SoilHydrologyInitTimeConst(bounds, soilhydrology_inst)
 
     call saturated_excess_runoff_inst%Init(bounds)
     call infiltration_excess_runoff_inst%Init(bounds)


### PR DESCRIPTION
### Description of changes
Initalization of time-varying `zwt`, `zwt_perched`, and `frost_table`  are moved to `InitCold` in `SoilHydrologyType`.

 Previously, `zwt`, `zwt_perched`, and `frost_table` were initialized in `SoilHydrologyInitTimeConstMod`.

### Specific notes

Contributors other than yourself, if any: Bill Sacks

CTSM Issues Fixed (include github issue #): Fixes  #575

Are answers expected to change (and if so in what way)? No. 

Any User Interface Changes (namelist or namelist defaults changes)? None.

Testing performed, if any:
Ran full `aux_clm` test suite and `clm_short` on cheyenne. Not tested on Hobart.  