### PR TITLE
dz --> dz_lake bug-fix in LakeTemperatureMod.F90 line 960

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,114 @@
 ===============================================================
+Tag name:  ctsm1.0.dev050
+Originator(s):  slevis (Samuel Levis,SLevisConsulting LLC,303-665-1310)
+Date:  Mon Jul 15 11:40:09 MDT 2019
+One-line Summary: dz --> dz_lake bug-fix in LakeTemperatureMod.F90 line 960
+
+Purpose of changes
+------------------
+
+ Bug-fix to prevent the model from aborting when running with fewer soil
+ layers than lake layers; not to imply that this was not a bug when the
+ model wasn't aborting. It was.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): #760
+
+Known bugs found since the previous tag (include github issue ID): #759 bug causing model to abort when nlevsoi = nlevgrnd
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers
+--------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by: @dlawrenncar @billsacks
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - 
+
+  tools-tests (test/tools):
+
+    cheyenne - 
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - 
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - 
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    hobart ------ OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline:
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: use_lch4 = .true.
+    - what platforms/compilers: all
+    - nature of change: diagnostic variable WTGQ only
+                 Confirmed this on cheynne and hobart by running
+                 ./summarize_cprnc_diffs -baseline .../tests_0712... -testid '*'
+                 and inspecting the file cprnc.summary.*.by_varname
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
+
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/761
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev049
 Originator(s):  erik (Erik Kluzek)
 Date: Sun Jun 23 20:56:55 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev050   slevis 07/15/2019 dz --> dz_lake bug-fix in LakeTemperatureMod.F90 line 960
   ctsm1.0.dev049     erik 06/23/2019 Update mosart and intel to intel-19 on cheyenne
   ctsm1.0.dev048     erik 06/23/2019 Updates for buildlib changes and cime and externals updates
   ctsm1.0.dev047    sacks 06/16/2019 Fix negative snow compaction during snow melt

--- a/src/biogeophys/LakeTemperatureMod.F90
+++ b/src/biogeophys/LakeTemperatureMod.F90
@@ -948,7 +948,7 @@ contains
     end do
 
     ! Calculate lakeresist and grnd_ch4_cond for CH4 Module
-    ! The CH4 will diffuse directly from the top soil layer to the atmosphere, so 
+    ! The CH4 will diffuse directly from the top lake layer to the atmosphere, so 
     ! the whole lake resistance is included.
 
     if (use_lch4) then
@@ -957,7 +957,7 @@ contains
              c = filter_lakec(fc)
 
              if (j > jconvect(c) .and. j < jconvectbot(c)) then  ! Assume resistance is zero for levels that convect
-                lakeresist(c) = lakeresist(c) + dz(c,j)/kme(c,j) ! dz/eddy or molecular diffusivity
+                lakeresist(c) = lakeresist(c) + dz_lake(c,j)/kme(c,j) ! dz/eddy or molecular diffusivity
              end if
 
              if (j == nlevlak) then ! Calculate grnd_ch4_cond


### PR DESCRIPTION
### Description of changes
As described in the title plus a comment correction.

### Specific notes

Contributors other than yourself, if any:
@billsacks @dlawrenncar 

CTSM Issues Fixed (include github issue #):
fixes #760 

Are answers expected to change (and if so in what way)?
Only in diagnostic variable WTGQ

Testing performed, if any:
Cheyenne test suite FAILs with DIFFs from dev049 baseline. 
The following commands...
./summarize_cprnc_diffs -basedir /glade/scratch/slevis/tests_0712-173856ch -testid '*'
vi cprnc.summary.\*.by_varname
...confirm that only WTGQ is different from dev049. 
I will repeat on Hobart.