### PR TITLE
Use universal_newlines in call to subprocess.Popen

### DIFF
--- a/python/ctsm/joblauncher/job_launcher_qsub.py
+++ b/python/ctsm/joblauncher/job_launcher_qsub.py
@@ -25,7 +25,8 @@ class JobLauncherQsub(JobLauncherBase):
         qsub_process = subprocess.Popen(self._qsub_command(stdout_path, stderr_path),
                                         stdin=subprocess.PIPE,
                                         stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE)
+                                        stderr=subprocess.PIPE,
+                                        universal_newlines=True)
         (out, err) = qsub_process.communicate(' '.join(command))
         if err:
             logger.info('qsub ERROR:\n%s', err)


### PR DESCRIPTION
### Description of changes

Without this, we run into the issue noted in
https://github.com/ESCOMP/ctsm/issues/692. This fixes the problem. I
don't fully understand the need for this, but from reading some stack
overflow posts, I'm not surprised that we need this.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
Resolves ESCOMP/ctsm#692

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
Manual testing of #692 issue. Also ran run_sys_tests with python2 loaded on cheyenne.
Also, from python directory: make python=python2 test, make python=python3 test, make lint
