### PR TITLE
Fix a few issues, and update cime to a version with CO2 SSP files as well as three presaero SSP files

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -29,8 +29,8 @@ required = True
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/ekluzek/cime
-branch = addSSPCO2npresaero
+repo_url = https://github.com/ESMCI/cime
+tag = branch_tags/cime5.6.15_a01
 required = True
 
 [externals_description]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -29,8 +29,8 @@ required = True
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/ESMCI/cime
-tag = cime5.6.14
+repo_url = https://github.com/ekluzek/cime
+branch = addSSPCO2npresaero
 required = True
 
 [externals_description]

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -1085,56 +1085,34 @@ lnd/clm2/surfdata_map/surfdata_conus_30_x8_hist_78pfts_CMIP6_simyr1850_c190128.n
 
 <stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
 >lnd/clm2/ndepdata/fndep_clm_SSP585_b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190211.nc</stream_fldfilename_ndep>
-<!-- Currently duplicate SSP5-8.5 ndep for SSP5-3.4 -->
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-3.4"
->lnd/clm2/ndepdata/fndep_clm_SSP585_b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190211.nc</stream_fldfilename_ndep>
+<!-- We currently only have the Tier I Nitogen deposition files available -->
 <stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
 >lnd/clm2/ndepdata/fndep_clm_SSP126_b.e21.BWSSP126cmip6.f09_g17.CMIP6-SSP1-2.6-WACCM.001_2014-2101_monthly_0.9x1.25_c190221.nc</stream_fldfilename_ndep>
-<!-- Currently duplicate SSP1.2.6 ndep for SSP1-1.9 -->
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-1.9"
->lnd/clm2/ndepdata/fndep_clm_SSP126_b.e21.BWSSP126cmip6.f09_g17.CMIP6-SSP1-2.6-WACCM.001_2014-2101_monthly_0.9x1.25_c190221.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
->lnd/clm2/ndepdata/fndep_clm_SSP126_b.e21.BWSSP126cmip6.f09_g17.CMIP6-SSP1-2.6-WACCM.001_2014-2101_monthly_0.9x1.25_c190221.nc</stream_fldfilename_ndep>
-
 <stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
 >lnd/clm2/ndepdata/fndep_clm_SSP245_b.e21.BWSSP245cmip6.f09_g17.CMIP6-SSP2-4.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</stream_fldfilename_ndep>
 <stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
 >lnd/clm2/ndepdata/fndep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</stream_fldfilename_ndep>
-<!-- Currently duplicate SSP3-7.0 ndep for SSP4-6.0 -->
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP4-6.0"
->lnd/clm2/ndepdata/fndep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</stream_fldfilename_ndep>
-<!-- Currently duplicate SSP5-3.4 ndep for SSP4-3.4 -->
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP4-3.4"
->lnd/clm2/ndepdata/fndep_clm_SSP585_b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190211.nc</stream_fldfilename_ndep>
 
+<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
+
+<!-- We currently only have the Tier I Nitogen deposition files available -->
+<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
+>lnd/clm2/ndepdata/fndep_clm_SSP585_b.e21.BWSSP585cmip6.f09_g17.CMIP6-SSP5-8.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190211.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
+>lnd/clm2/ndepdata/fndep_clm_SSP126_b.e21.BWSSP126cmip6.f09_g17.CMIP6-SSP1-2.6-WACCM.001_2014-2101_monthly_0.9x1.25_c190221.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
+>lnd/clm2/ndepdata/fndep_clm_SSP245_b.e21.BWSSP245cmip6.f09_g17.CMIP6-SSP2-4.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
+>lnd/clm2/ndepdata/fndep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</stream_fldfilename_ndep>
 
 <ndep_taxmode            phys="clm5_0" use_cn=".true.">cycle</ndep_taxmode>
 <ndep_varlist            phys="clm5_0" use_cn=".true.">NDEP_month</ndep_varlist>
 <ndep_taxmode            phys="clm5_0" use_cn=".true.">limit</ndep_taxmode>
 
-<!-- Use CMIP5 ndep forcing for CLM4.5 cases -->
 <ndep_taxmode            phys="clm4_5" use_cn=".true.">extend</ndep_taxmode>
 <ndep_varlist            phys="clm4_5" use_cn=".true.">NDEP_year</ndep_varlist>
 <stream_fldfilename_ndep phys="clm4_5" use_cn=".true." ssp_rcp="hist"
 >lnd/clm2/ndepdata/fndep_clm_hist_simyr1849-2006_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-
-<!-- And old CMIP5 for clm4_5 cases -->
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP1-1.9"
->lnd/clm2/ndepdata/fndep_clm_rcp2.6_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP1-2.6"
->lnd/clm2/ndepdata/fndep_clm_rcp2.6_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP3-7.0"
->lnd/clm2/ndepdata/fndep_clm_rcp6.0_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP2-4.5"
->lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP4-3.4"
->lnd/clm2/ndepdata/fndep_clm_rcp2.6_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP4-6.0"
->lnd/clm2/ndepdata/fndep_clm_rcp6.0_simyr1849-2106_1.9x2.5_c100810.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP5-3.4"
->lnd/clm2/ndepdata/fndep_clm_rcp4.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="1.9x2.5"   use_cn=".true."   ssp_rcp="SSP5-8.5"
->lnd/clm2/ndepdata/fndep_clm_rcp8.5_simyr1849-2106_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
 
 <ndepmapalgo                use_cn=".true." >bilinear</ndepmapalgo>
 

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -2269,6 +2269,8 @@ lnd/clm2/surfdata_map/surfdata_conus_30_x8_hist_78pfts_CMIP6_simyr1850_c190128.n
 >lnd/clm2/mappingdata/maps/ne4np4/map_5x5min_ORNL-Soil_to_ne4np4_nomask_aave_da_c170706.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="MODIS"  to_hgrid="ne4np4"    to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne4np4/map_3x3min_MODIS_to_ne4np4_nomask_aave_da_c120906.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="MODISv2"     to_hgrid="ne4np4"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/ne4np4/map_3x3min_MODISv2_to_ne4np4_nomask_aave_da_c190514.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="MODIS-wCsp"  to_hgrid="ne4np4"    to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne4np4/map_3x3min_MODIS-wCsp_to_ne4np4_nomask_aave_da_c160425.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="USGS"   to_hgrid="ne4np4"    to_lmask="nomask"
@@ -2295,6 +2297,8 @@ lnd/clm2/surfdata_map/surfdata_conus_30_x8_hist_78pfts_CMIP6_simyr1850_c190128.n
 >lnd/clm2/mappingdata/maps/ne16np4/map_0.5x0.5_MODIS_to_ne16np4_nomask_aave_da_c110922.nc</map>
 <map frm_hgrid="0.25x0.25"  frm_lmask="MODIS"  to_hgrid="ne16np4"   to_lmask="nomask" 
 >lnd/clm2/mappingdata/maps/ne16np4/map_0.25x0.25_MODIS_to_ne16np4_nomask_aave_da_c170321.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="MODISv2"     to_hgrid="ne16np4"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/ne16np4/map_3x3min_MODISv2_to_ne16np4_nomask_aave_da_c190514.nc</map>
 <map frm_hgrid="0.5x0.5"  frm_lmask="AVHRR"  to_hgrid="ne16np4"   to_lmask="nomask" 
 >lnd/clm2/mappingdata/maps/ne16np4/map_0.5x0.5_AVHRR_to_ne16np4_nomask_aave_da_c110922.nc</map>
 <map frm_hgrid="10x10min" frm_lmask="nomask" to_hgrid="ne16np4"   to_lmask="nomask"
@@ -2426,6 +2430,8 @@ lnd/clm2/surfdata_map/surfdata_conus_30_x8_hist_78pfts_CMIP6_simyr1850_c190128.n
 >lnd/clm2/mappingdata/maps/ne120np4/map_5minx5min_irrig_to_ne120np4_aave_da_110817.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="MODIS"  to_hgrid="ne120np4" to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne120np4/map_3x3min_MODIS_to_ne120np4_nomask_aave_da_c111111.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="MODISv2"     to_hgrid="ne120np4"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/ne120np4/map_3x3min_MODISv2_to_ne120np4_nomask_aave_da_c190514.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="MODIS-wCsp"  to_hgrid="ne120np4" to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne120np4/map_3x3min_MODIS-wCsp_to_ne120np4_nomask_aave_da_c160425.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="USGS"   to_hgrid="ne120np4" to_lmask="nomask"
@@ -2508,6 +2514,8 @@ lnd/clm2/surfdata_map/surfdata_conus_30_x8_hist_78pfts_CMIP6_simyr1850_c190128.n
 >lnd/clm2/mappingdata/maps/ne240np4/map_5x5min_ORNL-Soil_to_ne240np4_nomask_aave_da_c170706.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="MODIS"  to_hgrid="ne240np4"    to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne240np4/map_3x3min_MODIS_to_ne240np4_nomask_aave_da_c111111.nc</map>
+<map frm_hgrid="3x3min"    frm_lmask="MODISv2"     to_hgrid="ne240np4"   to_lmask="nomask" 
+>lnd/clm2/mappingdata/maps/ne240np4/map_3x3min_MODISv2_to_ne240np4_nomask_aave_da_c190514.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="MODIS-wCsp"  to_hgrid="ne240np4"    to_lmask="nomask"
 >lnd/clm2/mappingdata/maps/ne240np4/map_3x3min_MODIS-wCsp_to_ne240np4_nomask_aave_da_c160425.nc</map>
 <map frm_hgrid="3x3min"   frm_lmask="USGS"   to_hgrid="ne240np4"    to_lmask="nomask"

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -1109,10 +1109,9 @@ lnd/clm2/surfdata_map/surfdata_conus_30_x8_hist_78pfts_CMIP6_simyr1850_c190128.n
 <ndep_varlist            phys="clm5_0" use_cn=".true.">NDEP_month</ndep_varlist>
 <ndep_taxmode            phys="clm5_0" use_cn=".true.">limit</ndep_taxmode>
 
-<ndep_taxmode            phys="clm4_5" use_cn=".true.">extend</ndep_taxmode>
-<ndep_varlist            phys="clm4_5" use_cn=".true.">NDEP_year</ndep_varlist>
-<stream_fldfilename_ndep phys="clm4_5" use_cn=".true." ssp_rcp="hist"
->lnd/clm2/ndepdata/fndep_clm_hist_simyr1849-2006_1.9x2.5_c100428.nc</stream_fldfilename_ndep>
+<ndep_taxmode            phys="clm4_5" use_cn=".true.">cycle</ndep_taxmode>
+<ndep_varlist            phys="clm4_5" use_cn=".true.">NDEP_month</ndep_varlist>
+<ndep_taxmode            phys="clm4_5" use_cn=".true.">limit</ndep_taxmode>
 
 <ndepmapalgo                use_cn=".true." >bilinear</ndepmapalgo>
 

--- a/bld/namelist_files/namelist_defaults_clm4_5_tools.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5_tools.xml
@@ -7401,16 +7401,20 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <mkghg_bndtvghg  hgrid="lat-bands"                    >atm/waccm/lb/LBC_17500116-20150116_CMIP6_0p5degLat_c180905.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"                       >atm/waccm/lb/LBC_1750-2015_CMIP6_GlobAnnAvg_c180926.nc</mkghg_bndtvghg>
 
+<mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP1-1.9" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP119_0p5degLat_c190514.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP1-2.6" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP126_0p5degLat_c180905.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP2-4.5" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP245_0p5degLat_c180905.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP3-7.0" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP370_0p5degLat_c180905.nc</mkghg_bndtvghg>
+<mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP4-3.4" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP119_0p5degLat_c190514.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP4-6.0" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP460_0p5degLat_c180905.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP5-3.4" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP534os_0p5degLat_c180905.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="lat-bands" ssp_rcp="SSP5-8.5" >atm/waccm/lb/LBC_20140116-25001216_CMIP6_SSP585_0p5degLat_c180905.nc</mkghg_bndtvghg>
 
+<mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP1-1.9" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP119_0p5degLat_GlobAnnAvg_c190514.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP1-2.6" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP126_0p5degLat_GlobAnnAvg_c190301.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP2-4.5" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP245_0p5degLat_GlobAnnAvg_c190301.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP3-7.0" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP370_0p5degLat_GlobAnnAvg_c190301.nc</mkghg_bndtvghg>
+<mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP4-3.4" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP434_0p5degLat_GlobAnnAvg_c190514.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP4-6.0" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP460_0p5degLat_GlobAnnAvg_c190301.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP5-3.4" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP534os_0p5degLat_GlobAnnAvg_c190301.nc</mkghg_bndtvghg>
 <mkghg_bndtvghg  hgrid="global"    ssp_rcp="SSP5-8.5" >atm/waccm/lb/LBC_2014-2500_CMIP6_SSP585_0p5degLat_GlobAnnAvg_c190301.nc</mkghg_bndtvghg>

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -123,9 +123,9 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 872;
+my $ntests = 828;
 if ( defined($opts{'compare'}) ) {
-   $ntests += 540;
+   $ntests += 504;
 }
 plan( tests=>$ntests );
 
@@ -313,7 +313,7 @@ system( "../configure -s $mode" );
 foreach my $options ( 
                       "-bgc bgc -use_case 1850-2100_SSP1-2.6_transient -namelist '&a start_ymd=20100101/'",
                       "-bgc sp  -use_case 1850-2100_SSP2-4.5_transient -namelist '&a start_ymd=18501223/'",
-                      "-bgc bgc -use_case 1850-2100_SSP4-6.0_transient -namelist '&a start_ymd=20701029/'",
+                      "-bgc bgc -use_case 1850-2100_SSP3-7.0_transient -namelist '&a start_ymd=20701029/'",
                       "-bgc fates  -use_case 2000_control -no-megan",
                       "-bgc cn  -use_case 1850-2100_SSP5-8.5_transient -namelist '&a start_ymd=19201023/'",
                       "-bgc bgc -use_case 2000_control -namelist \"&a fire_method='nofire'/\" -crop",
@@ -1238,8 +1238,8 @@ $mode = "-phys clm4_5";
 system( "../configure -s $mode" );
 my @glc_res = ( "48x96", "0.9x1.25", "1.9x2.5" );
 my @use_cases = ( "1850-2100_SSP1-2.6_transient",
-                  "1850-2100_SSP3-4.5_transient",
-                  "1850-2100_SSP4-6.0_transient",
+                  "1850-2100_SSP2-4.5_transient",
+                  "1850-2100_SSP3-7.0_transient",
                   "1850-2100_SSP5-8.5_transient",
                   "1850_control",
                   "2000_control",
@@ -1287,13 +1287,12 @@ foreach my $res ( @tran_res ) {
    }
    &cleanup();
 }
-# Transient ssp_rcp scenarios
+# Transient ssp_rcp scenarios that work
 $mode = "-phys clm5_0";
 system( "../configure -s $mode" );
 my @tran_res = ( "0.9x1.25", "1.9x2.5", "10x15" );
 foreach my $usecase ( "1850_control", "1850-2100_SSP5-8.5_transient", "1850-2100_SSP1-2.6_transient", "1850-2100_SSP3-7.0_transient",
-                      "1850-2100_SSP4-3.4_transient", "1850-2100_SSP5-3.4_transient", "1850-2100_SSP2-4.5_transient", "1850-2100_SSP1-1.9_transient",
-                      "1850-2100_SSP4-6.0_transient" ) {
+                      "1850-2100_SSP2-4.5_transient" ) {
    foreach my $res ( @tran_res ) {
       $options = "-res $res -bgc bgc -crop -use_case $usecase -envxml_dir . ";
       &make_env_run();
@@ -1311,6 +1310,16 @@ foreach my $usecase ( "1850_control", "1850-2100_SSP5-8.5_transient", "1850-2100
       }
       &cleanup();
    }
+}
+# The SSP's that fail...
+my $res = "0.9x1.25";
+foreach my $usecase ( "1850-2100_SSP4-3.4_transient", "1850-2100_SSP5-3.4_transient", "1850-2100_SSP1-1.9_transient",
+                      "1850-2100_SSP4-6.0_transient" ) {
+      $options = "-res $res -bgc bgc -crop -use_case $usecase -envxml_dir . ";
+      &make_env_run();
+      eval{ system( "$bldnml $options > $tempfile 2>&1 " ); };
+      isnt( $?, 0, $usecase );
+      system( "cat $tempfile" );
 }
 
 print "\n==================================================\n";

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -169,10 +169,11 @@
     <valid_values>constant,diagnostic,prognostic</valid_values>
     <default_value>constant</default_value>
     <values>
-      <value compset="_CAM"     >diagnostic</value>
+      <value compset="_CAM"        >diagnostic</value>
       <value compset="_BGC%BDRD"   >diagnostic</value>
       <value compset="_BGC%BPRP"   >prognostic</value>
       <value compset="HIST.*_DATM" >diagnostic</value>
+      <value compset="SSP.*_DATM"  >diagnostic</value>
       <!-- This requires a coordination with a cime tag 
       <value compset="SSP.*_DATM"  >diagnostic</value>
       -->

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -11,6 +11,11 @@
   <category name="fates">
     <entry issue="667"              >FAIL ERS_D_Ld5.1x1_brazil.I2000Clm50FatesCruGs.cheyenne_intel.clm-FatesHydro COMPARE_base_rest</entry>
     <entry issue="667"              >FAIL ERS_D_Ld5.1x1_brazil.I2000Clm50FatesCruGs.hobart_nag.clm-FatesHydro RUN</entry>
+    <entry issue="714"              >PEND ERS_Lm40_Mmpi-serial.1x1_numaIA.I2000Clm50BgcCropGs.cheyenne_gnu.clm-monthly RUN</entry>
+    <entry issue="714"              >PEND ERS_Lm54_Mmpi-serial.1x1_numaIA.I2000Clm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput RUN</entry>
+    <entry issue="714"              >PEND ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput RUN</entry>
+    <entry issue="714"              >PEND ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput RUN</entry>
+    <entry issue="714"              >PEND ERS_Ly20_Mmpi-serial.1x1_numaIA.I2000Clm50BgcDvCropQianGs.cheyenne_gnu.clm-cropMonthOutput RUN</entry>
     <entry issue="NGEET/fates/#510" >FAIL SMS_Lm3_D_Mmpi-serial.1x1_brazil.I2000Clm50FatesCruGs.hobart_nag.clm-FatesHydro MEMLEAK</entry>
   </category>
 </expectedFails> 

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1577,6 +1577,7 @@
       <option name="wallclock">00:20:00</option>
       <option name="comment"  >Transient production low res future scenario SSP2-4.5 case with isotopes with a december 2050 start, use gnu to move off of intel</option>
     </options>
+  </test>
   <test name="SMS_Ld5" grid="f10_f10_musgs" compset="ISSP370Clm50BgcCrop" testmods="clm/ciso_dec2050Start">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1566,7 +1566,24 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment"  >Transient production low res future scenario case with isotopes with a december 2050 start</option>
+      <option name="comment"  >Transient production low res future scenario SSP5-8.5 case with isotopes with a december 2050 start</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f10_f10_musgs" compset="ISSP245Clm50BgcCrop" testmods="clm/ciso_dec2050Start">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Transient production low res future scenario SSP2-4.5 case with isotopes with a december 2050 start, use gnu to move off of intel</option>
+    </options>
+  <test name="SMS_Ld5" grid="f10_f10_musgs" compset="ISSP370Clm50BgcCrop" testmods="clm/ciso_dec2050Start">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Transient production low res future scenario SSP3-7.0 case with isotopes with a december 2050 start, use gnu to move off of intel</option>
     </options>
   </test>
   <test name="SMS_Lm1" grid="f09_g17_gl4" compset="I1850Clm50Bgc" testmods="clm/clm50KitchenSink">

--- a/doc/.ChangeLog_template
+++ b/doc/.ChangeLog_template
@@ -123,6 +123,8 @@ Changes answers relative to baseline:
 
    URL for LMWG diagnostics output used to validate new climate:
 	
+   Will new REFCASES need to be made for cesm and/or CAM?: No
+   (This will likely be true if the LII tests failed)
 
 Detailed list of changes
 ------------------------

--- a/doc/.release-ChangeLog_template
+++ b/doc/.release-ChangeLog_template
@@ -85,6 +85,9 @@ Changes answers relative to baseline:
 
   URL for LMWG diagnostics output for new climate:
 
+  Will new REFCASES need to be made for cesm and/or CAM?: No
+  (This will likely be true if the LII tests failed)
+
 Detailed list of changes:
 ------------------------
 

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+release-clm5.0.23     erik 05/15/2019 Update cime to bring in CO2 transient files for the CMIP6 SSP's as well as presaero for three of them
 release-clm5.0.22     erik 05/08/2019 Fix carbon isotope bug that caused wrong answers for isotopes under transient land-use change
 release-clm5.0.21     erik 05/03/2019 New ndep files, update fates, fix some issues
 release-clm5.0.20     erik 03/12/2019 Update all fsurdat files and bring in files for future scenarios, remove CMIP5 rcp options, bring in some bug fixes

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,4 +1,114 @@
 ===============================================================
+Tag name:  release-clm5.0.23
+Originator(s):  erik (Erik Kluzek)
+Date: Wed May 15 15:31:15 MDT 2019
+One-line Summary: Update cime to bring in CO2 transient files for the CMIP6 SSP's as well as presaero for three of them
+
+Purpose of this version:
+------------------------
+
+With updated cime with transient CO2 for all CMIP6 SSP scenarios and prescribed aerosol files for three of
+the CMIP6 SSP scenarios (SSP3-7.0, SSP2-4.5, SSP5-8.5). Previously all SSP scenaros would run, and use the
+closest SSP nitrogen deposition file, now only the ones that are available work (Tier I). Also CLM4.5 used
+the old CMIP5 ndep files, and now they use the CMIP6 ones available.
+
+Fix some small issues with some of the tools
+
+CTSM Master Tag This Corresponds To: ctsm1.0.dev025 (with many other changes)
+
+Summary of changes:
+-------------------
+
+Issues fixed (include CTSM Issue #): #707 #708 #711 #712
+  Fixes #707 -- Missing mapping files for hirespft
+  Fixes #708 -- time_bnds not set by tools/ncl_scripts/getco2_historical.ncl
+  Fixes #711 -- Model assumes the closest SSP scenario for ndep 
+  Fixes #712 -- Missing CO2 files for SSP1-1.9 and SSP4-3.4
+
+New issues found: #714 -- Fails with cheyenne_gnu for some longer single point tests
+
+Science changes since: release-clm5.0.22
+    Forcing period is different for present day compsets (I2000, I2003, and I2010)
+    SSP scenarios now have CMIP6 transient CO2 and presaero (for SP3-7.0, SSP2-4.5, SSP5-8.5)
+    clm4.5 will use CMIP6 SSP ndep datasets rather than CMIP5
+
+Software changes since: release-clm5.0.22
+    None
+
+Changes to User Interface since: release-clm5.0.22
+    Now SSP cases that don't have needed datasets will fail
+
+Testing: regular
+--------
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - OK (36 tests are different as expected)
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+    hobart --- PASS
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - PASS
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     cheyenne - OK
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    hobart_nag -------- OK
+    hobart_pgi -------- OK
+    hobart_intel ------ OK
+
+  regular tests (fates):
+
+    cheyenne_intel - OK
+    cheyenne_gnu --- OK
+    hobart_nag ----- OK
+
+Summary of Answer changes:
+-------------------------
+
+Baseline version for comparison: release-clm5.0.22
+
+Changes answers relative to baseline: Yes!
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: Present day compsets, SSP compsets, and Clm45 compsets
+    - what platforms/compilers: All
+    - nature of change: New datasets, new forcing period for present day
+
+  Will new REFCASES need to be made for cesm and/or CAM?: No
+  (This will likely be true if the LII tests failed)
+
+Detailed list of changes:
+------------------------
+
+Externals being used:
+
+   cism:   release-cesm2.0.04
+   rtm:    release-cesm2.0.02
+   mosart: release-cesm2.0.03
+   cime:   branch_tags/cime5.6.15_a01 (same as cim5.6.16)
+   FATES:  fates_s1.21.0_a7.0.0_br_rev2
+   PTCLM:  PTCLM2_180611
+
+CTSM Tag versions pulled over from master development branch: None
+
+Pull Requests that document the changes (include PR ids): #713
+(https://github.com/ESCOMP/ctsm/pull)
+   #713 -- Fix a few issues, and update cime to a version with CO2 SSP files as well as three presaero SSP files
+
+===============================================================
+===============================================================
 Tag name:  release-clm5.0.22
 Originator(s):  erik (Erik Kluzek)
 Date: Wed May  8 13:32:51 MDT 2019

--- a/tools/ncl_scripts/getco2_historical.ncl
+++ b/tools/ncl_scripts/getco2_historical.ncl
@@ -58,7 +58,7 @@ begin
    ntime   = dimsizes( ncg->date );
    sim_yr2 = ncg->date(ntime-1) / 10000;
 
-   sim_yr_rng = "_simyr_"+sim_yr0 + "-" + sim_yr2;
+   sim_yr_rng = "simyr_"+sim_yr0 + "-" + sim_yr2;
    
    cmip_vers = "_CMIP6_";
    outco2filename = "fco2_datm_"+hgrid+ssp_rcp+"_"+sim_yr_rng+cmip_vers+"c"+sdate+".nc";
@@ -103,7 +103,7 @@ begin
          end if
       end if
       nco->$vars(i)$@units = units(i);
-      nco->$vars(i)$@lname = lname(i);
+      nco->$vars(i)$@long_name = lname(i);
    end do
    filevardef ( nco, "time",      "float",    (/ "time" /) );
    filevardef ( nco, "time_bnds", "float",    (/ "time", "bounds" /) );
@@ -170,6 +170,7 @@ begin
    ;
    nco->date = (/ ncg->date /);
    nco->time = (/ ncg->time /);
+   nco->time_bnds = (/ ncg->time_bnds /);
    nco->date@comment = "This variable is NOT used when read by datm, the time coordinate is used";
    ;
    ; CO2


### PR DESCRIPTION
### Description of changes

With updated cime with CO2 and prescribed aerosol files in place.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
Fixes #711
Fixes #708
Fixes #707
Fixes #712 

Are answers expected to change (and if so in what way)? Yes (just for SSP and present day compsets)

Any User Interface Changes (namelist or namelist defaults changes)? Yes
  New CO2 SSP files and three SSP presaero files in place (SSP5-8.5, SSP2-4.5, SSP3-7.0)
  won't run for other cases, because of missing presaero files
  Also remove the ndep files that aren't in place (ndep files in place are: SSP1-2.6, SSP5-8.5, SSP2-4.5, SSP3-7.0)
  Will now abort on the other SSP's since the files aren't in place

Testing performed, if any: Ran ISSP compsets

These work:			
SMS_Ld5.f10_f10_musgs.ISSP245Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start			
SMS_Ld5.f10_f10_musgs.ISSP370Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start									
SMS_Ld5.f10_f10_musgs.ISSP585Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start

This is missing the presearo file:
SMS_Ld5.f10_f10_musgs.ISSP126Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start

These fail because of lack of ndep files
SMS_Ld5.f10_f10_musgs.ISSP119Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start			
SMS_Ld5.f10_f10_musgs.ISSP460Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start
SMS_Ld5.f10_f10_musgs.ISSP534Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start
SMS_Ld5.f10_f10_musgs.ISSP434Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start