### PR TITLE
Reduce dynbal fluxes with dynamic glaciers

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.7.9
+tag = cime5.8.0
 required = True
 
 [externals_description]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.8.0
+tag = ctsm/ctsm1.0/cime5.7.9/n01
 required = True
 
 [externals_description]

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2288,6 +2288,10 @@ sub setup_logic_dynamic_subgrid {
    setup_logic_do_harvest($opts, $nl_flags, $definition, $defaults, $nl);
 
    add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'reset_dynbal_baselines');
+   if ( &value_is_true($nl->get_value('reset_dynbal_baselines')) &&
+        &remove_leading_and_trailing_quotes($nl_flags->{'clm_start_type'}) eq "branch") {
+      $log->fatal_error("reset_dynbal_baselines has no effect in a branch run");
+   }
 }
 
 sub setup_logic_do_transient_pfts {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2287,6 +2287,7 @@ sub setup_logic_dynamic_subgrid {
    setup_logic_do_transient_crops($opts, $nl_flags, $definition, $defaults, $nl);
    setup_logic_do_harvest($opts, $nl_flags, $definition, $defaults, $nl);
 
+   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'reset_dynbal_baselines');
 }
 
 sub setup_logic_do_transient_pfts {

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2442,6 +2442,13 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <use_fates_inventory_init      use_fates=".true.">.false.</use_fates_inventory_init>
 
 <!-- =========================================  -->
+<!-- Defaults for dynamic subgrid               -->
+<!-- (some other defaults for dynamic subgrid   -->
+<!-- are set in the BuildNamelist code)         -->
+<!-- =========================================  -->
+<reset_dynbal_baselines>.false.</reset_dynbal_baselines>
+
+<!-- =========================================  -->
 <!-- Defaults for water tracers                 -->
 <!-- =========================================  -->
 

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -2287,6 +2287,52 @@ If TRUE, apply harvest from flanduse_timeseries file.
 (Also, only valid for use_cn = true.)
 </entry>
 
+<entry id="reset_dynbal_baselines" type="logical" category="physics"
+       group="dynamic_subgrid" valid_values="">
+If TRUE, reset baseline values of total column water and energy in the
+first step of the run. This should typically be set when transitioning
+from an offline spinup to a coupled run with transient glaciers, and
+*possibly* when transitioning the spinup to the transient portion of a
+coupled run with transient glaciers; it should typically remain unset at
+other times.
+
+These baseline values are computed only for particular columns
+(currently, only for glacier columns). They provide values that are
+subtracted from the current state when counting total column water and
+energy. For glacier columns, these discount the water and energy
+contents in the "virtual" glacier ice, while adding representative
+amounts of water and energy in the non-explicitly-modeled soil beneath
+the ice. Subtracting these baselines reduces the fictitious dynbal
+fluxes generated when total grid cell water and energy changes as a
+result of dynamic column/landunit areas.
+
+These baseline values are initially computed based on cold start
+states. If this flag remains unset (.false.), these baseline values will
+remain fixed at their cold start values. This will conserve mass and
+energy, but may result in larger-than-desired dynbal energy fluxes (and,
+in principle, also larger dynbal water fluxes; but currently, the mass
+of glacier ice remains fixed over time, so dynbal water fluxes are
+fairly small regardless of whether this flag is ever set). To further
+reduce these dynbal fluxes, you can set this flag to .true. when
+starting a startup or hybrid run from a partially or entirely spun-up
+state. This will reset the baseline values based on the state at the
+start of this run.
+
+Note that setting this flag can break water and energy conservation!
+Specifically, any water and energy that has previously been added to or
+removed from states that contribute to these baselines (currently, (a)
+glacier ice and (b) soil water and energy in the vegetated landunit in
+the same grid cell as glaciers) will effectively be ignored when
+computing conservation corrections due to land cover change. Instead,
+only the change in states from this point forward will be
+considered. So, for example, this flag should NOT be set when
+transitioning from a historical run to a future scenario.
+
+This setting only impacts startup and hybrid runs; it has no effect in a
+continue run; it is an error for this to be set in a branch
+run. Furthermore, this setting has no effect in a cold start run.
+</entry>
+
 <entry id="for_testing_allow_non_annual_changes" type="logical" category="physics"
        group="dynamic_subgrid" valid_values="" >
 If TRUE, allow area changes at times other than the year boundary. This should

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -2292,9 +2292,9 @@ If TRUE, apply harvest from flanduse_timeseries file.
 If TRUE, reset baseline values of total column water and energy in the
 first step of the run. This should typically be set when transitioning
 from an offline spinup to a coupled run with transient glaciers, and
-*possibly* when transitioning the spinup to the transient portion of a
-coupled run with transient glaciers; it should typically remain unset at
-other times.
+*possibly* when transitioning from the spinup to the transient portion
+of a coupled run with transient glaciers; it should typically remain
+unset at other times.
 
 These baseline values are computed only for particular columns
 (currently, only for glacier columns). They provide values that are

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -761,13 +761,13 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Ld10" grid="f10_f10_musgs" compset="IHistClm50SpG" testmods="clm/glcMEC_decrease">
+  <test name="ERP_P36x2_D_Ld10" grid="f10_f10_musgs" compset="IHistClm50SpG" testmods="clm/glcMEC_decrease">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment"  >test transient PFTs (via HIST) in conjunction with changing glacier area</option>
+      <option name="comment"  >Test transient PFTs (via HIST) in conjunction with changing glacier area. This test also covers the reset_dynbal_baselines option. CISM is not answer preserving across processor changes, but short test length should be OK.</option>
     </options>
   </test>
   <test name="ERS_D_Ld10" grid="f10_f10_musgs" compset="IHistClm50Sp" testmods="clm/collapse_pfts_78_to_16_decStart_f10">

--- a/cime_config/testdefs/testmods_dirs/clm/glcMEC_decrease/README
+++ b/cime_config/testdefs/testmods_dirs/clm/glcMEC_decrease/README
@@ -1,6 +1,2 @@
 This testmods directory is like the standard glcMEC testmods directory, except
 it forces a quick decrease in glacier area, along with rearranging the columns.
-
-In the collapse2gencrop branch this test needs
-do_transient_crops = .false.
-to get bfb answers with baseline.

--- a/cime_config/testdefs/testmods_dirs/clm/glcMEC_decrease/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/glcMEC_decrease/user_nl_clm
@@ -1,1 +1,7 @@
 for_testing_allow_non_annual_changes = .true.
+
+! Also test the reset_dynbal_baselines flag. We want at least one restart test that uses
+! this flag; for this test to have power, it should have some change in glacier area
+! after the restart. (So, in this decrease test, the glacier decrease should be slow
+! enough that there is some decrease after the restart.)
+reset_dynbal_baselines = .true.

--- a/cime_config/testdefs/testmods_dirs/clm/glcMEC_increase/README
+++ b/cime_config/testdefs/testmods_dirs/clm/glcMEC_increase/README
@@ -1,2 +1,2 @@
 This testmods directory is like the standard glcMEC testmods directory, except
-it forces a quick increas in glacier area.
+it forces a quick increase in glacier area.

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,217 @@
 ===============================================================
+Tag name:  ctsm1.0.dev031
+Originator(s):  sacks (Bill Sacks)
+Date: Wed Mar 13 15:00:26 MDT 2019
+One-line Summary: Reduce dynbal conservation fluxes for transient glaciers
+
+Purpose of changes
+------------------
+
+Subtract virtual states to reduce dynbal fluxes for transient glaciers.
+
+Up until now, when computing the dynbal correction fluxes for transient
+glacier columns, we have been (1) counting the mass and energy in the
+ice column as if that is a real state, but on the other hand (2) NOT
+accounting for the fact that glacier columns don't represent the soil
+under glacier. These two issues work in opposite directions, but (1)
+dominates, because there is much more ice (and energy, I think) in the
+roughly 50 m of glacial ice than there is in a typical 50 m soil column.
+
+In discussing this issue with Bill Lipscomb, we came up with the idea of
+subtracting some baseline value from each glacier column. I think that,
+as long as we subtract the same baseline value throughout an entire
+simulation for a given column, we will still conserve mass and energy
+through dynamic landunit transitions.
+
+So, here we subtract baseline values from glacier columns, accounting
+for the two issues mentioned above: (1) we subtract the water and energy
+in the glacier ice, because this is a virtual state in CTSM, and (2) we
+add the water and energy from the vegetated column(s), to account for
+the fact that we don't have an explicit representation of
+soil-under-glacier (this carries the assumption that the
+soil-under-glacier has the same state as the initial vegetated state in
+that grid cell). We set these baselines in initialization, so they begin
+equal to the cold start state. Water and ice in the glacial ice stay
+fixed over the course of a simulation, so the cold start values should
+be the same as the current values at any point in time. The heat content
+of the glacial ice does change over time, but by subtracting this
+baseline value, we can potentially reduce the dynbal sensible heat
+fluxes (however, note that it's also possible that these sensible heat
+fluxes could increase when subtracting the cold start value, if ice
+temperatures are closer to 0 deg C than to the cold start value,
+currently 250 K).
+
+In addition, this introduces a new namelist flag,
+reset_dynbal_baselines, which allows the user to reset these baselines
+at some desired point in the simulation. I think that, in general, this
+resetting would break conservation. But as long as it is done before the
+onset of transient glaciers, I think this should be okay. In this way,
+the user can minimize dynbal fluxes even further, by resetting the
+baselines after the system has spun up. If the states haven't changed
+much from this point to the point when glacier dynamics occur, then the
+dynbal fluxes should now be very small. (See the documentation of this
+flag in namelist_definition_ctsm.xml for more details.)
+
+Without this change, dynbal fluxes for a grid cell that undergoes 100%
+glaciation / deglaciation in a single year are around 50 m ice, 1 m
+liquid water, and a few tens of W m-2 (where those quantities of ice and
+water are dribbled throughout the year, so we end up with an ice flux of
+about 1.5e-6 mm/s throughout the year; and the energy flux is applied
+evenly throughout the year - i.e., tens of W m-2 every time step for a
+year). With this change, and with reset_dynbal_baselines set at an
+appropriate time, these fluxes can be reduced to close to zero.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+- Partially addresses ESCOMP/ctsm#274 (Dynamic landunits: improve water
+  and energy conservation)
+
+CIME Issues fixed (include issue #):
+- Fixes three issues related to inputdata checksum:
+  - ESCMI/cime#3033
+  - ESCMI/cime#3034
+  - ESCMI/cime#3036
+
+Known bugs introduced in this tag (include github issue ID):
+- ESCOMP/ctsm#659 (Subtract dynbal baselines from begwb and endwb)
+  - This can't be fixed until we're okay having this answer change on
+    master
+
+Known bugs found since the previous tag (include github issue ID):
+- ESCOMP/ctsm#658 (Methane should not depend on gridcell-level TWS)
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm5_0
+
+[X] clm4_5
+
+Significant answer changes for runs with transient glaciers.
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+- For runs with transient glaciers, careful thought should be given to
+  when to set reset_dynbal_baselines
+- Inconsistency between begwb/endwb and liq1/liq2/ice1/ice2 (see ESCOMP/ctsm#659)
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+- New namelist variable: reset_dynbal_baselines
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+- Inconsistency between begwb/endwb and liq1/liq2/ice1/ice2 (see ESCOMP/ctsm#659)
+
+Changes to tests or testing:
+- Tweaked a test with transient glacier areas, including adding this new
+  flag to the test
+
+Code reviewed by: Bill Lipscomb reviewed the conceptual ideas, but
+nobody has reviewed the actual code
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  tools-tests (test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+     cheyenne - not run
+
+  regular tests (aux_clm):
+
+    cheyenne ---- ok
+    hobart ------ ok
+
+    ok means tests pass, answers change as expected
+
+CTSM tag used for the baseline comparisons: ctsm1.0.dev030
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: ALL, but different configurations show
+      different levels of changes, as noted below
+    - what platforms/compilers: all
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+      - new climate (at least regionally) for some configurations;
+        roundoff for others: see below
+
+    There are three levels of changes here:
+
+    (1) For runs with transient glaciers, there are large answer changes
+        in regions with changing glacier area. These answer changes are
+        in the various dynbal fluxes - for liquid water and ice runoff,
+        and for the dynbal sensible heat flux.
+
+    (2) For runs with transient vegetation (Hist, Dv and Fates), there
+        are roundoff-level changes in the dynbal fluxes. For liquid
+        water and ice, these changes appear to only occur in grid cells
+        where there is some glacier area (because now both the before
+        and after gridcell water contents have changed by the same fixed
+        amount, which changes the difference at the roundoff level). For
+        heat, there are roundoff-level changes everywhere (because of
+        changes in the order of operations).
+
+    (3) All runs have large changes in the diagnostic variables,
+        ICE_CONTENT1, LIQUID_CONTENT1 and HEAT_CONTENT1, over grid cells
+        containing some glacier area.
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff? N/A
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: N/A
+
+   URL for LMWG diagnostics output used to validate new climate: N/A
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+- cime: cime5.7.9 -> ctsm/ctsm1.0/cime5.7.9/n01
+  - Fixes issues related to inputdata checksum
+
+Pull Requests that document the changes (include PR ids):
+- https://github.com/ESCOMP/ctsm/pull/650
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev030
 Originator(s):  sacks (Bill Sacks)
 Date: Fri Mar  8 15:08:34 MST 2019

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,21 +1,20 @@
 ===============================================================
 Tag name:  ctsm1.0.dev031
 Originator(s):  sacks (Bill Sacks)
-Date: Wed Mar 13 15:00:26 MDT 2019
-One-line Summary: Reduce dynbal conservation fluxes for transient glaciers
+Date: Wed Mar 13 15:03:42 MDT 2019
+One-line Summary: Subtract virtual states to reduce dynbal fluxes for transient glaciers
 
 Purpose of changes
 ------------------
 
-Subtract virtual states to reduce dynbal fluxes for transient glaciers.
-
-Up until now, when computing the dynbal correction fluxes for transient
-glacier columns, we have been (1) counting the mass and energy in the
-ice column as if that is a real state, but on the other hand (2) NOT
-accounting for the fact that glacier columns don't represent the soil
-under glacier. These two issues work in opposite directions, but (1)
-dominates, because there is much more ice (and energy, I think) in the
-roughly 50 m of glacial ice than there is in a typical 50 m soil column.
+Up until now, when computing the dynbal correction (conservation) fluxes
+for transient glacier columns, we have been (1) counting the mass and
+energy in the ice column as if that is a real state, but on the other
+hand (2) NOT accounting for the fact that glacier columns don't
+represent the soil under glacier. These two issues work in opposite
+directions, but (1) dominates, because there is much more ice (and
+energy, I think) in the roughly 50 m of glacial ice than there is in a
+typical 50 m soil column.
 
 In discussing this issue with Bill Lipscomb, we came up with the idea of
 subtracting some baseline value from each glacier column. I think that,

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev031    sacks 03/13/2019 Reduce dynbal conservation fluxes for transient glaciers
   ctsm1.0.dev030    sacks 03/08/2019 Update CIME; hookup expected test fails
   ctsm1.0.dev029   slevis 02/26/2019 Collapse landunits to the N most dominant
   ctsm1.0.dev028    sacks 02/26/2019 Interpolate out-of-the-box initial conditions and remove expensive tests

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev031    sacks 03/13/2019 Reduce dynbal conservation fluxes for transient glaciers
+  ctsm1.0.dev031    sacks 03/13/2019 Subtract virtual states to reduce dynbal fluxes for transient glaciers
   ctsm1.0.dev030    sacks 03/08/2019 Update CIME; hookup expected test fails
   ctsm1.0.dev029   slevis 02/26/2019 Collapse landunits to the N most dominant
   ctsm1.0.dev028    sacks 02/26/2019 Interpolate out-of-the-box initial conditions and remove expensive tests

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -206,10 +206,14 @@ contains
       endif
 
     call ComputeWaterMassNonLake(bounds, num_nolakec, filter_nolakec, &
-         waterstate_inst, waterdiagnostic_inst, begwb(bounds%begc:bounds%endc))
+         waterstate_inst, waterdiagnostic_inst, &
+         subtract_dynbal_baselines = .false., &
+         water_mass = begwb(bounds%begc:bounds%endc))
 
     call ComputeWaterMassLake(bounds, num_lakec, filter_lakec, &
-         waterstate_inst, begwb(bounds%begc:bounds%endc))
+         waterstate_inst, &
+         subtract_dynbal_baselines = .false., &
+         water_mass = begwb(bounds%begc:bounds%endc))
 
     do c = bounds%begc, bounds%endc
        h2osno_old(c) = h2osno(c)

--- a/src/biogeophys/HydrologyDrainageMod.F90
+++ b/src/biogeophys/HydrologyDrainageMod.F90
@@ -160,7 +160,9 @@ contains
       end do
 
       call ComputeWaterMassNonLake(bounds, num_nolakec, filter_nolakec, &
-           waterstatebulk_inst, waterdiagnosticbulk_inst, endwb(bounds%begc:bounds%endc))
+           waterstatebulk_inst, waterdiagnosticbulk_inst, &
+           subtract_dynbal_baselines = .false., &
+           water_mass = endwb(bounds%begc:bounds%endc))
 
       ! Determine wetland and land ice hydrology (must be placed here
       ! since need snow updated from CombineSnowLayers)

--- a/src/biogeophys/LakeHydrologyMod.F90
+++ b/src/biogeophys/LakeHydrologyMod.F90
@@ -631,7 +631,9 @@ contains
       ! Determine ending water balance and volumetric soil water
 
       call ComputeWaterMassLake(bounds, num_lakec, filter_lakec, &
-           waterstatebulk_inst, endwb(bounds%begc:bounds%endc))
+           waterstatebulk_inst, &
+           subtract_dynbal_baselines = .false., &
+           water_mass = endwb(bounds%begc:bounds%endc))
 
       do j = 1, nlevgrnd
          do fc = 1, num_lakec

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -95,6 +95,7 @@ module TemperatureType
 
      ! Heat content
      real(r8), pointer :: beta_col                 (:)   ! coefficient of convective velocity [-]
+     real(r8), pointer :: dynbal_baseline_heat_col (:)   ! baseline heat content subtracted from each column's total heat calculation (positive values are subtracted to avoid counting heat content of "virtual" states; negative values are added to account for missing states in the model)
      real(r8), pointer :: heat1_grc                (:)   ! grc initial gridcell total heat content
      real(r8), pointer :: heat2_grc                (:)   ! grc post land cover change total heat content
      real(r8), pointer :: liquid_water_temp1_grc   (:)   ! grc initial weighted average liquid water temperature (K)
@@ -257,6 +258,7 @@ contains
 
     ! Heat content
     allocate(this%beta_col                 (begc:endc))                      ; this%beta_col                 (:)   = nan
+    allocate(this%dynbal_baseline_heat_col (begc:endc))                      ; this%dynbal_baseline_heat_col (:)   = nan
     allocate(this%heat1_grc                (begg:endg))                      ; this%heat1_grc                (:)   = nan
     allocate(this%heat2_grc                (begg:endg))                      ; this%heat2_grc                (:)   = nan
     allocate(this%liquid_water_temp1_grc   (begg:endg))                      ; this%liquid_water_temp1_grc   (:)   = nan
@@ -839,6 +841,11 @@ contains
        if (col%itype(c) == icol_road_imperv) this%emg_col(c) = em_improad_lun(l)
        if (col%itype(c) == icol_road_perv  ) this%emg_col(c) = em_perroad_lun(l)
     end do
+
+    ! Initialize dynbal_baseline_heat_col: for some columns, this is set elsewhere in
+    ! initialization, but we need it to be 0 for columns for which it is not explicitly
+    ! set.
+    this%dynbal_baseline_heat_col(bounds%begc:bounds%endc) = 0._r8
 
   end subroutine InitCold
 

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -95,7 +95,10 @@ module TemperatureType
 
      ! Heat content
      real(r8), pointer :: beta_col                 (:)   ! coefficient of convective velocity [-]
-     real(r8), pointer :: dynbal_baseline_heat_col (:)   ! baseline heat content subtracted from each column's total heat calculation (positive values are subtracted to avoid counting heat content of "virtual" states; negative values are added to account for missing states in the model) [J/m^2]
+     ! For the following dynbal baseline variable: positive values are subtracted to avoid
+     ! counting liquid water content of "virtual" states; negative values are added to
+     ! account for missing states in the model.
+     real(r8), pointer :: dynbal_baseline_heat_col (:)   ! baseline heat content subtracted from each column's total heat calculation [J/m^2]
      real(r8), pointer :: heat1_grc                (:)   ! grc initial gridcell total heat content
      real(r8), pointer :: heat2_grc                (:)   ! grc post land cover change total heat content
      real(r8), pointer :: liquid_water_temp1_grc   (:)   ! grc initial weighted average liquid water temperature (K)

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -95,7 +95,7 @@ module TemperatureType
 
      ! Heat content
      real(r8), pointer :: beta_col                 (:)   ! coefficient of convective velocity [-]
-     real(r8), pointer :: dynbal_baseline_heat_col (:)   ! baseline heat content subtracted from each column's total heat calculation (positive values are subtracted to avoid counting heat content of "virtual" states; negative values are added to account for missing states in the model)
+     real(r8), pointer :: dynbal_baseline_heat_col (:)   ! baseline heat content subtracted from each column's total heat calculation (positive values are subtracted to avoid counting heat content of "virtual" states; negative values are added to account for missing states in the model) [J/m^2]
      real(r8), pointer :: heat1_grc                (:)   ! grc initial gridcell total heat content
      real(r8), pointer :: heat2_grc                (:)   ! grc post land cover change total heat content
      real(r8), pointer :: liquid_water_temp1_grc   (:)   ! grc initial weighted average liquid water temperature (K)
@@ -988,6 +988,12 @@ contains
     call restartvar(ncid=ncid, flag=flag, varname='taf', xtype=ncd_double, dim1name='landunit',                       &
          long_name='urban canopy air temperature', units='K',                                                         &
          interpinic_flag='interp', readvar=readvar, data=this%taf_lun)
+
+    call restartvar(ncid=ncid, flag=flag, varname='DYNBAL_BASELINE_HEAT', xtype=ncd_double, &
+         dim1name='column', &
+         long_name="baseline heat content subtracted from each column's total heat calculation", &
+         units='J/m2', &
+         interpinic_flag='interp', readvar=readvar, data=this%dynbal_baseline_heat_col)
 
     if (use_crop) then
        call restartvar(ncid=ncid, flag=flag,  varname='gdd1020', xtype=ncd_double,  &

--- a/src/biogeophys/TotalWaterAndHeatMod.F90
+++ b/src/biogeophys/TotalWaterAndHeatMod.F90
@@ -652,9 +652,12 @@ contains
     ! average liquid water temperature. For example, if we're subtracting out a baseline
     ! water amount because a particular water state is fictitious, we probably shouldn't
     ! include that particular state when determining the weighted average temperature of
-    ! liquid water. For now, though, we're just subtracting out the ice from glacier
-    ! columns (we're not subtracting any liquid water states), so I think we're okay not
-    ! correcting for that here.
+    ! liquid water. And conversely, if we're adding a state via these baselines, should
+    ! we also add some water temperature of that state? The tricky thing here is what to
+    ! do when we end up subtracting water due to the baselines, so for now I'm simply not
+    ! trying to account for the temperature of these baselines at all. This amounts to
+    ! assuming that the baselines that we add / subtract are at the average temperature
+    ! of the real liquid water in the column.
     do fc = 1, num_nolakec
        c = filter_nolakec(fc)
        heat(c) = heat(c) - dynbal_baseline_heat(c)
@@ -912,9 +915,12 @@ contains
     ! average liquid water temperature. For example, if we're subtracting out a baseline
     ! water amount because a particular water state is fictitious, we probably shouldn't
     ! include that particular state when determining the weighted average temperature of
-    ! liquid water. For now, though, we're just subtracting out the ice from glacier
-    ! columns (we're not subtracting any liquid water states), so I think we're okay not
-    ! correcting for that here.
+    ! liquid water. And conversely, if we're adding a state via these baselines, should
+    ! we also add some water temperature of that state? The tricky thing here is what to
+    ! do when we end up subtracting water due to the baselines, so for now I'm simply not
+    ! trying to account for the temperature of these baselines at all. This amounts to
+    ! assuming that the baselines that we add / subtract are at the average temperature
+    ! of the real liquid water in the column.
     do fc = 1, num_lakec
        c = filter_lakec(fc)
        heat(c) = heat(c) - dynbal_baseline_heat(c)

--- a/src/biogeophys/TotalWaterAndHeatMod.F90
+++ b/src/biogeophys/TotalWaterAndHeatMod.F90
@@ -216,9 +216,8 @@ contains
          snocan_patch =>    waterstate_inst%snocan_patch   , & ! Input:  [real(r8) (:)   ]  canopy snow water (mm H2O)
          h2osoi_ice   =>    waterstate_inst%h2osoi_ice_col , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
          h2osoi_liq   =>    waterstate_inst%h2osoi_liq_col , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
-         ! FIXME(wjs, 2019-03-02) add documentation for the following two variables:
-         dynbal_baseline_liq    => waterstate_inst%dynbal_baseline_liq_col, &
-         dynbal_baseline_ice    => waterstate_inst%dynbal_baseline_ice_col, &
+         dynbal_baseline_liq    => waterstate_inst%dynbal_baseline_liq_col, & ! Input:  [real(r8) (:)   ]  baseline liquid water content subtracted from each column's total liquid water calculation (mm H2O)
+         dynbal_baseline_ice    => waterstate_inst%dynbal_baseline_ice_col, & ! Input:  [real(r8) (:)   ]  baseline ice content subtracted from each column's total ice calculation (mm H2O)
          total_plant_stored_h2o => waterdiagnostic_inst%total_plant_stored_h2o_col, & ! Input:  [real(r8) (:,:) ] plant internal stored water (mm H2O)
          aquifer_water_baseline => waterstate_inst%aquifer_water_baseline, & ! Input: [real(r8)] baseline value for water in the unconfined aquifer (wa_col) for this bulk / tracer (mm)
          wa           =>    waterstate_inst%wa_col        & ! Input:  [real(r8) (:)   ] water in the unconfined aquifer (mm)
@@ -405,9 +404,8 @@ contains
          h2osno       =>    waterstate_inst%h2osno_col     , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_ice   =>    waterstate_inst%h2osoi_ice_col , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
          h2osoi_liq   =>    waterstate_inst%h2osoi_liq_col,  & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
-         ! FIXME(wjs, 2019-03-02) add documentation for the following two variables:
-         dynbal_baseline_liq    => waterstate_inst%dynbal_baseline_liq_col, &
-         dynbal_baseline_ice    => waterstate_inst%dynbal_baseline_ice_col  &
+         dynbal_baseline_liq    => waterstate_inst%dynbal_baseline_liq_col, & ! Input:  [real(r8) (:)   ]  baseline liquid water content subtracted from each column's total liquid water calculation (mm H2O)
+         dynbal_baseline_ice    => waterstate_inst%dynbal_baseline_ice_col  & ! Input:  [real(r8) (:)   ]  baseline ice content subtracted from each column's total ice calculation (mm H2O)
          )
 
     do fc = 1, num_lakec
@@ -508,8 +506,7 @@ contains
          nlev_improad => urbanparams_inst%nlev_improad, & ! number of impervious road layers
          t_soisno     => temperature_inst%t_soisno_col, & ! soil temperature (Kelvin)
          t_h2osfc     => temperature_inst%t_h2osfc_col, & ! surface water temperature (Kelvin)
-         ! FIXME(wjs, 2019-03-02) Document the following new variable
-         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col, &
+         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col, & ! Input:  [real(r8) (:)   ]  baseline heat content subtracted from each column's total heat calculation (J/m2)
          h2osoi_liq   => waterstatebulk_inst%h2osoi_liq_col, & ! liquid water (kg/m2)
          h2osoi_ice   => waterstatebulk_inst%h2osoi_ice_col, & ! frozen water (kg/m2)
          h2osno       => waterstatebulk_inst%h2osno_col, & ! snow water (mm H2O)
@@ -842,8 +839,7 @@ contains
          watsat       => soilstate_inst%watsat_col, & ! volumetric soil water at saturation (porosity)
          csol         => soilstate_inst%csol_col, & ! heat capacity, soil solids (J/m**3/Kelvin)
          t_soisno     => temperature_inst%t_soisno_col, & ! soil temperature (Kelvin)
-         ! FIXME(wjs, 2019-03-02) Document the following new variable
-         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col, &
+         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col, & ! Input:  [real(r8) (:)   ]  baseline heat content subtracted from each column's total heat calculation (J/m2)
          h2osoi_liq   => waterstatebulk_inst%h2osoi_liq_col, & ! liquid water (kg/m2)
          h2osoi_ice   => waterstatebulk_inst%h2osoi_ice_col, & ! frozen water (kg/m2)
          h2osno       => waterstatebulk_inst%h2osno_col & ! snow water (mm H2O)

--- a/src/biogeophys/TotalWaterAndHeatMod.F90
+++ b/src/biogeophys/TotalWaterAndHeatMod.F90
@@ -37,14 +37,16 @@ module TotalWaterAndHeatMod
   !
   ! For heat (ComputeHeat*): We use separate routines for lake vs. non-lake to keep these
   ! routines parallel with the water routines.
-  public :: ComputeWaterMassNonLake  ! Compute total water mass of non-lake columns
-  public :: ComputeWaterMassLake     ! Compute total water mass of lake columns
-  public :: ComputeLiqIceMassNonLake ! Compute total water mass of non-lake columns, separated into liquid and ice
-  public :: ComputeLiqIceMassLake    ! Compute total water mass of lake columns, separated into liquid and ice
-  public :: ComputeHeatNonLake       ! Compute heat content of non-lake columns
-  public :: ComputeHeatLake          ! Compute heat content of lake columns
-  public :: AdjustDeltaHeatForDeltaLiq ! Adjusts the change in gridcell heat content due to land cover change to account for the implicit heat flux associated with delta_liq
-  public :: LiquidWaterHeat          ! Get the total heat content of some mass of liquid water at a given temperature
+  public :: ComputeWaterMassNonLake         ! Compute total water mass of non-lake columns
+  public :: ComputeWaterMassLake            ! Compute total water mass of lake columns
+  public :: ComputeLiqIceMassNonLake        ! Compute total water mass of non-lake columns, separated into liquid and ice
+  public :: AccumulateSoilLiqIceMassNonLake ! Accumulate soil water mass of non-lake columns, separated into liquid and ice
+  public :: ComputeLiqIceMassLake           ! Compute total water mass of lake columns, separated into liquid and ice
+  public :: ComputeHeatNonLake              ! Compute heat content of non-lake columns
+  public :: AccumulateSoilHeatNonLake       ! Accumulate soil heat content of non-lake columns
+  public :: ComputeHeatLake                 ! Compute heat content of lake columns
+  public :: AdjustDeltaHeatForDeltaLiq      ! Adjusts the change in gridcell heat content due to land cover change to account for the implicit heat flux associated with delta_liq
+  public :: LiquidWaterHeat                 ! Get the total heat content of some mass of liquid water at a given temperature
 
   !
   ! !PUBLIC MEMBER DATA:
@@ -195,7 +197,6 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer :: c, j, fc                  ! indices
-    logical  :: has_h2o  ! whether this point potentially has water to add
     real(r8) :: h2ocan_col(bounds%begc:bounds%endc)  ! canopy water (mm H2O)
     real(r8) :: snocan_col(bounds%begc:bounds%endc)  ! canopy snow water (mm H2O)
     real(r8) :: liqcan                               ! canopy liquid water (mm H2O)
@@ -215,6 +216,9 @@ contains
          snocan_patch =>    waterstate_inst%snocan_patch   , & ! Input:  [real(r8) (:)   ]  canopy snow water (mm H2O)
          h2osoi_ice   =>    waterstate_inst%h2osoi_ice_col , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
          h2osoi_liq   =>    waterstate_inst%h2osoi_liq_col , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         ! FIXME(wjs, 2019-03-02) add documentation for the following two variables:
+         dynbal_baseline_liq    => waterstate_inst%dynbal_baseline_liq_col, &
+         dynbal_baseline_ice    => waterstate_inst%dynbal_baseline_ice_col, &
          total_plant_stored_h2o => waterdiagnostic_inst%total_plant_stored_h2o_col, & ! Input:  [real(r8) (:,:) ] plant internal stored water (mm H2O)
          aquifer_water_baseline => waterstate_inst%aquifer_water_baseline, & ! Input: [real(r8)] baseline value for water in the unconfined aquifer (wa_col) for this bulk / tracer (mm)
          wa           =>    waterstate_inst%wa_col        & ! Input:  [real(r8) (:)   ] water in the unconfined aquifer (mm)
@@ -286,9 +290,61 @@ contains
     end do
 
     ! Soil water content
+    call AccumulateSoilLiqIceMassNonLake(bounds, num_nolakec, filter_nolakec, &
+         waterstate_inst, &
+         liquid_mass = liquid_mass(bounds%begc:bounds%endc), &
+         ice_mass = ice_mass(bounds%begc:bounds%endc))
+
+    ! Subtract baselines set in initialization
+    do fc = 1, num_nolakec
+       c = filter_nolakec(fc)
+       liquid_mass(c) = liquid_mass(c) - dynbal_baseline_liq(c)
+       ice_mass(c) = ice_mass(c) - dynbal_baseline_ice(c)
+    end do
+
+    end associate
+
+  end subroutine ComputeLiqIceMassNonLake
+
+  !-----------------------------------------------------------------------
+  subroutine AccumulateSoilLiqIceMassNonLake(bounds, num_c, filter_c, &
+       waterstate_inst, liquid_mass, ice_mass)
+    !
+    ! !DESCRIPTION:
+    ! Accumulate soil water mass of non-lake columns (or some subset of non-lake
+    ! columns), separated into liquid and ice.
+    !
+    ! Adds to any existing values in liquid_mass and ice_mass.
+    !
+    ! Note: Changes to this routine should generally be accompanied by similar changes to
+    ! AccumulateSoilHeatNonLake
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)      , intent(in)    :: bounds
+    integer                , intent(in)    :: num_c                       ! number of column points in column filter (should not include lake points; can be a subset of the no-lake filter)
+    integer                , intent(in)    :: filter_c(:)                 ! column filter (should not include lake points; can be a subset of the no-lake filter)
+    class(waterstate_type) , intent(in)    :: waterstate_inst
+    real(r8)               , intent(inout) :: liquid_mass( bounds%begc: ) ! accumulated liquid mass (kg m-2)
+    real(r8)               , intent(inout) :: ice_mass( bounds%begc: )    ! accumulated ice mass (kg m-2)
+    !
+    ! !LOCAL VARIABLES:
+    integer :: c, j, fc  ! indices
+    logical :: has_h2o   ! whether this point potentially has water to add
+
+    character(len=*), parameter :: subname = 'AccumulateSoilLiqIceMassNonLake'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(liquid_mass) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(ice_mass) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+
+    associate( &
+         h2osoi_ice   =>    waterstate_inst%h2osoi_ice_col , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         h2osoi_liq   =>    waterstate_inst%h2osoi_liq_col   & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         )
+
     do j = 1, nlevgrnd
-       do fc = 1, num_nolakec
-          c = filter_nolakec(fc)
+       do fc = 1, num_c
+          c = filter_c(fc)
           if (col%itype(c) == icol_sunwall .or. col%itype(c) == icol_shadewall) then
              has_h2o = .false.
           else if (col%itype(c) == icol_roof) then
@@ -310,7 +366,8 @@ contains
 
     end associate
 
-  end subroutine ComputeLiqIceMassNonLake
+  end subroutine AccumulateSoilLiqIceMassNonLake
+
 
   !-----------------------------------------------------------------------
   subroutine ComputeLiqIceMassLake(bounds, num_lakec, filter_lakec, &
@@ -347,7 +404,10 @@ contains
          
          h2osno       =>    waterstate_inst%h2osno_col     , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_ice   =>    waterstate_inst%h2osoi_ice_col , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
-         h2osoi_liq   =>    waterstate_inst%h2osoi_liq_col   & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         h2osoi_liq   =>    waterstate_inst%h2osoi_liq_col,  & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         ! FIXME(wjs, 2019-03-02) add documentation for the following two variables:
+         dynbal_baseline_liq    => waterstate_inst%dynbal_baseline_liq_col, &
+         dynbal_baseline_ice    => waterstate_inst%dynbal_baseline_ice_col  &
          )
 
     do fc = 1, num_lakec
@@ -379,6 +439,13 @@ contains
           liquid_mass(c) = liquid_mass(c) + h2osoi_liq(c,j)
           ice_mass(c) = ice_mass(c) + h2osoi_ice(c,j)
        end do
+    end do
+
+    ! Subtract baselines set in initialization
+    do fc = 1, num_lakec
+       c = filter_lakec(fc)
+       liquid_mass(c) = liquid_mass(c) - dynbal_baseline_liq(c)
+       ice_mass(c) = ice_mass(c) - dynbal_baseline_ice(c)
     end do
 
     end associate
@@ -418,9 +485,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer :: fc
-    integer :: l,c,j
-
-    logical  :: has_h2o  ! whether this point potentially has water to add
+    integer :: c, j
 
     real(r8) :: h2ocan_col(bounds%begc:bounds%endc)  ! canopy water (mm H2O)
     real(r8) :: snocan_col(bounds%begc:bounds%endc)  ! canopy snow water (mm H2O)
@@ -441,13 +506,10 @@ contains
          snl          => col%snl, & ! number of snow layers
          dz           => col%dz, &  ! layer depth (m)
          nlev_improad => urbanparams_inst%nlev_improad, & ! number of impervious road layers
-         cv_wall      => urbanparams_inst%cv_wall, & ! heat capacity of urban wall (J/m^3/K)
-         cv_roof      => urbanparams_inst%cv_roof, & ! heat capacity of urban roof (J/m^3/K)
-         cv_improad   => urbanparams_inst%cv_improad, & ! heat capacity of urban impervious road (J/m^3/K)
-         watsat       => soilstate_inst%watsat_col, & ! volumetric soil water at saturation (porosity)
-         csol         => soilstate_inst%csol_col, & ! heat capacity, soil solids (J/m**3/Kelvin)
          t_soisno     => temperature_inst%t_soisno_col, & ! soil temperature (Kelvin)
          t_h2osfc     => temperature_inst%t_h2osfc_col, & ! surface water temperature (Kelvin)
+         ! FIXME(wjs, 2019-03-02) Document the following new variable
+         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col, &
          h2osoi_liq   => waterstatebulk_inst%h2osoi_liq_col, & ! liquid water (kg/m2)
          h2osoi_ice   => waterstatebulk_inst%h2osoi_ice_col, & ! frozen water (kg/m2)
          h2osno       => waterstatebulk_inst%h2osno_col, & ! snow water (mm H2O)
@@ -572,24 +634,118 @@ contains
 
     end do
 
+    do fc = 1, num_nolakec
+       c = filter_nolakec(fc)
+       heat(c) = heat_dry_mass(c) + heat_ice(c) + heat_liquid(c) + latent_heat_liquid(c)
+    end do
 
-    !--- below ground (soil & soil water) and related urban columns
+    call AccumulateSoilHeatNonLake(bounds, num_nolakec, filter_nolakec, &
+         urbanparams_inst, soilstate_inst, temperature_inst, waterstatebulk_inst, &
+         heat = heat(bounds%begc:bounds%endc), &
+         heat_liquid = heat_liquid(bounds%begc:bounds%endc), &
+         cv_liquid = cv_liquid(bounds%begc:bounds%endc))
+
+    ! Subtract baselines set in initialization
+    !
+    ! NOTE(wjs, 2019-03-01) I haven't given enough thought to how (if at all) we should
+    ! correct for heat_liquid and cv_liquid, which are used to determine the weighted
+    ! average liquid water temperature. For example, if we're subtracting out a baseline
+    ! water amount because a particular water state is fictitious, we probably shouldn't
+    ! include that particular state when determining the weighted average temperature of
+    ! liquid water. For now, though, we're just subtracting out the ice from glacier
+    ! columns (we're not subtracting any liquid water states), so I think we're okay not
+    ! correcting for that here.
+    do fc = 1, num_nolakec
+       c = filter_nolakec(fc)
+       heat(c) = heat(c) - dynbal_baseline_heat(c)
+    end do
+
+    end associate
+
+  end subroutine ComputeHeatNonLake
+
+  !-----------------------------------------------------------------------
+  subroutine AccumulateSoilHeatNonLake(bounds, num_c, filter_c, &
+       urbanparams_inst, soilstate_inst, temperature_inst, waterstatebulk_inst, &
+       heat, heat_liquid, cv_liquid)
+    !
+    ! !DESCRIPTION:
+    ! Accumulate soil heat of non-lake columns (or some subset of non-lake columns).
+    !
+    ! This includes related heat quantities for urban columns (wall, roof and road).
+    !
+    ! Adds to any existing values in heat, heat_liquid and cv_liquid.
+    !
+    ! Note: Changes to this routine should generally be accompanied by similar changes to
+    ! AccumulateSoilHeatNonLake
+    !
+    ! !ARGUMENTS:
+    type(bounds_type)         , intent(in)    :: bounds
+    integer                   , intent(in)    :: num_c                       ! number of column points in column filter (should not include lake points; can be a subset of the no-lake filter)
+    integer                   , intent(in)    :: filter_c(:)                 ! column filter (should not include lake points; can be a subset of the no-lake filter)
+    type(urbanparams_type)    , intent(in)    :: urbanparams_inst
+    type(soilstate_type)      , intent(in)    :: soilstate_inst
+    type(temperature_type)    , intent(in)    :: temperature_inst
+    type(waterstatebulk_type) , intent(in)    :: waterstatebulk_inst
+    real(r8)                  , intent(inout) :: heat( bounds%begc: )        ! accumulated heat content [J/m^2]
+    real(r8)                  , intent(inout) :: heat_liquid( bounds%begc: ) ! accumulated heat content: liquid water, excluding latent heat [J/m^2]
+    real(r8)                  , intent(inout) :: cv_liquid( bounds%begc: )   ! accumulated liquid water heat capacity [J/(m^2 K)]
+    !
+    ! !LOCAL VARIABLES:
+    integer :: fc
+    integer :: l, c, j
+    logical  :: has_h2o  ! whether this point potentially has water to add
+
+    real(r8) :: soil_heat_liquid(bounds%begc:bounds%endc)        ! sum of heat content: liquid water in soil, excluding latent heat [J/m^2]
+    real(r8) :: soil_heat_dry_mass(bounds%begc:bounds%endc)      ! sum of heat content: dry mass in soil [J/m^2]
+    real(r8) :: soil_heat_ice(bounds%begc:bounds%endc)           ! sum of heat content: ice in soil [J/m^2]
+    real(r8) :: soil_latent_heat_liquid(bounds%begc:bounds%endc) ! sum of heat content: latent heat of liquid water in soil [J/m^2]
+
+    character(len=*), parameter :: subname = 'AccumulateSoilHeatNonLake'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(heat) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(heat_liquid) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(cv_liquid) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+
+    associate( &
+         dz           => col%dz, &  ! layer depth (m)
+         nlev_improad => urbanparams_inst%nlev_improad, & ! number of impervious road layers
+         cv_wall      => urbanparams_inst%cv_wall, & ! heat capacity of urban wall (J/m^3/K)
+         cv_roof      => urbanparams_inst%cv_roof, & ! heat capacity of urban roof (J/m^3/K)
+         cv_improad   => urbanparams_inst%cv_improad, & ! heat capacity of urban impervious road (J/m^3/K)
+         watsat       => soilstate_inst%watsat_col, & ! volumetric soil water at saturation (porosity)
+         csol         => soilstate_inst%csol_col, & ! heat capacity, soil solids (J/m**3/Kelvin)
+         t_soisno     => temperature_inst%t_soisno_col, & ! soil temperature (Kelvin)
+         h2osoi_liq   => waterstatebulk_inst%h2osoi_liq_col, & ! liquid water (kg/m2)
+         h2osoi_ice   => waterstatebulk_inst%h2osoi_ice_col  & ! frozen water (kg/m2)
+         )
+
+    do fc = 1, num_c
+       c = filter_c(fc)
+
+       soil_heat_liquid(c) = 0._r8
+       soil_heat_dry_mass(c) = 0._r8
+       soil_heat_ice(c) = 0._r8
+       soil_latent_heat_liquid(c) = 0._r8
+    end do
+
     do j = 1, nlevgrnd
-       do fc = 1, num_nolakec
-          c = filter_nolakec(fc)
+       do fc = 1, num_c
+          c = filter_c(fc)
           l = col%landunit(c)
 
           if (col%itype(c)==icol_sunwall .or. col%itype(c)==icol_shadewall) then
              has_h2o = .false.
              if (j <= nlevurb) then
-                heat_dry_mass(c) = heat_dry_mass(c) + &
+                soil_heat_dry_mass(c) = soil_heat_dry_mass(c) + &
                      TempToHeat(temp = t_soisno(c,j), cv = (cv_wall(l,j) * dz(c,j)))
              end if
 
           else if (col%itype(c) == icol_roof) then
              if (j <= nlevurb) then
                 has_h2o = .true.
-                heat_dry_mass(c) = heat_dry_mass(c) + &
+                soil_heat_dry_mass(c) = soil_heat_dry_mass(c) + &
                      TempToHeat(temp = t_soisno(c,j), cv = (cv_roof(l,j) * dz(c,j)))
              else
                 has_h2o = .false.
@@ -599,12 +755,12 @@ contains
              has_h2o = .true.
 
              if (col%itype(c) == icol_road_imperv .and. j <= nlev_improad(l)) then
-                heat_dry_mass(c) = heat_dry_mass(c) + &
+                soil_heat_dry_mass(c) = soil_heat_dry_mass(c) + &
                      TempToHeat(temp = t_soisno(c,j), cv = (cv_improad(l,j) * dz(c,j)))
              else if (lun%itype(l) /= istwet .and. lun%itype(l) /= istice_mec) then
                 ! Note that this also includes impervious roads below nlev_improad (where
                 ! we have soil)
-                heat_dry_mass(c) = heat_dry_mass(c) + &
+                soil_heat_dry_mass(c) = soil_heat_dry_mass(c) + &
                      TempToHeat(temp = t_soisno(c,j), cv = (csol(c,j)*(1-watsat(c,j))*dz(c,j)))
              end if
           end if
@@ -614,22 +770,25 @@ contains
                   temp = t_soisno(c,j), &
                   h2o = h2osoi_liq(c,j), &
                   cv_liquid = cv_liquid(c), &
-                  heat_liquid = heat_liquid(c), &
-                  latent_heat_liquid = latent_heat_liquid(c))
-             heat_ice(c) = heat_ice(c) + &
+                  heat_liquid = soil_heat_liquid(c), &
+                  latent_heat_liquid = soil_latent_heat_liquid(c))
+
+             soil_heat_ice(c) = soil_heat_ice(c) + &
                   TempToHeat(temp = t_soisno(c,j), cv = (h2osoi_ice(c,j)*cpice))
           end if
        end do
     end do
 
-    do fc = 1, num_nolakec
-       c = filter_nolakec(fc)
-       heat(c) = heat_dry_mass(c) + heat_ice(c) + heat_liquid(c) + latent_heat_liquid(c)
+    do fc = 1, num_c
+       c = filter_c(fc)
+       heat_liquid(c) = heat_liquid(c) + soil_heat_liquid(c)
+       heat(c) = heat(c) + soil_heat_dry_mass(c) + soil_heat_ice(c) + &
+            soil_heat_liquid(c) + soil_latent_heat_liquid(c)
     end do
 
     end associate
 
-  end subroutine ComputeHeatNonLake
+  end subroutine AccumulateSoilHeatNonLake
 
   !-----------------------------------------------------------------------
   subroutine ComputeHeatLake(bounds, num_lakec, filter_lakec, &
@@ -680,6 +839,8 @@ contains
          watsat       => soilstate_inst%watsat_col, & ! volumetric soil water at saturation (porosity)
          csol         => soilstate_inst%csol_col, & ! heat capacity, soil solids (J/m**3/Kelvin)
          t_soisno     => temperature_inst%t_soisno_col, & ! soil temperature (Kelvin)
+         ! FIXME(wjs, 2019-03-02) Document the following new variable
+         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col, &
          h2osoi_liq   => waterstatebulk_inst%h2osoi_liq_col, & ! liquid water (kg/m2)
          h2osoi_ice   => waterstatebulk_inst%h2osoi_ice_col, & ! frozen water (kg/m2)
          h2osno       => waterstatebulk_inst%h2osno_col & ! snow water (mm H2O)
@@ -737,11 +898,26 @@ contains
     end do
 
     ! TODO(wjs, 2017-03-11) Include heat content of water in lakes, once we include
-    ! lake water as an explicit water state (https://github.com/NCAR/CLM/issues/2)
+    ! lake water as an explicit water state (https://github.com/ESCOMP/ctsm/issues/200)
 
     do fc = 1, num_lakec
        c = filter_lakec(fc)
        heat(c) = heat_dry_mass(c) + heat_ice(c) + heat_liquid(c) + latent_heat_liquid(c)
+    end do
+
+    ! Subtract baselines set in initialization
+    !
+    ! NOTE(wjs, 2019-03-01) I haven't given enough thought to how (if at all) we should
+    ! correct for heat_liquid and cv_liquid, which are used to determine the weighted
+    ! average liquid water temperature. For example, if we're subtracting out a baseline
+    ! water amount because a particular water state is fictitious, we probably shouldn't
+    ! include that particular state when determining the weighted average temperature of
+    ! liquid water. For now, though, we're just subtracting out the ice from glacier
+    ! columns (we're not subtracting any liquid water states), so I think we're okay not
+    ! correcting for that here.
+    do fc = 1, num_lakec
+       c = filter_lakec(fc)
+       heat(c) = heat(c) - dynbal_baseline_heat(c)
     end do
 
     end associate

--- a/src/biogeophys/TotalWaterAndHeatMod.F90
+++ b/src/biogeophys/TotalWaterAndHeatMod.F90
@@ -88,7 +88,9 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine ComputeWaterMassNonLake(bounds, num_nolakec, filter_nolakec, &
-       waterstate_inst, waterdiagnostic_inst, water_mass)
+       waterstate_inst, waterdiagnostic_inst, &
+       subtract_dynbal_baselines, &
+       water_mass)
     !
     ! !DESCRIPTION:
     ! Compute total water mass for all non-lake columns
@@ -102,6 +104,11 @@ contains
     integer                  , intent(in)    :: filter_nolakec(:)          ! column filter for non-lake points
     class(waterstate_type)   , intent(in)    :: waterstate_inst
     class(waterdiagnostic_type), intent(in)  :: waterdiagnostic_inst
+
+    ! BUG(wjs, 2019-03-12, ESCOMP/ctsm#659) When we can accept answer changes to methane,
+    ! remove this argument, always assuming it's true.
+    logical, intent(in) :: subtract_dynbal_baselines ! whether to subtract dynbal_baseline_liq and dynbal_baseline_ice from liquid_mass and ice_mass
+
     real(r8)                 , intent(inout) :: water_mass( bounds%begc: ) ! computed water mass (kg m-2)
     !
     ! !LOCAL VARIABLES:
@@ -120,6 +127,7 @@ contains
          filter_nolakec = filter_nolakec, &
          waterstate_inst = waterstate_inst, &
          waterdiagnostic_inst = waterdiagnostic_inst, &
+         subtract_dynbal_baselines = subtract_dynbal_baselines, &
          liquid_mass = liquid_mass(bounds%begc:bounds%endc), &
          ice_mass = ice_mass(bounds%begc:bounds%endc))
 
@@ -132,7 +140,9 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine ComputeWaterMassLake(bounds, num_lakec, filter_lakec, &
-       waterstate_inst, water_mass)
+       waterstate_inst, &
+       subtract_dynbal_baselines, &
+       water_mass)
     !
     ! !DESCRIPTION:
     ! Compute total water mass for all lake columns
@@ -145,6 +155,11 @@ contains
     integer                  , intent(in)    :: num_lakec                  ! number of column lake points in column filter
     integer                  , intent(in)    :: filter_lakec(:)            ! column filter for lake points
     class(waterstate_type)   , intent(in)    :: waterstate_inst
+
+    ! BUG(wjs, 2019-03-12, ESCOMP/ctsm#659) When we can accept answer changes to methane,
+    ! remove this argument, always assuming it's true.
+    logical, intent(in) :: subtract_dynbal_baselines ! whether to subtract dynbal_baseline_liq and dynbal_baseline_ice from liquid_mass and ice_mass
+
     real(r8)                 , intent(inout) :: water_mass( bounds%begc: ) ! computed water mass (kg m-2)
     !
     ! !LOCAL VARIABLES:
@@ -162,6 +177,7 @@ contains
          num_lakec = num_lakec, &
          filter_lakec = filter_lakec, &
          waterstate_inst = waterstate_inst, &
+         subtract_dynbal_baselines = subtract_dynbal_baselines, &
          liquid_mass = liquid_mass(bounds%begc:bounds%endc), &
          ice_mass = ice_mass(bounds%begc:bounds%endc))
 
@@ -175,7 +191,9 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine ComputeLiqIceMassNonLake(bounds, num_nolakec, filter_nolakec, &
-       waterstate_inst, waterdiagnostic_inst, liquid_mass, ice_mass)
+       waterstate_inst, waterdiagnostic_inst, &
+       subtract_dynbal_baselines, &
+       liquid_mass, ice_mass)
     !
     ! !DESCRIPTION:
     ! Compute total water mass for all non-lake columns, separated into liquid and ice
@@ -192,6 +210,11 @@ contains
     integer                  , intent(in)    :: filter_nolakec(:)           ! column filter for non-lake points
     class(waterstate_type)   , intent(in)    :: waterstate_inst
     class(waterdiagnostic_type), intent(in)  :: waterdiagnostic_inst
+
+    ! BUG(wjs, 2019-03-12, ESCOMP/ctsm#659) When we can accept answer changes to methane,
+    ! remove this argument, always assuming it's true.
+    logical, intent(in) :: subtract_dynbal_baselines ! whether to subtract dynbal_baseline_liq and dynbal_baseline_ice from liquid_mass and ice_mass
+
     real(r8)                 , intent(inout) :: liquid_mass( bounds%begc: ) ! computed liquid water mass (kg m-2)
     real(r8)                 , intent(inout) :: ice_mass( bounds%begc: )    ! computed ice mass (kg m-2)
     !
@@ -294,12 +317,14 @@ contains
          liquid_mass = liquid_mass(bounds%begc:bounds%endc), &
          ice_mass = ice_mass(bounds%begc:bounds%endc))
 
-    ! Subtract baselines set in initialization
-    do fc = 1, num_nolakec
-       c = filter_nolakec(fc)
-       liquid_mass(c) = liquid_mass(c) - dynbal_baseline_liq(c)
-       ice_mass(c) = ice_mass(c) - dynbal_baseline_ice(c)
-    end do
+    if (subtract_dynbal_baselines) then
+       ! Subtract baselines set in initialization
+       do fc = 1, num_nolakec
+          c = filter_nolakec(fc)
+          liquid_mass(c) = liquid_mass(c) - dynbal_baseline_liq(c)
+          ice_mass(c) = ice_mass(c) - dynbal_baseline_ice(c)
+       end do
+    end if
 
     end associate
 
@@ -370,7 +395,9 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine ComputeLiqIceMassLake(bounds, num_lakec, filter_lakec, &
-       waterstate_inst, liquid_mass, ice_mass)
+       waterstate_inst, &
+       subtract_dynbal_baselines, &
+       liquid_mass, ice_mass)
     !
     ! !DESCRIPTION:
     ! Compute total water mass for all lake columns, separated into liquid and ice
@@ -386,6 +413,11 @@ contains
     integer               , intent(in)    :: num_lakec                   ! number of column lake points in column filter
     integer               , intent(in)    :: filter_lakec(:)             ! column filter for lake points
     class(waterstate_type), intent(in)    :: waterstate_inst
+
+    ! BUG(wjs, 2019-03-12, ESCOMP/ctsm#659) When we can accept answer changes to methane,
+    ! remove this argument, always assuming it's true.
+    logical, intent(in) :: subtract_dynbal_baselines ! whether to subtract dynbal_baseline_liq and dynbal_baseline_ice from liquid_mass and ice_mass
+
     real(r8)              , intent(inout) :: liquid_mass( bounds%begc: ) ! computed liquid water mass (kg m-2)
     real(r8)              , intent(inout) :: ice_mass( bounds%begc: )    ! computed ice mass (kg m-2)
     !
@@ -439,12 +471,14 @@ contains
        end do
     end do
 
-    ! Subtract baselines set in initialization
-    do fc = 1, num_lakec
-       c = filter_lakec(fc)
-       liquid_mass(c) = liquid_mass(c) - dynbal_baseline_liq(c)
-       ice_mass(c) = ice_mass(c) - dynbal_baseline_ice(c)
-    end do
+    if (subtract_dynbal_baselines) then
+       ! Subtract baselines set in initialization
+       do fc = 1, num_lakec
+          c = filter_lakec(fc)
+          liquid_mass(c) = liquid_mass(c) - dynbal_baseline_liq(c)
+          ice_mass(c) = ice_mass(c) - dynbal_baseline_ice(c)
+       end do
+    end if
 
     end associate
 

--- a/src/biogeophys/WaterStateType.F90
+++ b/src/biogeophys/WaterStateType.F90
@@ -41,8 +41,12 @@ module WaterStateType
      real(r8), pointer :: liqcan_patch           (:)   ! patch canopy liquid water (mm H2O)
 
      real(r8), pointer :: wa_col                 (:)   ! col water in the unconfined aquifer (mm)
-     real(r8), pointer :: dynbal_baseline_liq_col(:)   ! baseline liquid water content subtracted from each column's total liquid water calculation (positive values are subtracted to avoid counting liquid water content of "virtual" states; negative values are added to account for missing states in the model) (mm H2O)
-     real(r8), pointer :: dynbal_baseline_ice_col(:)   ! baseline ice content subtracted from each column's total ice calculation (positive values are subtracted to avoid counting ice content of "virtual" states; negative values are added to account for missing states in the model) (mm H2O)
+
+     ! For the following dynbal baseline variables: positive values are subtracted to
+     ! avoid counting liquid water content of "virtual" states; negative values are added
+     ! to account for missing states in the model.
+     real(r8), pointer :: dynbal_baseline_liq_col(:)   ! baseline liquid water content subtracted from each column's total liquid water calculation (mm H2O)
+     real(r8), pointer :: dynbal_baseline_ice_col(:)   ! baseline ice content subtracted from each column's total ice calculation (mm H2O)
 
      real(r8) :: aquifer_water_baseline                ! baseline value for water in the unconfined aquifer (wa_col) for this bulk / tracer (mm)
 

--- a/src/biogeophys/WaterStateType.F90
+++ b/src/biogeophys/WaterStateType.F90
@@ -608,6 +608,21 @@ contains
          long_name=this%info%lname('water in the unconfined aquifer'), units='mm', &
          interpinic_flag='interp', readvar=readvar, data=this%wa_col)
 
+    call restartvar(ncid=ncid, flag=flag, &
+         varname=this%info%fname('DYNBAL_BASELINE_LIQ'), &
+         xtype=ncd_double, &
+         dim1name='column', &
+         long_name=this%info%lname("baseline liquid water mass subtracted from each column's total water calculation"), &
+         units='kg/m2', &
+         interpinic_flag='interp', readvar=readvar, data=this%dynbal_baseline_liq_col)
+
+    call restartvar(ncid=ncid, flag=flag, &
+         varname=this%info%fname('DYNBAL_BASELINE_ICE'), &
+         xtype=ncd_double, &
+         dim1name='column', &
+         long_name=this%info%lname("baseline ice mass subtracted from each column's total ice calculation"), &
+         units='kg/m2', &
+         interpinic_flag='interp', readvar=readvar, data=this%dynbal_baseline_ice_col)
 
     ! Determine volumetric soil water (for read only)
     if (flag == 'read' ) then

--- a/src/biogeophys/WaterStateType.F90
+++ b/src/biogeophys/WaterStateType.F90
@@ -40,7 +40,9 @@ module WaterStateType
      real(r8), pointer :: snocan_patch           (:)   ! patch canopy snow water (mm H2O)
      real(r8), pointer :: liqcan_patch           (:)   ! patch canopy liquid water (mm H2O)
 
-     real(r8), pointer :: wa_col                 (:)     ! col water in the unconfined aquifer (mm) 
+     real(r8), pointer :: wa_col                 (:)   ! col water in the unconfined aquifer (mm)
+     real(r8), pointer :: dynbal_baseline_liq_col(:)   ! baseline liquid water content subtracted from each column's total liquid water calculation (positive values are subtracted to avoid counting liquid water content of "virtual" states; negative values are added to account for missing states in the model) (mm H2O)
+     real(r8), pointer :: dynbal_baseline_ice_col(:)   ! baseline ice content subtracted from each column's total ice calculation (positive values are subtracted to avoid counting ice content of "virtual" states; negative values are added to account for missing states in the model) (mm H2O)
 
      real(r8) :: aquifer_water_baseline                ! baseline value for water in the unconfined aquifer (wa_col) for this bulk / tracer (mm)
 
@@ -132,6 +134,12 @@ contains
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
     call AllocateVar1d(var = this%wa_col, name = 'wa_col', &
+         container = tracer_vars, &
+         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
+    call AllocateVar1d(var = this%dynbal_baseline_liq_col, name = 'dynbal_baseline_liq_col', &
+         container = tracer_vars, &
+         bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
+    call AllocateVar1d(var = this%dynbal_baseline_ice_col, name = 'dynbal_baseline_ice_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
 
@@ -489,6 +497,12 @@ contains
             end if
          end do
       end if
+
+      ! Initialize dynbal_baseline_liq_col and dynbal_baseline_ice_col: for some columns,
+      ! these are set elsewhere in initialization, but we need them to be 0 for columns
+      ! for which they are not explicitly set.
+      this%dynbal_baseline_liq_col(bounds%begc:bounds%endc) = 0._r8
+      this%dynbal_baseline_ice_col(bounds%begc:bounds%endc) = 0._r8
 
     end associate
 

--- a/src/dyn_subgrid/CMakeLists.txt
+++ b/src/dyn_subgrid/CMakeLists.txt
@@ -16,8 +16,10 @@ list(APPEND clm_sources "${clm_genf90_sources}")
 list(APPEND clm_sources
   dynColumnStateUpdaterMod.F90
   dynColumnTemplateMod.F90
+  dynConsBiogeophysMod.F90
   dynPatchStateUpdaterMod.F90
   dynPriorWeightsMod.F90
+  dynSubgridControlMod.F90
   dynTimeInfoMod.F90
   dynLandunitAreaMod.F90
   dynInitColumnsMod.F90

--- a/src/dyn_subgrid/dynConsBiogeophysMod.F90
+++ b/src/dyn_subgrid/dynConsBiogeophysMod.F90
@@ -578,13 +578,15 @@ contains
 
     call ComputeLiqIceMassNonLake(bounds, num_nolakec, filter_nolakec, &
          waterstate_inst, waterdiagnostic_inst, &
-         liquid_mass_col(bounds%begc:bounds%endc), &
-         ice_mass_col(bounds%begc:bounds%endc))
+         subtract_dynbal_baselines = .true., &
+         liquid_mass = liquid_mass_col(bounds%begc:bounds%endc), &
+         ice_mass = ice_mass_col(bounds%begc:bounds%endc))
 
     call ComputeLiqIceMassLake(bounds, num_lakec, filter_lakec, &
          waterstate_inst, &
-         liquid_mass_col(bounds%begc:bounds%endc), &
-         ice_mass_col(bounds%begc:bounds%endc))
+         subtract_dynbal_baselines = .true., &
+         liquid_mass = liquid_mass_col(bounds%begc:bounds%endc), &
+         ice_mass = ice_mass_col(bounds%begc:bounds%endc))
 
     call c2g(bounds, &
          carr = liquid_mass_col(bounds%begc:bounds%endc), &

--- a/src/dyn_subgrid/dynConsBiogeophysMod.F90
+++ b/src/dyn_subgrid/dynConsBiogeophysMod.F90
@@ -24,25 +24,32 @@ module dynConsBiogeophysMod
   use WaterDiagnosticBulkType , only : waterdiagnosticbulk_type
   use WaterBalanceType        , only : waterbalance_type
   use WaterType               , only : water_type
+  use TotalWaterAndHeatMod    , only : AccumulateSoilLiqIceMassNonLake
+  use TotalWaterAndHeatMod    , only : AccumulateSoilHeatNonLake
   use TotalWaterAndHeatMod    , only : ComputeLiqIceMassNonLake, ComputeLiqIceMassLake
   use TotalWaterAndHeatMod    , only : ComputeHeatNonLake, ComputeHeatLake
   use TotalWaterAndHeatMod    , only : AdjustDeltaHeatForDeltaLiq
   use TotalWaterAndHeatMod    , only : heat_base_temp
-  use subgridAveMod           , only : p2c, c2g
+  use subgridAveMod           , only : p2c, c2g, c2l
+  use GridcellType            , only : grc
   use LandunitType            , only : lun
   use ColumnType              , only : col
   use PatchType               , only : patch
-  use clm_varcon              , only : tfrz, cpliq, hfus
+  use clm_varcon              , only : tfrz, cpliq, hfus, ispval
+  use landunit_varcon         , only : istsoil, istice_mec
   use dynSubgridControlMod    , only : get_for_testing_zero_dynbal_fluxes
+  use filterColMod            , only : filter_col_type, col_filter_from_ltypes
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   implicit none
   private
   !
-  public :: dyn_hwcontent_init         ! compute grid-level heat and water content, before land cover change
-  public :: dyn_hwcontent_final        ! compute grid-level heat and water content and dynbal fluxes after land cover change
+  public :: dyn_hwcontent_set_baselines ! set start-of-run baseline values for heat and water content in some columns
+  public :: dyn_hwcontent_init          ! compute grid-level heat and water content, before land cover change
+  public :: dyn_hwcontent_final         ! compute grid-level heat and water content and dynbal fluxes after land cover change
   !
   ! !PRIVATE MEMBER FUNCTIONS
+  ! FIXME(wjs, 2019-02-27) add new private routines here
   private :: dyn_water_content_final      ! compute grid-level water content and dynbal fluxes after landcover change, for a single water tracer or bulk water
   private :: dyn_water_content            ! compute gridcell total liquid and ice water contents
   private :: dyn_heat_content             ! compute gridcell total heat contents
@@ -52,6 +59,259 @@ module dynConsBiogeophysMod
   !---------------------------------------------------------------------------
 
 contains
+
+  !-----------------------------------------------------------------------
+  subroutine dyn_hwcontent_set_baselines(bounds, num_icemecc, filter_icemecc, &
+       urbanparams_inst, soilstate_inst, water_inst, temperature_inst)
+    !
+    ! !DESCRIPTION:
+    ! FIXME(wjs, 2019-02-27) Fill this in
+    !
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+
+    ! The following filter should include inactive as well as active points. This could
+    ! be important if an inactive point later becomes active, so that we have an
+    ! appropriate baseline value for that point.
+    integer, intent(in) :: num_icemecc  ! number of points in filter_icemecc
+    integer, intent(in) :: filter_icemecc(:) ! filter for icemec (i.e., glacier) columns
+
+    type(urbanparams_type), intent(in) :: urbanparams_inst
+    type(soilstate_type), intent(in) :: soilstate_inst
+    type(water_type), intent(inout) :: water_inst
+    type(temperature_type), intent(inout) :: temperature_inst
+    !
+    ! !LOCAL VARIABLES:
+    integer :: i
+    type(filter_col_type) :: natveg_and_glc_filterc
+
+    character(len=*), parameter :: subname = 'dyn_hwcontent_set_baselines'
+    !-----------------------------------------------------------------------
+
+    ! Note that we include inactive points in the following. This could be important if
+    ! an inactive point later becomes active, so that we have an appropriate baseline
+    ! value for that point.
+    natveg_and_glc_filterc = col_filter_from_ltypes( &
+         bounds = bounds, &
+         ltypes = [istsoil, istice_mec], &
+         include_inactive = .true.)
+
+    do i = water_inst%bulk_and_tracers_beg, water_inst%bulk_and_tracers_end
+       associate(bulk_or_tracer => water_inst%bulk_and_tracers(i))
+
+       call dyn_water_content_set_baselines(bounds, natveg_and_glc_filterc, &
+            num_icemecc, filter_icemecc, &
+            bulk_or_tracer%waterstate_inst)
+       end associate
+    end do
+
+    call dyn_heat_content_set_baselines(bounds, natveg_and_glc_filterc, &
+         num_icemecc, filter_icemecc, &
+         urbanparams_inst, soilstate_inst, water_inst%waterstatebulk_inst, &
+         temperature_inst)
+
+  end subroutine dyn_hwcontent_set_baselines
+
+  !-----------------------------------------------------------------------
+  subroutine dyn_water_content_set_baselines(bounds, natveg_and_glc_filterc, &
+       num_icemecc, filter_icemecc, &
+       waterstate_inst)
+    !
+    ! !DESCRIPTION:
+    ! FIXME(wjs, 2019-02-27) fill this in
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+    type(filter_col_type), intent(in) :: natveg_and_glc_filterc  ! filter for natural veg and glacier columns
+
+    ! The following filter should include inactive as well as active points
+    integer, intent(in) :: num_icemecc  ! number of points in filter_icemecc
+    integer, intent(in) :: filter_icemecc(:) ! filter for icemec (i.e., glacier) columns
+
+    class(waterstate_type), intent(inout) :: waterstate_inst
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: soil_liquid_mass_col(bounds%begc:bounds%endc)
+    real(r8) :: soil_ice_mass_col(bounds%begc:bounds%endc)
+
+    character(len=*), parameter :: subname = 'dyn_water_content_set_baselines'
+    !-----------------------------------------------------------------------
+
+    ! FIXME(wjs, 2019-03-01) add documentation for these associated variables
+    associate( &
+         dynbal_baseline_liq => waterstate_inst%dynbal_baseline_liq_col, &
+         dynbal_baseline_ice => waterstate_inst%dynbal_baseline_ice_col  &
+         )
+
+    soil_liquid_mass_col(bounds%begc:bounds%endc) = 0._r8
+    soil_ice_mass_col   (bounds%begc:bounds%endc) = 0._r8
+
+    call AccumulateSoilLiqIceMassNonLake(bounds, &
+         natveg_and_glc_filterc%num, natveg_and_glc_filterc%indices, &
+         waterstate_inst, &
+         liquid_mass = soil_liquid_mass_col(bounds%begc:bounds%endc), &
+         ice_mass = soil_ice_mass_col(bounds%begc:bounds%endc))
+
+    ! For glacier columns, the liquid and ice in the "soil" (i.e., in the glacial ice) is
+    ! a virtual pool. So we'll subtract this amount when determining the dynbal
+    ! fluxes. (Note that a positive value in these baseline variables indicates an extra
+    ! stock that will be subtracted later.) But glacier columns do not represent the soil
+    ! under the glacial ice. Let's assume that the soil state under each glacier column is
+    ! the same as the soil state in the natural vegetation landunit on that grid cell. We
+    ! subtract this from the dynbal baseline variables to indicate a missing stock.
+    call set_glacier_baselines(bounds, num_icemecc, filter_icemecc, &
+         vals_col = soil_liquid_mass_col(bounds%begc:bounds%endc), &
+         baselines_col = dynbal_baseline_liq(bounds%begc:bounds%endc))
+    call set_glacier_baselines(bounds, num_icemecc, filter_icemecc, &
+         vals_col = soil_ice_mass_col(bounds%begc:bounds%endc), &
+         baselines_col = dynbal_baseline_ice(bounds%begc:bounds%endc))
+
+    end associate
+
+  end subroutine dyn_water_content_set_baselines
+
+  !-----------------------------------------------------------------------
+  subroutine dyn_heat_content_set_baselines(bounds, natveg_and_glc_filterc, &
+       num_icemecc, filter_icemecc, &
+       urbanparams_inst, soilstate_inst, waterstatebulk_inst, &
+       temperature_inst)
+    !
+    ! !DESCRIPTION:
+    ! FIXME(wjs, 2019-02-27) fill this in
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+    type(filter_col_type), intent(in) :: natveg_and_glc_filterc  ! filter for natural veg and glacier columns
+
+    ! The following filter should include inactive as well as active points
+    integer, intent(in) :: num_icemecc  ! number of points in filter_icemecc
+    integer, intent(in) :: filter_icemecc(:) ! filter for icemec (i.e., glacier) columns
+
+    type(urbanparams_type), intent(in) :: urbanparams_inst
+    type(soilstate_type), intent(in) :: soilstate_inst
+    type(waterstatebulk_type), intent(in) :: waterstatebulk_inst
+    type(temperature_type), intent(inout) :: temperature_inst
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: soil_heat_col(bounds%begc:bounds%endc) ! soil heat content [J/m^2]
+    real(r8) :: soil_heat_liquid_col(bounds%begc:bounds%endc)  ! unused; just needed for AccumulateSoilHeatNonLake interface
+    real(r8) :: soil_cv_liquid_col(bounds%begc:bounds%endc)  ! unused; just needed for AccumulateSoilHeatNonLake interface
+
+    character(len=*), parameter :: subname = 'dyn_heat_content_set_baselines'
+    !-----------------------------------------------------------------------
+
+    ! FIXME(wjs, 2019-03-01) add documentation for these associated variables
+    associate( &
+         dynbal_baseline_heat => temperature_inst%dynbal_baseline_heat_col &
+         )
+
+    soil_heat_col(bounds%begc:bounds%endc) = 0._r8
+    soil_heat_liquid_col(bounds%begc:bounds%endc) = 0._r8
+    soil_cv_liquid_col(bounds%begc:bounds%endc) = 0._r8
+
+    call AccumulateSoilHeatNonLake(bounds, &
+         natveg_and_glc_filterc%num, natveg_and_glc_filterc%indices, &
+         urbanparams_inst, soilstate_inst, temperature_inst, waterstatebulk_inst, &
+         heat = soil_heat_col(bounds%begc:bounds%endc), &
+         heat_liquid = soil_heat_liquid_col(bounds%begc:bounds%endc), &
+         cv_liquid = soil_cv_liquid_col(bounds%begc:bounds%endc))
+
+    ! See comments in dyn_water_content_set_baselines for rationale for these glacier
+    ! baselines. Even though the heat in glacier ice can interact with the rest of the
+    ! system (e.g., giving off heat to the atmosphere or receiving heat from the
+    ! atmosphere), it is still a virtual state in the sense that the glacier ice column
+    ! is virtual. And, as for water, we subtract the heat of the soil in the associated
+    ! natural vegetated landunit to account for the fact that we don't explicitly model
+    ! the soil under glacial ice.
+    !
+    ! Aside from these considerations of what is virtual vs. real, another rationale
+    ! driving the use of these baselines is the desire to minimize the dynbal fluxes. For
+    ! the sake of conservation, it seems okay to pick any fixed baseline when summing the
+    ! energy (or water) content of a given column (as long as that baseline doesn't
+    ! change over time). By using the baselines computed here, we reduce the dynbal
+    ! fluxes to more reasonable values.
+    call set_glacier_baselines(bounds, num_icemecc, filter_icemecc, &
+         vals_col = soil_heat_col(bounds%begc:bounds%endc), &
+         baselines_col = dynbal_baseline_heat(bounds%begc:bounds%endc))
+
+    end associate
+
+  end subroutine dyn_heat_content_set_baselines
+
+  !-----------------------------------------------------------------------
+  subroutine set_glacier_baselines(bounds, num_icemecc, filter_icemecc, &
+       vals_col, baselines_col)
+    !
+    ! !DESCRIPTION:
+    ! Set baselines for each glacier column, for some dynbal term.
+    !
+    ! The baselines for a given glacier column are set equal to the input value in that
+    ! glacier column minus the average value for the vegetated landunit on that column's
+    ! gridcell.
+    !
+    ! !ARGUMENTS:
+    type(bounds_type), intent(in) :: bounds
+
+    ! The following filter should include inactive as well as active points
+    integer, intent(in) :: num_icemecc  ! number of points in filter_icemecc
+    integer, intent(in) :: filter_icemecc(:) ! filter for icemec (i.e., glacier) columns
+
+    real(r8), intent(in) :: vals_col( bounds%begc: ) ! values in each column; must be set for at least natural veg and glacier columns
+    real(r8), intent(inout) :: baselines_col( bounds%begc: ) ! baselines in each column; will be set for all points in the icemecc filter
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: fc, c, l, g  ! indices
+    integer  :: l_natveg     ! index of natural veg landunit on this grid cell
+    real(r8) :: vals_lun(bounds%begl:bounds%endl)
+
+    character(len=*), parameter :: subname = 'set_glacier_baselines'
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(vals_col) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(baselines_col) == [bounds%endc]), errMsg(sourcefile, __LINE__))
+
+    ! Average values from column to landunit for the natural veg landunit, in case there
+    ! are multiple columns on the natural veg landunit.
+    !
+    ! It's somewhat inefficient that we produce landunit averages for all landunits, when
+    ! all we really need are averages for the natural veg landunit. But since this
+    ! subroutine is only called in initialization, code reuse/simplicity is more important
+    ! than performance.
+    !
+    ! No thought has been given to c2l_scale_type here. This may need to be fixed if we
+    ! ever start caring about urban averages in this routine.
+    call c2l(bounds = bounds, &
+         carr = vals_col(bounds%begc:bounds%endc), &
+         larr = vals_lun(bounds%begl:bounds%endl), &
+         c2l_scale_type = 'urbanf', &
+         include_inactive = .true.)
+
+    do fc = 1, num_icemecc
+       c = filter_icemecc(fc)
+       g = col%gridcell(c)
+
+       ! Start by setting the baseline for this glacier column equal to the value in this
+       ! glacier column.
+       baselines_col(c) = vals_col(c)
+
+       ! Now subtract the value in the natural vegetated landunit on this gridcell. This
+       ! subtraction represents the missing stock, since glacier columns do not have
+       ! explicit stocks for the soil under the glacial ice. So we are assuming here that
+       ! the soil state under each glacier column is the same as the soil state in the
+       ! natural vegetation landunit on that grid cell.
+       !
+       ! Note that we don't do this subtraction if the gridcell doesn't have a natural
+       ! vegetation landunit. But we shouldn't have any transient glacier areas in that
+       ! case anyway, so that shouldn't matter.
+       l_natveg = grc%landunit_indices(istsoil, g)
+       if (l_natveg /= ispval) then
+          baselines_col(c) = baselines_col(c) - vals_lun(l_natveg)
+       end if
+    end do
+
+  end subroutine set_glacier_baselines
+
 
   !---------------------------------------------------------------------------
   subroutine dyn_hwcontent_init(bounds, &

--- a/src/dyn_subgrid/dynSubgridControlMod.F90
+++ b/src/dyn_subgrid/dynSubgridControlMod.F90
@@ -26,6 +26,7 @@ module dynSubgridControlMod
   public :: get_do_transient_crops  ! return the value of the do_transient_crops control flag
   public :: run_has_transient_landcover ! returns true if any aspects of prescribed transient landcover are enabled
   public :: get_do_harvest          ! return the value of the do_harvest control flag
+  public :: get_reset_dynbal_baselines ! return the value of the reset_dynbal_baselines control flag
   public :: get_for_testing_allow_non_annual_changes ! return true if user has requested to allow area changes at times other than the year boundary, for testing purposes
   public :: get_for_testing_zero_dynbal_fluxes ! return true if user has requested to set the dynbal water and energy fluxes to zero, for testing purposes
   !
@@ -40,6 +41,8 @@ module dynSubgridControlMod
      logical :: do_transient_pfts  = .false. ! whether to apply transient natural PFTs from dataset
      logical :: do_transient_crops = .false. ! whether to apply transient crops from dataset
      logical :: do_harvest         = .false. ! whether to apply harvest from dataset
+
+     logical :: reset_dynbal_baselines = .false. ! whether to reset baseline values of total column water and energy in the first step of the run
 
      ! The following is only meant for testing: Whether area changes are allowed at times
      ! other than the year boundary. This should only arise in some test configurations
@@ -114,6 +117,7 @@ contains
     logical :: do_transient_pfts
     logical :: do_transient_crops
     logical :: do_harvest
+    logical :: reset_dynbal_baselines
     logical :: for_testing_allow_non_annual_changes
     logical :: for_testing_zero_dynbal_fluxes
     ! other local variables:
@@ -128,6 +132,7 @@ contains
          do_transient_pfts, &
          do_transient_crops, &
          do_harvest, &
+         reset_dynbal_baselines, &
          for_testing_allow_non_annual_changes, &
          for_testing_zero_dynbal_fluxes
 
@@ -136,6 +141,7 @@ contains
     do_transient_pfts  = .false.
     do_transient_crops = .false.
     do_harvest         = .false.
+    reset_dynbal_baselines = .false.
     for_testing_allow_non_annual_changes = .false.
     for_testing_zero_dynbal_fluxes = .false.
 
@@ -159,6 +165,7 @@ contains
     call shr_mpi_bcast (do_transient_pfts, mpicom)
     call shr_mpi_bcast (do_transient_crops, mpicom)
     call shr_mpi_bcast (do_harvest, mpicom)
+    call shr_mpi_bcast (reset_dynbal_baselines, mpicom)
     call shr_mpi_bcast (for_testing_allow_non_annual_changes, mpicom)
     call shr_mpi_bcast (for_testing_zero_dynbal_fluxes, mpicom)
 
@@ -167,6 +174,7 @@ contains
          do_transient_pfts = do_transient_pfts, &
          do_transient_crops = do_transient_crops, &
          do_harvest = do_harvest, &
+         reset_dynbal_baselines = reset_dynbal_baselines, &
          for_testing_allow_non_annual_changes = for_testing_allow_non_annual_changes, &
          for_testing_zero_dynbal_fluxes = for_testing_zero_dynbal_fluxes)
 
@@ -183,7 +191,7 @@ contains
   subroutine check_namelist_consistency
     !
     ! !DESCRIPTION:
-    ! Check consistency of namelist settingsn
+    ! Check consistency of namelist settings
     !
     ! !USES:
     use clm_varctl     , only : iulog, use_cndv, use_fates, use_cn, use_crop
@@ -307,6 +315,18 @@ contains
     get_do_harvest = dyn_subgrid_control_inst%do_harvest
 
   end function get_do_harvest
+
+  !-----------------------------------------------------------------------
+  logical function get_reset_dynbal_baselines()
+    ! !DESCRIPTION:
+    ! Return the value of the reset_dynbal_baselines control flag
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT(dyn_subgrid_control_inst%initialized, errMsg(sourcefile, __LINE__))
+
+    get_reset_dynbal_baselines = dyn_subgrid_control_inst%reset_dynbal_baselines
+
+  end function get_reset_dynbal_baselines
 
   !-----------------------------------------------------------------------
   logical function get_for_testing_allow_non_annual_changes()

--- a/src/dyn_subgrid/test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(dynColumnTemplate_test)
 add_subdirectory(dynColumnStateUpdater_test)
+add_subdirectory(dynConsBiogeophys_test)
 add_subdirectory(dynPatchStateUpdater_test)
 add_subdirectory(dynInitColumns_test)
 add_subdirectory(dynLandunitArea_test)

--- a/src/dyn_subgrid/test/dynConsBiogeophys_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynConsBiogeophys_test/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(pfunit_sources
+  test_dyn_cons_biogeophys.pf)
+
+create_pFUnit_test(dynConsBiogeophys test_dynConsBiogeophys_exe
+  "${pfunit_sources}" "")
+
+target_link_libraries(test_dynConsBiogeophys_exe clm csm_share esmf_wrf_timemgr)
+

--- a/src/dyn_subgrid/test/dynConsBiogeophys_test/test_dyn_cons_biogeophys.pf
+++ b/src/dyn_subgrid/test/dynConsBiogeophys_test/test_dyn_cons_biogeophys.pf
@@ -1,0 +1,274 @@
+module test_dyn_cons_biogeophys
+
+  ! Tests of dynConsBiogeophysMod
+
+  use pfunit_mod
+  use dynConsBiogeophysMod
+  use shr_kind_mod , only : r8 => shr_kind_r8
+  use unittestSubgridMod
+  use unittestArrayMod, only : col_array
+  use unittestFilterBuilderMod, only : filter_from_range
+  use unittestWaterTypeFactory, only : unittest_water_type_factory_type
+  use clm_varpar, only : nlevgrnd, nlevsno, maxpatch_glcmec
+  use column_varcon, only : icemec_class_to_col_itype
+  use landunit_varcon, only : istsoil, istice_mec, istdlak
+  use ColumnType, only : col
+  use LandunitType, only : lun
+  use PatchType, only : patch
+  use SoilStateType, only : soilstate_type
+  use TemperatureType, only : temperature_type
+  use UrbanParamsType, only : urbanparams_type
+  use WaterType, only : water_type
+  use TotalWaterAndHeatMod, only : AccumulateSoilLiqIceMassNonLake
+  use TotalWaterAndHeatMod, only : AccumulateSoilHeatNonLake
+
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: TestDCB
+     type(unittest_water_type_factory_type) :: water_type_factory
+     type(soilstate_type) :: soilstate_inst
+     type(temperature_type) :: temperature_inst
+     type(urbanparams_type) :: urbanparams_inst
+     type(water_type) :: water_inst
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type TestDCB
+
+  integer, parameter :: my_nlevsoi = 6
+  integer, parameter :: nlevgrnd_additional = 5
+  integer, parameter :: my_nlevsno = 4
+
+  real(r8), parameter :: tol = 1.e-13_r8
+
+contains
+
+  subroutine setUp(this)
+    class(TestDCB), intent(inout) :: this
+
+    maxpatch_glcmec = 10
+    call this%water_type_factory%init()
+    call this%water_type_factory%setup_before_subgrid( &
+         my_nlevsoi = my_nlevsoi, &
+         nlevgrnd_additional = nlevgrnd_additional, &
+         my_nlevsno = my_nlevsno)
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(TestDCB), intent(inout) :: this
+
+    if (associated(this%soilstate_inst%watsat_col)) then
+       deallocate(this%soilstate_inst%watsat_col)
+    end if
+    if (associated(this%soilstate_inst%csol_col)) then
+       deallocate(this%soilstate_inst%csol_col)
+    end if
+
+    if (associated(this%temperature_inst%t_soisno_col)) then
+       deallocate(this%temperature_inst%t_soisno_col)
+    end if
+    if (associated(this%temperature_inst%dynbal_baseline_heat_col)) then
+       deallocate(this%temperature_inst%dynbal_baseline_heat_col)
+    end if
+
+    if (associated(this%urbanparams_inst%nlev_improad)) then
+       deallocate(this%urbanparams_inst%nlev_improad)
+    end if
+
+    call this%water_type_factory%teardown(this%water_inst)
+
+    call unittest_subgrid_teardown()
+  end subroutine tearDown
+
+  @Test
+  subroutine test_setBaselines(this)
+    ! A basic test of dyn_hwcontent_set_baselines
+    !
+    ! This covers the relevant logic in dynConsBiogeophysMod, but NOT the logic invoked
+    ! in TotalWaterAndHeatMod (we take the latter as a given). This particularly covers
+    ! the setting of baselines for a glacier column based on the average value from the
+    ! vegetated landunit. This includes coverage of some particular points that would not
+    ! currently be covered in system tests (which was part of the motivation for creating
+    ! this unit test):
+    ! - calculating baselines for inactive as well as active points (since, in typical
+    !   operation, all relevant glacier points begin active)
+    ! - averaging vegetated values from column to landunit (since, in typical operation,
+    !   there is only one column on the natural vegetation landunit)
+    class(TestDCB), intent(inout) :: this
+    real(r8), parameter :: wt_veg_col1 = 0.25_r8
+    real(r8), parameter :: wt_veg_col2 = 0.75_r8
+    integer :: veg_col1, veg_col2, glc_col
+    integer :: num_icemecc, num_natveg_and_icemecc
+    integer, allocatable :: filter_icemecc(:), filter_natveg_and_icemecc(:)
+    integer :: c
+    real(r8), allocatable :: expected_vals_liq_col(:)
+    real(r8), allocatable :: expected_vals_ice_col(:)
+    real(r8), allocatable :: expected_vals_heat_col(:)
+    real(r8), allocatable :: ignored_heatliq_col(:)
+    real(r8), allocatable :: ignored_cvliq_col(:)
+
+    ! ------------------------------------------------------------------------
+    ! Create subgrid structure.
+    !
+    ! There is one ice_mec column (the target column for this test) and two vegetated
+    ! columns (to test averaging from column to landunit). The weights of all of those
+    ! columns on the grid cell are 0, and they are all inactive (in order to ensure that
+    ! the code operates on inactive as well as active points). In addition, there is one
+    ! lake column that fills 100% of the grid cell (just so we have something that fills
+    ! the grid cell).
+    ! ------------------------------------------------------------------------
+
+    call unittest_subgrid_setup_start()
+    call unittest_add_gridcell()
+
+    ! Add vegetated landunit
+    call unittest_add_landunit(my_gi=gi, ltype=istsoil, wtgcell=0._r8)
+    call unittest_add_column(my_li=li, ctype=1, wtlunit=wt_veg_col1)
+    call unittest_add_patch(my_ci=ci, ptype=1, wtcol=1._r8)
+    veg_col1 = ci
+    call unittest_add_column(my_li=li, ctype=1, wtlunit=wt_veg_col2)
+    call unittest_add_patch(my_ci=ci, ptype=1, wtcol=1._r8)
+    veg_col2 = ci
+
+    ! Add glacier landunit
+    call unittest_add_landunit(my_gi=gi, ltype=istice_mec, wtgcell=0._r8)
+    call unittest_add_column(my_li=li, &
+         ctype = icemec_class_to_col_itype(1), &
+         wtlunit=1._r8)
+    call unittest_add_patch(my_ci=ci, ptype=0, wtcol=1._r8)
+    glc_col = ci
+
+    ! Add lake landunit
+    call unittest_add_landunit(my_gi=gi, ltype=istdlak, wtgcell=1._r8)
+    call unittest_add_column(my_li=li, ctype=istdlak*100, wtlunit=1._r8)
+    call unittest_add_patch(my_ci=ci, ptype=0, wtcol=1._r8)
+
+    call unittest_subgrid_setup_end()
+
+    ! Make everything inactive except lake
+    lun%active(bounds%begl:bounds%endl-1) = .false.
+    col%active(bounds%begc:bounds%endc-1) = .false.
+    patch%active(bounds%begp:bounds%endp-1) = .false.
+
+    ! ------------------------------------------------------------------------
+    ! Initialize various necessary data structures and variables
+    ! ------------------------------------------------------------------------
+
+    ! Create filters
+    call filter_from_range(start=glc_col, end=glc_col, &
+         numf=num_icemecc, filter=filter_icemecc)
+    call filter_from_range(start=veg_col1, end=glc_col, &
+         numf=num_natveg_and_icemecc, filter=filter_natveg_and_icemecc)
+
+    ! Initialize necessary variables in soilstate_inst
+    allocate(this%soilstate_inst%csol_col(bounds%begc:bounds%endc, nlevgrnd))
+    allocate(this%soilstate_inst%watsat_col(bounds%begc:bounds%endc, nlevgrnd))
+    do c = bounds%begc, bounds%endc
+       ! Use a different value of csol and watsat for each column
+       this%soilstate_inst%csol_col(c,:) = 1.e6_r8 * (c - bounds%begc + 1)
+       this%soilstate_inst%watsat_col(c,:) = 0.05_r8 * (c - bounds%begc + 1)
+    end do
+
+    ! Initialize necessary variables in temperature_inst
+    allocate(this%temperature_inst%t_soisno_col(bounds%begc:bounds%endc, -nlevsno+1:nlevgrnd))
+    allocate(this%temperature_inst%dynbal_baseline_heat_col(bounds%begc:bounds%endc))
+    do c = bounds%begc, bounds%endc
+       ! Use a different value of temperature for each column
+       if (c == glc_col) then
+          this%temperature_inst%t_soisno_col(c,:) = 250._r8
+       else
+          this%temperature_inst%t_soisno_col(c,:) = 275._r8 + (c - bounds%begc)
+       end if
+
+       ! mimic initialization done in TemperatureType: InitCold
+       this%temperature_inst%dynbal_baseline_heat_col(c) = 0._r8
+    end do
+
+    ! Initialize necessary variables in urbanparams_inst
+    allocate(this%urbanparams_inst%nlev_improad(bounds%begl:bounds%endl))
+    ! Arbitrary value, not important here
+    this%urbanparams_inst%nlev_improad(bounds%begl:bounds%endl) = 3
+
+    ! Initialize water_inst
+    ! (snl and dz are totally arbitrary here: these are unimportant for this test)
+    call this%water_type_factory%setup_after_subgrid(snl = -2, dz = 0.05_r8)
+    call this%water_type_factory%create_water_type( &
+         water_inst = this%water_inst, &
+         t_soisno_col = this%temperature_inst%t_soisno_col(bounds%begc:bounds%endc,:), &
+         watsat_col = this%soilstate_inst%watsat_col(bounds%begc:bounds%endc,:))
+
+    ! ------------------------------------------------------------------------
+    ! Call the routine we're testing
+    ! ------------------------------------------------------------------------
+
+    call dyn_hwcontent_set_baselines(bounds, num_icemecc, filter_icemecc, &
+         this%urbanparams_inst, this%soilstate_inst, &
+         this%water_inst, this%temperature_inst)
+
+    ! ------------------------------------------------------------------------
+    ! Compute expected values
+    !
+    ! Note that we take these Accumulate routines as a given: We're not trying to catch
+    ! problems in those routines here; rather, we're just trying to see if the logic that
+    ! uses the results of those routines is correct.
+    ! ------------------------------------------------------------------------
+
+    expected_vals_liq_col = col_array(0._r8)
+    expected_vals_ice_col = col_array(0._r8)
+    expected_vals_heat_col = col_array(0._r8)
+    ignored_heatliq_col = col_array(0._r8)
+    ignored_cvliq_col = col_array(0._r8)
+
+    call AccumulateSoilLiqIceMassNonLake(bounds, &
+         num_natveg_and_icemecc, filter_natveg_and_icemecc, &
+         this%water_inst%waterstatebulk_inst, &
+         liquid_mass = expected_vals_liq_col, &
+         ice_mass = expected_vals_ice_col)
+
+    call AccumulateSoilHeatNonLake(bounds, &
+         num_natveg_and_icemecc, filter_natveg_and_icemecc, &
+         this%urbanparams_inst, this%soilstate_inst, this%temperature_inst, &
+         this%water_inst%waterstatebulk_inst, &
+         heat = expected_vals_heat_col, &
+         heat_liquid = ignored_heatliq_col, &
+         cv_liquid = ignored_cvliq_col)
+
+    ! ------------------------------------------------------------------------
+    ! Assert results
+    ! ------------------------------------------------------------------------
+
+    call assertBaselines( &
+         expected_vals_col = expected_vals_liq_col, &
+         baselines_col = this%water_inst%waterstatebulk_inst%dynbal_baseline_liq_col, &
+         msg = 'liq')
+    call assertBaselines( &
+         expected_vals_col = expected_vals_ice_col, &
+         baselines_col = this%water_inst%waterstatebulk_inst%dynbal_baseline_ice_col, &
+         msg = 'ice')
+    call assertBaselines( &
+         expected_vals_col = expected_vals_heat_col, &
+         baselines_col = this%temperature_inst%dynbal_baseline_heat_col, &
+         msg = 'heat')
+
+  contains
+    subroutine assertBaselines(expected_vals_col, baselines_col, msg)
+      real(r8), intent(in) :: expected_vals_col(bounds%begc:)
+      real(r8), intent(in) :: baselines_col(bounds%begc:)
+      character(len=*), intent(in) :: msg
+
+      real(r8) :: expected_baseline_glc
+      real(r8) :: expected_baselines(bounds%begc:bounds%endc)
+
+      expected_baseline_glc = expected_vals_col(glc_col) - &
+           (wt_veg_col1*expected_vals_col(veg_col1) + wt_veg_col2*expected_vals_col(veg_col2))
+
+      expected_baselines(:) = 0._r8
+      expected_baselines(glc_col) = expected_baseline_glc
+
+      @assertEqual(expected_baselines(:), baselines_col(:), tolerance=tol, message=msg)
+    end subroutine assertBaselines
+
+  end subroutine test_setBaselines
+
+end module test_dyn_cons_biogeophys

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -24,6 +24,7 @@ module clm_initializeMod
   use reweightMod     , only : reweight_wrapup
   use filterMod       , only : allocFilters, filter, filter_inactive_and_active
   use FatesInterfaceMod, only : set_fates_global_elements
+  use dynSubgridControlMod, only: dynSubgridControl_init, get_reset_dynbal_baselines
 
   use clm_instMod       
   ! 
@@ -56,7 +57,6 @@ contains
     use initGridCellsMod , only: initGridCells
     use ch4varcon        , only: ch4conrd
     use UrbanParamsType  , only: UrbanInput, IsSimpleBuildTemp
-    use dynSubgridControlMod, only: dynSubgridControl_init
     !
     ! !LOCAL VARIABLES:
     integer           :: ier                     ! error status
@@ -452,6 +452,16 @@ contains
 
     ! ------------------------------------------------------------------------
     ! Initialize baseline water and energy states needed for dynamic subgrid operation
+    !
+    ! This will be overwritten by the restart file, but needs to be done for a cold start
+    ! case.
+    !
+    ! BACKWARDS_COMPATIBILITY(wjs, 2019-03-05) dyn_hwcontent_set_baselines is called again
+    ! later in initialization if reset_dynbal_baselines is set. I think we could just have
+    ! a single call in that location (adding some logic to also do the call if we're doing
+    ! a cold start) once we can assume that all finidat files have the necessary restart
+    ! fields on them. But for now, having the extra call here handles the case where the
+    ! relevant restart fields are missing from an old finidat file.
     ! ------------------------------------------------------------------------
 
     !$OMP PARALLEL DO PRIVATE (nc, bounds_clump)
@@ -572,6 +582,38 @@ contains
        ! (to be compatible with routines still using finidat)
        finidat = trim(finidat_interp_dest)
 
+    end if
+
+    ! ------------------------------------------------------------------------
+    ! If requested, reset dynbal baselines
+    !
+    ! This needs to happen after reading the restart file (including after reading the
+    ! interpolated restart file, if applicable).
+    ! ------------------------------------------------------------------------
+
+    if (get_reset_dynbal_baselines()) then
+       if (nsrest == nsrStartup) then
+          if (masterproc) then
+             write(iulog,*) ' '
+             write(iulog,*) 'Resetting dynbal baselines'
+             write(iulog,*) ' '
+          end if
+
+          !$OMP PARALLEL DO PRIVATE (nc, bounds_clump)
+          do nc = 1,nclumps
+             call get_clump_bounds(nc, bounds_clump)
+
+             call dyn_hwcontent_set_baselines(bounds_clump, &
+                  filter_inactive_and_active(nc)%num_icemecc, &
+                  filter_inactive_and_active(nc)%icemecc, &
+                  urbanparams_inst, soilstate_inst, water_inst, temperature_inst)
+          end do
+       else if (nsrest == nsrBranch) then
+          call endrun(msg='ERROR clm_initializeMod: '//&
+               'Cannot set reset_dynbal_baselines in a branch run')
+       end if
+       ! nsrContinue not explicitly handled: it's okay for reset_dynbal_baselines to
+       ! remain set in a continue run, but it has no effect
     end if
 
     ! ------------------------------------------------------------------------

--- a/src/main/subgridAveMod.F90
+++ b/src/main/subgridAveMod.F90
@@ -733,7 +733,7 @@ contains
   end subroutine p2g_2d
 
   !-----------------------------------------------------------------------
-  subroutine c2l_1d (bounds, carr, larr, c2l_scale_type)
+  subroutine c2l_1d (bounds, carr, larr, c2l_scale_type, include_inactive)
     !
     ! !DESCRIPTION:
     ! Perfrom subgrid-average from columns to landunits
@@ -744,8 +744,16 @@ contains
     real(r8), intent(in)  :: carr( bounds%begc: )  ! input column array
     real(r8), intent(out) :: larr( bounds%begl: )  ! output landunit array
     character(len=*), intent(in) :: c2l_scale_type ! scale factor type for averaging (see note at top of module)
+
+    ! If include_inactive is present and .true., then include inactive as well as active
+    ! columns in the averages. The purpose of this is to produce valid landunit-level
+    ! output for inactive landunits. This should only be set if carr has no NaN values,
+    ! even for inactive columns.
+    logical, intent(in), optional :: include_inactive
+
     !
     ! !LOCAL VARIABLES:
+    logical  :: l_include_inactive
     integer  :: c,l,index                       ! indices
     logical  :: found                              ! temporary for error check
     real(r8) :: scale_c2l(bounds%begc:bounds%endc) ! scale factor for column->landunit mapping
@@ -755,6 +763,12 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL((ubound(carr) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
     SHR_ASSERT_ALL((ubound(larr) == (/bounds%endl/)), errMsg(sourcefile, __LINE__))
+
+    if (present(include_inactive)) then
+       l_include_inactive = include_inactive
+    else
+       l_include_inactive = .false.
+    end if
 
     if (c2l_scale_type == 'unity') then
        do c = bounds%begc,bounds%endc
@@ -802,7 +816,7 @@ contains
     larr(bounds%begl : bounds%endl) = spval
     sumwt(bounds%begl : bounds%endl) = 0._r8
     do c = bounds%begc,bounds%endc
-       if (col%active(c) .and. col%wtlunit(c) /= 0._r8) then
+       if ((col%active(c) .or. l_include_inactive) .and. col%wtlunit(c) /= 0._r8) then
           if (carr(c) /= spval .and. scale_c2l(c) /= spval) then
              l = col%landunit(c)
              if (sumwt(l) == 0._r8) larr(l) = 0._r8

--- a/src/unit_test_shr/unittestWaterTypeFactory.F90
+++ b/src/unit_test_shr/unittestWaterTypeFactory.F90
@@ -21,7 +21,9 @@ module unittestWaterTypeFactory
   !
   !    - In the unit test tearDown method, before unittest_subgrid_teardown: call teardown()
 
+#include "shr_assert.h"
   use shr_kind_mod , only : r8 => shr_kind_r8
+  use shr_log_mod, only : errMsg => shr_log_errMsg
   use clm_varpar, only : nlevsoi, nlevgrnd, nlevsno
   use ColumnType, only : col
   use WaterType, only : water_type, water_params_type
@@ -39,6 +41,9 @@ module unittestWaterTypeFactory
      procedure, public :: create_water_type
      procedure, public :: teardown
   end type unittest_water_type_factory_type
+
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
 
 contains
 
@@ -85,6 +90,7 @@ contains
   end subroutine setup_after_subgrid
 
   subroutine create_water_type(this, water_inst, &
+       t_soisno_col, watsat_col, &
        enable_consistency_checks, enable_isotopes)
     ! Initialize water_inst
     !
@@ -97,14 +103,31 @@ contains
     ! false.
     class(unittest_water_type_factory_type), intent(in) :: this
     type(water_type), intent(inout) :: water_inst
+
+    ! Temperature of each soil and snow layer, for each column and layer. Second
+    ! dimension should go from -nlevsno+1..nlevgrnd. If not provided, we use arbitrary
+    ! values for this variable.
+    real(r8), intent(in), optional :: t_soisno_col( bounds%begc: , -nlevsno+1: )
+
+    ! watsat for each soil layer, for each column. Second dimension should go from
+    ! 1..nlevgrnd. If not provided, we use arbitrary values for this variable.
+    real(r8), intent(in), optional :: watsat_col( bounds%begc: , 1: )
+
     logical, intent(in), optional :: enable_consistency_checks
     logical, intent(in), optional :: enable_isotopes
 
     logical :: l_enable_consistency_checks
     logical :: l_enable_isotopes
     type(water_params_type) :: params
-    real(r8), allocatable :: watsat_col(:,:)
-    real(r8), allocatable :: t_soisno_col(:,:)
+    real(r8) :: l_watsat_col(bounds%begc:bounds%endc, nlevgrnd)
+    real(r8) :: l_t_soisno_col(bounds%begc:bounds%endc, -nlevsno+1:nlevgrnd)
+
+    if (present(t_soisno_col)) then
+       SHR_ASSERT_ALL((ubound(t_soisno_col) == [bounds%endc, nlevgrnd]), errMsg(sourcefile, __LINE__))
+    end if
+    if (present(watsat_col)) then
+       SHR_ASSERT_ALL((ubound(watsat_col) == [bounds%endc, nlevgrnd]), errMsg(sourcefile, __LINE__))
+    end if
 
     if (present(enable_consistency_checks)) then
        l_enable_consistency_checks = enable_consistency_checks
@@ -122,16 +145,23 @@ contains
          enable_consistency_checks = l_enable_consistency_checks, &
          enable_isotopes = l_enable_isotopes)
 
-    allocate(watsat_col(bounds%begc:bounds%endc, nlevgrnd))
-    watsat_col(:,:) = 0._r8
-    allocate(t_soisno_col(bounds%begc:bounds%endc, -nlevsno+1:nlevgrnd))
-    t_soisno_col(:,:) = 275._r8
+    if (present(watsat_col)) then
+       l_watsat_col(:,:) = watsat_col(:,:)
+    else
+       l_watsat_col(:,:) = 0.2_r8
+    end if
+
+    if (present(t_soisno_col)) then
+       l_t_soisno_col(:,:) = t_soisno_col(:,:)
+    else
+       l_t_soisno_col(:,:) = 275._r8
+    end if
 
     call water_inst%InitForTesting(bounds, params, &
          h2osno_col = col_array(0._r8), &
          snow_depth_col = col_array(0._r8), &
-         watsat_col = watsat_col, &
-         t_soisno_col = t_soisno_col)
+         watsat_col = l_watsat_col, &
+         t_soisno_col = l_t_soisno_col)
   end subroutine create_water_type
 
   subroutine teardown(this, water_inst)


### PR DESCRIPTION
### Description of changes

Subtract virtual states to reduce dynbal fluxes for transient glaciers

Up until now, when computing the dynbal correction fluxes for transient
glacier columns, we have been (1) counting the mass and energy in the
ice column as if that is a real state, but on the other hand (2) NOT
accounting for the fact that glacier columns don't represent the soil
under glacier. These two issues work in opposite directions, but (1)
dominates, because there is much more ice (and energy, I think) in the
roughly 50 m of glacial ice than there is in a typical 50 m soil
column.

In discussing this issue with @whlipscomb, we came up with the idea of
subtracting some baseline value from each glacier column. I think that,
as long as we subtract the same baseline value throughout an entire
simulation for a given column, we will still conserve mass and energy
through dynamic landunit transitions.

So, here we subtract baseline values from glacier columns, accounting
for the two issues mentioned above: (1) we subtract the water and energy
in the glacier ice, because this is a virtual state in CTSM, and (2) we
add the water and energy from the vegetated column(s), to account for
the fact that we don't have an explicit representation of
soil-under-glacier (this carries the assumption that the
soil-under-glacier has the same state as the initial vegetated state in
that grid cell). We set these baselines in initialization, so they begin
equal to the cold start state. Water and ice in the glacial ice stay
fixed over the course of a simulation, so the cold start values should
be the same as the current values at any point in time. The heat content
of the glacial ice does change over time, but by subtracting this
baseline value, we should be able to reduce the dynbal sensible heat
fluxes.

In addition, this introduces a new namelist flag,
`reset_dynbal_baselines`, which allows the user to reset these baselines
at some desired point in the simulation. I think that, in general, this
resetting would break conservation. But as long as it is done before the
onset of transient glaciers, I think this should be okay. In this way,
the user can minimize dynbal fluxes even further, by resetting the
baselines after the system has spun up.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
- Partially addresses #274

Are answers expected to change (and if so in what way)? YES
- Changes answers significantly for runs with transient glaciers
  (substantial changes in dynbal water and energy fluxes)
- For other transient cases, possible roundoff-level changes for dynbal
  fluxes (if, e.g., a grid cell that has some static glacier has
  transient crop area: the total water and energy of the grid cell will
  change significantly, but by the same amount before and after the
  transition, leading to roundoff-level differences in fluxes)
- For all cases: Large changes in some diagnostic terms related to total
  water and energy

Any User Interface Changes (namelist or namelist defaults changes)?
- New namelist variable: reset_dynbal_baselines

Testing performed, if any:
- So far, just manual testing
- Will run full test suite
- In addition, will run full test suite with minimal changes to achieve
  no greater than roundoff-level diffs from master, to confirm that the
  only answer changes came from the new subtraction of baselines for
  glacier columns
