### PR TITLE
fixes to transpiration boundary condition to FATES-HYDRO

### DIFF
--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1266,7 +1266,7 @@ contains
          
          
          call clm_fates%wrap_accumulatefluxes(nc,fn,filterp(1:fn))
-         call clm_fates%wrap_hydraulics_drive(bounds,nc,soilstate_inst, &
+         call clm_fates%wrap_hydraulics_drive(bounds,nc,fn,filterp(1:fn),soilstate_inst, &
                waterstate_inst,waterflux_inst,solarabs_inst,energyflux_inst)
 
       else

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1419,6 +1419,13 @@ contains
      do s = 1, this%fates(nc)%nsites
         ! filter flag == 1 means that this patch has not been called for photosynthesis
         this%fates(nc)%bc_in(s)%filter_photo_pa(:) = 1
+
+        ! set transpiration input boundary condition to zero. The exposed
+        ! vegetation filter may not even call every patch.
+
+        this%fates(nc)%bc_in(s)%qflx_transp_pa(:) = 0._r8
+
+
      end do
   end subroutine prep_canopyfluxes
 
@@ -2343,6 +2350,7 @@ contains
  ! ======================================================================================
 
  subroutine wrap_hydraulics_drive(this, bounds_clump, nc, &
+                                 fn, filterp, &
                                  soilstate_inst, waterstate_inst, waterflux_inst, &
                                  solarabs_inst, energyflux_inst)
 
@@ -2351,6 +2359,8 @@ contains
    class(hlm_fates_interface_type), intent(inout) :: this
    type(bounds_type),intent(in)                   :: bounds_clump
    integer,intent(in)                             :: nc
+   integer, intent(in)                            :: fn
+   integer, intent(in)                            :: filterp(fn)
    type(soilstate_type)    , intent(inout)        :: soilstate_inst
    type(waterstate_type)   , intent(inout)        :: waterstate_inst
    type(waterflux_type)    , intent(inout)        :: waterflux_inst
@@ -2361,6 +2371,7 @@ contains
    integer :: s
    integer :: c 
    integer :: j
+   integer :: f   ! loop index for the patch filter
    integer :: ifp
    integer :: p
    integer :: nlevsoil 
@@ -2397,12 +2408,28 @@ contains
             soilstate_inst%eff_porosity_col(c,1:nlevsoil)
 
       do ifp = 1, this%fates(nc)%sites(s)%youngest_patch%patchno 
-         p = ifp+col%patchi(c)
-         this%fates(nc)%bc_in(s)%swrad_net_pa(ifp) = solarabs_inst%fsa_patch(p)
-         this%fates(nc)%bc_in(s)%lwrad_net_pa(ifp) = energyflux_inst%eflx_lwrad_net_patch(p)
-         this%fates(nc)%bc_in(s)%qflx_transp_pa(ifp) = waterflux_inst%qflx_tran_veg_patch(p)
+          p = ifp+col%patchi(c)
+          ! fsa_patch was filled on the nourban_pa filter, which should cover
+          ! all fates patches.
+          ! These are not currently used anyway (RGK 07/30/19)
+          this%fates(nc)%bc_in(s)%swrad_net_pa(ifp) = solarabs_inst%fsa_patch(p)
+          this%fates(nc)%bc_in(s)%lwrad_net_pa(ifp) = energyflux_inst%eflx_lwrad_net_patch(p)
       end do
-   end do
+
+  end do
+
+
+  ! The exposed vegetation filter "filterp" dictates which patches
+  ! had their transpiration updated during canopy_fluxes(). Patches
+  ! not in the filter had been zero'd during prep_canopyfluxes().
+  
+  do f = 1,fn
+      p = filterp(f)
+      c = patch%column(p)
+      s = this%f2hmap(nc)%hsites(c)
+      ifp = p - col%patchi(c)
+      this%fates(nc)%bc_in(s)%qflx_transp_pa(ifp) = waterflux_inst%qflx_tran_veg_patch(p)
+  end do
 
    ! Call Fates Hydraulics
    ! ------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of changes

During canopy_fluxes(), only patches within the exposed vegetation filter are updated with valid transpiration rates.  We had previously been passing in all values to the fates patches, for use in FATES-HYDRO.  However, this caused fates patches that were not exposed to use uninitialized transpiration rates, instead of zero.  This PR applies a fix so that transpiration is zero in FATES patches by default, and updated only in patches that are in the exposed filter.

### Specific notes

This is NOT a backwards incompatible api change, and is NOT synced with a FATES side change. 


Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

https://github.com/NGEET/fates/issues/559

Are answers expected to change (and if so in what way)?

Yes, this may change answers, but only for obscure cases when FATES-HYDRO is active.

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for gnu/pgi and hobart for gnu/pgi/nag is the standard for tags on master)

TBD

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
