### PR TITLE
remove flushing flags for fates history variables

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_default_2trop.c190205.nc</fates_paramfile>
+<fates_paramfile>/glade/u/home/rgknox/ctsm/src/fates/parameter_files/fates_params_default_14pft.c190221.nc</fates_paramfile>
+
+<!-- lnd/clm2/paramdata/fates_params_default_2trop.c190205.nc</fates_paramfile>  -->
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1974,6 +1974,8 @@ contains
    character(len=fates_short_string_length) :: dim2name
    character(len=fates_long_string_length) :: ioname
    integer :: d_index, dk_index
+   real(r8) :: set_nonfates   ! either 0. or spval (what to set non-fates
+                              ! columns to)
    
    type(fates_bounds_type) :: fates_bounds
    type(fates_bounds_type) :: fates_clump
@@ -2057,6 +2059,16 @@ contains
                  vdefault => this%fates_hist%hvars(ivar)%use_default, &
                  vavgflag => this%fates_hist%hvars(ivar)%avgflag)
 
+        if( this%fates_hist%hvars(ivar)%set_nonfates == 0 ) then
+           set_nonfates = 0._r8
+        else if( this%fates_hist%hvars(ivar)%set_nonfates == 1 ) then
+           set_nonfates = spval
+        else
+           write(iulog,*) 'an unknown flag was specified by a fates history'
+           write(iulog,*) 'variable that is used to specify non-fates sites'
+           call endrun(msg=errMsg(sourcefile, __LINE__))
+        end if
+
         dk_index = this%fates_hist%hvars(ivar)%dim_kinds_index
         ioname = trim(this%fates_hist%dim_kinds(dk_index)%name)
         
@@ -2064,16 +2076,16 @@ contains
         case(patch_r8)
            call hist_addfld1d(fname=trim(vname),units=trim(vunits),         &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_patch=this%fates_hist%hvars(ivar)%r81d,    &
+                              ptr_patch=this%fates_hist%hvars(ivar)%r81d,   &
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
            
         case(site_r8)
            call hist_addfld1d(fname=trim(vname),units=trim(vunits),         &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r81d,      & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
 
         case(patch_ground_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
@@ -2083,7 +2095,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_patch=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
            
         case(patch_size_pft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
@@ -2093,7 +2105,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_patch=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_ground_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2102,7 +2114,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,      & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_size_pft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2111,7 +2123,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,      & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_size_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2120,7 +2132,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_pft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2129,7 +2141,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_age_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2138,7 +2150,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_height_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2147,7 +2159,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_fuel_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2156,7 +2168,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_cwdsc_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2165,7 +2177,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_can_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2174,7 +2186,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_cnlf_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2183,7 +2195,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_cnlfpft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2192,7 +2204,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_scag_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2201,7 +2213,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_scagpft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2210,7 +2222,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              set_lake=set_nonfates,set_urb=set_nonfates)
         case(site_agepft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2219,7 +2231,7 @@ contains
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
                               default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)           
+                              set_lake=set_nonfates,set_urb=set_nonfates)           
 
         case default
            write(iulog,*) 'A FATES iotype was created that was not registerred'

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1974,8 +1974,6 @@ contains
    character(len=fates_short_string_length) :: dim2name
    character(len=fates_long_string_length) :: ioname
    integer :: d_index, dk_index
-   real(r8) :: set_nonfates   ! either 0. or spval (what to set non-fates
-                              ! columns to)
    
    type(fates_bounds_type) :: fates_bounds
    type(fates_bounds_type) :: fates_clump
@@ -2059,16 +2057,6 @@ contains
                  vdefault => this%fates_hist%hvars(ivar)%use_default, &
                  vavgflag => this%fates_hist%hvars(ivar)%avgflag)
 
-        if( this%fates_hist%hvars(ivar)%set_nonfates == 0 ) then
-           set_nonfates = 0._r8
-        else if( this%fates_hist%hvars(ivar)%set_nonfates == 1 ) then
-           set_nonfates = spval
-        else
-           write(iulog,*) 'an unknown flag was specified by a fates history'
-           write(iulog,*) 'variable that is used to specify non-fates sites'
-           call endrun(msg=errMsg(sourcefile, __LINE__))
-        end if
-
         dk_index = this%fates_hist%hvars(ivar)%dim_kinds_index
         ioname = trim(this%fates_hist%dim_kinds(dk_index)%name)
         
@@ -2077,15 +2065,13 @@ contains
            call hist_addfld1d(fname=trim(vname),units=trim(vunits),         &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_patch=this%fates_hist%hvars(ivar)%r81d,   &
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
            
         case(site_r8)
            call hist_addfld1d(fname=trim(vname),units=trim(vunits),         &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r81d,      & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
 
         case(patch_ground_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
@@ -2094,8 +2080,7 @@ contains
                               type2d=trim(dim2name),                        & ! <--- type2d
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_patch=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
            
         case(patch_size_pft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
@@ -2104,8 +2089,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_patch=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_ground_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2113,8 +2097,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,      & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_size_pft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2122,8 +2105,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,      & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_size_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2131,8 +2113,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_pft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2140,8 +2121,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_age_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2149,8 +2129,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_height_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2158,8 +2137,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_fuel_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2167,8 +2145,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_cwdsc_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2176,8 +2153,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_can_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2185,8 +2161,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_cnlf_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2194,8 +2169,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_cnlfpft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2203,8 +2177,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_scag_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2212,8 +2185,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_scagpft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2221,8 +2193,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)
+                              default=trim(vdefault))
         case(site_agepft_r8)
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
@@ -2230,9 +2201,7 @@ contains
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=set_nonfates,set_urb=set_nonfates)           
-
+                              default=trim(vdefault))
         case default
            write(iulog,*) 'A FATES iotype was created that was not registerred'
            write(iulog,*) 'in CLM.:',trim(ioname)


### PR DESCRIPTION
### Description of changes

Fates will internally set the parts of this history output arrays that are not under its control to either zero or ignore flags.   The zeroing and flagging in the interface call was redundant, and was actually making it impossible to output certain variables (like flags) that are only relevant on fates columns.

As a long-term goal, it would be potentially better for FATES to not handle all of the flushing and zero'ing of its buffers, but given the system we currently have, its best not to also do this via the interface.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

This change should not effect non-fates runs in any way.  It also should not effect fates runs, as I believe we were flushing everything to zero up until now, which was consistent with the flushing flag set in the interface call.

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:

TBD

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
