### PR TITLE
Fates api 7.3.0

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.26.1_api.7.2.0
+tag = sci.1.27.1_api.7.3.0
 required = True
 
 [PTCLM]

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.2_12pft_c190515.nc </fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.3.0_12pft_c190530.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.2_12pft_c190513.nc </fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.2_12pft_c190515.nc </fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.1_12pft_c190513.nc </fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.2_12pft_c190513.nc </fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.0_12pft_c190409.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.2.1_12pft_c190513.nc </fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->


### PR DESCRIPTION
### Description of changes

This updates the default file and the external pointer to be compatible with fates sci1.27.1_api7.3.0.

Note, this is only a "minor" API change, which I use to flag changes in input file structure (ie parameter file variable names and definitions have changed).  The software interface between the models has not changed.


### Specific notes

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

see FATES PR 530: https://github.com/NGEET/fates/pull/530


**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
