### PR TITLE
Replace h2ocan with liqcan+snocan: First stage

### DIFF
--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -726,25 +726,13 @@ contains
              h2ocan_new = snocan(p) + liqcan(p)
 
              ! FIXME(wjs, 2019-04-19) Remove the following block of code
-             if (h2ocan(p) > 0._r8 .and. h2ocan_new <= 0._r8) then
-                write(iulog,*) 'FracWet: h2ocan > 0 but not h2ocan_new:'
+             if (abs(h2ocan(p) - h2ocan_new) > 1.e-13_r8) then
+                write(iulog,*) 'FracWet: difference too big:'
                 write(iulog,*) p, h2ocan(p), h2ocan_new, snocan(p), liqcan(p)
-                call endrun(msg='FracWet: h2ocan > 0 but not h2ocan_new')
-             end if
-             if (h2ocan_new > 0._r8 .and. h2ocan(p) <= 0._r8) then
-                write(iulog,*) 'FracWet: h2ocan_new > 0 but not h2ocan:'
-                write(iulog,*) p, h2ocan(p), h2ocan_new, snocan(p), liqcan(p)
-                call endrun(msg='FracWet: h2ocan_new > 0 but not h2ocan')
+                call endrun(msg='FracWet: difference too big')
              end if
 
              if (h2ocan_new > 0._r8) then
-                ! FIXME(wjs, 2019-04-19) Remove the following block of code
-                if (abs(h2ocan(p) - h2ocan_new) > 1.e-13_r8) then
-                   write(iulog,*) 'FracWet: difference too big:'
-                   write(iulog,*) p, h2ocan(p), h2ocan_new, snocan(p), liqcan(p)
-                   call endrun(msg='FracWet: difference too big')
-                end if
-
                 vegt    = frac_veg_nosno(p)*(elai(p) + esai(p))
                 dewmxi  = 1.0_r8/dewmx(p)
                 fwet(p) = ((dewmxi/vegt)*h2ocan_new)**0.666666666666_r8


### PR DESCRIPTION
### Description of changes

This PR is the first step towards cleaning up the relationship between h2ocan, liqcan and snocan. This replaces uses of `h2ocan_patch(p)` with `(liqcan_patch(p) + snocan_patch(p))`, generally via a temporary variable, `h2ocan_new = liqcan_patch(p) + snocan_patch(p)`. In each part of the code where I have made this replacement, I have put in temporary checks to ensure that these two values of h2ocan (`h2ocan_patch(p) vs. liqcan_patch(p)+snocan_patch(p)`) are the same within roundoff. I have run the full aux_clm test suite on these changes to ensure that the two expressions are always the same within roundoff.

This does change answers, because in general, h2ocan_patch differs at the roundoff level from liqcan_patch+snocan_patch. These roundoff-level differences can lead to divergent code behavior. The most obvious example of this is in the check of h2ocan > 0 in subroutine FracWet. I have found that, due to roundoff errors, it is possible for h2ocan_patch > 0 by roundoff, while (liqcan_patch + snocan_patch) <= 0 by roundoff. (Presumably the reverse could also be true, though I haven't seen that – but I haven't spent much time looking for it.)

My spot-checks of differences from baselines have shown some pretty big differences for instantaneous values or daily averages. See the two attached screen shots, one showing differences in ground evaporation (FGEV) for a one-day average from test `SMS_D_Ld1.f09_g17.I1850Clm45BgcCruGs.cheyenne_intel.clm-default`, and one showing differences in sensible heat flux for a single time step from test `SMS_Ld1.f09_g17.I1850Clm50Bgc.cheyenne_intel.clm-drydepnomegan`.
<img width="1160" alt="4C972227-7A13-424B-84FB-5D9AC6DE4CDF" src="https://user-images.githubusercontent.com/6266741/56461158-63e34500-636b-11e9-8ec7-7d6e2316c566.png">
<img width="590" alt="F3C37595-0769-4F2E-B0DA-DD6E3F068FDF" src="https://user-images.githubusercontent.com/6266741/56461161-75c4e800-636b-11e9-9df0-c52ace60fba5.png">

I have NOT done any climatological comparisons (e.g., with the diagnostics package) to see if there are any changes in the mean state.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
- Next step towards resolving #199 

Are answers expected to change (and if so in what way)?
YES: see above

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
Full aux_clm test suite