### PR TITLE
interface changes for fates-parteh (nutrients)

### DIFF
--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -192,6 +192,9 @@ module histFileMod
      integer :: beg1d_out                      ! on-node 1d hbuf pointer start index
      integer :: end1d_out                      ! on-node 1d hbuf pointer end index
      integer :: num1d_out                      ! size of hbuf first dimension (all nodes)
+     integer :: numdims                        ! the actual number of dimensions, this allows
+                                               ! for 2D arrays, where the second dimension is allowed
+                                               ! to be 1
      integer :: num2d                          ! size of hbuf second dimension (e.g. number of vertical levels)
      integer :: hpindex                        ! history pointer index 
      character(len=scale_type_strlen) :: p2c_scale_type       ! scale factor when averaging patch to column
@@ -307,7 +310,7 @@ contains
   end subroutine hist_printflds
 
   !-----------------------------------------------------------------------
-  subroutine masterlist_addfld (fname, type1d, type1d_out, &
+  subroutine masterlist_addfld (fname, numdims, type1d, type1d_out, &
         type2d, num2d, units, avgflag, long_name, hpindex, &
         p2c_scale_type, c2l_scale_type, l2g_scale_type, &
         no_snow_behavior)
@@ -323,6 +326,7 @@ contains
     !
     ! !ARGUMENTS:
     character(len=*), intent(in)  :: fname            ! field name
+    integer         , intent(in)  :: numdims          ! number of dimensions
     character(len=*), intent(in)  :: type1d           ! 1d data type
     character(len=*), intent(in)  :: type1d_out       ! 1d output type
     character(len=*), intent(in)  :: type2d           ! 2d output type
@@ -401,6 +405,7 @@ contains
     masterlist(f)%field%type1d         = type1d
     masterlist(f)%field%type1d_out     = type1d_out
     masterlist(f)%field%type2d         = type2d
+    masterlist(f)%field%numdims        = numdims
     masterlist(f)%field%num2d          = num2d
     masterlist(f)%field%hpindex        = hpindex
     masterlist(f)%field%p2c_scale_type = p2c_scale_type
@@ -1055,6 +1060,7 @@ contains
     integer :: t                   ! tape index
     integer :: f                   ! field index
     integer :: num2d               ! size of second dimension (e.g. number of vertical levels)
+    integer :: numdims             ! number of dimensions
     character(len=*),parameter :: subname = 'hist_update_hbuf'
     character(len=hist_dim_name_length) :: type2d     ! hbuf second dimension type ["levgrnd","levlak","numrad","ltype","natpft","cft","glc_nec","elevclas","subname(n)"]
     !-----------------------------------------------------------------------
@@ -1062,10 +1068,12 @@ contains
     do t = 1,ntapes
 !$OMP PARALLEL DO PRIVATE (f, num2d)
        do f = 1,tape(t)%nflds
-          num2d = tape(t)%hlist(f)%field%num2d
-          if ( num2d == 1) then   
+          numdims = tape(t)%hlist(f)%field%numdims
+          
+          if ( numdims == 1) then   
              call hist_update_hbuf_field_1d (t, f, bounds)
           else
+             num2d = tape(t)%hlist(f)%field%num2d
              call hist_update_hbuf_field_2d (t, f, bounds, num2d)
           end if
        end do
@@ -2613,7 +2621,7 @@ contains
              call ncd_defvar(varname='fates_agmap_levagepft', xtype=ncd_int, dim1name='fates_levagepft', &
                    long_name='FATES age-class map into patch age x pft', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_levelem',xtype=ncd_int, dim1name='fates_levelem', &
-                   long_name='FATES element (C,N,P,...) identifier', ncid=nfid(t))
+                   long_name='FATES element (C,N,P,...) identifier', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_elmap_levelpft', xtype=ncd_int, dim1name='fates_levelpft', &
                    long_name='FATES element map into element x pft   ', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_pftmap_levelpft', xtype=ncd_int, dim1name='fates_levelpft', &
@@ -2914,6 +2922,7 @@ contains
     integer :: num2d                     ! hbuf second dimension size
     integer :: nt                        ! time index
     integer :: ier                       ! error status
+    integer :: numdims                   ! number of dimensions
     character(len=avgflag_strlen) :: avgflag  ! time averaging flag
     character(len=max_chars) :: long_name! long name
     character(len=max_chars) :: units    ! units
@@ -2957,6 +2966,7 @@ contains
        end1d_out  = tape(t)%hlist(f)%field%end1d_out
        num1d_out  = tape(t)%hlist(f)%field%num1d_out
        type2d     = tape(t)%hlist(f)%field%type2d
+       numdims    = tape(t)%hlist(f)%field%numdims
        num2d      = tape(t)%hlist(f)%field%num2d
        nt         = tape(t)%ntimes
 
@@ -2989,7 +2999,7 @@ contains
           endif
 
           if (dim2name == 'undefined') then
-             if (num2d == 1) then
+             if (numdims == 1) then
                 call ncd_defvar(ncid=nfid(t), varname=varname, xtype=tape(t)%ncprec, &
                      dim1name=dim1name, dim2name='time', &
                      long_name=long_name, units=units, cell_method=avgstr, &
@@ -3001,7 +3011,7 @@ contains
                      missing_value=spval, fill_value=spval)
              end if
           else
-             if (num2d == 1) then
+             if (numdims == 1) then
                 call ncd_defvar(ncid=nfid(t), varname=varname, xtype=tape(t)%ncprec, &
                      dim1name=dim1name, dim2name=dim2name, dim3name='time', &
                      long_name=long_name, units=units, cell_method=avgstr, &
@@ -3022,7 +3032,7 @@ contains
 
           ! Allocate dynamic memory
 
-          if (num2d == 1) then
+          if (numdims == 1) then
              allocate(hist1do(beg1d_out:end1d_out), stat=ier)
              if (ier /= 0) then
                 write(iulog,*) trim(subname),' ERROR: allocation'
@@ -3033,7 +3043,7 @@ contains
 
           ! Write history output.  Always output land and ocean runoff on xy grid.
 
-          if (num2d == 1) then
+          if (numdims == 1) then
              call ncd_io(flag='write', varname=varname, &
                   dim1name=type1d_out, data=hist1do, ncid=nfid(t), nt=nt)
           else
@@ -3044,7 +3054,7 @@ contains
 
           ! Deallocate dynamic memory
 
-          if (num2d == 1) then
+          if (numdims == 1) then
              deallocate(hist1do)
           end if
 
@@ -4702,10 +4712,11 @@ contains
 
     ! Add field to masterlist
 
-    call masterlist_addfld (fname=trim(fname), type1d=l_type1d, type1d_out=l_type1d_out, &
-         type2d='unset', num2d=1, &
-         units=units, avgflag=avgflag, long_name=long_name, hpindex=hpindex, &
-         p2c_scale_type=scale_type_p2c, c2l_scale_type=scale_type_c2l, l2g_scale_type=scale_type_l2g)
+    call masterlist_addfld (fname=trim(fname), numdims=1, type1d=l_type1d, & 
+          type1d_out=l_type1d_out, type2d='unset', num2d=1, &
+          units=units, avgflag=avgflag, long_name=long_name, hpindex=hpindex, &
+          p2c_scale_type=scale_type_p2c, c2l_scale_type=scale_type_c2l, & 
+          l2g_scale_type=scale_type_l2g)
 
     l_default = 'active'
     if (present(default)) then
@@ -5017,12 +5028,12 @@ contains
 
     ! Add field to masterlist
 
-    call masterlist_addfld (fname=trim(fname), type1d=l_type1d, type1d_out=l_type1d_out, &
-         type2d=type2d, num2d=num2d, &
-         units=units, avgflag=avgflag, long_name=long_name, hpindex=hpindex, &
-         p2c_scale_type=scale_type_p2c, c2l_scale_type=scale_type_c2l, l2g_scale_type=scale_type_l2g, &
-         no_snow_behavior=no_snow_behavior)
-
+    call masterlist_addfld (fname=trim(fname), numdims=2, type1d=l_type1d, & 
+          type1d_out=l_type1d_out, type2d=type2d, num2d=num2d, &
+          units=units, avgflag=avgflag, long_name=long_name, hpindex=hpindex, &
+          p2c_scale_type=scale_type_p2c, c2l_scale_type=scale_type_c2l, & 
+          l2g_scale_type=scale_type_l2g, no_snow_behavior=no_snow_behavior)
+    
     l_default = 'active'
     if (present(default)) then
        l_default = default

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -25,7 +25,8 @@ module histFileMod
   use FatesInterfaceMod , only : nlevsclass, nlevage
   use FatesInterfaceMod , only : nlevheight
   use EDTypesMod     , only : nfsc, ncwd
-  use FatesInterfaceMod , only : numpft_ed => numpft
+  use EDTypesMod        , only : num_elements_fates => num_elements
+  use FatesInterfaceMod , only : numpft_fates => numpft
   use ncdio_pio 
 
   !
@@ -2056,18 +2057,22 @@ contains
     
     if(use_fates)then
        call ncd_defdim(lnfid, 'fates_levscag', nlevsclass * nlevage, dimid)
-       call ncd_defdim(lnfid, 'fates_levscagpf', nlevsclass * nlevage * numpft_ed, dimid)
-       call ncd_defdim(lnfid, 'fates_levagepft', nlevage * numpft_ed, dimid)
+       call ncd_defdim(lnfid, 'fates_levscagpf', nlevsclass * nlevage * numpft_fates, dimid)
+       call ncd_defdim(lnfid, 'fates_levagepft', nlevage * numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levscls', nlevsclass, dimid)
-       call ncd_defdim(lnfid, 'fates_levpft', numpft_ed, dimid)
+       call ncd_defdim(lnfid, 'fates_levpft', numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levage', nlevage, dimid)
        call ncd_defdim(lnfid, 'fates_levheight', nlevheight, dimid)
        call ncd_defdim(lnfid, 'fates_levfuel', nfsc, dimid)
        call ncd_defdim(lnfid, 'fates_levcwdsc', ncwd, dimid)
-       call ncd_defdim(lnfid, 'fates_levscpf', nlevsclass*numpft_ed, dimid)
+       call ncd_defdim(lnfid, 'fates_levscpf', nlevsclass*numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levcan', nclmax, dimid)
        call ncd_defdim(lnfid, 'fates_levcnlf', nlevleaf * nclmax, dimid)
-       call ncd_defdim(lnfid, 'fates_levcnlfpf', nlevleaf * nclmax * numpft_ed, dimid)
+       call ncd_defdim(lnfid, 'fates_levcnlfpf', nlevleaf * nclmax * numpft_fates, dimid)
+       call ncd_defdim(lnfid, 'fates_levelem', num_elements_fates, dimid)
+       call ncd_defdim(lnfid, 'fates_levelpft', num_elements_fates * numpft_fates, dimid)
+       call ncd_defdim(lnfid, 'fates_levelcwd', num_elements_fates * ncwd, dimid)
+       call ncd_defdim(lnfid, 'fates_levelage', num_elements_fates * nlevage, dimid)
     end if
 
     if ( .not. lhistrest )then
@@ -2502,6 +2507,15 @@ contains
     use FatesInterfaceMod, only : fates_hdim_canmap_levcnlfpf
     use FatesInterfaceMod, only : fates_hdim_lfmap_levcnlfpf
     use FatesInterfaceMod, only : fates_hdim_pftmap_levcnlfpf
+    use FatesInterfaceMod, only : fates_hdim_levelem
+    use FatesInterfaceMod, only : fates_hdim_elmap_levelpft
+    use FatesInterfaceMod, only : fates_hdim_pftmap_levelpft
+    use FatesInterfaceMod, only : fates_hdim_elmap_levelcwd
+    use FatesInterfaceMod, only : fates_hdim_cwdmap_levelcwd
+    use FatesInterfaceMod, only : fates_hdim_elmap_levelage
+    use FatesInterfaceMod, only : fates_hdim_agemap_levelage
+
+
     !
     ! !ARGUMENTS:
     integer, intent(in) :: t              ! tape index
@@ -2598,6 +2612,20 @@ contains
                    long_name='FATES pft map into patch age x pft', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_agmap_levagepft', xtype=ncd_int, dim1name='fates_levagepft', &
                    long_name='FATES age-class map into patch age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_levelem',xtype=ncd_int, dim1name='fates_levelem', &
+                   long_name='FATES element (C,N,P,...) identifier', ncid=nfid(t))
+             call ncd_defvar(varname='fates_elmap_levelpft', xtype=ncd_int, dim1name='fates_levelpft', &
+                   long_name='FATES element map into element x pft   ', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_pftmap_levelpft', xtype=ncd_int, dim1name='fates_levelpft', &
+                   long_name='FATES pft map into element x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_elmap_levelcwd', xtype=ncd_int, dim1name='fates_levelcwd', &
+                   long_name='FATES element map into element x cwd', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_cwdmap_levelcwd', xtype=ncd_int, dim1name='fates_levelcwd', &
+                   long_name='FATES cwd map into element x cwd', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_elmap_levelage', xtype=ncd_int, dim1name='fates_levelage', &
+                   long_name='FATES element map into age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_agemap_levelage', xtype=ncd_int, dim1name='fates_levage', &
+                   long_name='FATES element map into age x pft', units='-', ncid=nfid(t))
 
           end if
 
@@ -2633,7 +2661,14 @@ contains
              call ncd_io(varname='fates_agmap_levscagpft',data=fates_hdim_agmap_levscagpft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_pftmap_levscagpft',data=fates_hdim_pftmap_levscagpft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_pftmap_levagepft',data=fates_hdim_pftmap_levagepft, ncid=nfid(t), flag='write')
-             call ncd_io(varname='fates_agmap_levagepft',data=fates_hdim_agmap_levagepft, ncid=nfid(t), flag='write')             
+             call ncd_io(varname='fates_agmap_levagepft',data=fates_hdim_agmap_levagepft, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_levelem',data=fates_hdim_levelem, ncid=nfid(t),flag='write')
+             call ncd_io(varname='fates_elmap_levelpft',data=fates_hdim_elmap_levelpft, ncid=nfid(t),flag='write')
+             call ncd_io(varname='fates_pftmap_levelpft',data=fates_hdim_pftmap_levelpft, ncid=nfid(t),flag='write')
+             call ncd_io(varname='fates_elmap_levelcwd',data=fates_hdim_elmap_levelcwd, ncid=nfid(t),flag='write')
+             call ncd_io(varname='fates_cwdmap_levelcwd',data=fates_hdim_cwdmap_levelcwd, ncid=nfid(t),flag='write')
+             call ncd_io(varname='fates_elmap_levelage',data=fates_hdim_elmap_levelage, ncid=nfid(t),flag='write')
+             call ncd_io(varname='fates_agemap_levelage',data=fates_hdim_agemap_levelage, ncid=nfid(t),flag='write')
           end if
 
        endif
@@ -4786,7 +4821,7 @@ contains
     case ('fates_levscls')
        num2d = nlevsclass
     case ('fates_levpft')
-       num2d = numpft_ed
+       num2d = numpft_fates
     case ('fates_levage')
        num2d = nlevage
     case ('fates_levheight')
@@ -4796,23 +4831,31 @@ contains
     case ('fates_levcwdsc')
        num2d = ncwd
     case ('fates_levscpf')
-       num2d = nlevsclass*numpft_ed
+       num2d = nlevsclass*numpft_fates
     case ('fates_levscag')
        num2d = nlevsclass*nlevage
     case ('fates_levscagpf')
-       num2d = nlevsclass*nlevage*numpft_ed
+       num2d = nlevsclass*nlevage*numpft_fates
     case ('fates_levagepft')
-       num2d = nlevage*numpft_ed
+       num2d = nlevage*numpft_fates
     case ('fates_levcan')
        num2d = nclmax
     case ('fates_levcnlf')
        num2d = nlevleaf * nclmax
     case ('fates_levcnlfpf')
-       num2d = nlevleaf * nclmax * numpft_ed
+       num2d = nlevleaf * nclmax * numpft_fates
     case ('ltype')
        num2d = max_lunit
     case ('natpft')
        num2d = natpft_size
+    case ('fates_levelem')
+       num2d = num_elements_fates
+    case ('fates_levelpft')
+       num2d = num_elements_fates*numpft_fates
+    case ('fates_levelcwd')
+       num2d = num_elements_fates*ncwd
+    case ('fates_levelage')
+       num2d = num_elements_fates*nlevage
     case('cft')
        if (cft_size > 0) then
           num2d = cft_size

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -2624,7 +2624,7 @@ contains
                    long_name='FATES cwd map into element x cwd', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_elmap_levelage', xtype=ncd_int, dim1name='fates_levelage', &
                    long_name='FATES element map into age x pft', units='-', ncid=nfid(t))
-             call ncd_defvar(varname='fates_agemap_levelage', xtype=ncd_int, dim1name='fates_levage', &
+             call ncd_defvar(varname='fates_agemap_levelage', xtype=ncd_int, dim1name='fates_levelage', &
                    long_name='FATES element map into age x pft', units='-', ncid=nfid(t))
 
           end if

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1229,7 +1229,7 @@ contains
            call get_clump_bounds(nc, bounds_clump)
 
            do s = 1,this%fates(nc)%nsites
-              call init_site_vars(this%fates(nc)%sites(s))
+              call init_site_vars(this%fates(nc)%sites(s),this%fates(nc)%bc_in(s) )
               call zero_site(this%fates(nc)%sites(s))
            end do
            
@@ -1306,7 +1306,7 @@ contains
         end if
      end do
      !$OMP END PARALLEL DO
-
+     
    end subroutine init_coldstart
 
    ! ======================================================================================

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2329,10 +2329,11 @@ contains
    use FatesIODimensionsMod, only : fates_bounds_type
    use FatesInterfaceMod, only : nlevsclass, nlevage
    use FatesInterfaceMod, only : nlevheight
-   use EDtypesMod, only : nfsc, ncwd
-   use EDtypesMod, only : nlevleaf, nclmax
+   use EDtypesMod,        only : nfsc
+   use FatesLitterMod,    only : ncwd
+   use EDtypesMod,        only : nlevleaf, nclmax
    use FatesInterfaceMod, only : numpft_fates => numpft
-   use clm_varpar, only : nlevgrnd
+   use clm_varpar,        only : nlevgrnd
 
    implicit none
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1884,6 +1884,12 @@ contains
          this%fates(nc)%bc_in(s)%tot_litc     = totlitc(c)
       end do
       
+      ! Update history variables that track these variables
+      call this%fates_hist%update_history_cbal(nc, &
+            this%fates(nc)%nsites,  &
+            this%fates(nc)%sites,   &
+            this%fates(nc)%bc_in)
+
     end associate
  end subroutine wrap_bgc_summary
 
@@ -1936,7 +1942,8 @@ contains
    use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
    use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
-   use FatesIOVariableKindMod, only : site_height_r8
+   use FatesIOVariableKindMod, only : site_height_r8, site_elem_r8, site_elpft_r8
+   use FatesIOVariableKindMod, only : site_elcwd_r8, site_elage_r8
    use FatesIODimensionsMod, only : fates_bounds_type
 
 
@@ -2057,151 +2064,29 @@ contains
                               default=trim(vdefault),                       &
                               set_lake=0._r8,set_urb=0._r8)
 
-        case(patch_ground_r8)
+        case(patch_ground_r8, patch_size_pft_r8)
+
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
            call hist_addfld2d(fname=trim(vname),units=trim(vunits),         & ! <--- addfld2d
                               type2d=trim(dim2name),                        & ! <--- type2d
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
                               ptr_patch=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
+                              default=trim(vdefault))
            
-        case(patch_size_pft_r8)
+        case(site_ground_r8, site_size_pft_r8, site_size_r8, site_pft_r8, &
+             site_age_r8, site_height_r8, site_fuel_r8, site_cwdsc_r8, &
+             site_can_r8,site_cnlf_r8, site_cnlfpft_r8, site_scag_r8, & 
+             site_scagpft_r8, site_agepft_r8, site_elem_r8, site_elpft_r8, &
+             site_elcwd_r8, site_elage_r8)
+
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
            dim2name = this%fates_hist%dim_bounds(d_index)%name
            call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
                               type2d=trim(dim2name),                        &
                               avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_patch=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_ground_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,      & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_size_pft_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,      & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_size_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_pft_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_age_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_height_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_fuel_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_cwdsc_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_can_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_cnlf_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_cnlfpft_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_scag_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_scagpft_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)
-        case(site_agepft_r8)
-           d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
-           dim2name = this%fates_hist%dim_bounds(d_index)%name
-           call hist_addfld2d(fname=trim(vname),units=trim(vunits),         &
-                              type2d=trim(dim2name),                        &
-                              avgflag=trim(vavgflag),long_name=trim(vlong), &
-                              ptr_col=this%fates_hist%hvars(ivar)%r82d,    & 
-                              default=trim(vdefault),                       &
-                              set_lake=0._r8,set_urb=0._r8)           
+                              ptr_col=this%fates_hist%hvars(ivar)%r82d,     & 
+                              default=trim(vdefault))
 
         case default
            write(iulog,*) 'A FATES iotype was created that was not registerred'
@@ -2245,7 +2130,7 @@ contains
              this%fates(nc)%bc_in(s)%decomp_id(j) = j
              ! Check to make sure that dz = dz_decomp_sisl when vertical soil dynamics
              ! are active
-             if(abs(this%fates(nc)%bc_in(s)%dz_decomp_sisl(j)-this%fates(nc)%bc_in(s)%dz_sisl(j))<1.e-10_r8)then
+             if(abs(this%fates(nc)%bc_in(s)%dz_decomp_sisl(j)-this%fates(nc)%bc_in(s)%dz_sisl(j))>1.e-10_r8)then
                 write(iulog,*) 'when vertical soil decomp dynamics are on'
                 write(iulog,*) 'fates assumes that the decomposition depths equal the soil depths'
                 write(iulog,*) 'layer: ',j

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1234,8 +1234,7 @@ contains
            end do
            
            call set_site_properties(this%fates(nc)%nsites, &
-                                    this%fates(nc)%sites,  &
-                                    this%fates(nc)%bc_in)
+                                    this%fates(nc)%sites)
 
            ! ----------------------------------------------------------------------------
            ! Initialize Hydraulics Code if turned on

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -107,7 +107,6 @@ module CLMFatesInterfaceMod
    use FatesHistoryInterfaceMod, only : fates_history_interface_type
    use FatesRestartInterfaceMod, only : fates_restart_interface_type
 
-   use ChecksBalancesMod     , only : SummarizeNetFluxes, FATES_BGC_Carbon_BalanceCheck
    use EDTypesMod            , only : ed_patch_type
    use EDTypesMod            , only : num_elements
    use FatesInterfaceMod     , only : hlm_numlevgrnd
@@ -1884,29 +1883,6 @@ contains
          this%fates(nc)%bc_in(s)%tot_somc     = totsomc(c)
          this%fates(nc)%bc_in(s)%tot_litc     = totlitc(c)
       end do
-
-      is_beg_day = is_beg_curr_day()
-      dtime = get_step_size()
-      nstep = get_nstep()
-
-      call SummarizeNetFluxes(this%fates(nc)%nsites,  &
-                             this%fates(nc)%sites,    &
-                             this%fates(nc)%bc_in,    &
-                             is_beg_day)
-      
-
-      call FATES_BGC_Carbon_Balancecheck(this%fates(nc)%nsites,  &
-                                         this%fates(nc)%sites, &
-                                         this%fates(nc)%bc_in,  &
-                                         is_beg_day,            &
-                                         dtime, nstep)
-      
-
-      ! Update history variables that track these variables
-      call this%fates_hist%update_history_cbal(nc, &
-                               this%fates(nc)%nsites,  &
-                               this%fates(nc)%sites)
-
       
     end associate
  end subroutine wrap_bgc_summary

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2257,6 +2257,27 @@ contains
        this%fates(nc)%bc_in(s)%z_sisl(1:nlevsoil)     = col%z(c,1:nlevsoil)
        this%fates(nc)%bc_in(s)%dz_decomp_sisl(1:nlevdecomp) = &
              dzsoi_decomp(1:nlevdecomp)
+
+       if (use_vertsoilc) then
+          do j=1,nlevsoil
+             this%fates(nc)%bc_in(s)%decomp_id(j) = j
+             ! Check to make sure that dz = dz_decomp_sisl when vertical soil dynamics
+             ! are active
+             if(abs(this%fates(nc)%bc_in(s)%dz_decomp_sisl(j)-this%fates(nc)%bc_in(s)%dz_sisl(j))<1.e-10_r8)then
+                write(iulog,*) 'when vertical soil decomp dynamics are on'
+                write(iulog,*) 'fates assumes that the decomposition depths equal the soil depths'
+                write(iulog,*) 'layer: ',j
+                write(iulog,*) 'dz_decomp_sisl(j): ',this%fates(nc)%bc_in(s)%dz_decomp_sisl(j)
+                write(iulog,*) 'dz_sisl(j): ',this%fates(nc)%bc_in(s)%dz_sisl(j)
+                call endrun(msg=errMsg(sourcefile, __LINE__))
+             end if
+          end do
+       else
+          do j=1,nlevsoil
+             this%fates(nc)%bc_in(s)%decomp_id(j) = 1
+          end do
+       end if
+
     end do
 
     return

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -123,7 +123,7 @@ module CLMFatesInterfaceMod
    use EDCanopyStructureMod  , only : canopy_summarization, update_hlm_dynamics
    use FatesPlantRespPhotosynthMod, only : FatesPlantRespPhotosynthDrive
    use EDAccumulateFluxesMod , only : AccumulateFluxes_ED
-   use EDPhysiologyMod       , only : flux_into_litter_pools
+   use EDPhysiologyMod       , only : FluxIntoLitterPools
    use FatesPlantHydraulicsMod, only : hydraulics_drive
    use FatesPlantHydraulicsMod, only : HydrSiteColdStart
    use FatesPlantHydraulicsMod, only : InitHydrSites
@@ -688,7 +688,7 @@ contains
       
       ! call subroutine to aggregate fates litter output fluxes and 
       ! package them for handing across interface
-      call flux_into_litter_pools(this%fates(nc)%nsites, &
+      call FluxIntoLitterPools(this%fates(nc)%nsites, &
             this%fates(nc)%sites,  &
             this%fates(nc)%bc_in,  &
             this%fates(nc)%bc_out)


### PR DESCRIPTION
### Description of changes

This set of changes has modifications that support multiple elements (nutrients) in FATES.  There will be more changes in the future that will focus specifically on CLM side hypotheses, and how they couple with fates, however the current set of changes just focuses on the following:
1) update/correction to how the registering of history variables is performed
2) slight modifications to how soil layer/decomposition layers are passed to fates
3) changed name of FATES to CLM litter fluxes
4) modifications to the history file to allow for a second dimension that is length 1.

Note item 4, and this may have impacts on non-fates code.

### Specific notes

This is syncronized with:  https://github.com/NGEET/fates/pull/524

Are answers expected to change (and if so in what way)?

These changes should not change any model states not associated with FATES.  These changes could potentially enable other modules to make use of 2D history output, where the second dimension is length 1.

Any User Interface Changes (namelist or namelist defaults changes)?     no

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

Testing is TBD

@bishtgautam , I will be submitting very similar changes to ELM in the near future, including changes to the history.


**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
