### PR TITLE
Fix interp. of surfdat soil layers so we can use interp. for 10SL case

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,147 @@
 ===============================================================
+Tag name:  ctsm1.0.dev054
+Originator(s):  sacks (Bill Sacks)
+Date: Fri Aug  2 07:57:51 MDT 2019
+One-line Summary: Fix interpolation of surfdat soil layers so we can use interpolation for 10SL case
+
+Purpose of changes
+------------------
+
+Previously, on master, there was special-purpose code for the 10SL case
+that avoided doing interpolation from the surface dataset to the soil
+variables in the model. It would be cleaner - especially now that we
+allow user-defined soil layer structures - if we could use the general
+interpolation code always, rather than sometimes having special-purpose
+code that avoids doing the interpolation.
+
+This tag accomplishes that generality. In order to preserve answers for
+clm45 cases, I needed to make three changes:
+
+1. The constant 0.025 needed an _r8 appended to it; otherwise, zisoifl
+   could differ by roundoff from zisoi.
+
+2. I changed which level is used when zisoi(lev) is exactly equal to
+   zisoifl(j) for some j: I changed the conditional in the following:
+
+      if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
+         clay = clay3d(g,j+1)
+         sand = sand3d(g,j+1)
+         om_frac = organic3d(g,j+1)/organic_max
+      endif
+
+   to:
+
+      if (zisoi(lev) > zisoifl(j) .AND. zisoi(lev) <= zisoifl(j+1)) then
+
+   Previously, when the zisoi values in the model exactly lined up with
+   the zisoi values in the file, we would set clay in model level j
+   equal to the value from level j+1 from the surface dataset (and
+   similarly for sand and om_frac); in the new code, we use level j from
+   the surface dataset for model level j in this case.
+
+3. I changed the way zisoifl is calculated for the lowest layer, so that
+   it matches zisoi(nlevsoi) when running with 10SL_3.5m. Previously, we
+   had:
+
+      zisoi(10)   =     0.38018819123227207690E+01
+      zisoifl(10) =     0.34330930154359391437E+01
+
+   This tag changes zisoifl(10) to match zisoi(10).
+
+Bugs fixed or introduced
+------------------------
+
+Known bugs found since the previous tag (include github issue ID):
+- #772: Interpolation of clay, sand and om_frac can use the wrong layer
+  (points out more fundamental issues with this interpolation of layers
+  from the surface dataset)
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by: Sam Levis
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  tools-tests (test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - not run
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - not run
+
+  regular tests (aux_clm):
+
+    cheyenne ---- pass
+    hobart ------ pass
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: NO (but see note below)
+
+   In principle, the changes in this tag could change answers for some
+   soil layer structures, but there were no answer changes for any of
+   the cases covered by the test suite.
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/ctsm/pull/771
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev053
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
 Date: Thu Aug  1 16:56:09 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev054    sacks 08/02/2019 Fix interpolation of surfdat soil layers so we can use interpolation for 10SL case
   ctsm1.0.dev053   slevis 08/01/2019 Soil layer definition clean-up and user-defined option
   ctsm1.0.dev052    sacks 07/22/2019 Fix rare soil color bug in mksurfdata_map
   ctsm1.0.dev051    sacks 07/19/2019 Update water tracers for remainder of first stage of hydrology

--- a/python/ctsm/machine_defaults.py
+++ b/python/ctsm/machine_defaults.py
@@ -43,7 +43,7 @@ MACHINE_DEFAULTS = {
         job_launcher_defaults={
             JOB_LAUNCHER_QSUB: QsubDefaults(
                 queue='regular',
-                walltime='06:00:00',
+                walltime='11:50:00',
                 extra_args='',
                 # The following assumes a single node, with a single mpi proc; we may want
                 # to add more flexibility in the future, making the node / proc counts

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -21,12 +21,13 @@ module SoilStateInitTimeConstMod
   private :: ReadNL
   !
   ! !PUBLIC DATA:
-    real(r8), public :: organic_max  ! organic matter (kg/m3) where soil is assumed to act like peat
-
-  ! Control variables (from namelist)
-  logical, public :: organic_frac_squared ! If organic fraction should be squared (as in CLM4.5)
+  real(r8), public :: organic_max  ! organic matter (kg/m3) where soil is assumed to act like peat
 
   ! !PRIVATE DATA:
+
+  ! Control variables (from namelist)
+  logical, private :: organic_frac_squared ! If organic fraction should be squared (as in CLM4.5)
+
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
   !-----------------------------------------------------------------------

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -303,9 +303,12 @@ contains
     ! --------------------------------------------------------------------
 
     ! Note that the depths on the file are assumed to be the same as the depths in the
-    ! model when running with 10SL_3.5m. We need to specify zsoifl down to nlevsoifl+1
-    ! (rather than just nlevsoifl) so that we can get the appropriate zisoifl at level
-    ! nlevsoifl (i.e., the bottom interface depth).
+    ! model when running with 10SL_3.5m. Ideally zsoifl and zisoifl would be read from
+    ! the surface dataset rather than assumed here.
+    !
+    ! We need to specify zsoifl down to nlevsoifl+1 (rather than just nlevsoifl) so that
+    ! we can get the appropriate zisoifl at level nlevsoifl (i.e., the bottom interface
+    ! depth).
     allocate(zsoifl(1:nlevsoifl+1), zisoifl(0:nlevsoifl))
     do j = 1, nlevsoifl+1
        zsoifl(j) = 0.025_r8*(exp(0.5_r8*(j-0.5_r8))-1._r8)    !node depths
@@ -368,6 +371,12 @@ contains
                 om_frac = organic3d(g,1)/organic_max
              else if (lev <= nlevsoi) then
                 do j = 1,nlevsoifl-1
+                   ! NOTE(wjs, 2019-08-01) It appears that the code currently doesn't set
+                   ! clay, sand and om_frac explicitly under some conditions. It probably
+                   ! should. My understanding is that currently things work okay, though,
+                   ! because clay, sand and om_frac will remain set at their previous
+                   ! values, which is probably reasonable enough. See also
+                   ! <https://github.com/ESCOMP/ctsm/pull/771#discussion_r309509596>.
                    if (zisoi(lev) > zisoifl(j) .AND. zisoi(lev) <= zisoifl(j+1)) then
                       clay = clay3d(g,j+1)
                       sand = sand3d(g,j+1)

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -148,7 +148,6 @@ contains
     type(file_desc_t)  :: ncid                          ! netcdf id
     real(r8) ,pointer  :: zsoifl (:)                    ! Output: [real(r8) (:)]  original soil midpoint 
     real(r8) ,pointer  :: zisoifl (:)                   ! Output: [real(r8) (:)]  original soil interface depth 
-    real(r8) ,pointer  :: dzsoifl (:)                   ! Output: [real(r8) (:)]  original soil thickness 
     real(r8) ,pointer  :: gti (:)                       ! read in - fmax 
     real(r8) ,pointer  :: sand3d (:,:)                  ! read in - soil texture: percent sand (needs to be a pointer for use in ncdio)
     real(r8) ,pointer  :: clay3d (:,:)                  ! read in - soil texture: percent clay (needs to be a pointer for use in ncdio)
@@ -303,22 +302,19 @@ contains
     ! get original soil depths to be used in interpolation of sand and clay
     ! --------------------------------------------------------------------
 
-    allocate(zsoifl(1:nlevsoifl), zisoifl(0:nlevsoifl), dzsoifl(1:nlevsoifl))
-    do j = 1, nlevsoifl
-       zsoifl(j) = 0.025*(exp(0.5_r8*(j-0.5_r8))-1._r8)    !node depths
+    ! Note that the depths on the file are assumed to be the same as the depths in the
+    ! model when running with 10SL_3.5m. We need to specify zsoifl down to nlevsoifl+1
+    ! (rather than just nlevsoifl) so that we can get the appropriate zisoifl at level
+    ! nlevsoifl (i.e., the bottom interface depth).
+    allocate(zsoifl(1:nlevsoifl+1), zisoifl(0:nlevsoifl))
+    do j = 1, nlevsoifl+1
+       zsoifl(j) = 0.025_r8*(exp(0.5_r8*(j-0.5_r8))-1._r8)    !node depths
     enddo
-
-    dzsoifl(1) = 0.5_r8*(zsoifl(1)+zsoifl(2))             !thickness b/n two interfaces
-    do j = 2,nlevsoifl-1
-       dzsoifl(j)= 0.5_r8*(zsoifl(j+1)-zsoifl(j-1))
-    enddo
-    dzsoifl(nlevsoifl) = zsoifl(nlevsoifl)-zsoifl(nlevsoifl-1)
 
     zisoifl(0) = 0._r8
-    do j = 1, nlevsoifl-1
+    do j = 1, nlevsoifl
        zisoifl(j) = 0.5_r8*(zsoifl(j)+zsoifl(j+1))         !interface depths
     enddo
-    zisoifl(nlevsoifl) = zsoifl(nlevsoifl) + 0.5_r8*dzsoifl(nlevsoifl)
 
     ! --------------------------------------------------------------------
     ! Set soil hydraulic and thermal properties: non-lake
@@ -329,7 +325,6 @@ contains
     !   value because thermal conductivity and heat capacity for urban 
     !   roof, sunwall and shadewall are prescribed in SoilThermProp.F90 
     !   in SoilPhysicsMod.F90
-
 
     do c = begc, endc
        g = col%gridcell(c)
@@ -367,36 +362,26 @@ contains
        else
 
           do lev = 1,nlevgrnd
-             ! DML - this if statement could probably be removed and just the
-             ! top part used for all soil layer structures
-             if (.not. organic_frac_squared) then
-                if (lev .eq. 1) then
-                   clay = clay3d(g,1)
-                   sand = sand3d(g,1)
-                   om_frac = organic3d(g,1)/organic_max
-                else if (lev <= nlevsoi) then
-                   do j = 1,nlevsoifl-1
-                      if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
-                         clay = clay3d(g,j+1)
-                         sand = sand3d(g,j+1)
-                         om_frac = organic3d(g,j+1)/organic_max
-                      endif
-                   end do
-                else
-                   clay = clay3d(g,nlevsoifl)
-                   sand = sand3d(g,nlevsoifl)
-                   om_frac = 0._r8
-                endif
+             if (lev .eq. 1) then
+                clay = clay3d(g,1)
+                sand = sand3d(g,1)
+                om_frac = organic3d(g,1)/organic_max
+             else if (lev <= nlevsoi) then
+                do j = 1,nlevsoifl-1
+                   if (zisoi(lev) > zisoifl(j) .AND. zisoi(lev) <= zisoifl(j+1)) then
+                      clay = clay3d(g,j+1)
+                      sand = sand3d(g,j+1)
+                      om_frac = organic3d(g,j+1)/organic_max
+                   endif
+                end do
              else
-                if (lev <= nlevsoi) then ! duplicate clay and sand values from 10th soil layer
-                   clay = clay3d(g,lev)
-                   sand = sand3d(g,lev)
-                   om_frac = (organic3d(g,lev)/organic_max)**2._r8
-                else
-                   clay = clay3d(g,nlevsoi)
-                   sand = sand3d(g,nlevsoi)
-                   om_frac = 0._r8
-                endif
+                clay = clay3d(g,nlevsoifl)
+                sand = sand3d(g,nlevsoifl)
+                om_frac = 0._r8
+             endif
+
+             if (organic_frac_squared) then
+                om_frac = om_frac**2._r8
              end if
 
              if (lun%urbpoi(l)) then
@@ -591,7 +576,7 @@ contains
     ! --------------------------------------------------------------------
 
     deallocate(sand3d, clay3d, organic3d)
-    deallocate(zisoifl, zsoifl, dzsoifl)
+    deallocate(zisoifl, zsoifl)
 
   end subroutine SoilStateInitTimeConst
 


### PR DESCRIPTION
Previously, on master, there was special-purpose code for the 10SL case
that avoided doing interpolation from the surface dataset to the soil
variables in the model. (In a recent commit, @slevisconsulting changed
the logic to be based on organic_frac_squared, but that dependence was
not correct.) It would be cleaner - especially now that we allow
user-defined soil layer structures - if we could use the general
interpolation code always, rather than sometimes having special-purpose
code that avoids doing the interpolation.

This commit accomplishes that generality. In order to preserve answers
for clm45 cases, I needed to make three changes:

1. The constant 0.025 needed an _r8 appended to it; otherwise, zisoifl
   could differ by roundoff from zisoi. I'm confident that this is a
   correct fix.

2. I changed which level is used when zisoi(lev) is exactly equal to
   zisoifl(j) for some j: I changed the conditional in the following:

      if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
         clay = clay3d(g,j+1)
         sand = sand3d(g,j+1)
         om_frac = organic3d(g,j+1)/organic_max
      endif

   to:

      if (zisoi(lev) > zisoifl(j) .AND. zisoi(lev) <= zisoifl(j+1)) then

   I am pretty sure, but not positive, that this is a correct fix in
   general: Previously, when the zisoi values in the model exactly lined
   up with the zisoi values in the file, we would set clay in model
   level j equal to the value from level j+1 from the surface dataset
   (and similarly for sand and om_frac); in the new code, we use level j
   from the surface dataset for model level j in this case. I assume
   this is the right thing to do, though am not 100% positive.

3. I changed the way zisoifl is calculated for the lowest layer, so that
   it matches zisoi(nlevsoi) when running with 10SL_3.5m. I think this
   is the correct thing to do, but I'm not positive of this. Previously,
   we had:

      zisoi(10)   =     0.38018819123227207690E+01
      zisoifl(10) =     0.34330930154359391437E+01

   This commit changes zisoifl(10) to match zisoi(10).

With these changes, the following tests are bit-for-bit with master:

SMS_D_Ld1_P4x1.f10_f10_musgs.I2000Clm45BgcCropQianRsGs.bishorn_gnu.clm-default
(with additional changes to define this compset properly)

SMS_D_Ld1_P4x1.f10_f10_musgs.I2000Clm50BgcCropQianRsGs.bishorn_gnu.clm-default