### PR TITLE
Fix the FUN bug, where an if statement was backwards...

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -363,7 +363,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190518.nc</paramfile>
+<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190529.nc</paramfile>
 <paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190518.nc</paramfile>
 
 <!-- ================================================================== -->

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm1.0.dev043
 Originator(s):  erik (Erik Kluzek)
-Date: Tue Jun  4 12:13:49 MDT 2019
+Date: Wed Jun  5 10:17:06 MDT 2019
 One-line Summary: Fix FUN bug (frac_ideal_C_use was backwards in regard to delta_CN), and replace Ball-Berry mbbopt with the CLM4.5 version
 
 Purpose of changes

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -186,7 +186,7 @@ Changes to tests or testing: None
 Code reviewed by:
  @billsacks
 
-CTSM testing:
+CTSM testing: regular
 
  [PASS means all tests PASS and OK means tests PASS other than expected fails.]
 
@@ -206,10 +206,7 @@ If the tag used for baseline comparisons was NOT the previous tag, note that her
 Answer changes
 --------------
 
-Changes answers relative to baseline:
-
-  If a tag changes answers relative to baseline comparison the
-  following should be filled in (otherwise remove this section):
+Changes answers relative to baseline: Yes!
 
   Summarize any changes to answers, i.e.,
     - what code configurations: ALL

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,123 @@
 ===============================================================
+Tag name:  ctsm1.0.dev043
+Originator(s):  erik (Erik Kluzek)
+Date: Tue Jun  4 12:13:49 MDT 2019
+One-line Summary: Fix FUN bug (frac_ideal_C_use was backwards in regard to delta_CN), and replace Ball-Berry mbbopt with the CLM4.5 version
+
+Purpose of changes
+------------------
+
+Carbon allocation to uptake responds to CN(uptake-cost) and CN(actual). The intended implementation is: For C:N 
+less than the target C:N, C allocation is reduced with cost. For C:N greater than the target C:N, C allocation 
+is increased with high C:N. However, the actual implementation is reversed. This change fixes that problem.
+
+Also the Ball-Berry mbbopt values had been changed in the creation of CLM5.0, as part of the tuning, but the new
+values don't work well (as our final tuning uses Medlyn photosynshesis rather than Ball-Berry). This brings the values
+for Ball-Berry for CLM5.0 back to the CLM4.5 values.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):  #704 #705
+
+   Fixes #705 -- Ball-Berry parameters in CLM5.0 should go back to the previous values in CLM4.5
+   Fixes #704 -- FUN code logic to reduce or increase carbon allocation used for uptake is reversed
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm5_0
+
+[X] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values): New clm5.0 paramdata file
+
+Changes to the datasets (e.g., parameter, surface or initial files): mbbopt now use the clm4_5 values
+   rather than the pretuned clm5_0 values (before Medlyn was being used)
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): None
+
+Changes to tests or testing: None
+
+Code reviewed by: self, olyson
+
+
+CTSM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (134 tests are different from baseline as expected)
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    hobart ------ OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes!
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: Anything with use_FUN=T (so Clm50Bgc compsets) 
+        Also with Clm5.0 and Ball-Berry (stomatalcond_method='Ball-Berry1987') (so Clm50Nwp compsets)
+    - what platforms/compilers: All
+    - nature of change: climate is similar
+
+       "Our assessment is that the impact is relatively small, but would affect climate; 
+        however it doesn’t appear to strongly affect transient C response."
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+      Experiments were done on the release branch
+       - casename: oleson/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_1850
+                   oleson/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_hist
+
+   URL for LMWG diagnostics output used to validate new climate:
+
+http://webext.cgd.ucar.edu/I1850/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_1850/lnd/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_1850.21_40-clm50_release-clm5.0.15_2deg_GSWP3V1_1850.21_40/setsIndex.html
+
+We've also completed a historical run. Diagnostics are here:
+
+http://webext.cgd.ucar.edu/I20TR/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_hist/lnd/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_hist.1995_2014-clm50_release-clm5.0.15_2deg_GSWP3V1_hist.1995_2014/setsIndex.html
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids): #727
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #727 -- Fix the FUN bug, where an if statement was backwards
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev042
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
 Date: Tue May 21 23:29:31 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev043     erik 06/04/2019 Fix FUN bug (frac_ideal_C_use was backwards in regard to delta_CN), 
+  ctsm1.0.dev043     erik 06/05/2019 Fix FUN bug (frac_ideal_C_use was backwards in regard to delta_CN), 
                                      and replace Ball-Berry mbbopt with the CLM4.5 version
   ctsm1.0.dev042   slevis 05/21/2019 Rename, correct, and simplify parameters dewmx and sno_stor_max
   ctsm1.0.dev041    sacks 05/17/2019 Add water tracers to CanopyHydrologyMod

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,7 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev043     erik 06/04/2019 Fix FUN bug (frac_ideal_C_use was backwards in regard to delta_CN), 
+                                     and replace Ball-Berry mbbopt with the CLM4.5 version
   ctsm1.0.dev042   slevis 05/21/2019 Rename, correct, and simplify parameters dewmx and sno_stor_max
   ctsm1.0.dev041    sacks 05/17/2019 Add water tracers to CanopyHydrologyMod
   ctsm1.0.dev040   slevis 05/03/2019 Move some hard-coded parameters from code to params.nc file

--- a/doc/README.CHECKLIST.master_tags
+++ b/doc/README.CHECKLIST.master_tags
@@ -25,6 +25,8 @@ https://github.com/ESCOMP/ctsm/wiki/CTSM-development-workflow
    3b -- update the ExpectedFails list if expected fails changes in 1a
         $EDITOR cime_config/testdefs/ExpectedTestFails.xml
    3c -- make sure you understand any changes to the baselines -- to document in ChangeLog
+   3d -- Check the log file for run_sys_tests (../run_sys_test.log), to make sure that 
+         externals are correct (see 2c above)
 
 (4) Use diff and status to make sure any new files are in the repo and only the correct
     changes are on the branch
@@ -43,6 +45,7 @@ https://github.com/ESCOMP/ctsm/wiki/CTSM-development-workflow
    5c -- Update date stamp on ChangeLog
         ./UpDateChangeLog.pl -update
    5d -- Commit new change files
+   5e -- Push all the changes on your local branches to the branch on your fork
 
 (6) Submit a pull request (PR) for the changes
     Have someone review it if you are able. At minimum review it youself. The PR mechanism

--- a/src/biogeochem/CNFUNMod.F90
+++ b/src/biogeochem/CNFUNMod.F90
@@ -1232,20 +1232,20 @@ fix_loop:   do FIX =plants_are_fixing, plants_not_fixing !loop around percentage
                      else
                        delta_CN = (leafc(p)+leafc_storage(p))/(leafn(p)+leafn_storage(p)) - leafcn(ivt(p)) ! leaf CN ratio                                                              
                      end if
-                     ! C used for uptake is reduced if the cost of N is very high                
+                     ! C used for uptake is reduced if the cost of N is very high
                      frac_ideal_C_use = max(0.0_r8,1.0_r8 - (total_N_resistance-fun_cn_flex_a(ivt(p)))/fun_cn_flex_b(ivt(p)) )
-                     ! then, if the plant is very much in need of N, the C used for uptake is increased accordingly.                  
-                     if(delta_CN .gt.0.and. frac_ideal_C_use.lt.1.0)then           
-                       frac_ideal_C_use = frac_ideal_C_use + (1.0_r8-frac_ideal_C_use)*min(1.0_r8, delta_CN/fun_cn_flex_c(ivt(p)))
-                     end if    
-                     ! If we have too much N (e.g. from free N retranslocation) then make frac_ideal_c_use even lower.    
-                     ! For a CN delta of fun_cn_flex_c, then we reduce C expendiure to the minimum of 0.5. 
-                     ! This seems a little intense? 
+                     ! then, if the plant is very much in need of N, the C used for uptake is increased accordingly.
                      if(delta_CN.lt.0.0)then
-                        frac_ideal_C_use = frac_ideal_C_use + 0.5_r8*(1.0_r8*delta_CN/fun_cn_flex_c(ivt(p)))
-                     endif 
+                       frac_ideal_C_use = frac_ideal_C_use + (1.0_r8-frac_ideal_C_use)*min(1.0_r8, delta_CN/fun_cn_flex_c(ivt(p)))
+                     end if
+                     ! If we have too much N (e.g. from free N retranslocation) then make frac_ideal_c_use even lower.
+                     ! For a CN delta of fun_cn_flex_c, then we reduce C expendiure to the minimum of 0.5.
+                     ! This seems a little intense?
+                     if(delta_CN .gt.0.and. frac_ideal_C_use.lt.1.0)then
+                       frac_ideal_C_use = frac_ideal_C_use + 0.5_r8*(1.0_r8*delta_CN/fun_cn_flex_c(ivt(p)))
+                     end if
+                     ! don't let this go above 1 or below an arbitrary minimum (to prevent zero N uptake).
                      frac_ideal_C_use = max(min(1.0_r8,frac_ideal_C_use),0.5_r8) 
-                     ! don't let this go above 1 or below an arbirtray minimum (to prevent zero N uptake). 
                  else
                      frac_ideal_C_use= 1.0_r8
                  end if


### PR DESCRIPTION
Apply the difference from the olyson/delta_CN_FUNbug off of release-clm5.0.15 to ctsm/master.

### Description of changes

Technical notes: Page 167

The bug in the FUN model source code is that the functions corresponding
to these two conditions relevant to deltaCN are placed in a wrong order. So
under the deltaCN > 0 condition, it actually uses the function for deltaCN <
0.

``` fortran
1238 if(delta_CN .gt.0.and. frac_ideal_C_use.lt.1.0)then
1239 frac_ideal_C_use = frac_ideal_C_use + (1.0_r8-frac_ideal_C_use)*min(1.0_r8, delta_CN/fun_cn_flex_c(ivt(p)));
1240 end if
1241 ! If we have too much N (e.g. from free N retranslocation) then make frac_ideal_c_use even lower.
1242 ! For a CN delta of fun_cn_flex_c, then we reduce C expendiure to the minimum of 0.5.
1243 ! This seems a little intense?
1244 if(delta_CN.lt.0.0)then
1245 frac_ideal_C_use = frac_ideal_C_use + 0.5_r8*(1.0_r8*delta_CN/fun_cn_flex_c(ivt(p)))
1246 endif
```

Clm5.0/src/biogeochem/CNFUNMod.F90

Original code

``` fortran
1238 if(delta_CN.lt.0.0)then
1239 frac_ideal_C_use = frac_ideal_C_use + (1.0_r8-frac_ideal_C_use)*min(1.0_r8, delta_CN/fun_cn_flex_c(ivt(p)));
1240 end if
1241 ! If we have too much N (e.g. from free N retranslocation) then make frac_ideal_c_use even lower.
1242 ! For a CN delta of fun_cn_flex_c, then we reduce C expendiure to the minimum of 0.5.
1243 ! This seems a little intense?
1244 if(delta_CN .gt.0.and. frac_ideal_C_use.lt.1.0)then
1245 frac_ideal_C_use = frac_ideal_C_use
```

### Specific notes

Contributors other than yourself, if any: @olyson, @rosiealice, Yanyan Cheng, Maoiyi Huang

CTSM Issues Fixed (include github issue #): #704 
 Fixes #704 -- FUN bug

Are answers expected to change (and if so in what way)? yes (when FUN is on, so Clm50Bgc)

Any User Interface Changes (namelist or namelist defaults changes)? None

Testing performed, if any: regular testing being done

We've completed 40 year global 1850 runs (after AD and post-AD spinup) for a control and with the bug fix (on release-clm5.0.15). Diagnostics are here:

http://webext.cgd.ucar.edu/I1850/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_1850/lnd/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_1850.21_40-clm50_release-clm5.0.15_2deg_GSWP3V1_1850.21_40/setsIndex.html

We've also completed a historical run. Diagnostics are here:

http://webext.cgd.ucar.edu/I20TR/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_hist/lnd/clm50_release-clm5.0.15_delta_CN_FUNbug_2deg_GSWP3V1_hist.1995_2014-clm50_release-clm5.0.15_2deg_GSWP3V1_hist.1995_2014/setsIndex.html

Our assessment is that the impact is relatively small, but would affect climate; however it doesn’t appear to strongly affect transient C response.

