### PR TITLE
Remove excess canopy liquid/snow regardless of temperature

### DIFF
--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -315,18 +315,16 @@ contains
                    qflx_snotempunload(p) = 0._r8
                    snounload(p)=0._r8
 
-                   if (forc_t(c) > tfrz) then ! Above freezing (Use t_veg?)
-                      xliqrun = (liqcan(p) - liqcanmx)/dtime
-                      if (xliqrun > 0._r8) then
-                         qflx_liqcanfall(p) = xliqrun
-                         liqcan(p) = liqcanmx
-                      end if
-                   else ! Below freezing
-                      xsnorun = (snocan(p) - snocanmx)/dtime
-                      if (xsnorun > 0._r8) then ! exceeds snow capacity
-                         qflx_snocanfall(p) = xsnorun
-                         snocan(p) = snocanmx
-                      end if
+                   ! Remove excess liquid / snow exceeding canopy capacity
+                   xliqrun = (liqcan(p) - liqcanmx)/dtime
+                   if (xliqrun > 0._r8) then
+                      qflx_liqcanfall(p) = xliqrun
+                      liqcan(p) = liqcanmx
+                   end if
+                   xsnorun = (snocan(p) - snocanmx)/dtime
+                   if (xsnorun > 0._r8) then ! exceeds snow capacity
+                      qflx_snocanfall(p) = xsnorun
+                      snocan(p) = snocanmx
                    end if
                 end if
              end if


### PR DESCRIPTION
### Description of changes

Previously: if it was above freezing, snow was allowed to accumulate
beyond the specified capacity, and if it was below freezing, liquid was
allowed to accumulate beyond the specified capacity. Sean Swenson, Keith
Oleson and Dave Lawrence agreed that this seems wrong.

This commit changes the behavior so that both liquid and snow canopy
capacities are enforced regardless of temperature.

### Specific notes

Contributors other than yourself, if any:
- Change supported by @swensosc @olyson @dlawrenncar 

CTSM Issues Fixed (include github issue #):
Resolves ESCOMP/ctsm#699

Are answers expected to change (and if so in what way)? YES
We expect answer changes, though probably fairly small. @olyson will investigate this after it comes to master.

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: none yet
