### PR TITLE
Fixing the balance check to check for possible errors in all columns/patches

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm1.0.dev032
 Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
-Date:  Fri Apr  5 13:49:22 MDT 2019
+Date: Mon Apr  8 08:26:57 MDT 2019
 One-line Summary: Fixing the balance check to check for possible errors over all columns/patches
 
 Purpose of changes
@@ -23,12 +23,12 @@ Below is the list of the balance checks with a similar issue:
 5. Surface energy balance check
 6. Soil energy balance check (Issue #55)
 
-For remediating this issue, we used MAXVAL and MAXLOC intrinsic functions
+For remediating this issue, we used MAXVAL and MAXLOC Fortran intrinsic functions
 to compare the largest error with the warning and error thresholds instead
 of checking the last column or looping over all columns.
 
 
-In addition, this PR also makes slight changes to ./run_sys_tests output
+In addition, this PR also makes slight changes to ./run_sys_tests outputi/case
 directory structure. Previously for each case in a test suite, there were 
 two set of directories created by run_sys_tests as follows:
  * one directory which included run/ and bld/ and named as $SCRATCH/[case-name]....
@@ -36,9 +36,9 @@ two set of directories created by run_sys_tests as follows:
      for ./case.build, ./case.submit... under $SCRATCH/tests-[testID]/[case-name]....
 
 This made debugging confusing and populated many folders in user's scratch.
-Now, for every case in a test, all directories related to that cases
-including bld/ and run/ directories are nested under the case directory.
-This is similar to ./create_test output folder structure.
+Now, for every case in a test, all directories related to that case
+including bld/ and run/ directories are nested under the case directory under $SCRATCH/tests-[testID]/[case-name]....
+This is now similar to ./create_test output folder structure.
 
 
 
@@ -80,7 +80,7 @@ NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the
 Caveats for developers (e.g., code that is duplicated that requires double maintenance):
 
 Changes to tests or testing: 
- - ./run_sys_test is changed so that it nests bld/ and run/ directories under the case directory as $SCRATCH/tests-[testID/[case-name]...
+ - ./run_sys_test is changed so that it nests bld/ and run/ directories under the case directory as $SCRATCH/tests-[testID]/[case-name]...
    The output folder structure now is similar to ./create_test for each case in a test.
 
 Code reviewed by: Bill Sacks

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,132 @@
 ===============================================================
+Tag name:  ctsm1.0.dev032
+Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
+Date:  Fri Apr  5 13:49:22 MDT 2019
+One-line Summary: Fixing the balance check to check for possible errors over all columns/patches
+
+Purpose of changes
+------------------
+Up until now, the BalanceCheckMod code in biogeophysics did not check all
+the possible errors over all columns or patches with the error threshold for
+aborting clm and it merely compared the last column/patch found (where
+warning threshold is met) with the error threshold.
+Therefore, there was always a possibility that the abort is not triggered
+when it should have been. This issue was first mentioned in ctsm issue #55
+for soil energy balance check, but a similar issue is also present for
+other balance checks in BalanceCheckMod.F90 .
+
+Below is the list of the balance checks with a similar issue:
+1. Water balance check
+2. Snow balance check
+3. Solar radiation energy balance check
+4. Longwave radiation energy balance check
+5. Surface energy balance check
+6. Soil energy balance check (Issue #55)
+
+For remediating this issue, we used MAXVAL and MAXLOC intrinsic functions
+to compare the largest error with the warning and error thresholds instead
+of checking the last column or looping over all columns.
+
+
+In addition, this PR also makes slight changes to ./run_sys_tests output
+directory structure. Previously for each case in a test suite, there were 
+two set of directories created by run_sys_tests as follows:
+ * one directory which included run/ and bld/ and named as $SCRATCH/[case-name]....
+ * The case directory which included logs , timings, CaseDocs/, and misc. scripts
+     for ./case.build, ./case.submit... under $SCRATCH/tests-[testID]/[case-name]....
+
+This made debugging confusing and populated many folders in user's scratch.
+Now, for every case in a test, all directories related to that cases
+including bld/ and run/ directories are nested under the case directory.
+This is similar to ./create_test output folder structure.
+
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+- Resolves ESCOMP/ctsm issue#55
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values): None
+
+Changes to the datasets (e.g., parameter, surface or initial files): None
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+
+Changes to tests or testing: 
+ - ./run_sys_test is changed so that it nests bld/ and run/ directories under the case directory as $SCRATCH/tests-[testID/[case-name]...
+   The output folder structure now is similar to ./create_test for each case in a test.
+
+Code reviewed by: Bill Sacks
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run 
+
+  tools-tests (test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+     cheyenne - not run
+
+  regular tests (aux_clm):
+
+    cheyenne ---- ok
+    hobart ------ ok
+
+
+CTSM tag used for the baseline comparisons: ctsm1.0.dev031
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: No
+
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/ctsm/pull/670
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev031
 Originator(s):  sacks (Bill Sacks)
 Date: Wed Mar 13 15:03:42 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev032   negins 04/05/2019 Fixing the balance check to check for possible errors over all columns/patches
+  ctsm1.0.dev032   negins 04/08/2019 Fixing the balance check to check for possible errors over all columns/patches
   ctsm1.0.dev031    sacks 03/13/2019 Subtract virtual states to reduce dynbal fluxes for transient glaciers
   ctsm1.0.dev030    sacks 03/08/2019 Update CIME; hookup expected test fails
   ctsm1.0.dev029   slevis 02/26/2019 Collapse landunits to the N most dominant

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev032   negins 04/05/2019 Fixing the balance check to check for possible errors over all columns/patches
   ctsm1.0.dev031    sacks 03/13/2019 Subtract virtual states to reduce dynbal fluxes for transient glaciers
   ctsm1.0.dev030    sacks 03/08/2019 Update CIME; hookup expected test fails
   ctsm1.0.dev029   slevis 02/26/2019 Collapse landunits to the N most dominant

--- a/python/ctsm/run_sys_tests.py
+++ b/python/ctsm/run_sys_tests.py
@@ -496,7 +496,7 @@ def _build_create_test_cmd(cime_path, test_args, testid, testroot, create_test_a
     """
     command = [os.path.join(cime_path, 'scripts', 'create_test'),
                '--test-id', testid,
-               '--test-root', testroot]
+               '--output-root', testroot]
     command.extend(test_args)
     command.extend(create_test_args)
     return command

--- a/python/ctsm/test/test_machine.py
+++ b/python/ctsm/test/test_machine.py
@@ -120,7 +120,10 @@ class TestCreateMachine(unittest.TestCase):
         machine = create_machine('cheyenne', defaults, account='a123')
         self.assertMachineInfo(machine=machine,
                                name='cheyenne',
-                               scratch_dir='/glade/scratch/sacks',
+                               scratch_dir=os.path.join(os.path.sep,
+                                                        'glade',
+                                                        'scratch',
+                                                        get_user()),
                                account='a123')
         self.assertQsubInfo(machine=machine,
                             queue='regular',

--- a/python/ctsm/test/test_run_sys_tests.py
+++ b/python/ctsm/test/test_run_sys_tests.py
@@ -100,7 +100,7 @@ class TestRunSysTests(unittest.TestCase):
         (1) The use of a testlist argument
 
         (2) The standard arguments to create_test (the path to create_test, the arguments
-        --test-id and --test-root, and the absence of --compare and --generate)
+        --test-id and --output-root, and the absence of --compare and --generate)
 
         (3) That a cs.status.fails file was created
         """
@@ -117,7 +117,7 @@ class TestRunSysTests(unittest.TestCase):
         six.assertRegex(self, command, r'^ *{}\s'.format(re.escape(expected_create_test)))
         six.assertRegex(self, command, r'--test-id +{}\s'.format(self._expected_testid()))
         expected_testroot_path = os.path.join(self._scratch, self._expected_testroot())
-        six.assertRegex(self, command, r'--test-root +{}\s'.format(expected_testroot_path))
+        six.assertRegex(self, command, r'--output-root +{}\s'.format(expected_testroot_path))
         six.assertRegex(self, command, r'test1 +test2(\s|$)')
         assertNotRegex(self, command, r'--compare\s')
         assertNotRegex(self, command, r'--generate\s')
@@ -156,7 +156,7 @@ class TestRunSysTests(unittest.TestCase):
         command = all_commands[0].cmd
         six.assertRegex(self, command, r'--test-id +mytestid(\s|$)')
         expected_testroot = os.path.join(testroot_base, 'tests_mytestid')
-        six.assertRegex(self, command, r'--test-root +{}(\s|$)'.format(expected_testroot))
+        six.assertRegex(self, command, r'--output-root +{}(\s|$)'.format(expected_testroot))
         six.assertRegex(self, command, r'--testfile +/path/to/testfile(\s|$)')
         six.assertRegex(self, command, r'--compare +mycompare(\s|$)')
         six.assertRegex(self, command, r'--generate +mygenerate(\s|$)')

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -699,10 +699,10 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = col%active(c))
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = col%active )
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = col%active(c) ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = col%active ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -420,11 +420,11 @@ contains
 
        end do
        
-       errh2o_max_val = maxval( abs(errh2o(bounds%begc:bounds%endc)), mask = (errh2o(bounds%begc:bounds%endc) < spval) )
+       errh2o_max_val = maxval( abs(errh2o(bounds%begc:bounds%endc)), mask = (errh2o(bounds%begc:bounds%endc) /= spval) )
 
        if (errh2o_max_val > h2o_warning_thresh) then
 
-           indexc = maxloc( abs(errh2o(bounds%begc:bounds%endc)), 1 , mask = (errh2o(bounds%begc:bounds%endc) < spval) ) + bounds%begc -1
+           indexc = maxloc( abs(errh2o(bounds%begc:bounds%endc)), 1 , mask = (errh2o(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
            write(iulog,*)'WARNING:  water balance error ',&
              ' nstep= ',nstep, &
              ' local indexc= ',indexc,&
@@ -516,15 +516,16 @@ contains
                 snow_sinks(c) = 0._r8
                 errh2osno(c) = 0._r8
              end if
-
+          else
+             errh2osno(c) = 0._r8
           end if
        end do
 
 
-       errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)),  mask = (errh2osno(bounds%begc:bounds%endc) < spval) )
+       errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)),  mask = (errh2osno(bounds%begc:bounds%endc) /= spval) )
        
        if (errh2osno_max_val > h2o_warning_thresh) then
-            indexc = maxloc( abs(errh2osno(bounds%begc:bounds%endc)), 1 ,  mask = (errh2osno(bounds%begc:bounds%endc) < spval) ) + bounds%begc -1
+            indexc = maxloc( abs(errh2osno(bounds%begc:bounds%endc)), 1 ,  mask = (errh2osno(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
             write(iulog,*)'WARNING:  snow balance error '
             write(iulog,*)'nstep= ',nstep, &
                  ' local indexc= ',indexc, &
@@ -618,11 +619,11 @@ contains
 
        ! Solar radiation energy balance check
 
-       errsol_max_val = maxval( abs(errsol(bounds%begp:bounds%endp)), mask = (errsol(bounds%begp:bounds%endp) < spval) ) 
+       errsol_max_val = maxval( abs(errsol(bounds%begp:bounds%endp)), mask = (errsol(bounds%begp:bounds%endp) /= spval) ) 
 
        if  ((errsol_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
-           indexp = maxloc( abs(errsol(bounds%begp:bounds%endp)), 1 , mask = (errsol(bounds%begp:bounds%endp) < spval) ) + bounds%begp -1
+           indexp = maxloc( abs(errsol(bounds%begp:bounds%endp)), 1 , mask = (errsol(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
            indexg = patch%gridcell(indexp)
            !write(iulog,*)'indexg         = ',indexg
            write(iulog,*)'WARNING:: BalanceCheck, solar radiation balance error (W/m2)'
@@ -647,10 +648,10 @@ contains
        
        ! Longwave radiation energy balance check
 
-       errlon_max_val = maxval( abs(errlon(bounds%begp:bounds%endp)), mask = (errlon(bounds%begp:bounds%endp) < spval) )
+       errlon_max_val = maxval( abs(errlon(bounds%begp:bounds%endp)), mask = (errlon(bounds%begp:bounds%endp) /= spval) )
 
        if ((errlon_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
-            indexp = maxloc( abs(errlon(bounds%begp:bounds%endp)), 1 , mask = (errlon(bounds%begp:bounds%endp) < spval) ) + bounds%begp -1
+            indexp = maxloc( abs(errlon(bounds%begp:bounds%endp)), 1 , mask = (errlon(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
             write(iulog,*)'indexp         = ',indexp
             write(iulog,*)'WARNING: BalanceCheck: longwave energy balance error (W/m2)'
             write(iulog,*)'nstep        = ',nstep
@@ -663,11 +664,11 @@ contains
 
        ! Surface energy balance check
 
-       errseb_max_val = maxval( abs(errseb(bounds%begp:bounds%endp)), mask = (errseb(bounds%begp:bounds%endp) < spval) )
+       errseb_max_val = maxval( abs(errseb(bounds%begp:bounds%endp)), mask = (errseb(bounds%begp:bounds%endp) /= spval) )
 
        if ((errseb_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
-           indexp = maxloc( abs(errseb(bounds%begp:bounds%endp)), 1 , mask = (errseb(bounds%begp:bounds%endp) < spval) ) + bounds%begp -1
+           indexp = maxloc( abs(errseb(bounds%begp:bounds%endp)), 1 , mask = (errseb(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
            indexc = patch%column(indexp)
            indexg = patch%gridcell(indexp)
 
@@ -700,10 +701,10 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)), mask = (errsoi_col(bounds%begc:bounds%endc) < spval) )
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)), mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) )
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) < spval) ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -590,52 +590,48 @@ contains
           end if
        end do
 
-       found = .false.
-       do c = bounds%begc,bounds%endc
-          if (col%active(c)) then
-             if (abs(errh2osno(c)) > 1.0e-9_r8) then
-                found = .true.
-                indexc = c
-             end if
-          end if
-       end do
-       if ( found ) then
-          write(iulog,*)'WARNING:  snow balance error '
-          write(iulog,*)'nstep= ',nstep, &
-               ' local indexc= ',indexc, &
-               ! ' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
-               ' col%itype= ',col%itype(indexc), &
-               ' lun%itype= ',lun%itype(col%landunit(indexc)), &
-               ' errh2osno= ',errh2osno(indexc)
 
-          if (abs(errh2osno(indexc)) > 1.e-5_r8 .and. (DAnstep > skip_steps) ) then
-             write(iulog,*)'clm model is stopping - error is greater than 1e-5 (mm)'
-             write(iulog,*)'nstep              = ',nstep
-             write(iulog,*)'errh2osno          = ',errh2osno(indexc)
-             write(iulog,*)'snl                = ',col%snl(indexc)
-             write(iulog,*)'snow_depth         = ',snow_depth(indexc)
-             write(iulog,*)'frac_sno_eff       = ',frac_sno_eff(indexc)
-             write(iulog,*)'h2osno             = ',h2osno(indexc)
-             write(iulog,*)'h2osno_old         = ',h2osno_old(indexc)
-             write(iulog,*)'snow_sources       = ',snow_sources(indexc)*dtime
-             write(iulog,*)'snow_sinks         = ',snow_sinks(indexc)*dtime
-             write(iulog,*)'qflx_prec_grnd     = ',qflx_prec_grnd(indexc)*dtime
-             write(iulog,*)'qflx_snow_grnd_col = ',qflx_snow_grnd_col(indexc)*dtime
-             write(iulog,*)'qflx_rain_grnd_col = ',qflx_rain_grnd_col(indexc)*dtime
-             write(iulog,*)'qflx_sub_snow      = ',qflx_sub_snow(indexc)*dtime
-             write(iulog,*)'qflx_snow_drain    = ',qflx_snow_drain(indexc)*dtime
-             write(iulog,*)'qflx_evap_grnd     = ',qflx_evap_grnd(indexc)*dtime
-             write(iulog,*)'qflx_dew_snow      = ',qflx_dew_snow(indexc)*dtime
-             write(iulog,*)'qflx_dew_grnd      = ',qflx_dew_grnd(indexc)*dtime
-             write(iulog,*)'qflx_snwcp_ice     = ',qflx_snwcp_ice(indexc)*dtime
-             write(iulog,*)'qflx_snwcp_liq     = ',qflx_snwcp_liq(indexc)*dtime
-             write(iulog,*)'qflx_snwcp_discarded_ice = ',qflx_snwcp_discarded_ice(indexc)*dtime
-             write(iulog,*)'qflx_snwcp_discarded_liq = ',qflx_snwcp_discarded_liq(indexc)*dtime
-             write(iulog,*)'qflx_sl_top_soil   = ',qflx_sl_top_soil(indexc)*dtime
-             write(iulog,*)'clm model is stopping'
+       errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)),  mask = (errh2osno(bounds%begc:bounds%endc) < spval) )
+       write(iulog,*)'errh2osno_max_val ', errh2osno_max_val
+       
+       if (errh2osno_max_val > h2o_warning_thresh) then
+            indexc = maxloc( abs( errh2osno(bounds%begc:bounds%endc)), 1,  mask = (errh2osno(bounds%begc:bounds%endc) < spval)) + bounds%begc -1
+            write(iulog,*)'WARNING:  snow balance error '
+            write(iulog,*)'nstep= ',nstep, &
+                 ' local indexc= ',indexc, &
+                 ! ' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
+                 ' col%itype= ',col%itype(indexc), &
+                 ' lun%itype= ',lun%itype(col%landunit(indexc)), &
+                 ' errh2osno= ',errh2osno(indexc)
 
-             call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
-          end if
+            if ((errh2osno_max_val > h2o_error_thresh) .and. (DAnstep > skip_steps) ) then
+                 write(iulog,*)'clm model is stopping - error is greater than 1e-5 (mm)'
+                 write(iulog,*)'nstep              = ',nstep
+                 write(iulog,*)'errh2osno          = ',errh2osno(indexc)
+                 write(iulog,*)'snl                = ',col%snl(indexc)
+                 write(iulog,*)'snow_depth         = ',snow_depth(indexc)
+                 write(iulog,*)'frac_sno_eff       = ',frac_sno_eff(indexc)
+                 write(iulog,*)'h2osno             = ',h2osno(indexc)
+                 write(iulog,*)'h2osno_old         = ',h2osno_old(indexc)
+                 write(iulog,*)'snow_sources       = ',snow_sources(indexc)*dtime
+                 write(iulog,*)'snow_sinks         = ',snow_sinks(indexc)*dtime
+                 write(iulog,*)'qflx_prec_grnd     = ',qflx_prec_grnd(indexc)*dtime
+                 write(iulog,*)'qflx_snow_grnd_col = ',qflx_snow_grnd_col(indexc)*dtime
+                 write(iulog,*)'qflx_rain_grnd_col = ',qflx_rain_grnd_col(indexc)*dtime
+                 write(iulog,*)'qflx_sub_snow      = ',qflx_sub_snow(indexc)*dtime
+                 write(iulog,*)'qflx_snow_drain    = ',qflx_snow_drain(indexc)*dtime
+                 write(iulog,*)'qflx_evap_grnd     = ',qflx_evap_grnd(indexc)*dtime
+                 write(iulog,*)'qflx_dew_snow      = ',qflx_dew_snow(indexc)*dtime
+                 write(iulog,*)'qflx_dew_grnd      = ',qflx_dew_grnd(indexc)*dtime
+                 write(iulog,*)'qflx_snwcp_ice     = ',qflx_snwcp_ice(indexc)*dtime
+                 write(iulog,*)'qflx_snwcp_liq     = ',qflx_snwcp_liq(indexc)*dtime
+                 write(iulog,*)'qflx_snwcp_discarded_ice = ',qflx_snwcp_discarded_ice(indexc)*dtime
+                 write(iulog,*)'qflx_snwcp_discarded_liq = ',qflx_snwcp_discarded_liq(indexc)*dtime
+                 write(iulog,*)'qflx_sl_top_soil   = ',qflx_sl_top_soil(indexc)*dtime
+                 write(iulog,*)'clm model is stopping'
+                 call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
+            end if
+
        end if
 
        ! Energy balance checks

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -268,7 +268,7 @@ contains
      real(r8) :: dtime                                  ! land model time step (sec)
      integer  :: nstep                                  ! time step number
      integer  :: DAnstep                                ! time step number since last Data Assimilation (DA)
-     logical  :: found                                  ! flag in search loop
+!     logical  :: found                                  ! flag in search loop
      integer  :: indexp,indexc,indexl,indexg            ! index of first found in search loop
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
@@ -474,70 +474,6 @@ contains
        
        end if
        
-
-!       if ( found ) then
-!
-!          write(iulog,*)'WARNING:  water balance error ',&
-!               ' nstep= ',nstep, &
-!               ' local indexc= ',indexc,&
-!               ! ' global indexc= ',GetGlobalIndex(decomp_index=indexc, clmlevel=namec), &
-!               ' errh2o= ',errh2o(indexc)
-!
-!          if ((col%itype(indexc) == icol_roof .or. &
-!               col%itype(indexc) == icol_road_imperv .or. &
-!               col%itype(indexc) == icol_road_perv) .and. &
-!               abs(errh2o(indexc)) > 1.e-5_r8 .and. (DAnstep > skip_steps) ) then
-!
-!             write(iulog,*)'clm urban model is stopping - error is greater than 1e-5 (mm)'
-!             write(iulog,*)'nstep                 = ',nstep
-!             write(iulog,*)'errh2o                = ',errh2o(indexc)
-!             write(iulog,*)'forc_rain             = ',forc_rain_col(indexc)*dtime
-!             write(iulog,*)'forc_snow             = ',forc_snow_col(indexc)*dtime
-!             write(iulog,*)'endwb                 = ',endwb(indexc)
-!             write(iulog,*)'begwb                 = ',begwb(indexc)
-!             write(iulog,*)'qflx_evap_tot         = ',qflx_evap_tot(indexc)*dtime
-!             write(iulog,*)'qflx_sfc_irrig        = ',qflx_sfc_irrig(indexc)*dtime
-!             write(iulog,*)'qflx_surf             = ',qflx_surf(indexc)*dtime
-!             write(iulog,*)'qflx_qrgwl            = ',qflx_qrgwl(indexc)*dtime
-!             write(iulog,*)'qflx_drain            = ',qflx_drain(indexc)*dtime
-!             write(iulog,*)'qflx_ice_runoff_snwcp = ',qflx_ice_runoff_snwcp(indexc)*dtime
-!             write(iulog,*)'qflx_ice_runoff_xs    = ',qflx_ice_runoff_xs(indexc)*dtime
-!             write(iulog,*)'qflx_snwcp_discarded_ice = ',qflx_snwcp_discarded_ice(indexc)*dtime
-!             write(iulog,*)'qflx_snwcp_discarded_liq = ',qflx_snwcp_discarded_liq(indexc)*dtime
-!             write(iulog,*)'deltawb          = ',endwb(indexc)-begwb(indexc)
-!             write(iulog,*)'deltawb/dtime    = ',(endwb(indexc)-begwb(indexc))/dtime
-!             write(iulog,*)'deltaflux        = ',forc_rain_col(indexc)+forc_snow_col(indexc) - (qflx_evap_tot(indexc) + &
-!                  qflx_surf(indexc)+qflx_drain(indexc))
-!
-!             write(iulog,*)'clm model is stopping'
-!             call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
-!
-!          else if (abs(errh2o(indexc)) > 1.e-5_r8 .and. (DAnstep > skip_steps) ) then
-!
-!             write(iulog,*)'clm model is stopping - error is greater than 1e-5 (mm)'
-!             write(iulog,*)'nstep                 = ',nstep
-!             write(iulog,*)'errh2o                = ',errh2o(indexc)
-!             write(iulog,*)'forc_rain             = ',forc_rain_col(indexc)*dtime
-!             write(iulog,*)'forc_snow             = ',forc_snow_col(indexc)*dtime
-!             write(iulog,*)'endwb                 = ',endwb(indexc)
-!             write(iulog,*)'begwb                 = ',begwb(indexc)
-!             
-!             write(iulog,*)'qflx_evap_tot         = ',qflx_evap_tot(indexc)*dtime
-!             write(iulog,*)'qflx_sfc_irrig        = ',qflx_sfc_irrig(indexc)*dtime
-!             write(iulog,*)'qflx_surf             = ',qflx_surf(indexc)*dtime
-!             write(iulog,*)'qflx_qrgwl            = ',qflx_qrgwl(indexc)*dtime
-!             write(iulog,*)'qflx_drain            = ',qflx_drain(indexc)*dtime
-!             write(iulog,*)'qflx_drain_perched    = ',qflx_drain_perched(indexc)*dtime
-!             write(iulog,*)'qflx_flood            = ',qflx_floodc(indexc)*dtime
-!             write(iulog,*)'qflx_ice_runoff_snwcp = ',qflx_ice_runoff_snwcp(indexc)*dtime
-!             write(iulog,*)'qflx_ice_runoff_xs    = ',qflx_ice_runoff_xs(indexc)*dtime
-!             write(iulog,*)'qflx_glcice_dyn_water_flux = ', qflx_glcice_dyn_water_flux(indexc)*dtime
-!             write(iulog,*)'qflx_snwcp_discarded_ice = ',qflx_snwcp_discarded_ice(indexc)*dtime
-!             write(iulog,*)'qflx_snwcp_discarded_liq = ',qflx_snwcp_discarded_liq(indexc)*dtime
-!             write(iulog,*)'clm model is stopping'
-!             call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
-!          end if
-!       end if
 
        ! Snow balance check
 
@@ -771,25 +707,21 @@ contains
 
        ! Soil energy balance check
 
-       found = .false.
-       do c = bounds%begc,bounds%endc
-          if (col%active(c)) then
-             if (abs(errsoi_col(c)) > 1.0e-5_r8 ) then
-                found = .true.
-                indexc = c
-             end if
-          end if
-       end do
-       if ( found ) then
-          write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
-          write(iulog,*)'nstep         = ',nstep
-          write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)
-          if (abs(errsoi_col(indexc)) > 1.e-4_r8 .and. (DAnstep > skip_steps) ) then
-             write(iulog,*)'clm model is stopping'
-             call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
-          end if
-       end if
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)), mask = (errsoi_col(bounds%begc:bounds%endc) < spval) )
+       !write(iulog,*)'errsoi_col_max_val         = ',errsoi_col_max_val
 
+       if (errsoi_col_max_val > 1.0e-5_r8 ) then
+           indexc = maxloc(abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) < spval)) + bounds%begp -1
+           write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
+           write(iulog,*)'nstep         = ',nstep
+           write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)
+
+           if ((errsoi_col_max_val > 1.e-4_r8) .and. (DAnstep > skip_steps)) then
+              write(iulog,*)'clm model is stopping'
+              call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
+           end if
+       end if 
+       
      end associate
 
    end subroutine BalanceCheck

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -272,6 +272,19 @@ contains
      integer  :: indexp,indexc,indexl,indexg            ! index of first found in search loop
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]
+
+     real(r8) :: errh2o_max_val                         ! Maximum value of error in water conservation error  over all columns [mm H2O]
+     real(r8) :: errh2osno_max_val                      ! Maximum value of error in h2osno conservation error over all columns [kg m-2]
+     real(r8) :: errsol_max_val                         ! Maximum value of error in solar radiation conservation error over all columns [W m-2]
+     real(r8) :: errlon_max_val                         ! Maximum value of error in longwave radiation conservation error over all columns [W m-2]
+     real(r8) :: errseb_max_val                         ! Maximum value of error in surface energy conservation error over all columns [W m-2]
+     real(r8) :: errsoi_col_max_val                     ! Maximum value of column-level soil/lake energy conservation error over all columns [W m-2]
+
+     real(r8), parameter :: h2o_warning_thresh       = 1.e-9_r8                       ! land model time step (sec)
+     real(r8), parameter :: h2o_error_thresh         = 1.e-5_r8                       ! land model time step (sec)
+     real(r8), parameter :: energy_warning_thresh    = 1.e-7_r8                       ! land model time step (sec)
+     real(r8), parameter :: energy_error_thresh      = 1.e-5_r8                       ! land model time step (sec)
+
      !-----------------------------------------------------------------------
 
      associate(                                                                   & 

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -420,11 +420,11 @@ contains
 
        end do
        
-       errh2o_max_val = maxval( abs(errh2o(bounds%begc:bounds%endc)), mask = (errh2o(bounds%begc:bounds%endc) /= spval) )
+       errh2o_max_val = maxval(abs(errh2o(bounds%begc:bounds%endc)))
 
        if (errh2o_max_val > h2o_warning_thresh) then
 
-           indexc = maxloc( abs(errh2o(bounds%begc:bounds%endc)), 1 , mask = (errh2o(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
+           indexc = maxloc( abs(errh2o(bounds%begc:bounds%endc)), 1 ) + bounds%begc -1
            write(iulog,*)'WARNING:  water balance error ',&
              ' nstep= ',nstep, &
              ' local indexc= ',indexc,&
@@ -522,10 +522,10 @@ contains
        end do
 
 
-       errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)),  mask = (errh2osno(bounds%begc:bounds%endc) /= spval) )
+       errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)))
        
        if (errh2osno_max_val > h2o_warning_thresh) then
-            indexc = maxloc( abs(errh2osno(bounds%begc:bounds%endc)), 1 ,  mask = (errh2osno(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
+            indexc = maxloc( abs(errh2osno(bounds%begc:bounds%endc)), 1) + bounds%begc -1
             write(iulog,*)'WARNING:  snow balance error '
             write(iulog,*)'nstep= ',nstep, &
                  ' local indexc= ',indexc, &
@@ -664,11 +664,11 @@ contains
 
        ! Surface energy balance check
 
-       errseb_max_val = maxval( abs(errseb(bounds%begp:bounds%endp)), mask = (errseb(bounds%begp:bounds%endp) /= spval) )
+       errseb_max_val = maxval( abs(errseb(bounds%begp:bounds%endp)))
 
        if ((errseb_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
-           indexp = maxloc( abs(errseb(bounds%begp:bounds%endp)), 1 , mask = (errseb(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
+           indexp = maxloc( abs(errseb(bounds%begp:bounds%endp)), 1 ) + bounds%begp -1
            indexc = patch%column(indexp)
            indexg = patch%gridcell(indexp)
 
@@ -701,10 +701,10 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)), mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) )
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) )
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -699,11 +699,10 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) )
-
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = col%active(bounds%begc:bounds%endc))
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = col%active(bounds%begc:bounds%endc) ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -704,11 +704,11 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) )
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = col%active(c))
        write(iulog,*)'errsoi_col_max_val      :', errsoi_col_max_val
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = col%active(c) ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -421,6 +421,7 @@ contains
        end do
        
        errh2o_max_val = maxval(abs(errh2o(bounds%begc:bounds%endc)))
+       write(iulog,*)'errh2o_max_val      :', errh2o_max_val
 
        if (errh2o_max_val > h2o_warning_thresh) then
 
@@ -523,6 +524,7 @@ contains
 
 
        errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)))
+       write(iulog,*)'errh2osno_max_val      :', errh2osno_max_val
        
        if (errh2osno_max_val > h2o_warning_thresh) then
             indexc = maxloc( abs(errh2osno(bounds%begc:bounds%endc)), 1) + bounds%begc -1
@@ -620,6 +622,7 @@ contains
        ! Solar radiation energy balance check
 
        errsol_max_val = maxval( abs(errsol(bounds%begp:bounds%endp)), mask = (errsol(bounds%begp:bounds%endp) /= spval) ) 
+       write(iulog,*)'errsol_max_val      :', errsol_max_val
 
        if  ((errsol_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
@@ -649,6 +652,7 @@ contains
        ! Longwave radiation energy balance check
 
        errlon_max_val = maxval( abs(errlon(bounds%begp:bounds%endp)), mask = (errlon(bounds%begp:bounds%endp) /= spval) )
+       write(iulog,*)'errlon_max_val      :', errlon_max_val
 
        if ((errlon_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
             indexp = maxloc( abs(errlon(bounds%begp:bounds%endp)), 1 , mask = (errlon(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
@@ -665,6 +669,7 @@ contains
        ! Surface energy balance check
 
        errseb_max_val = maxval( abs(errseb(bounds%begp:bounds%endp)))
+       write(iulog,*)'errseb_max_val      :', errseb_max_val
 
        if ((errseb_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
@@ -702,6 +707,7 @@ contains
        ! Soil energy balance check
 
        errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) )
+       write(iulog,*)'errsoi_col_max_val      :', errsoi_col_max_val
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
            indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 ) + bounds%begc -1

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -268,7 +268,6 @@ contains
      real(r8) :: dtime                                  ! land model time step (sec)
      integer  :: nstep                                  ! time step number
      integer  :: DAnstep                                ! time step number since last Data Assimilation (DA)
-!     logical  :: found                                  ! flag in search loop
      integer  :: indexp,indexc,indexl,indexg            ! index of first found in search loop
      real(r8) :: forc_rain_col(bounds%begc:bounds%endc) ! column level rain rate [mm/s]
      real(r8) :: forc_snow_col(bounds%begc:bounds%endc) ! column level snow rate [mm/s]

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -706,11 +706,11 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) )
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) )
        write(iulog,*)'errsoi_col_max_val      :', errsoi_col_max_val
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -699,10 +699,11 @@ contains
 
        ! Soil energy balance check
 
-       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = col%active )
+       errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) )
+
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = col%active ) + bounds%begc -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) /= spval) ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -627,7 +627,6 @@ contains
 
            indexp = maxloc( abs(errsol(bounds%begp:bounds%endp)), 1 , mask = (errsol(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
            indexg = patch%gridcell(indexp)
-           !write(iulog,*)'indexg         = ',indexg
            write(iulog,*)'WARNING:: BalanceCheck, solar radiation balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsol        = ',errsol(indexp)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -420,7 +420,6 @@ contains
        end do
        
        errh2o_max_val = maxval(abs(errh2o(bounds%begc:bounds%endc)))
-       write(iulog,*)'errh2o_max_val      :', errh2o_max_val
 
        if (errh2o_max_val > h2o_warning_thresh) then
 
@@ -523,7 +522,6 @@ contains
 
 
        errh2osno_max_val = maxval( abs(errh2osno(bounds%begc:bounds%endc)))
-       write(iulog,*)'errh2osno_max_val      :', errh2osno_max_val
        
        if (errh2osno_max_val > h2o_warning_thresh) then
             indexc = maxloc( abs(errh2osno(bounds%begc:bounds%endc)), 1) + bounds%begc -1
@@ -621,7 +619,6 @@ contains
        ! Solar radiation energy balance check
 
        errsol_max_val = maxval( abs(errsol(bounds%begp:bounds%endp)), mask = (errsol(bounds%begp:bounds%endp) /= spval) ) 
-       write(iulog,*)'errsol_max_val      :', errsol_max_val
 
        if  ((errsol_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
@@ -650,7 +647,6 @@ contains
        ! Longwave radiation energy balance check
 
        errlon_max_val = maxval( abs(errlon(bounds%begp:bounds%endp)), mask = (errlon(bounds%begp:bounds%endp) /= spval) )
-       write(iulog,*)'errlon_max_val      :', errlon_max_val
 
        if ((errlon_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
             indexp = maxloc( abs(errlon(bounds%begp:bounds%endp)), 1 , mask = (errlon(bounds%begp:bounds%endp) /= spval) ) + bounds%begp -1
@@ -667,7 +663,6 @@ contains
        ! Surface energy balance check
 
        errseb_max_val = maxval( abs(errseb(bounds%begp:bounds%endp)))
-       write(iulog,*)'errseb_max_val      :', errseb_max_val
 
        if ((errseb_max_val > energy_warning_thresh) .and. (DAnstep > skip_steps)) then
 
@@ -705,7 +700,6 @@ contains
        ! Soil energy balance check
 
        errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)) , mask = col%active(c))
-       write(iulog,*)'errsoi_col_max_val      :', errsoi_col_max_val
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
            indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = col%active(c) ) + bounds%begc -1

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -608,7 +608,11 @@ contains
                      + eflx_wasteheat_patch(p) + eflx_heat_from_ac_patch(p) + eflx_traffic_patch(p)
              end if
              !TODO MV - move this calculation to a better place - does not belong in BalanceCheck 
-             netrad(p) = fsa(p) - eflx_lwrad_net(p) 
+             netrad(p) = fsa(p) - eflx_lwrad_net(p)
+          else
+             errsol(p) = 0._r8
+             errlon(p) = 0._r8
+             errseb(p) = 0._r8
           end if
        end do
 
@@ -699,7 +703,7 @@ contains
        errsoi_col_max_val  =  maxval( abs(errsoi_col(bounds%begc:bounds%endc)), mask = (errsoi_col(bounds%begc:bounds%endc) < spval) )
 
        if (errsoi_col_max_val > 1.0e-5_r8 ) then
-           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) < spval) ) + bounds%begp -1
+           indexc = maxloc( abs(errsoi_col(bounds%begc:bounds%endc)), 1 , mask = (errsoi_col(bounds%begc:bounds%endc) < spval) ) + bounds%begc -1
            write(iulog,*)'WARNING: BalanceCheck: soil balance error (W/m2)'
            write(iulog,*)'nstep         = ',nstep
            write(iulog,*)'errsoi_col    = ',errsoi_col(indexc)


### PR DESCRIPTION
### Description of changes

Up until now, the BalanceCheckMod code in biogeophysics did not check all the possible errors over all columns or patches with the error threshold for aborting clm and it merely compared the last column/patch found (where warning threshold is met) with the error threshold. Therefore, there was always a possibility that the abort is not triggered when it should have been. @lvankampenhout and @billsacks pointed out this issue (Issue #55) for soil energy balance check. A similar issue is also happening for the other balance checks in `BalanceCheckMod.F90`. 

Below is the list of the balance checks with a similar issue:
1. Water balance check
2. Snow balance check
3. Solar radiation energy balance check
4. Longwave radiation energy balance check
5. Surface energy balance check
6. Soil energy balance check (Issue #55) 

The simple psuedo-code below illustrates the problems with all these balance checks. First loop compares the error over all columns with the `warning_threshhold` and save only the last column where `found= true`. The second block compares only the last column found with the `error_threshhold`. Hence there is always a possibility of an error higher than `error_threshhold`  that is simply skipped in the second comparison. 
```
! Sample balance check psuedo code

found = .false.
do c = bounds%begc,bounds%endc
      if (error(c) > warning_threshold ) then
         found = .true.
         indexc = c
      end if
end do

if ( found ) then
   write(iulog,*)'WARNING: BalanceCheck !!!!'
   if (error(c) > error_threshhold ) then
      write(iulog,*)'clm model is stopping'
      call endrun
   end if
end if
```

For remediating this problem, we used `MAXVAL` and `MAXLOC` to compare the largest error with the warning and error thresholds. 

### Specific notes

Contributors other than yourself, if any: @billsacks 

CTSM Issues Fixed (include github issue #): Fixes issue #55 

Are answers expected to change (and if so in what way)? 
No. However there are possible cases that were previously working, but are no longer working, since in balance checks there might be errors larger than the error threshhold, which were previously skipped. 

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
* Manual testing making sure the code checks for the maximum error across all columns or patches with the error threshold. 
* Full `aux_clm` test suites on both Cheyenne and Hobart. 