### PR TITLE
Soil texture interpolation bug-fix

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,13 +1,13 @@
 ===============================================================
 Tag name:  ctsm1.0.dev058
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
-Date:  Wed Aug 21 14:45:49 MDT 2019
+Date:  Thu Aug 22 10:02:49 MDT 2019
 One-line Summary: Soil texture interpolation bug-fix
 
 Purpose of changes
 ------------------
 
- When assigning soil texture values from data-set soil levels to model
+ When assigning soil texture values from dataset soil levels to model
  soil levels, we should be comparing zsoi (NOT zisoi) in the model with
  zisoi on the file, i.e. we should be asking whether the node
  center (NOT interface) of a given model level falls between two
@@ -53,7 +53,12 @@ NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the
 
 Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
 
-Changes to tests or testing: none
+Changes to tests or testing:
+ Unexpected failure of test
+ SMS_D_Ld10.f10_f10_musgs.I2000Clm50BgcCropGs.hobart_nag.clm-tracer_consistency
+ Bill Sacks did some follow-up testing and concluded that this may be a
+ compiler-specific issue, so he changed the test from "nag" to "intel"
+ and generated the new test's corresponding baseline
 
 Code reviewed by: @billsacks
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,133 @@
 ===============================================================
+Tag name:  ctsm1.0.dev057
+Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
+Date:  Mon Aug 19 17:24:02 MDT 2019
+One-line Summary: Soil texture interpolation bug-fix
+
+Purpose of changes
+------------------
+
+ When assigning soil texture values from data-set soil levels to model
+ soil levels, we should be comparing zsoi (NOT zisoi) in the model with
+ zisoi on the file, i.e. we should be asking whether the node
+ center (NOT interface) of a given model level falls between two
+ interface depths on the file.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): #772
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm5_0
+
+[X] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by: @billsacks
+
+
+CTSM testing:
+
+[... Remove before making master tag.  Available test levels:
+
+    a) regular (must be run before handing off a tag to SEs and must be run
+     before committing a tag)
+    b) build_namelist (if namelists and/or build_system changed))
+    c) tools (only if tools are modified and no CTSM source is modified)
+    d) short (for use during development and in rare cases where only a small
+          change with known behavior is added ... eg. a minor bug fix)
+    e) doc (no source testing required)
+
+... ]
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - 
+
+  tools-tests (test/tools):
+
+    cheyenne - 
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - 
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - 
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    hobart ------ OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline:
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: not clm45
+    - what platforms/compilers: all
+    - nature of change: larger than roundoff/same climate
+      based on the assumption that shifting soil texture assignments by
+      one level in model soil levels below the top-most level should not
+      generate climate-changing differences.
+
+Detailed list of changes
+------------------------
+ 1. Changed zisoi to zsoi as described in the Purpose section above.
+    This caused the larger than roundoff changes. Before the fix some
+    model soil levels were getting assigned soil textures from a deeper
+    soil level in the dataset than they should.
+ 2. In the same section of code I completed the if-block to address all
+    zsoi vs. zisoifl comparisons. This ensures explicit assignment of
+    soil textures for all model soil levels and avoids leaving some
+    model soil levels with the texture assignment of the previous model
+    soil level.
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull/788)
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev055
 Originator(s):  sacks (Bill Sacks)
 Date: Tue Aug  6 14:06:50 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev057   slevis 08/19/2019 Soil texture interpolation bug-fix
   ctsm1.0.dev055    sacks 08/06/2019 Modularize snow cover fraction method
   ctsm1.0.dev054    sacks 08/02/2019 Fix interpolation of surfdat soil layers so we can use interpolation for 10SL case
   ctsm1.0.dev053   slevis 08/01/2019 Soil layer definition clean-up and user-defined option

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev058   slevis 08/21/2019 Soil texture interpolation bug-fix
+  ctsm1.0.dev058   slevis 08/22/2019 Soil texture interpolation bug-fix
   ctsm1.0.dev057    sacks 08/20/2019 Fix frac_sno bugs
   ctsm1.0.dev056    sacks 08/16/2019 Start adding water tracers to LakeHydrology, and related refactoring
   ctsm1.0.dev055    sacks 08/06/2019 Modularize snow cover fraction method

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -376,14 +376,10 @@ contains
              else if (lev <= nlevsoi) then
                 found = 0  ! reset value
                 ! For remaining model soil levels, search within the dataset's
-                ! range of zisoifl values. Look for model interface depths
-                ! that are between the dataset's interface depths. IN ONE OF
-                ! THE NEXT FEW COMMITS I WILL REPLACE the first occurrence of
-                ! "interface" with "node" in this comment and in the three
-                ! corresponding if-statements below. At that time clean up this
-                ! comment, too.
+                ! range of zisoifl values. Look for model node depths
+                ! that are between the dataset's interface depths.
                 do j = 1,nlevsoifl-1
-                   if (zisoi(lev) > zisoifl(j) .AND. zisoi(lev) <= zisoifl(j+1)) then
+                   if (zsoi(lev) > zisoifl(j) .AND. zsoi(lev) <= zisoifl(j+1)) then
                       clay = clay3d(g,j+1)
                       sand = sand3d(g,j+1)
                       om_frac = organic3d(g,j+1)/organic_max
@@ -394,7 +390,7 @@ contains
                 ! If not found, search below the dataset's range of zisoifl
                 ! depths
                 if (found == 0) then
-                   if (zisoi(lev) > zisoifl(nlevsoifl)) then
+                   if (zsoi(lev) > zisoifl(nlevsoifl)) then
                       clay = clay3d(g,nlevsoifl)
                       sand = sand3d(g,nlevsoifl)
                       om_frac = organic3d(g,nlevsoifl)/organic_max
@@ -403,7 +399,7 @@ contains
                 end if
                 ! If still not found, search closer to the surface again
                 if (found == 0) then
-                   if (zisoi(lev) <= zisoifl(1)) then
+                   if (zsoi(lev) <= zisoifl(1)) then
                       clay = clay3d(g,1)
                       sand = sand3d(g,1)
                       om_frac = organic3d(g,1)/organic_max

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -412,7 +412,8 @@ contains
                 end if
                 ! If still not found, then something's wrong
                 if (found == 0) then
-                   call endrun(msg="ERROR finding a soil dataset depth to interpolate the model depth to for model level ="//lev//' '//errmsg(sourcefile, __LINE__))
+                   write(iulog,*) 'For model soil level =', lev
+                   call endrun(msg="ERROR finding a soil dataset depth to interpolate the model depth to"//errmsg(sourcefile, __LINE__))
                 end if
              else  ! if lev > nlevsoi
                 clay = clay3d(g,nlevsoifl)

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -375,38 +375,33 @@ contains
                 om_frac = organic3d(g,1)/organic_max
              else if (lev <= nlevsoi) then
                 found = 0  ! reset value
-                ! For remaining model soil levels, search within the dataset's
-                ! range of zisoifl values. Look for model node depths
-                ! that are between the dataset's interface depths.
-                do j = 1,nlevsoifl-1
-                   if (zsoi(lev) > zisoifl(j) .AND. zsoi(lev) <= zisoifl(j+1)) then
-                      clay = clay3d(g,j+1)
-                      sand = sand3d(g,j+1)
-                      om_frac = organic3d(g,j+1)/organic_max
-                      found = 1
-                   endif
-                   if (found == 1) exit  ! no need to stay in the loop
-                end do
-                ! If not found, search below the dataset's range of zisoifl
-                ! depths
-                if (found == 0) then
-                   if (zsoi(lev) > zisoifl(nlevsoifl)) then
-                      clay = clay3d(g,nlevsoifl)
-                      sand = sand3d(g,nlevsoifl)
-                      om_frac = organic3d(g,nlevsoifl)/organic_max
-                      found = 1
-                   end if
+                if (zsoi(lev) <= zisoifl(1)) then
+                   ! Search above the dataset's range of zisoifl depths
+                   clay = clay3d(g,1)
+                   sand = sand3d(g,1)
+                   om_frac = organic3d(g,1)/organic_max
+                   found = 1
+                else if (zsoi(lev) > zisoifl(nlevsoifl)) then
+                   ! Search below the dataset's range of zisoifl depths
+                   clay = clay3d(g,nlevsoifl)
+                   sand = sand3d(g,nlevsoifl)
+                   om_frac = organic3d(g,nlevsoifl)/organic_max
+                   found = 1
+                else
+                   ! For remaining model soil levels, search within dataset's
+                   ! range of zisoifl values. Look for model node depths
+                   ! that are between the dataset's interface depths.
+                   do j = 1,nlevsoifl-1
+                      if (zsoi(lev) > zisoifl(j) .AND. zsoi(lev) <= zisoifl(j+1)) then
+                         clay = clay3d(g,j+1)
+                         sand = sand3d(g,j+1)
+                         om_frac = organic3d(g,j+1)/organic_max
+                         found = 1
+                      endif
+                      if (found == 1) exit  ! no need to stay in the loop
+                   end do
                 end if
-                ! If still not found, search closer to the surface again
-                if (found == 0) then
-                   if (zsoi(lev) <= zisoifl(1)) then
-                      clay = clay3d(g,1)
-                      sand = sand3d(g,1)
-                      om_frac = organic3d(g,1)/organic_max
-                      found = 1
-                   end if
-                end if
-                ! If still not found, then something's wrong
+                ! If not found, then something's wrong
                 if (found == 0) then
                    write(iulog,*) 'For model soil level =', lev
                    call endrun(msg="ERROR finding a soil dataset depth to interpolate the model depth to"//errmsg(sourcefile, __LINE__))

--- a/src/biogeophys/SoilStateInitTimeConstMod.F90
+++ b/src/biogeophys/SoilStateInitTimeConstMod.F90
@@ -378,7 +378,7 @@ contains
                    ! because clay, sand and om_frac will remain set at their previous
                    ! values, which is probably reasonable enough. See also
                    ! <https://github.com/ESCOMP/ctsm/pull/771#discussion_r309509596>.
-                   if (zisoi(lev) > zisoifl(j) .AND. zisoi(lev) <= zisoifl(j+1)) then
+                   if (zsoi(lev) > zisoifl(j) .AND. zsoi(lev) <= zisoifl(j+1)) then
                       clay = clay3d(g,j+1)
                       sand = sand3d(g,j+1)
                       om_frac = organic3d(g,j+1)/organic_max


### PR DESCRIPTION
### Description of changes
Referring to 
https://github.com/ESCOMP/ctsm/blob/842185f8ce5da306c7ad1a7955cffca827239c48/src/biogeophys/SoilStateInitTimeConstMod.F90#L398-L404

Changes as recommended by @billsacks in #772:
"... we should be comparing zsoi in the model with zisoi on the file - asking if the node center of a given layer in the model falls in between two interface depths on the file."

### Specific notes

Contributors other than yourself, if any: @billsacks

CTSM Issues Fixed (include github issue #): Fixes #772 

Are answers expected to change (and if so in what way)?
Yes. Quoting from #772 "... the vertical interpolation of clay, sand and om_frac from the surface dataset to the model's soil layer structure will sometimes use a different soil layer (off by 1) from what should ideally be used."

Any User Interface Changes (namelist or namelist defaults changes)?
No

Testing performed, if any:
None