### PR TITLE
Convert the file from NetCDF-4 classic format to NetCDF-3 classic format

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -89,7 +89,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <stomatalcond_method phys="clm4_5"                         >Ball-Berry1987</stomatalcond_method>
 
 <!-- Carbon isotope concentration files -->
-<atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C13_CMIP6_1850-2015_yearly_v2.0_c171012.nc</atm_c13_filename>
+<atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C13_CMIP6_1850-2015_yearly_v2.0_c190528.nc</atm_c13_filename>
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="SSP1-1.9" >lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP119_1850-2100_yearly_c181209.nc</atm_c13_filename>
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="SSP1-2.6" >lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP126_1850-2100_yearly_c181209.nc</atm_c13_filename>
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="SSP2-4.5" >lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP245_1850-2100_yearly_c181209.nc</atm_c13_filename>
@@ -97,7 +97,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="SSP5-3.4" >lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP534os_1850-2100_yearly_c181209.nc</atm_c13_filename>
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="SSP5-8.5" >lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP5B_1850-2100_yearly_c181209.nc</atm_c13_filename>
 
-<atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C14_CMIP6_3x1_global_1850-2015_yearly_v2.0_c171012.nc</atm_c14_filename>
+<atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C14_CMIP6_3x1_global_1850-2015_yearly_v2.0_c190528.nc</atm_c14_filename>
 <atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="SSP1-1.9" >lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP119_3x1_global_1850-2100_yearly_c181209.nc</atm_c14_filename>
 <atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="SSP1-2.6" >lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP126_3x1_global_1850-2100_yearly_c181209.nc</atm_c14_filename>
 <atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="SSP2-4.5" >lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP245_3x1_global_1850-2100_yearly_c181209.nc</atm_c14_filename>

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+release-clm5.0.25     erik 05/29/2019 Change two files from NetCDF-4 format to NetCDF-3 (because some machines have trouble with NetCDF-4 in pnetcdf)
 release-clm5.0.24     erik 05/22/2019 Correct ndep end year for SSPs, 2-degree CMIP6WACCMDECK with C-isotopes off, fixes mksurfdata for high resolution
 release-clm5.0.23     erik 05/15/2019 Update cime to bring in CO2 transient files for the CMIP6 SSP's as well as presaero for three of them
 release-clm5.0.22     erik 05/08/2019 Fix carbon isotope bug that caused wrong answers for isotopes under transient land-use change

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,4 +1,93 @@
 ===============================================================
+Tag name:  release-clm5.0.25
+Originator(s):  erik (Erik Kluzek)
+Date: Wed May 29 11:16:13 MDT 2019
+One-line Summary: Change two files from NetCDF-4 format to NetCDF-3 (because some machines have trouble with NetCDF-4 in pnetcdf)
+
+Purpose of this version:
+------------------------
+
+There are two files in NetCDF-4 format that the model uses. Copy these files to NetCDF-3 classic format and point
+to the new version in the CLM XML database (use nccopy -k classic). There are some machines that have trouble with
+reading NetCDF-4 files in pnetcdf.
+
+There are still some NetCDF-4 files for mksurfdata_map, but some of these are required to be in NetCDF-4 format. And we only
+support mksurfdata_map and mkmapdata on cheyenne.
+
+
+CTSM Master Tag This Corresponds To: ctsm1.0.dev025 (with many other changes)
+
+Summary of changes:
+-------------------
+
+Issues fixed (include CTSM Issue #): #734
+  Fixes #734 -- Isotope historical files are in NetCDF-4 format need them in NetCDF-3 or NetCDF-5
+
+Science changes since: release-clm5.0.24
+    None
+
+Software changes since: release-clm5.0.24
+    None
+
+Changes to User Interface since: release-clm5.0.24
+    None
+
+Testing:
+--------
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (6 tests compare different to baseline)
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+    hobart --- PASS
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    hobart_nag -------- OK
+    hobart_pgi -------- OK
+    hobart_intel ------ OK
+
+  regular tests (prealpha):
+
+    cheyenne_intel - OK
+    cheyenne_gnu --- OK
+    hobart_nag ----- OK
+
+Summary of Answer changes:
+-------------------------
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here: previous
+
+Changes answers relative to baseline: No! bit-for-bit
+
+Detailed list of changes:
+------------------------
+
+Externals being used: No updates
+
+   cism:   release-cesm2.0.04
+   rtm:    release-cesm2.0.02
+   mosart: release-cesm2.0.03
+   cime:   cim5.6.16
+   FATES:  fates_s1.21.0_a7.0.0_br_rev2
+   PTCLM:  PTCLM2_180611
+
+CTSM Tag versions pulled over from master development branch: None
+
+Pull Requests that document the changes (include PR ids): #737
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #737 -- Convert the file from NetCDF-4 classic format to NetCDF-3 classic format
+
+===============================================================
+===============================================================
 Tag name:  release-clm5.0.24
 Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
 Date: Wed May 22 13:33:48 MDT 2019


### PR DESCRIPTION


### Description of changes

Update C13 and C14 historical time series files to be in NetCDF-3 classic format rather than NetCDF-4. This is a problem with pnetcdf on certain external machines. "nccopy -k classic file1 file2" was used for the conversion.

### Specific notes

Contributors other than yourself, if any: @jedwards4b found the problem

CTSM Issues Fixed (include github issue #): #734 

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? C13 and C14 historical files pointed to

Testing performed, if any: Running SMS_D_Ly2.1x1_numaIA.IHistClm50BgcCropGs.cheyenne_intel.clm-ciso_bombspike1963
