### PR TITLE
update default fates parameter file

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_default_2trop.c190114.nc</fates_paramfile>
+<fates_paramfile>/glade/u/home/rgknox/ctsm/src/fates/parameter_files/fates_params_default_2trop.c190131.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>/glade/u/home/rgknox/ctsm/src/fates/parameter_files/fates_params_default_2trop.c190131.nc</fates_paramfile>
+<fates_paramfile>/glade/u/home/rgknox/ctsm/src/fates/parameter_files/fates_params_default_2trop.c190204.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>/glade/u/home/rgknox/ctsm/src/fates/parameter_files/fates_params_default_2trop.c190204.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_default_2trop.c190205.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->


### PR DESCRIPTION
### Description of changes

This changeset updates the default fates parameter file for testing.  Changes since last change are most notably, the addition of the leaf age dimension.  This is a minor API compatibility change.

### Specific notes

See corresponding NGEET/fates PR: https://github.com/NGEET/fates/pull/462

Contributors other than yourself, if any:

@xuchongang

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

FATES simulations are expected to have small differences because of subtle changes in the default parameter configuration. FATES is also expected to have roundoff/machine-precision differences when parameters are kept the same because of changes in order of operations.

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

TBD

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
