### PR TITLE
Renaming, correcting, simplifying parameters dewmx and sno_stor_max

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -363,8 +363,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190502.nc</paramfile>
-<paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190425.nc</paramfile>
+<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190518.nc</paramfile>
+<paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190518.nc</paramfile>
 
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,131 @@
 ===============================================================
+Tag name:  ctsm1.0.dev042
+Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
+Date:  Mon May 20 14:43:44 MDT 2019
+One-line Summary: Rename, correct, and simplify parameters dewmx and sno_stor_max
+
+Purpose of changes
+------------------
+
+ To rename
+ dewmx to liq_canopy_storage_scalar
+ sno_stor_max to sno_canopy_storage_scalar
+ in the code and in the clm45 and clm50 param files.
+
+ To change snocanmx, liqcanmx, and fcansno to...
+ snocanmx = params_inst%snow_canopy_storage_scalar(p) * (elai(p) + esai(p))
+ liqcanmx = params_inst%liq_canopy_storage_scalar(p) * (elai(p) + esai(p))
+ fcansno(p) = (snocan(p) / (vegt * params_inst%sno_stor_max))**0.15_r8
+
+ Rewrote fwet(p) to follow the same format as fcansno(p).
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): #710
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+
+Changes made to namelist defaults (e.g., changed parameter values):
+
+Changes to the datasets (e.g., parameter, surface or initial files):
+ Pointing to new clm45 and clm50 param files containing the two renamed
+ parameters listed above.
+
+Substantial timing or memory changes: [For timing changes, can check PFS test(s) in the test suite]
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+
+Changes to tests or testing:
+
+Code reviewed by:
+ @billsacks
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - 
+
+  tools-tests (test/tools):
+
+    cheyenne - 
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+     cheyenne - 
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    hobart ------ OK
+ Roundoff changes were expected.
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline:
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: ALL
+    - what platforms/compilers: ALL
+    - nature of change: roundoff
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff?
+   The code modifications causing the change were of the order-of-calculations
+   type in two lines of code.
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: 
+
+   URL for LMWG diagnostics output used to validate new climate:
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/719
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev041
 Originator(s):  sacks (Bill Sacks)
 Date:  Fri May 17 06:02:38 MDT 2019

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm1.0.dev042
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
-Date:  Mon May 20 14:43:44 MDT 2019
+Date: Tue May 21 23:29:31 MDT 2019
 One-line Summary: Rename, correct, and simplify parameters dewmx and sno_stor_max
 
 Purpose of changes
@@ -24,6 +24,7 @@ Bugs fixed or introduced
 ------------------------
 
 Issues fixed (include CTSM Issue #): #710
+   Fixes #710 -- rename dewmx
 
 
 Significant changes to scientifically-supported configurations
@@ -43,25 +44,25 @@ Does this tag change answers significantly for any of the following physics conf
 Notes of particular relevance for users
 ---------------------------------------
 
-Caveats for users (e.g., need to interpolate initial conditions):
+Caveats for users (e.g., need to interpolate initial conditions): None
 
-Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
 
-Changes made to namelist defaults (e.g., changed parameter values):
+Changes made to namelist defaults (e.g., changed parameter values): New default parameter file
 
 Changes to the datasets (e.g., parameter, surface or initial files):
  Pointing to new clm45 and clm50 param files containing the two renamed
  parameters listed above.
 
-Substantial timing or memory changes: [For timing changes, can check PFS test(s) in the test suite]
+Substantial timing or memory changes: None
 
 Notes of particular relevance for developers: (including Code reviews and testing)
 ---------------------------------------------
 NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
 
-Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): None
 
-Changes to tests or testing:
+Changes to tests or testing: None
 
 Code reviewed by:
  @billsacks
@@ -72,15 +73,7 @@ CTSM testing:
 
   build-namelist tests:
 
-    cheyenne - 
-
-  tools-tests (test/tools):
-
-    cheyenne - 
-
-  PTCLM testing (tools/shared/PTCLM/test):
-
-     cheyenne - 
+    cheyenne - PASS (196 different because of new param file)
 
   regular tests (aux_clm):
 
@@ -109,17 +102,10 @@ Changes answers relative to baseline:
    The code modifications causing the change were of the order-of-calculations
    type in two lines of code.
 
-   If this tag changes climate describe the run(s) done to evaluate the new
-   climate (put details of the simulations in the experiment database)
-       - casename: 
-
-   URL for LMWG diagnostics output used to validate new climate:
-	
-
 Detailed list of changes
 ------------------------
 
-List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
 
 Pull Requests that document the changes (include PR ids):
  https://github.com/ESCOMP/ctsm/pull/719

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev042   slevis 05/20/2019 Rename, correct, and simplify parameters dewmx and sno_stor_max
+  ctsm1.0.dev042   slevis 05/21/2019 Rename, correct, and simplify parameters dewmx and sno_stor_max
   ctsm1.0.dev041    sacks 05/17/2019 Add water tracers to CanopyHydrologyMod
   ctsm1.0.dev040   slevis 05/03/2019 Move some hard-coded parameters from code to params.nc file
   ctsm1.0.dev039    sacks 05/01/2019 Remove excess canopy liquid/snow regardless of temperature

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev042   slevis 05/20/2019 Rename, correct, and simplify parameters dewmx and sno_stor_max
   ctsm1.0.dev041    sacks 05/17/2019 Add water tracers to CanopyHydrologyMod
   ctsm1.0.dev040   slevis 05/03/2019 Move some hard-coded parameters from code to params.nc file
   ctsm1.0.dev039    sacks 05/01/2019 Remove excess canopy liquid/snow regardless of temperature

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -651,7 +651,6 @@ contains
      integer  :: fp,p             ! indices
      real(r8) :: h2ocan           ! total canopy water (mm H2O)
      real(r8) :: vegt             ! lsai
-     real(r8) :: dewmxi           ! inverse of dew parameter [1/mm]
      !-----------------------------------------------------------------------
 
      associate(                                              & 
@@ -674,11 +673,9 @@ contains
 
              if (h2ocan > 0._r8) then
                 vegt    = frac_veg_nosno(p)*(elai(p) + esai(p))
-                dewmxi  = 1.0_r8/params_inst%liq_canopy_storage_scalar  ! wasteful division
-                fwet(p) = ((dewmxi/vegt)*h2ocan)**0.666666666666_r8
+                fwet(p) = (h2ocan / (vegt * params_inst%liq_canopy_storage_scalar))**0.666666666666_r8
                 fwet(p) = min (fwet(p),maximum_leaf_wetted_fraction)   ! Check for maximum limit of fwet
                 if (snocan(p) > 0._r8) then
-                   dewmxi  = 1.0_r8/params_inst%liq_canopy_storage_scalar  ! wasteful division
                    fcansno(p) = (snocan(p) / (vegt * params_inst%snow_canopy_storage_scalar))**0.15_r8 ! must match snocanmx 
                    fcansno(p) = min (fcansno(p),1.0_r8)
                 else

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -1119,7 +1119,6 @@ contains
      integer  :: fp,p             ! indices
      real(r8) :: h2ocan           ! total canopy water (mm H2O)
      real(r8) :: vegt             ! lsai
-     real(r8) :: dewmxi           ! inverse of maximum allowed dew [1/mm]
      !-----------------------------------------------------------------------
 
      SHR_ASSERT_FL((ubound(frac_veg_nosno, 1) == bounds%endp), sourcefile, __LINE__)
@@ -1138,12 +1137,10 @@ contains
 
            if (h2ocan > 0._r8) then
               vegt    = frac_veg_nosno(p)*(elai(p) + esai(p))
-              dewmxi = 1.0_r8 / params_inst%liq_canopy_storage_scalar  ! wasteful division
-              fwet(p) = ((dewmxi/vegt)*h2ocan)**0.666666666666_r8
+              fwet(p) = (h2ocan / (vegt * params_inst%liq_canopy_storage_scalar))**0.666666666666_r8
               fwet(p) = min (fwet(p),maximum_leaf_wetted_fraction)   ! Check for maximum limit of fwet
               if (snocan(p) > 0._r8) then
-                 dewmxi = 1.0_r8 / params_inst%liq_canopy_storage_scalar  ! wasteful division
-                 fcansno(p) = ((dewmxi / (vegt * params_inst%snow_canopy_storage_scalar * 10.0_r8)) * snocan(p))**0.15_r8 ! must match snocanmx 
+                 fcansno(p) = (snocan(p) / (vegt * params_inst%snow_canopy_storage_scalar))**0.15_r8 ! must match snocanmx 
                  fcansno(p) = min (fcansno(p),1.0_r8)
               else
                  fcansno(p) = 0._r8

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -679,7 +679,7 @@ contains
                 fwet(p) = min (fwet(p),maximum_leaf_wetted_fraction)   ! Check for maximum limit of fwet
                 if (snocan(p) > 0._r8) then
                    dewmxi  = 1.0_r8/params_inst%liq_canopy_storage_scalar  ! wasteful division
-                   fcansno(p) = ((dewmxi / (vegt * params_inst%snow_canopy_storage_scalar * 10.0_r8)) * snocan(p))**0.15_r8 ! must match snocanmx
+                   fcansno(p) = (snocan(p) / (vegt * params_inst%snow_canopy_storage_scalar))**0.15_r8 ! must match snocanmx 
                    fcansno(p) = min (fcansno(p),1.0_r8)
                 else
                    fcansno(p) = 0._r8


### PR DESCRIPTION
### Description of changes

Rename
dewmx to liq_canopy_storage_scalar
sno_stor_max to sno_canopy_storage_scalar

Change snocanmx, liqcanmx, and fcansno to...
`snocanmx = params_inst%snow_canopy_storage_scalar(p) * (elai(p) + esai(p))`
`liqcanmx = params_inst%liq_canopy_storage_scalar(p) * (elai(p) + esai(p))`
`fcansno(p) = (snocan(p) / (vegt * params_inst%sno_stor_max))**0.15_r8`

### Specific notes

Contributors other than yourself, if any:
@billsacks @swensosc 

CTSM Issues Fixed (include github issue #):
fixes #710 

Are answers expected to change (and if so in what way)?
Roundoff

Any User Interface Changes (namelist or namelist defaults changes)?
New clm45 and clm50 param files to include the new names

Testing performed, if any:
./create_test ERS_D_Ld10.f10_f10_musgs.I2000Clm50BgcCropGs.cheyenne_intel.clm-rm_indiv_lunits_and_collapse_to_dom -c ctsm1.0.dev041
and
./create_test ERS_D_Ld6.f10_f10_musgs.I1850Clm45BgcCrop.cheyenne_intel.clm-clm50CMIP6frc -c ctsm1.0.dev041
both PASS