### PR TITLE
Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1834,19 +1834,6 @@ sub setup_logic_start_type {
   my $var = "start_type";
   my $drv_start_type = $nl->get_value($var);
   my $my_start_type  = $nl_flags->{'clm_start_type'};
-  my $nsrest         = $nl->get_value('override_nsrest');
-
-  if ( defined($nsrest) ) {
-    if ( $nsrest == 0 ) { $my_start_type = "startup";  }
-    if ( $nsrest == 1 ) { $my_start_type = "continue"; }
-    if ( $nsrest == 3 ) { $my_start_type = "branch";   }
-    if ( "$my_start_type" eq "$drv_start_type" ) {
-      $log->fatal_error("no need to set override_nsrest to same as start_type.");
-    }
-    if ( "$drv_start_type" !~ /startup/ ) {
-      $log->fatal_error("can NOT set override_nsrest if driver is NOT a startup type.");
-    }
-  }
 
   if ( $my_start_type =~ /branch/ ) {
     if (not defined $nl->get_value('nrevsn')) {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2825,13 +2825,6 @@ sub setup_logic_methane {
         $log->fatal_error("lake_decomp_fact set without allowlakeprod=.true.");
       }
     }
-    my $anoxia = $nl->get_value('anoxia');
-    if ( ! defined($anoxia) ||
-         (defined($anoxia) && ! &value_is_true($anoxia)) ) {
-      if ( defined($nl->get_value('anoxia_wtsat')) ) {
-        $log->fatal_error("anoxia_wtsat set without anoxia=.true.");
-      }
-    }
     my $pftspec_rootprof = $nl->get_value('pftspecific_rootingprofile');
     if ( ! defined($pftspec_rootprof) ||
          (defined($pftspec_rootprof) && &value_is_true($pftspec_rootprof) ) ) {
@@ -2840,7 +2833,7 @@ sub setup_logic_methane {
       }
     }
   } else {
-    my @vars = ( "allowlakeprod", "anoxia", "anoxia_wtsat", "pftspecific_rootingprofile" );
+    my @vars = ( "allowlakeprod", "anoxia", "pftspecific_rootingprofile" );
     foreach my $var ( @vars ) {
       if ( defined($nl->get_value($var)) ) {
         $log->fatal_error("$var set without methane model configuration on (use_lch4)");

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -167,7 +167,7 @@ OPTIONS
      -glc_nec <name>          Glacier number of elevation classes [0 | 3 | 5 | 10 | 36]
                               (default is 0) (standard option with land-ice model is 10)
      -help [or -h]            Print usage to STDOUT.
-     -light_res <value>       Resolution of lightning dataset to use for CN fire (hcru or T62)
+     -light_res <value>       Resolution of lightning dataset to use for CN fire (360x720 or 94x192)
      -ignore_ic_date          Ignore the date on the initial condition files
                               when determining what input initial condition file to use.
      -ignore_ic_year          Ignore just the year part of the date on the initial condition files

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -161,6 +161,7 @@ OPTIONS
      -dynamic_vegetation      Toggle for dynamic vegetation model. (default is off)
                               (can ONLY be turned on when BGC type is 'cn' or 'bgc')
                               This turns on the namelist variable: use_cndv
+                              (Deprecated, this will be removed)
      -fire_emis               Produce a fire_emis_nl namelist that will go into the
                               "drv_flds_in" file for the driver to pass fire emissions to the atm.
                               (Note: buildnml copies the file for use by the driver)
@@ -1250,6 +1251,8 @@ sub setup_cmdl_dynamic_vegetation {
         my @valid_values   = $definition->get_valid_values( $var );
         $log->fatal_error("$var has a value ($val) that is NOT valid. Valid values are: @valid_values");
      }
+     $log->warning("The use_cndv=T option is deprecated. We do NOT recommend using it." . 
+                   " It's known to have issues and it's not calibrated.");
   }
 }
 #-------------------------------------------------------------------------------

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -365,8 +365,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190729.nc</paramfile>
-<paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190518.nc</paramfile>
+<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190829.nc</paramfile>
+<paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190829.nc</paramfile>
 
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -365,7 +365,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190529.nc</paramfile>
+<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190729.nc</paramfile>
 <paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190518.nc</paramfile>
 
 <!-- ================================================================== -->

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -624,12 +624,6 @@ baseline proportion of nitrogen allocated for electron transport (J)
 Time step (seconds)
 </entry>
 
-<entry id="override_nsrest" type="integer"  category="clm_restart" 
-       group="clm_inparm" valid_values="3">
-Override the start type from the driver: it can only be
-set to 3 meaning branch.
-</entry>
-
 <entry id="use_fates" type="logical" category="physics"
         group="clm_inparm" valid_values="" value=".false.">
 Toggle to turn on the FATES model

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1997,14 +1997,6 @@ E-folding depth over which decomposition is slowed with depth in all soils.
 If TRUE, reduce heterotrophic respiration according to available oxygen predicted by CH4 submodel.
 </entry>
 
-<entry id="anoxia_wtsat" type="logical" category="clm_vertcn"
-       group="clm_inparm" valid_values="" >
-If TRUE, weight calculation of oxygen limitation by the inundated fraction and diagnostic saturated column gas
-concentration profile calculated in the CH4 submodel. Only applies if anoxia = TRUE.
-(EXPERIMENTAL AND NOT FUNCTIONAL!)
-(deprecated -- will be removed)
-</entry>
-
 <entry id="froz_q10" type="real" category="clm_vertcn"
        group="clm_inparm" valid_values="" >
 separate q10 for frozen soil respiration rates.  default to same as above zero rates

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -408,22 +408,22 @@ my %failtest = (
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
-     "clm50CNDVwtransient"       =>{ options=>" -envxml_dir . -use_case 20thC_transient -dynamic_vegetation -res 10x15",
+     "clm50CNDVwtransient"       =>{ options=>" -envxml_dir . -use_case 20thC_transient -dynamic_vegetation -res 10x15 -ignore_warnings",
                                      namelst=>"",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm5_0",
                                    },
-     "CNDV with flanduse_timeseries - clm4_5"=>{ options=>"-bgc bgc -dynamic_vegetation -envxml_dir .",
+     "CNDV with flanduse_timeseries - clm4_5"=>{ options=>"-bgc bgc -dynamic_vegetation -envxml_dir . -ignore_warnings",
                                      namelst=>"flanduse_timeseries='my_flanduse_timeseries_file.nc'",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
-     "use_cndv=T without bldnml op"=>{ options=>"-bgc cn -envxml_dir .",
+     "use_cndv=T without bldnml op"=>{ options=>"-bgc cn -envxml_dir . -ignore_warnings",
                                      namelst=>"use_cndv=.true.",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
                                    },
-     "use_cndv=F with dyn_veg op"=>{ options=>"-bgc cn -dynamic_vegetation -envxml_dir .",
+     "use_cndv=F with dyn_veg op"=>{ options=>"-bgc cn -dynamic_vegetation -envxml_dir . -ignore_warnings",
                                      namelst=>"use_cndv=.false.",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm4_5",
@@ -1268,7 +1268,7 @@ foreach my $phys ( "clm4_5", 'clm5_0' ) {
   my $mode = "-phys $phys";
   &make_config_cache($phys);
   my @clmoptions = ( "-bgc bgc -envxml_dir .", "-bgc bgc -envxml_dir . -clm_accelerated_spinup=on", "-bgc bgc -envxml_dir . -light_res 360x720",
-                     "-bgc sp -envxml_dir . -vichydro", "-bgc bgc -dynamic_vegetation", "-bgc bgc -clm_demand flanduse_timeseries -sim_year 1850-2000",
+                     "-bgc sp -envxml_dir . -vichydro", "-bgc bgc -dynamic_vegetation -ignore_warnings", "-bgc bgc -clm_demand flanduse_timeseries -sim_year 1850-2000",
                      "-bgc bgc -envxml_dir . -namelist '&a use_c13=.true.,use_c14=.true.,use_c14_bombspike=.true./'" );
   foreach my $clmopts ( @clmoptions ) {
      my @clmres = ( "ne120np4", "10x15", "0.9x1.25", "1.9x2.5" );

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -192,6 +192,8 @@ def buildnml(case, caseroot, compname):
             clm_startfile = "%s.clm2%s.r.%s-%s.nc"%(run_refcase,inst_string,run_refdate,run_reftod)
             if not os.path.exists(os.path.join(rundir, clm_startfile)):
                 clm_startfile = "%s.clm2.r.%s-%s.nc"%(run_refcase,run_refdate,run_reftod)
+                logger.warning( "WARNING: the start file being used for a multi-instance case is a single instance: "+clm_startfile )
+
             clm_icfile = "%s = \'%s\'"%(startfile_type, clm_startfile)
         else:
             clm_icfile = ""

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -18,9 +18,9 @@
     <desc lnd="CLM50[%SP][%SP-VIC][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%BGC-CROP-CMIP6DECK][%BGC-CROP-CMIP6WACCMDECK][%NWP-SP][%NWP-BGC-CROP]">clm5.0:</desc>
     <desc option="SP"              >Satellite phenology:</desc>
     <desc option="CN"              >CN: Carbon Nitrogen model</desc>
-    <desc option="CNDV"            >CNDV: CN with Dynamic Vegetation</desc>
+    <desc option="CNDV"            >CNDV: CN with Dynamic Vegetation (deprecated)</desc>
     <desc option="CN-CROP"         >CN with prognostic crop:</desc>
-    <desc option="CNDV-CROP"       >CNDV with prognostic crop:</desc>
+    <desc option="CNDV-CROP"       >CNDV with prognostic crop: (deprecated)</desc>
 
     <desc option="SP-VIC"          >Satellite phenology with VIC hydrology:</desc>
     <desc option="BGC"             >BGC (vert. resol. CN and methane):</desc>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -682,14 +682,6 @@
       <option name="comment"  >cism is not answer preserving across processor changes, but short test length should be ok.</option>
     </options>
   </test>
-  <test name="ERP_P180x2_D_Ld5" grid="f19_g17" compset="I2000Clm50BgcDvCrop" testmods="clm/crop">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:20:00</option>
-    </options>
-  </test>
   <test name="ERP_P180x2_D_Ld5" grid="f19_g17" compset="I2000Clm50Sp" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
@@ -698,12 +690,13 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_P72x2_Lm25" grid="f10_f10_musgs" compset="I2000Clm50BgcDvCrop" testmods="clm/monthly">
+  <test name="ERP_P72x2_Lm25" grid="f10_f10_musgs" compset="I2000Clm50BgcCrop" testmods="clm/monthly">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
       <option name="wallclock">01:40:00</option>
+      <option name="comment"  >threaded ERP test for crop just over 2-years</option>
     </options>
   </test>
   <test name="ERP_P36x2_D_Ld5" grid="f10_f10_musgs" compset="I1850Clm45BgcCrop" testmods="clm/crop">
@@ -722,14 +715,6 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-    </options>
-  </test>
-  <test name="ERP_P36x2_Lm25" grid="f10_f10_musgs" compset="I2000Clm50BgcDvCrop" testmods="clm/monthly">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
-    </machines>
-    <options>
-      <option name="wallclock">01:20:00</option>
     </options>
   </test>
   <test name="ERP_P72x2_Ly3" grid="f10_f10_musgs" compset="I2000Clm50BgcCrop" testmods="clm/irrig_o3_reduceOutput">
@@ -942,13 +927,14 @@
       <option name="comment"  >tests mid-year restart, with the restart file being written after more than 2 years, which Sam Levis says is important for testing crop restarts</option>
     </options>
   </test>
-  <test name="ERS_Ly20_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcDvCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="ERS_ (Crop keeps a 20 year running mean)Ly20_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
-      <option name="wallclock">01:40:00</option>
+      <option name="wallclock"     >01:40:00</option>
       <option name="tput_tolerance">0.5</option>
+      <option name="comment"       >20 year single point tests with BGC-Crop (Crop keeps a 20 year running mean)</option>
     </options>
   </test>
   <test name="ERS_Ly3" grid="f10_f10_musgs" compset="I1850Clm50BgcCropCmip6" testmods="clm/basic">
@@ -1439,12 +1425,13 @@
       <option name="wallclock">01:40:00</option>
     </options>
   </test>
-  <test name="SMS_Ly3_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcDvCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="SMS_Ly3_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcDvCropQianGs" testmods="clm/ignor_warn_cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
     <options>
       <option name="wallclock">01:40:00</option>
+      <option name="comment"  >Single point 3-year test with DV"</option>
     </options>
   </test>
   <test name="SMS_P48x1_D_Ld5" grid="f10_f10_musgs" compset="I2000Clm50Cn" testmods="clm/default">

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -927,7 +927,7 @@
       <option name="comment"  >tests mid-year restart, with the restart file being written after more than 2 years, which Sam Levis says is important for testing crop restarts</option>
     </options>
   </test>
-  <test name="ERS_ (Crop keeps a 20 year running mean)Ly20_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="ERS_Ly20_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>

--- a/cime_config/testdefs/testmods_dirs/clm/_includes/ignore_warnings/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/_includes/ignore_warnings/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange --append CLM_BLDNML_OPTS="-ignore_warnings"

--- a/cime_config/testdefs/testmods_dirs/clm/ignor_warn_cropMonthOutput/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/ignor_warn_cropMonthOutput/include_user_mods
@@ -1,0 +1,2 @@
+../_include/ignore_warnings
+../cropMonthOutput

--- a/cime_config/testdefs/testmods_dirs/clm/ignor_warn_cropMonthOutput/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/ignor_warn_cropMonthOutput/include_user_mods
@@ -1,2 +1,2 @@
-../_include/ignore_warnings
+../_includes/ignore_warnings
 ../cropMonthOutput

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm1.0.dev061
 Originator(s):  erik (Erik Kluzek)
-Date: Sat Aug 31 21:38:33 MDT 2019
+Date: Sun Sep  1 22:37:07 MDT 2019
 One-line Summary: Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated
 
 Purpose of changes
@@ -81,6 +81,9 @@ CTSM testing: regular
 
     cheyenne ---- OK
     hobart ------ OK
+
+An additional fail is ERP_P36x2_D_Ld5.f10_f10_musgs.I2000Clm50Cn.cheyenne_gnu.clm-default, because
+of #798. Because it's an issue with cime, I'm not marking it as an expected error.
 
 If the tag used for baseline comparisons was NOT the previous tag, note that here: previous
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,107 @@
 ===============================================================
+Tag name:  ctsm1.0.dev061
+Originator(s):  erik (Erik Kluzek)
+Date: Sat Aug 31 21:38:33 MDT 2019
+One-line Summary: Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated
+
+Purpose of changes
+------------------
+
+New clm5 paramsfile that has the bad date of 631 changed to 701. Along with some simple bit for
+bit changes. Removing some problematic options. Making Dynamic Vegetation a deprecated option 
+that requires you to use -ignore_warnings with it.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):  #463 #79 #97 #98 #104 #122 #173 #794 #795 #796
+
+   Fixes #463 bad date on params file that didn't allow using ESMF library with Crop
+   Fixes #79 correct documentation of qflx_evap_tot
+   Fixes #97 remove override_nsrest
+   Fixes #98 add warning when using single instance of a startup file for multi-instance cases
+   Fixes #104 use get_step_size_real when putting into a real variable
+   Fixes #122 decomp pool arrays should not start at 0 but 1
+   Fixes #173 remove psi_soil_ref as not used
+   Fixes #794 remove anoxia_wtsat
+   Fixes #795 Correct documentation of -light_res
+   Fixes #796 Deprecate Dynamic Vegetation
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): Remove namelist items
+   Remove namelist items:  anoxia_wtsat, override_nsrest
+   Turning dynamic Vegetation on, now displays a warning, and requires using -ignore_warnings in CLM_BLDNML_OPTS
+
+Changes made to namelist defaults (e.g., changed parameter values): New paramdata files
+
+Changes to the datasets (e.g., parameter, surface or initial files): 
+   clm5 paramdata file has correct date for crop of 701 (rather than incorrect 631)
+   clm5 and clm4_5 paramdata file removed an unused variable
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): None
+
+Changes to tests or testing: DV tests removed or changed
+
+Code reviewed by: self
+
+CTSM testing: regular
+
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (compare shows changes becausse of paramdata files)
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    hobart ------ OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here: previous
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: No bit-for-bit
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids): #797
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #797 -- Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated 
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev060
 Originator(s):  sacks (Bill Sacks)
 Date:  Thu Aug 29 11:18:20 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev061     erik 08/31/2019 Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated
+  ctsm1.0.dev061     erik 09/01/2019 Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated
   ctsm1.0.dev060    sacks 08/29/2019 In SnowWater, truncate small h2osoi residuals
   ctsm1.0.dev059    sacks 08/24/2019 Continue adding water tracers to LakeHydrology
   ctsm1.0.dev058   slevis 08/22/2019 Soil texture interpolation bug-fix

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev061     erik 08/31/2019 Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated
   ctsm1.0.dev060    sacks 08/29/2019 In SnowWater, truncate small h2osoi residuals
   ctsm1.0.dev059    sacks 08/24/2019 Continue adding water tracers to LakeHydrology
   ctsm1.0.dev058   slevis 08/22/2019 Soil texture interpolation bug-fix

--- a/doc/IMPORTANT_NOTES
+++ b/doc/IMPORTANT_NOTES
@@ -30,6 +30,7 @@ Namelist items that are not regularly tested or used. Some aren't even implement
     urban_traffic
     use_extralakelayers
     use_lai_streams
+    use_cndv
     use_snicar_frc
     use_vichydro
     usefrootc

--- a/doc/IMPORTANT_NOTES
+++ b/doc/IMPORTANT_NOTES
@@ -13,7 +13,6 @@ Namelist items that are not regularly tested or used. Some aren't even implement
     CNratio_floating
     all_active
     allowlakeprod
-    anoxia_wtsat
     carbon_resp_opt
     ch4offline
     downreg_opt

--- a/src/biogeochem/CNAnnualUpdateMod.F90
+++ b/src/biogeochem/CNAnnualUpdateMod.F90
@@ -28,7 +28,7 @@ contains
     ! On the radiation time step, update annual summation variables
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size, get_days_per_year
+    use clm_time_manager, only: get_step_size_real, get_days_per_year
     use clm_varcon      , only: secspday
     use SubgridAveMod   , only: p2c
     !
@@ -50,7 +50,7 @@ contains
     type(filter_col_type) :: filter_endofyear_c
     !-----------------------------------------------------------------------
 
-    dt = real( get_step_size(), r8 )
+    dt = get_step_size_real()
     secspyear = get_days_per_year() * secspday
 
     do fc = 1,num_soilc

--- a/src/biogeochem/CNBalanceCheckMod.F90
+++ b/src/biogeochem/CNBalanceCheckMod.F90
@@ -11,7 +11,7 @@ module CNBalanceCheckMod
   use decompMod                       , only : bounds_type
   use abortutils                      , only : endrun
   use clm_varctl                      , only : iulog, use_nitrif_denitrif
-  use clm_time_manager                , only : get_step_size
+  use clm_time_manager                , only : get_step_size_real
   use CNVegNitrogenFluxType           , only : cnveg_nitrogenflux_type
   use CNVegNitrogenStateType          , only : cnveg_nitrogenstate_type
   use CNVegCarbonFluxType             , only : cnveg_carbonflux_type
@@ -153,7 +153,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       err_found = .false.
       do fc = 1,num_soilc
@@ -274,7 +274,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       err_found = .false.
       do fc = 1,num_soilc

--- a/src/biogeochem/CNC14DecayMod.F90
+++ b/src/biogeochem/CNC14DecayMod.F90
@@ -5,7 +5,7 @@ module CNC14DecayMod
   !
   ! !USES:
   use shr_kind_mod                       , only : r8 => shr_kind_r8
-  use clm_time_manager                   , only : get_step_size, get_days_per_year
+  use clm_time_manager                   , only : get_step_size_real, get_days_per_year
   use clm_varpar                         , only : ndecomp_cascade_transitions, nlevdecomp, ndecomp_pools
   use clm_varcon                         , only : secspday
   use clm_varctl                         , only : spinup_state
@@ -86,7 +86,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
       days_per_year = get_days_per_year()
 
       half_life = 5730._r8 * secspday * days_per_year

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -7,7 +7,7 @@ module CNCStateUpdate1Mod
   use shr_kind_mod                       , only : r8 => shr_kind_r8
   use shr_log_mod                        , only : errMsg => shr_log_errMsg
   use clm_varpar                         , only : ndecomp_cascade_transitions, nlevdecomp
-  use clm_time_manager                   , only : get_step_size, get_step_size_real
+  use clm_time_manager                   , only : get_step_size_real
   use clm_varpar                         , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use pftconMod                          , only : npcropmin, nc3crop, pftcon
   use abortutils                         , only : endrun
@@ -123,7 +123,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
 
 
@@ -183,7 +183,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! Below is the input into the soil biogeochemistry model
 

--- a/src/biogeochem/CNCStateUpdate2Mod.F90
+++ b/src/biogeochem/CNCStateUpdate2Mod.F90
@@ -8,7 +8,7 @@ module CNCStateUpdate2Mod
   use shr_kind_mod                   , only : r8 => shr_kind_r8
   use shr_log_mod                    , only : errMsg => shr_log_errMsg
   use abortutils                     , only : endrun
-  use clm_time_manager               , only : get_step_size
+  use clm_time_manager               , only : get_step_size_real
   use clm_varpar                     , only : nlevdecomp, i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use CNvegCarbonStateType           , only : cnveg_carbonstate_type
   use CNVegCarbonFluxType            , only : cnveg_carbonflux_type
@@ -55,7 +55,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! column level carbon fluxes from gap-phase mortality
       do j = 1,nlevdecomp
@@ -162,7 +162,7 @@ contains
          )
      
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! column level carbon fluxes from harvest mortality
       do j = 1, nlevdecomp

--- a/src/biogeochem/CNCStateUpdate3Mod.F90
+++ b/src/biogeochem/CNCStateUpdate3Mod.F90
@@ -8,7 +8,7 @@ module CNCStateUpdate3Mod
   use shr_kind_mod                   , only : r8 => shr_kind_r8
   use shr_log_mod                    , only : errMsg => shr_log_errMsg
   use abortutils                     , only : endrun
-  use clm_time_manager               , only : get_step_size
+  use clm_time_manager               , only : get_step_size_real
   use clm_varpar                     , only : nlevdecomp, ndecomp_pools, i_cwd, i_met_lit, i_cel_lit, i_lig_lit
   use CNVegCarbonStateType          , only : cnveg_carbonstate_type
   use CNVegCarbonFluxType           , only : cnveg_carbonflux_type
@@ -53,7 +53,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! column level carbon fluxes from fire
       do j = 1, nlevdecomp

--- a/src/biogeochem/CNFUNMod.F90
+++ b/src/biogeochem/CNFUNMod.F90
@@ -124,7 +124,7 @@ module CNFUNMod
   !
   ! !USES:
   use clm_varcon      , only: secspday, fun_period
-  use clm_time_manager, only: get_step_size,get_nstep,get_curr_date,get_days_per_year
+  use clm_time_manager, only: get_step_size_real,get_nstep,get_curr_date,get_days_per_year
   !
   ! !ARGUMENTS:
   type(bounds_type)             , intent(in)    :: bounds
@@ -165,7 +165,7 @@ module CNFUNMod
   !--------------------------------------------------------------------
   !---
   ! set time steps
-  dt           = real(get_step_size(), r8)
+  dt           = get_step_size_real()
   dayspyr      = get_days_per_year()
   nstep        = get_nstep()
   timestep_fun = real(secspday * fun_period)
@@ -210,7 +210,7 @@ module CNFUNMod
        & soilbiogeochem_nitrogenstate_inst)
 
 ! !USES:
-   use clm_time_manager, only : get_step_size, get_curr_date, get_days_per_year 
+   use clm_time_manager, only : get_step_size_real, get_curr_date, get_days_per_year 
    use clm_varpar      , only : nlevdecomp
    use clm_varcon      , only : secspday, smallValue, fun_period, tfrz, dzsoi_decomp, spval
    use clm_varctl      , only : use_nitrif_denitrif
@@ -790,7 +790,7 @@ module CNFUNMod
   end do
   
   ! Time step of FUN
-  dt           =  real(get_step_size(), r8)
+  dt           =  get_step_size_real()
   call t_stopf('CNFUNzeroarrays')
   !--------------------------------------------------------------------
   !----------------------------

--- a/src/biogeochem/CNFireBaseMod.F90
+++ b/src/biogeochem/CNFireBaseMod.F90
@@ -314,7 +314,7 @@ contains
    ! seconds_per_year is the number of seconds in a year.
    !
    ! !USES:
-   use clm_time_manager     , only: get_step_size,get_days_per_year,get_curr_date
+   use clm_time_manager     , only: get_step_size_real,get_days_per_year,get_curr_date
    use clm_varpar           , only: max_patch_per_col
    use clm_varctl           , only: use_cndv, spinup_state
    use clm_varcon           , only: secspday
@@ -563,7 +563,7 @@ contains
 
      ! Get model step size
      ! calculate burned area fraction per sec
-     dt = real( get_step_size(), r8 )
+     dt = get_step_size_real()
 
      dayspyr = get_days_per_year()
      !

--- a/src/biogeochem/CNFireLi2014Mod.F90
+++ b/src/biogeochem/CNFireLi2014Mod.F90
@@ -91,7 +91,7 @@ contains
     ! Computes column-level burned area 
     !
     ! !USES:
-    use clm_time_manager     , only: get_step_size, get_days_per_year, get_curr_date, get_nstep
+    use clm_time_manager     , only: get_step_size_real, get_days_per_year, get_curr_date, get_nstep
     use clm_varpar           , only: max_patch_per_col
     use clm_varcon           , only: secspday, secsphr
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
@@ -243,7 +243,7 @@ contains
      call get_curr_date (kyr, kmo, kda, mcsec)
      dayspyr = get_days_per_year()
      ! Get model step size
-     dt      = real( get_step_size(), r8 )
+     dt      = get_step_size_real()
      !
      ! On first time-step, just set area burned to zero and exit
      !
@@ -644,7 +644,7 @@ contains
    ! seconds_per_year is the number of seconds in a year.
    !
    ! !USES:
-   use clm_time_manager     , only: get_step_size,get_days_per_year,get_curr_date
+   use clm_time_manager     , only: get_step_size_real,get_days_per_year,get_curr_date
    use clm_varpar           , only: max_patch_per_col
    use clm_varctl           , only: use_cndv
    use clm_varcon           , only: secspday
@@ -890,7 +890,7 @@ contains
 
      ! Get model step size
      ! calculate burned area fraction per sec
-     dt = real( get_step_size(), r8 )
+     dt = get_step_size_real()
 
      dayspyr = get_days_per_year()
      !

--- a/src/biogeochem/CNFireLi2016Mod.F90
+++ b/src/biogeochem/CNFireLi2016Mod.F90
@@ -92,7 +92,7 @@ contains
     ! Computes column-level burned area 
     !
     ! !USES:
-    use clm_time_manager     , only: get_step_size, get_days_per_year, get_curr_date, get_nstep
+    use clm_time_manager     , only: get_step_size_real, get_days_per_year, get_curr_date, get_nstep
     use clm_varpar           , only: max_patch_per_col
     use clm_varcon           , only: secspday, secsphr
     use clm_varctl           , only: spinup_state
@@ -261,7 +261,7 @@ contains
      call get_curr_date (kyr, kmo, kda, mcsec)
      dayspyr = get_days_per_year()
      ! Get model step size
-     dt      = real( get_step_size(), r8 )
+     dt      = get_step_size_real()
      !
      ! On first time-step, just set area burned to zero and exit
      !

--- a/src/biogeochem/CNNDynamicsMod.F90
+++ b/src/biogeochem/CNNDynamicsMod.F90
@@ -156,7 +156,7 @@ contains
        waterfluxbulk_inst, soilbiogeochem_nitrogenflux_inst)
 
 
-    use clm_time_manager , only : get_days_per_year, get_step_size
+    use clm_time_manager , only : get_days_per_year
     use shr_sys_mod      , only : shr_sys_flush
     use clm_varcon       , only : secspday, spval
  
@@ -200,7 +200,7 @@ contains
     ! All N fixation goes to the soil mineral N pool.
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year, get_step_size
+    use clm_time_manager , only : get_days_per_year
     use shr_sys_mod      , only : shr_sys_flush
     use clm_varcon       , only : secspday, spval
     use CNSharedParamsMod    , only: use_fun

--- a/src/biogeochem/CNNStateUpdate1Mod.F90
+++ b/src/biogeochem/CNNStateUpdate1Mod.F90
@@ -6,7 +6,7 @@ module CNNStateUpdate1Mod
   !
   ! !USES:
   use shr_kind_mod                    , only: r8 => shr_kind_r8
-  use clm_time_manager                , only : get_step_size, get_step_size_real
+  use clm_time_manager                , only : get_step_size_real
   use clm_varpar                      , only : nlevdecomp, ndecomp_pools, ndecomp_cascade_transitions
   use clm_varpar                      , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use clm_varctl                      , only : iulog, use_nitrif_denitrif
@@ -119,7 +119,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
 
       ! soilbiogeochemistry fluxes TODO - this should be moved elsewhere

--- a/src/biogeochem/CNNStateUpdate2Mod.F90
+++ b/src/biogeochem/CNNStateUpdate2Mod.F90
@@ -6,7 +6,7 @@ module CNNStateUpdate2Mod
   !
   ! !USES:
   use shr_kind_mod                    , only : r8 => shr_kind_r8
-  use clm_time_manager                , only : get_step_size
+  use clm_time_manager                , only : get_step_size_real
   use clm_varpar                      , only : nlevsoi, nlevdecomp
   use clm_varpar                      , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use clm_varctl                      , only : iulog
@@ -56,7 +56,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! column-level nitrogen fluxes from gap-phase mortality
 
@@ -162,7 +162,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! column-level nitrogen fluxes from harvest mortality
 

--- a/src/biogeochem/CNNStateUpdate3Mod.F90
+++ b/src/biogeochem/CNNStateUpdate3Mod.F90
@@ -8,7 +8,7 @@ module CNNStateUpdate3Mod
   ! !USES:
   use shr_kind_mod                    , only: r8 => shr_kind_r8
   use clm_varpar                      , only: nlevdecomp, ndecomp_pools
-  use clm_time_manager                , only : get_step_size
+  use clm_time_manager                , only : get_step_size_real
   use clm_varctl                      , only : iulog, use_nitrif_denitrif
   use clm_varpar                      , only : i_cwd, i_met_lit, i_cel_lit, i_lig_lit
   use CNVegNitrogenStateType          , only : cnveg_nitrogenstate_type
@@ -60,7 +60,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       do j = 1, nlevdecomp
          ! column loop

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -351,7 +351,7 @@ contains
     ! initialized, and after pftcon file is read in.
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size
+    use clm_time_manager, only: get_step_size_real
     use clm_varctl      , only: use_crop
     use clm_varcon      , only: secspday
     !
@@ -362,7 +362,7 @@ contains
     !
     ! Get time-step and what fraction of a day it is
     !
-    dt      = real( get_step_size(), r8 )
+    dt      = get_step_size_real()
     fracday = dt/secspday
 
     ! set constants for CNSeasonDecidPhenology 

--- a/src/biogeochem/CNProductsMod.F90
+++ b/src/biogeochem/CNProductsMod.F90
@@ -10,7 +10,7 @@ module CNProductsMod
   use shr_log_mod             , only : errMsg => shr_log_errMsg
   use decompMod               , only : bounds_type
   use abortutils              , only : endrun
-  use clm_time_manager        , only : get_step_size
+  use clm_time_manager        , only : get_step_size_real
   use SpeciesBaseType         , only : species_base_type
   use PatchType               , only : patch
   !
@@ -501,7 +501,7 @@ contains
     end do
 
     ! set time steps
-    dt = real( get_step_size(), r8 )
+    dt = get_step_size_real()
 
     ! update product state variables
     do g = bounds%begg, bounds%endg

--- a/src/biogeochem/CNRootDynMod.F90
+++ b/src/biogeochem/CNRootDynMod.F90
@@ -7,7 +7,7 @@ module CNRootDynMod
 !
 ! !USES:
    use shr_kind_mod                    , only : r8 => shr_kind_r8
-   use clm_time_manager                , only : get_step_size
+   use clm_time_manager                , only : get_step_size_real
    use clm_varpar                      , only : nlevsoi, nlevgrnd
    use clm_varctl                      , only : use_vertsoilc, use_bedrock
    use decompMod                       , only : bounds_type
@@ -102,7 +102,7 @@ subroutine CNRootDyn(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
     )
    
 ! set time steps
-   dt = get_step_size()
+   dt = get_step_size_real()
 
 ! set minpsi to permanent wilting point
    minpsi = -1.5_r8

--- a/src/biogeochem/CNSharedParamsMod.F90
+++ b/src/biogeochem/CNSharedParamsMod.F90
@@ -24,7 +24,6 @@ module CNSharedParamsMod
 
   type(CNParamsShareType), protected :: CNParamsShareInst
 
-  logical, public :: anoxia_wtsat = .false.
   logical, public :: use_fun      = .false.             ! Use the FUN2.0 model
   integer, public :: nlev_soildecomp_standard = 5
 

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -263,7 +263,8 @@ module CNVegCarbonFluxType
      real(r8), pointer :: dwt_conv_cflux_dribbled_grc               (:)     ! (gC/m2/s) dwt_conv_cflux_grc dribbled evenly throughout the year
      real(r8), pointer :: dwt_wood_productc_gain_patch              (:)     ! (gC/m2/s) addition to wood product pools from landcover change; although this is a patch-level flux, it is expressed per unit GRIDCELL area
      real(r8), pointer :: dwt_crop_productc_gain_patch              (:)     ! (gC/m2/s) addition to crop product pools from landcover change; although this is a patch-level flux, it is expressed per unit GRIDCELL area
-     real(r8), pointer :: dwt_slash_cflux_col                       (:)     ! (gC/m2/s) conversion slash flux due to landcover change
+     real(r8), pointer :: dwt_slash_cflux_patch                     (:)     ! (gC/m2/s) conversion slash flux due to landcover change
+     real(r8), pointer :: dwt_slash_cflux_grc                       (:)     ! (gC/m2/s) dwt_slash_cflux_patch summed to the gridcell-level
      real(r8), pointer :: dwt_frootc_to_litr_met_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_cel_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_lig_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
@@ -629,7 +630,8 @@ contains
     allocate(this%harvest_c_to_litr_lig_c_col       (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_litr_lig_c_col  (:,:)=nan
     allocate(this%harvest_c_to_cwdc_col             (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_cwdc_col        (:,:)=nan
 
-    allocate(this%dwt_slash_cflux_col               (begc:endc))                  ; this%dwt_slash_cflux_col (:) =nan
+    allocate(this%dwt_slash_cflux_patch             (begp:endp))                  ; this%dwt_slash_cflux_patch        (:) =nan
+    allocate(this%dwt_slash_cflux_grc               (begg:endg))                  ; this%dwt_slash_cflux_grc          (:) =nan
     allocate(this%dwt_frootc_to_litr_met_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_met_c_col (:,:)=nan
     allocate(this%dwt_frootc_to_litr_cel_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_cel_c_col (:,:)=nan
     allocate(this%dwt_frootc_to_litr_lig_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_lig_c_col (:,:)=nan
@@ -2876,10 +2878,19 @@ contains
             '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_wood_productc_gain_patch, default='inactive')
 
-        this%dwt_slash_cflux_col(begc:endc) = spval
-        call hist_addfld1d (fname='DWT_SLASH_CFLUX', units='gC/m^2/s', &
-             avgflag='A', long_name='slash C flux to litter and CWD due to land use', &
-             ptr_col=this%dwt_slash_cflux_col)
+       this%dwt_slash_cflux_grc(begg:endg) = spval
+       call hist_addfld1d (fname='DWT_SLASH_CFLUX', units='gC/m^2/s', &
+            avgflag='A', &
+            long_name='slash C flux (to litter diagnostic only) (0 at all times except first timestep of year)', &
+            ptr_gcell=this%dwt_slash_cflux_grc)
+
+       this%dwt_slash_cflux_patch(begp:endp) = spval
+       call hist_addfld1d (fname='DWT_SLASH_CFLUX_PATCH', units='gC/m^2/s', &
+            avgflag='A', &
+            long_name='patch-level slash C flux (to litter diagnostic only) ' // &
+            '(0 at all times except first timestep of year) ' // &
+            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='DWT_FROOTC_TO_LITR_MET_C', units='gC/m^2/s',  type2d='levdcmp', &
@@ -3050,10 +3061,19 @@ contains
             long_name='C13 conversion C flux (immediate loss to atm), dribbled throughout the year', &
             ptr_gcell=this%dwt_conv_cflux_dribbled_grc, default='inactive')
 
-       this%dwt_slash_cflux_col(begc:endc) = spval
-       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX', units='gC/m^2/s', &
-            avgflag='A', long_name='C13 slash C flux to litter and CWD due to land use', &
-            ptr_col=this%dwt_slash_cflux_col, default='inactive')
+       this%dwt_slash_cflux_grc(begg:endg) = spval
+       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX', units='gC13/m^2/s', &
+            avgflag='A', long_name='C13 slash C flux (to litter diagnostic only)' // &
+            '(0 at all times except first timestep of year)', &
+            ptr_gcell=this%dwt_slash_cflux_grc, default='inactive')
+
+       this%dwt_slash_cflux_patch(begp:endp) = spval
+       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX_PATCH', units='gC13/m^2/s', &
+            avgflag='A', &
+            long_name='patch-level C13 slash C flux (to litter diagnostic only) ' // &
+            '(0 at all times except first timestep of year) ' // &
+            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='C13_DWT_FROOTC_TO_LITR_MET_C', units='gC13/m^2/s',  type2d='levdcmp', &
@@ -3206,10 +3226,19 @@ contains
             long_name='C14 conversion C flux (immediate loss to atm), dribbled throughout the year', &
             ptr_gcell=this%dwt_conv_cflux_dribbled_grc, default='inactive')
 
-       this%dwt_slash_cflux_col(begc:endc) = spval
-       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX', units='gC/m^2/s', &
-            avgflag='A', long_name='C14 slash C flux to litter and CWD due to land use', &
-            ptr_col=this%dwt_slash_cflux_col, default='inactive')
+       this%dwt_slash_cflux_grc(begg:endg) = spval
+       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX', units='gC14/m^2/s', &
+            avgflag='A', long_name='C14 slash C flux (to litter diagnostic only)' // &
+            '(0 at all times except first timestep of year)', &
+            ptr_gcell=this%dwt_slash_cflux_grc, default='inactive')
+
+       this%dwt_slash_cflux_patch(begp:endp) = spval
+       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX_PATCH', units='gC14/m^2/s', &
+            avgflag='A', &
+            long_name='patch-level C14 slash C flux (to litter diagnostic only)' // &
+            '(0 at all times except first timestep of year) ' // &
+            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='C14_DWT_FROOTC_TO_LITR_MET_C', units='gC14/m^2/s',  type2d='levdcmp', &
@@ -3364,7 +3393,6 @@ contains
        ! also initialize dynamic landcover fluxes so that they have
        ! real values on first timestep, prior to calling pftdyn_cnbal
        if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
-          this%dwt_slash_cflux_col(c) = 0._r8
           do j = 1, nlevdecomp_full
              this%dwt_frootc_to_litr_met_c_col(c,j) = 0._r8
              this%dwt_frootc_to_litr_cel_c_col(c,j) = 0._r8
@@ -3965,10 +3993,7 @@ contains
        this%dwt_seedc_to_leaf_grc(g)        = 0._r8
        this%dwt_seedc_to_deadstem_grc(g)    = 0._r8
        this%dwt_conv_cflux_grc(g)           = 0._r8
-    end do
-
-    do c = bounds%begc,bounds%endc
-       this%dwt_slash_cflux_col(c)              = 0._r8
+       this%dwt_slash_cflux_grc(g)           = 0._r8
     end do
 
     do j = 1, nlevdecomp_full

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -3994,7 +3994,7 @@ contains
     ! Perform patch and column-level carbon summary calculations
     !
     ! !USES:
-    use clm_time_manager                   , only: get_step_size
+    use clm_time_manager                   , only: get_step_size_real
     use clm_varcon                         , only: secspday
     use clm_varctl                         , only: nfix_timeconst, carbon_resp_opt
     use subgridAveMod                      , only: p2c, c2g
@@ -4031,7 +4031,7 @@ contains
 
     ! calculate patch-level summary carbon fluxes and states
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     do fp = 1,num_soilp
        p = filter_soilp(fp)

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -263,8 +263,7 @@ module CNVegCarbonFluxType
      real(r8), pointer :: dwt_conv_cflux_dribbled_grc               (:)     ! (gC/m2/s) dwt_conv_cflux_grc dribbled evenly throughout the year
      real(r8), pointer :: dwt_wood_productc_gain_patch              (:)     ! (gC/m2/s) addition to wood product pools from landcover change; although this is a patch-level flux, it is expressed per unit GRIDCELL area
      real(r8), pointer :: dwt_crop_productc_gain_patch              (:)     ! (gC/m2/s) addition to crop product pools from landcover change; although this is a patch-level flux, it is expressed per unit GRIDCELL area
-     real(r8), pointer :: dwt_slash_cflux_patch                     (:)     ! (gC/m2/s) conversion slash flux due to landcover change
-     real(r8), pointer :: dwt_slash_cflux_grc                       (:)     ! (gC/m2/s) dwt_slash_cflux_patch summed to the gridcell-level
+     real(r8), pointer :: dwt_slash_cflux_col                       (:)     ! (gC/m2/s) conversion slash flux due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_met_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_cel_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_lig_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
@@ -630,8 +629,7 @@ contains
     allocate(this%harvest_c_to_litr_lig_c_col       (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_litr_lig_c_col  (:,:)=nan
     allocate(this%harvest_c_to_cwdc_col             (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_cwdc_col        (:,:)=nan
 
-    allocate(this%dwt_slash_cflux_patch             (begp:endp))                  ; this%dwt_slash_cflux_patch        (:) =nan
-    allocate(this%dwt_slash_cflux_grc               (begg:endg))                  ; this%dwt_slash_cflux_grc          (:) =nan
+    allocate(this%dwt_slash_cflux_col               (begc:endc))                  ; this%dwt_slash_cflux_col (:) =nan
     allocate(this%dwt_frootc_to_litr_met_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_met_c_col (:,:)=nan
     allocate(this%dwt_frootc_to_litr_cel_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_cel_c_col (:,:)=nan
     allocate(this%dwt_frootc_to_litr_lig_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_lig_c_col (:,:)=nan
@@ -2878,19 +2876,10 @@ contains
             '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_wood_productc_gain_patch, default='inactive')
 
-       this%dwt_slash_cflux_grc(begg:endg) = spval
-       call hist_addfld1d (fname='DWT_SLASH_CFLUX', units='gC/m^2/s', &
-            avgflag='A', &
-            long_name='slash C flux (to litter diagnostic only) (0 at all times except first timestep of year)', &
-            ptr_gcell=this%dwt_slash_cflux_grc)
-
-       this%dwt_slash_cflux_patch(begp:endp) = spval
-       call hist_addfld1d (fname='DWT_SLASH_CFLUX_PATCH', units='gC/m^2/s', &
-            avgflag='A', &
-            long_name='patch-level slash C flux (to litter diagnostic only) ' // &
-            '(0 at all times except first timestep of year) ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
+        this%dwt_slash_cflux_col(begc:endc) = spval
+        call hist_addfld1d (fname='DWT_SLASH_CFLUX', units='gC/m^2/s', &
+             avgflag='A', long_name='slash C flux to litter and CWD due to land use', &
+             ptr_col=this%dwt_slash_cflux_col)
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='DWT_FROOTC_TO_LITR_MET_C', units='gC/m^2/s',  type2d='levdcmp', &
@@ -3061,19 +3050,10 @@ contains
             long_name='C13 conversion C flux (immediate loss to atm), dribbled throughout the year', &
             ptr_gcell=this%dwt_conv_cflux_dribbled_grc, default='inactive')
 
-       this%dwt_slash_cflux_grc(begg:endg) = spval
-       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX', units='gC13/m^2/s', &
-            avgflag='A', long_name='C13 slash C flux (to litter diagnostic only)' // &
-            '(0 at all times except first timestep of year)', &
-            ptr_gcell=this%dwt_slash_cflux_grc, default='inactive')
-
-       this%dwt_slash_cflux_patch(begp:endp) = spval
-       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX_PATCH', units='gC13/m^2/s', &
-            avgflag='A', &
-            long_name='patch-level C13 slash C flux (to litter diagnostic only) ' // &
-            '(0 at all times except first timestep of year) ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
+       this%dwt_slash_cflux_col(begc:endc) = spval
+       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX', units='gC/m^2/s', &
+            avgflag='A', long_name='C13 slash C flux to litter and CWD due to land use', &
+            ptr_col=this%dwt_slash_cflux_col, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='C13_DWT_FROOTC_TO_LITR_MET_C', units='gC13/m^2/s',  type2d='levdcmp', &
@@ -3226,19 +3206,10 @@ contains
             long_name='C14 conversion C flux (immediate loss to atm), dribbled throughout the year', &
             ptr_gcell=this%dwt_conv_cflux_dribbled_grc, default='inactive')
 
-       this%dwt_slash_cflux_grc(begg:endg) = spval
-       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX', units='gC14/m^2/s', &
-            avgflag='A', long_name='C14 slash C flux (to litter diagnostic only)' // &
-            '(0 at all times except first timestep of year)', &
-            ptr_gcell=this%dwt_slash_cflux_grc, default='inactive')
-
-       this%dwt_slash_cflux_patch(begp:endp) = spval
-       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX_PATCH', units='gC14/m^2/s', &
-            avgflag='A', &
-            long_name='patch-level C14 slash C flux (to litter diagnostic only)' // &
-            '(0 at all times except first timestep of year) ' // &
-            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
-            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
+       this%dwt_slash_cflux_col(begc:endc) = spval
+       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX', units='gC/m^2/s', &
+            avgflag='A', long_name='C14 slash C flux to litter and CWD due to land use', &
+            ptr_col=this%dwt_slash_cflux_col, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='C14_DWT_FROOTC_TO_LITR_MET_C', units='gC14/m^2/s',  type2d='levdcmp', &
@@ -3393,6 +3364,7 @@ contains
        ! also initialize dynamic landcover fluxes so that they have
        ! real values on first timestep, prior to calling pftdyn_cnbal
        if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
+          this%dwt_slash_cflux_col(c) = 0._r8
           do j = 1, nlevdecomp_full
              this%dwt_frootc_to_litr_met_c_col(c,j) = 0._r8
              this%dwt_frootc_to_litr_cel_c_col(c,j) = 0._r8
@@ -3993,7 +3965,10 @@ contains
        this%dwt_seedc_to_leaf_grc(g)        = 0._r8
        this%dwt_seedc_to_deadstem_grc(g)    = 0._r8
        this%dwt_conv_cflux_grc(g)           = 0._r8
-       this%dwt_slash_cflux_grc(g)           = 0._r8
+    end do
+
+    do c = bounds%begc,bounds%endc
+       this%dwt_slash_cflux_col(c)              = 0._r8
     end do
 
     do j = 1, nlevdecomp_full

--- a/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -501,7 +501,7 @@ contains
     use pftconMod              , only : ntrp_soybean, nirrig_trp_soybean
     use clm_varcon             , only : secspday
     use clm_varctl             , only : use_c13, use_c14
-    use clm_time_manager       , only : get_step_size
+    use clm_time_manager       , only : get_step_size_real
     use CanopyStateType        , only : canopystate_type
     use PhotosynthesisMod      , only : photosyns_type
     use CropType               , only : crop_type
@@ -648,7 +648,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! set number of days to recover negative cpool
       dayscrecover = params_inst%dayscrecover

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -196,7 +196,7 @@ contains
     use clm_varctl            , only : downreg_opt
     use clm_varctl            , only : CN_residual_opt
     use clm_varctl            , only : CN_partition_opt
-    use clm_time_manager       , only : get_step_size
+    use clm_time_manager       , only : get_step_size_real
     use CNVegStateType        , only : cnveg_state_type
     use CropType              , only : crop_type
     use CanopyStateType        , only : canopystate_type
@@ -401,7 +401,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! patch loop to distribute the available N between the competing patches
       ! on the basis of relative demand, and allocate C and N to new growth and storage
@@ -1193,7 +1193,7 @@ contains
     use clm_varctl             , only : use_c13, use_c14
     use clm_varctl             , only : nscalar_opt, plant_ndemand_opt, substrate_term_opt, temp_scalar_opt
     use clm_varpar             , only : nlevdecomp
-    use clm_time_manager       , only : get_step_size
+    use clm_time_manager       , only : get_step_size_real
     use CanopyStateType        , only : canopystate_type
     use PhotosynthesisMod      , only : photosyns_type
     use CropType               , only : crop_type
@@ -1368,7 +1368,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       ! set number of days to recover negative cpool
       dayscrecover = params_inst%dayscrecover     ! loop over patches to assess the total plant N demand

--- a/src/biogeochem/SatellitePhenologyMod.F90
+++ b/src/biogeochem/SatellitePhenologyMod.F90
@@ -408,7 +408,7 @@ contains
     !
     ! !USES:
     use clm_varctl      , only : fsurdat
-    use clm_time_manager, only : get_curr_date, get_step_size, get_nstep
+    use clm_time_manager, only : get_curr_date, get_step_size_real, get_nstep
     !
     ! !ARGUMENTS:
     type(bounds_type), intent(in) :: bounds  
@@ -427,7 +427,7 @@ contains
          (/31,28,31,30,31,30,31,31,30,31,30,31/) !days per month
     !-----------------------------------------------------------------------
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     call get_curr_date(kyr, kmo, kda, ksec, offset=int(dtime))
 

--- a/src/biogeochem/ch4Mod.F90
+++ b/src/biogeochem/ch4Mod.F90
@@ -16,7 +16,7 @@ module ch4Mod
   use clm_varcon                     , only : denh2o, denice, tfrz, grav, spval, rgas, grlnd
   use clm_varcon                     , only : catomw, s_con, d_con_w, d_con_g, c_h_inv, kh_theta, kh_tbase
   use landunit_varcon                , only : istsoil, istcrop, istdlak
-  use clm_time_manager               , only : get_step_size, get_nstep
+  use clm_time_manager               , only : get_step_size_real, get_nstep
   use clm_varctl                     , only : iulog, use_cn, use_nitrif_denitrif, use_lch4
   use abortutils                     , only : endrun
   use decompMod                      , only : bounds_type
@@ -1788,7 +1788,7 @@ contains
       qflxlagd          = params_inst%qflxlagd
       highlatfact       = params_inst%highlatfact
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
       nstep = get_nstep()
       dtime_ch4 = dtime
       redoxlags = redoxlag*secspday ! days --> s
@@ -2390,7 +2390,7 @@ contains
          co2_decomp_depth => ch4_inst%co2_decomp_depth_sat_col   ! Output: [real(r8) (:,:)]  CO2 production during decomposition in each soil layer (nlevsoi) (mol/m3/s)
       endif
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       q10ch4           = params_inst%q10ch4
       q10ch4base       = params_inst%q10ch4base
@@ -2615,7 +2615,7 @@ contains
     ! Oxidation will be limited by available oxygen in ch4_tran.
     
     ! !USES:
-    use clm_time_manager, only : get_step_size
+    use clm_time_manager, only : get_step_size_real
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in) :: bounds    
@@ -2690,7 +2690,7 @@ contains
       endif
 
       ! Get land model time step
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Set oxidation parameters
       vmax_ch4_oxid   = params_inst%vmax_ch4_oxid
@@ -2772,7 +2772,7 @@ contains
 
     ! !USES:
     use clm_varcon       , only : rpi
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use pftconMod        , only : nc3_arctic_grass, nc3_nonarctic_grass, nc4_grass, noveg, pftcon
     use ch4varcon        , only : transpirationloss, use_aereoxid_prog
     !
@@ -2878,7 +2878,7 @@ contains
          ch4_prod_depth   =>  ch4_inst%ch4_prod_depth_sat_col   ! Input:  [real(r8) (:,:)]  production of CH4 in each soil layer (nlevsoi) (mol/m3/s)
       endif
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Set aerenchyma parameters
       aereoxid           = params_inst%aereoxid
@@ -3023,7 +3023,7 @@ contains
     ! Bubbles are released to the water table surface in ch4_tran.
 
     ! !USES:
-    use clm_time_manager   , only : get_step_size
+    use clm_time_manager   , only : get_step_size_real
     use LakeCon           
     !
     ! !ARGUMENTS:
@@ -3099,7 +3099,7 @@ contains
       endif
 
       ! Get land model time step
-      dtime = get_step_size()
+      dtime = get_step_size_real()
       vgc_max = params_inst%vgc_max
 
       bubble_f = 0.57_r8 ! CH4 content in gas bubbles (Kellner et al. 2006)
@@ -3168,7 +3168,7 @@ contains
     ! Then CH4 diffusive flux is calculated and consistency is checked.
 
     ! !USES:
-    use clm_time_manager   , only : get_step_size, get_nstep
+    use clm_time_manager   , only : get_step_size_real, get_nstep
     use TridiagonalMod     , only : Tridiagonal
     use ch4varcon          , only : ch4frzout, use_aereoxid_prog
     !
@@ -3325,7 +3325,7 @@ contains
       endif
 
       ! Get land model time step
-      dtime = get_step_size()
+      dtime = get_step_size_real()
       nstep = get_nstep()
 
       ! Set transport parameters
@@ -4031,7 +4031,7 @@ contains
     ! !DESCRIPTION: Annual mean fields.
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size, get_days_per_year, get_nstep
+    use clm_time_manager, only: get_step_size_real, get_days_per_year, get_nstep
     use clm_varcon      , only: secspday
     !
     ! !ARGUMENTS:
@@ -4072,7 +4072,7 @@ contains
          )
 
       ! set time steps
-      dt = real(get_step_size(), r8)
+      dt = get_step_size_real()
       secsperyear = real( get_days_per_year() * secspday, r8)
 
       do fc = 1,num_methc

--- a/src/biogeochem/dynCNDVMod.F90
+++ b/src/biogeochem/dynCNDVMod.F90
@@ -58,7 +58,7 @@ contains
     ! Time interpolate cndv pft weights from annual to time step
     !
     ! !USES:
-    use clm_time_manager, only : get_curr_date, get_step_size, get_nstep, get_curr_yearfrac
+    use clm_time_manager, only : get_curr_date, get_step_size_real, get_nstep, get_curr_yearfrac
     use landunit_varcon , only : istsoil ! CNDV incompatible with dynLU
     !
     ! !ARGUMENTS:
@@ -85,7 +85,7 @@ contains
     ! SCAM not defined and create_croplandunit = .false.
 
     nstep         = get_nstep()
-    dtime         = get_step_size()
+    dtime         = get_step_size_real()
 
     wt1 = 1.0_r8 - get_curr_yearfrac(offset = -int(dtime))
 

--- a/src/biogeochem/dynConsBiogeochemMod.F90
+++ b/src/biogeochem/dynConsBiogeochemMod.F90
@@ -587,6 +587,36 @@ contains
     end do
     
 
+    ! calculate patch-to-column slash fluxes into litter and CWD pools
+    do p = bounds%begp, bounds%endp
+       c = patch%column(p)
+
+       ! fine and coarse root to litter and CWD slash carbon fluxes
+       cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
+               cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
+               dwt_frootc_to_litter(p)/dt + &
+               dwt_livecrootc_to_litter(p)/dt + &
+               dwt_deadcrootc_to_litter(p)/dt
+
+       if ( use_c13 ) then
+          c13_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
+                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
+                  dwt_frootc13_to_litter(p)/dt + &
+                  dwt_livecrootc13_to_litter(p)/dt + &
+                  dwt_deadcrootc13_to_litter(p)/dt
+       endif
+
+       if ( use_c14 ) then
+          c14_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
+                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
+                  dwt_frootc14_to_litter(p)/dt + &
+                  dwt_livecrootc14_to_litter(p)/dt + &
+                  dwt_deadcrootc14_to_litter(p)/dt
+       endif
+
+    end do
+
+    
     ! calculate patch-to-column for fluxes into litter and CWD pools
     do j = 1, nlevdecomp
        do p = bounds%begp, bounds%endp
@@ -754,45 +784,6 @@ contains
        cnveg_nitrogenflux_inst%dwt_conv_nflux_grc(g) = &
             cnveg_nitrogenflux_inst%dwt_conv_nflux_grc(g) + &
             cnveg_nitrogenflux_inst%dwt_conv_nflux_patch(p)
-
-    end do
-
-    ! calculate patch-to-gridcell slash fluxes into litter and CWD pools
-    ! Note that patch-level fluxes are stored per unit GRIDCELL area - thus, we don't
-    ! need to multiply by the patch's gridcell weight when translating patch-level
-    ! fluxes into gridcell-level fluxes.
-
-    do p = bounds%begp, bounds%endp
-       g = patch%gridcell(p)
-
-       ! fine and coarse root to litter and CWD slash carbon fluxes
-       cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
-               dwt_frootc_to_litter(p)/dt + &
-               dwt_livecrootc_to_litter(p)/dt + &
-               dwt_deadcrootc_to_litter(p)/dt
-       cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
-               cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
-               cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
-
-       if ( use_c13 ) then
-          c13_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
-                  dwt_frootc13_to_litter(p)/dt + &
-                  dwt_livecrootc13_to_litter(p)/dt + &
-                  dwt_deadcrootc13_to_litter(p)/dt
-          c13_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
-                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
-                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
-       endif
-
-       if ( use_c14 ) then
-          c14_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
-                  dwt_frootc14_to_litter(p)/dt + &
-                  dwt_livecrootc14_to_litter(p)/dt + &
-                  dwt_deadcrootc14_to_litter(p)/dt
-          c14_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
-                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
-                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
-       endif
 
     end do
 

--- a/src/biogeochem/dynConsBiogeochemMod.F90
+++ b/src/biogeochem/dynConsBiogeochemMod.F90
@@ -60,7 +60,7 @@ contains
     use landunit_varcon    , only : istsoil, istcrop
     use clm_varpar         , only : nlevdecomp
     use clm_varcon         , only : c13ratio, c14ratio, c3_r2, c4_r2
-    use clm_time_manager   , only : get_step_size
+    use clm_time_manager   , only : get_step_size_real
     use dynPriorWeightsMod , only : prior_weights_type
     use dynPatchStateUpdaterMod, only : patch_state_updater_type
     !
@@ -310,7 +310,7 @@ contains
     endif
     
     ! Get time step
-    dt = real( get_step_size(), r8 )
+    dt = get_step_size_real()
 
     patch_initiating = patch_state_updater%patch_initiating(bounds)
 

--- a/src/biogeochem/dynConsBiogeochemMod.F90
+++ b/src/biogeochem/dynConsBiogeochemMod.F90
@@ -587,36 +587,6 @@ contains
     end do
     
 
-    ! calculate patch-to-column slash fluxes into litter and CWD pools
-    do p = bounds%begp, bounds%endp
-       c = patch%column(p)
-
-       ! fine and coarse root to litter and CWD slash carbon fluxes
-       cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
-               cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
-               dwt_frootc_to_litter(p)/dt + &
-               dwt_livecrootc_to_litter(p)/dt + &
-               dwt_deadcrootc_to_litter(p)/dt
-
-       if ( use_c13 ) then
-          c13_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
-                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
-                  dwt_frootc13_to_litter(p)/dt + &
-                  dwt_livecrootc13_to_litter(p)/dt + &
-                  dwt_deadcrootc13_to_litter(p)/dt
-       endif
-
-       if ( use_c14 ) then
-          c14_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
-                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
-                  dwt_frootc14_to_litter(p)/dt + &
-                  dwt_livecrootc14_to_litter(p)/dt + &
-                  dwt_deadcrootc14_to_litter(p)/dt
-       endif
-
-    end do
-
-    
     ! calculate patch-to-column for fluxes into litter and CWD pools
     do j = 1, nlevdecomp
        do p = bounds%begp, bounds%endp
@@ -784,6 +754,45 @@ contains
        cnveg_nitrogenflux_inst%dwt_conv_nflux_grc(g) = &
             cnveg_nitrogenflux_inst%dwt_conv_nflux_grc(g) + &
             cnveg_nitrogenflux_inst%dwt_conv_nflux_patch(p)
+
+    end do
+
+    ! calculate patch-to-gridcell slash fluxes into litter and CWD pools
+    ! Note that patch-level fluxes are stored per unit GRIDCELL area - thus, we don't
+    ! need to multiply by the patch's gridcell weight when translating patch-level
+    ! fluxes into gridcell-level fluxes.
+
+    do p = bounds%begp, bounds%endp
+       g = patch%gridcell(p)
+
+       ! fine and coarse root to litter and CWD slash carbon fluxes
+       cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
+               dwt_frootc_to_litter(p)/dt + &
+               dwt_livecrootc_to_litter(p)/dt + &
+               dwt_deadcrootc_to_litter(p)/dt
+       cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
+               cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
+               cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
+
+       if ( use_c13 ) then
+          c13_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
+                  dwt_frootc13_to_litter(p)/dt + &
+                  dwt_livecrootc13_to_litter(p)/dt + &
+                  dwt_deadcrootc13_to_litter(p)/dt
+          c13_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
+                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
+                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
+       endif
+
+       if ( use_c14 ) then
+          c14_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
+                  dwt_frootc14_to_litter(p)/dt + &
+                  dwt_livecrootc14_to_litter(p)/dt + &
+                  dwt_deadcrootc14_to_litter(p)/dt
+          c14_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
+                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
+                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
+       endif
 
     end do
 

--- a/src/biogeophys/AerosolMod.F90
+++ b/src/biogeophys/AerosolMod.F90
@@ -8,7 +8,7 @@ module AerosolMod
   use shr_infnan_mod   , only : nan => shr_infnan_nan, assignment(=)
   use decompMod        , only : bounds_type
   use clm_varpar       , only : nlevsno, nlevgrnd 
-  use clm_time_manager , only : get_step_size
+  use clm_time_manager , only : get_step_size_real
   use atm2lndType      , only : atm2lnd_type
   use WaterFluxBulkType    , only : waterfluxbulk_type
   use WaterStateBulkType   , only : waterstatebulk_type
@@ -603,7 +603,7 @@ contains
          mss_cnc_dst4  => aerosol_inst%mss_cnc_dst4_col       & ! Output: [real(r8) (:,:) ]  mass concentration of dust species 4 (col,lyr) [kg/kg]
          )
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       do fc = 1, num_on
          c = filter_on(fc)
@@ -803,7 +803,7 @@ contains
       ! is in the top layer after deposition, and is not immediately
       ! washed out before radiative calculations are done
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       do fc = 1, num_snowc
          c = filter_snowc(fc)

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -71,13 +71,13 @@ contains
     !
     ! !USES:
     use spmdMod           , only : masterproc
-    use clm_time_manager  , only : get_step_size
+    use clm_time_manager  , only : get_step_size_real
     ! !ARGUMENTS:
     !
     ! !LOCAL VARIABLES:
     real(r8) :: dtime                    ! land model time step (sec)
     !-----------------------------------------------------------------------
-    dtime = get_step_size()
+    dtime = get_step_size_real()
     ! Skip a minimum of two time steps, but otherwise skip the number of time-steps in the skip_size rounded to the nearest integer
     skip_steps = max(2, nint( (skip_size / dtime) ) )
 
@@ -248,7 +248,7 @@ contains
      !
      ! !USES:
      use clm_varcon        , only : spval
-     use clm_time_manager  , only : get_step_size, get_nstep
+     use clm_time_manager  , only : get_step_size_real, get_nstep
      use clm_time_manager  , only : get_nstep_since_startup_or_lastDA_restart_or_pause
      use CanopyStateType   , only : canopystate_type
      use subgridAveMod
@@ -375,7 +375,7 @@ contains
 
        nstep = get_nstep()
        DAnstep = get_nstep_since_startup_or_lastDA_restart_or_pause()
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Determine column level incoming snow and rain
        ! Assume no incident precipitation on urban wall columns (as in CanopyHydrologyMod.F90).

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -218,7 +218,7 @@ contains
     !
     ! !USES:
     use shr_const_mod      , only : SHR_CONST_RGAS
-    use clm_time_manager   , only : get_step_size, get_prev_date,is_end_curr_day
+    use clm_time_manager   , only : get_step_size_real, get_prev_date,is_end_curr_day
     use clm_varcon         , only : sb, cpair, hvap, vkc, grav, denice
     use clm_varcon         , only : denh2o, tfrz, tlsai_crit, alpha_aero
     use clm_varcon         , only : c14ratio
@@ -566,7 +566,7 @@ contains
 
       ! Determine step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
       is_end_day = is_end_curr_day()
 
       ! Make a local copy of the exposedvegp filter. With the current implementation,

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -16,7 +16,7 @@ module CanopyHydrologyMod
   use shr_sys_mod     , only : shr_sys_flush
   use decompMod       , only : bounds_type
   use abortutils      , only : endrun
-  use clm_time_manager, only : get_step_size
+  use clm_time_manager, only : get_step_size_real
   use clm_varctl      , only : iulog
   use column_varcon   , only : icol_sunwall, icol_shadewall
   use subgridAveMod   , only : p2c
@@ -217,7 +217,7 @@ contains
           b_waterdiagnostic_inst => water_inst%waterdiagnosticbulk_inst &
           )
 
-     dtime = get_step_size()
+     dtime = get_step_size_real()
 
      ! Note about filters in this routine: Most of the work here just needs to be done
      ! for patches that have some canopy, so we use the soil filter. However, the final

--- a/src/biogeophys/EnergyFluxType.F90
+++ b/src/biogeophys/EnergyFluxType.F90
@@ -909,7 +909,7 @@ contains
     !
     ! !USES 
     use accumulMod       , only : init_accum_field
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     !
     ! !ARGUMENTS:
@@ -921,7 +921,7 @@ contains
     integer, parameter :: not_used = huge(1)
     !---------------------------------------------------------------------
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     call init_accum_field(name='BTRANAV', units='-', &
          desc='average over an hour of btran', accum_type='timeavg', accum_period=nint(3600._r8/dtime), &

--- a/src/biogeophys/GlacierSurfaceMassBalanceMod.F90
+++ b/src/biogeophys/GlacierSurfaceMassBalanceMod.F90
@@ -12,7 +12,7 @@ module GlacierSurfaceMassBalanceMod
   use clm_varcon     , only : secspday
   use clm_varpar     , only : nlevgrnd
   use clm_varctl     , only : glc_snow_persistence_max_days
-  use clm_time_manager, only : get_step_size
+  use clm_time_manager, only : get_step_size_real
   use landunit_varcon, only : istice_mec
   use ColumnType     , only : col                
   use LandunitType   , only : lun
@@ -112,7 +112,7 @@ contains
          qflx_glcice_melt => waterfluxbulk_inst%qflx_glcice_melt_col       & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          )
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     do fc = 1, num_do_smb_c
        c = filter_do_smb_c(fc)

--- a/src/biogeophys/HydrologyDrainageMod.F90
+++ b/src/biogeophys/HydrologyDrainageMod.F90
@@ -54,7 +54,7 @@ contains
     use clm_varcon       , only : denh2o, denice
     use clm_varctl       , only : use_vichydro
     use clm_varpar       , only : nlevgrnd, nlevurb
-    use clm_time_manager , only : get_step_size, get_nstep
+    use clm_time_manager , only : get_step_size_real, get_nstep
     use SoilHydrologyMod , only : CLMVICMap, Drainage, PerchedLateralFlow, LateralFlowPowerLaw
     use SoilWaterMovementMod , only : use_aquifer_layer
     !
@@ -121,7 +121,7 @@ contains
 
       ! Determine time step and step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       if (use_vichydro) then
          call CLMVICMap(bounds, num_hydrologyc, filter_hydrologyc, &

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -113,7 +113,7 @@ contains
     use column_varcon        , only : icol_shadewall
     use clm_varctl           , only : use_cn
     use clm_varpar           , only : nlevgrnd, nlevsno, nlevsoi, nlevurb
-    use clm_time_manager     , only : get_step_size, get_nstep
+    use clm_time_manager     , only : get_step_size_real, get_nstep
     use SnowHydrologyMod     , only : SnowCompaction, CombineSnowLayers, DivideSnowLayers, SnowCapping
     use SnowHydrologyMod     , only : SnowWater, ZeroEmptySnowLayers, BuildSnowFilter 
     use SoilHydrologyMod     , only : CLMVICMap, SetSoilWaterFractions, SetFloodc
@@ -224,7 +224,7 @@ contains
 
       ! Determine step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Determine initial snow/no-snow filters (will be modified possibly by
       ! routines CombineSnowLayers and DivideSnowLayers below

--- a/src/biogeophys/InfiltrationExcessRunoffMod.F90
+++ b/src/biogeophys/InfiltrationExcessRunoffMod.F90
@@ -13,7 +13,6 @@ module InfiltrationExcessRunoffMod
   use abortutils       , only : endrun
   use clm_varctl       , only : iulog, use_vichydro
   use clm_varcon       , only : spval, e_ice
-  use clm_time_manager , only : get_step_size
   use SoilHydrologyType, only : soilhydrology_type
   use SoilStateType    , only : soilstate_type
   use SaturatedExcessRunoffMod, only : saturated_excess_runoff_type

--- a/src/biogeophys/LakeHydrologyMod.F90
+++ b/src/biogeophys/LakeHydrologyMod.F90
@@ -79,7 +79,7 @@ contains
     ! !USES:
     use clm_varcon      , only : denh2o, denice, spval, hfus, tfrz, cpliq, cpice
     use clm_varctl      , only : iulog
-    use clm_time_manager, only : get_step_size
+    use clm_time_manager, only : get_step_size_real
     use SnowHydrologyMod, only : UpdateQuantitiesForNewSnow
     use SnowHydrologyMod, only : SnowCompaction, CombineSnowLayers, SnowWater
     use SnowHydrologyMod, only : ZeroEmptySnowLayers, BuildSnowFilter, SnowCapping
@@ -235,7 +235,7 @@ contains
     end if
 
     ! Determine step size
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! Compute "summed" (really just copies here) fluxes onto "ground" (really the lake
     ! surface here), for bulk water and each tracer. (Subroutine name mimics the one in

--- a/src/biogeophys/LakeTemperatureMod.F90
+++ b/src/biogeophys/LakeTemperatureMod.F90
@@ -115,7 +115,7 @@ contains
     use QSatMod            , only : QSat
     use TridiagonalMod     , only : Tridiagonal
     use clm_varpar         , only : nlevlak, nlevgrnd, nlevsno
-    use clm_time_manager   , only : get_step_size
+    use clm_time_manager   , only : get_step_size_real
     use clm_varcon         , only : hfus, cpliq, cpice, tkwat, tkice, denice
     use clm_varcon         , only : vkc, grav, denh2o, tfrz, cnfac
     use clm_varctl         , only : iulog, use_lch4
@@ -268,7 +268,7 @@ contains
     ! 1!) Initialization
     ! Determine step size
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! Initialize constants
     cwat = cpliq*denh2o ! water heat capacity per unit volume
@@ -1266,7 +1266,7 @@ contains
      ! Errors will be trapped at the end of LakeTemperature.
      !
      ! !USES:
-     use clm_time_manager , only : get_step_size
+     use clm_time_manager , only : get_step_size_real
      use clm_varcon       , only : tfrz, hfus, denh2o, denice, cpliq, cpice
      use clm_varpar       , only : nlevsno, nlevgrnd, nlevlak
      !
@@ -1329,7 +1329,7 @@ contains
 
        ! Get step size
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Initialization
 

--- a/src/biogeophys/LunaMod.F90
+++ b/src/biogeophys/LunaMod.F90
@@ -196,7 +196,7 @@ module LunaMod
     ! subroutine CanopyFluxes 
   
     ! !USES:
-    use clm_time_manager      , only : get_step_size, is_end_curr_day
+    use clm_time_manager      , only : get_step_size_real, is_end_curr_day
     use clm_varpar            , only : nlevsoi, mxpft
     use perf_mod              , only : t_startf, t_stopf
     use clm_varctl            , only : use_cn
@@ -312,7 +312,7 @@ module LunaMod
     !set timestep
 
     !Initialize enzyme decay Q10
-    dtime        =  get_step_size()
+    dtime        =  get_step_size_real()
 
     is_end_day   =  is_end_curr_day()
     fnps         =  0.15_r8
@@ -500,7 +500,7 @@ subroutine Acc240_Climate_LUNA(bounds, fn, filterp, oair, cair, &
     ! subroutine CanopyFluxes 
   
     ! !USES:
-    use clm_time_manager      , only : get_step_size, is_end_curr_day
+    use clm_time_manager      , only : get_step_size_real, is_end_curr_day
     implicit none
     
       ! !ARGUMENTS:
@@ -554,7 +554,7 @@ subroutine Acc240_Climate_LUNA(bounds, fn, filterp, oair, cair, &
     !set timestep
 
     !Initialize enzyme decay Q10
-    dtime        =  get_step_size()
+    dtime        =  get_step_size_real()
     is_end_day   =  is_end_curr_day()
     do f  =  1,fn
       p  =  filterp(f)
@@ -628,7 +628,7 @@ subroutine Acc24_Climate_LUNA(bounds, fn, filterp, canopystate_inst, photosyns_i
     ! subroutine CanopyFluxes 
   
     ! !USES:
-    use clm_time_manager      , only : get_step_size
+    use clm_time_manager      , only : get_step_size_real
     implicit none
     
     ! !ARGUMENTS:
@@ -676,7 +676,7 @@ subroutine Acc24_Climate_LUNA(bounds, fn, filterp, canopystate_inst, photosyns_i
     !set timestep
 
     !Initialize enzyme decay Q10
-    dtime        =  get_step_size()
+    dtime        =  get_step_size_real()
     do f  =  1,fn
       p  =  filterp(f)
       ft =  patch%itype(p)
@@ -727,7 +727,7 @@ subroutine Clear24_Climate_LUNA(bounds, fn, filterp, canopystate_inst, photosyns
     ! subroutine CanopyFluxes 
   
     ! !USES:
-    use clm_time_manager      , only : get_step_size, is_end_curr_day
+    use clm_time_manager      , only : get_step_size_real, is_end_curr_day
     implicit none
     
     ! !ARGUMENTS:
@@ -765,7 +765,7 @@ subroutine Clear24_Climate_LUNA(bounds, fn, filterp, canopystate_inst, photosyns
     !set timestep
 
     !Initialize enzyme decay Q10
-    dtime        =  get_step_size()
+    dtime        =  get_step_size_real()
     is_end_day   =  is_end_curr_day()
     do f  =  1,fn
       p  =  filterp(f)

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -976,7 +976,7 @@ contains
     ! !USES:
     use clm_varcon        , only : rgas, tfrz, spval
     use GridcellType      , only : grc
-    use clm_time_manager  , only : get_step_size, is_near_local_noon
+    use clm_time_manager  , only : get_step_size_real, is_near_local_noon
     use clm_varctl     , only : cnallocate_carbon_only
     use clm_varctl     , only : lnc_opt, reduce_dayl_factor, vcmax_opt    
     use pftconMod      , only : nbrdlf_dcd_tmp_shrub, npcropmin
@@ -1233,7 +1233,7 @@ contains
 
       ! Determine seconds of current time step
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Activation energy, from:
       ! Bernacchi et al (2001) Plant, Cell and Environment 24:253-259
@@ -2443,7 +2443,7 @@ contains
     ! !USES:
     use clm_varcon        , only : rgas, tfrz, rpi, spval
     use GridcellType      , only : grc
-    use clm_time_manager  , only : get_step_size, is_near_local_noon
+    use clm_time_manager  , only : get_step_size_real, is_near_local_noon
     use clm_varctl        , only : cnallocate_carbon_only
     use clm_varctl        , only : lnc_opt, reduce_dayl_factor, vcmax_opt    
     use clm_varpar        , only : nlevsoi
@@ -2787,7 +2787,7 @@ contains
 
       ! Determine seconds off current time step
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Activation energy, from:
       ! Bernacchi et al (2001) Plant, Cell and Environment 24:253-259

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -89,7 +89,6 @@ module  PhotosynthesisMod
      real(r8), allocatable, private :: kmax               (:,:)
      real(r8), allocatable, private :: psi50              (:,:)
      real(r8), allocatable, private :: ck                 (:,:)
-     real(r8), allocatable, public  :: psi_soil_ref       (:)
      real(r8), allocatable, private :: lmr_intercept_atkin(:)
   contains
      procedure, private :: allocParams
@@ -618,7 +617,6 @@ contains
     allocate( this%kmax        (0:mxpft,nvegwcs) )  ; this%kmax(:,:)       = nan
     allocate( this%psi50       (0:mxpft,nvegwcs) )  ; this%psi50(:,:)      = nan
     allocate( this%ck          (0:mxpft,nvegwcs) )  ; this%ck(:,:)         = nan
-    allocate( this%psi_soil_ref(0:mxpft) )          ; this%psi_soil_ref(:) = nan
 
     if ( use_hydrstress .and. nvegwcs /= 4 )then
        call endrun(msg='Error:: the Plant Hydraulics Stress methodology is for the spacA function is hardcoded for nvegwcs==4' &
@@ -657,10 +655,6 @@ contains
     call ncd_io(varname=trim(tString),data=temp1d, flag='read', ncid=ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))
     params_inst%krmax=temp1d
-    tString = "psi_soil_ref"
-    call ncd_io(varname=trim(tString),data=temp1d, flag='read', ncid=ncid, readvar=readv)
-    if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))
-    params_inst%psi_soil_ref=temp1d
     tString = "lmr_intercept_atkin"
     call ncd_io(varname=trim(tString),data=temp1d, flag='read', ncid=ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))

--- a/src/biogeophys/SnowHydrologyMod.F90
+++ b/src/biogeophys/SnowHydrologyMod.F90
@@ -36,7 +36,7 @@ module SnowHydrologyMod
   use TopoMod, only : topo_type
   use ColumnType      , only : column_type, col
   use landunit_varcon , only : istsoil, istdlak, istsoil, istwet, istice_mec, istcrop
-  use clm_time_manager, only : get_step_size, get_nstep
+  use clm_time_manager, only : get_step_size_real, get_nstep
   use filterColMod    , only : filter_col_type, col_filter_from_filter_and_logical_array
   !
   ! !PUBLIC TYPES:
@@ -397,7 +397,7 @@ contains
          )
 
     ! Get time step
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     call NewSnowBulkDensity(bounds, num_c, filter_c, &
          atm2lnd_inst, bifall(bounds%begc:bounds%endc))
@@ -975,7 +975,7 @@ contains
 
     ! Determine model time step
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! Renew the mass of ice lens (h2osoi_ice) and liquid (h2osoi_liq) in the
     ! surface snow layer resulting from sublimation (frost) / evaporation (condense)
@@ -1294,7 +1294,7 @@ contains
 
     ! Get time step
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! Begin calculation - note that the following column loops are only invoked if snl(c) < 0
 
@@ -1505,7 +1505,7 @@ contains
 
     ! Determine model time step
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! Check the mass of ice lens of snow, when the total is less than a small value,
     ! combine it with the underlying neighbor.
@@ -2343,7 +2343,7 @@ contains
     )
 
     ! Determine model time step
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! Initialize capping fluxes for all columns in domain (lake or non-lake)
     do fc = 1, num_initc

--- a/src/biogeophys/SnowSnicarMod.F90
+++ b/src/biogeophys/SnowSnicarMod.F90
@@ -1026,7 +1026,7 @@ contains
     !   I am aware.
     !
     ! !USES:
-    use clm_time_manager , only : get_step_size, get_nstep
+    use clm_time_manager , only : get_step_size_real, get_nstep
     use clm_varpar       , only : nlevsno
     use clm_varcon       , only : spval
     use shr_const_mod    , only : SHR_CONST_RHOICE, SHR_CONST_PI
@@ -1097,7 +1097,7 @@ contains
   
 
       ! set timestep and step interval
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! loop over columns that have at least one snow layer
       do fc = 1, num_snowc

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -45,7 +45,7 @@ contains
     ! Update surface fluxes based on the new ground temperature
     !
     ! !USES:
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use clm_varcon       , only : hvap, cpair, grav, vkc, tfrz, sb 
     use landunit_varcon  , only : istsoil, istcrop
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
@@ -166,7 +166,7 @@ contains
 
       ! Get step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       call t_startf('bgp2_loop_1')
       do fc = 1,num_nolakec

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -131,7 +131,7 @@ contains
          qflx_evap_soi           => waterfluxbulk_inst%qflx_evap_soi_patch      , & ! Output: [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
          qflx_evap_veg           => waterfluxbulk_inst%qflx_evap_veg_patch      , & ! Output: [real(r8) (:)   ]  vegetation evaporation (mm H2O/s) (+ = to atm)
          qflx_tran_veg           => waterfluxbulk_inst%qflx_tran_veg_patch      , & ! Input:  [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)
-         qflx_evap_tot           => waterfluxbulk_inst%qflx_evap_tot_patch      , & ! Output: [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_veg + qflx_tran_veg
+         qflx_evap_tot           => waterfluxbulk_inst%qflx_evap_tot_patch      , & ! Output: [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
          qflx_evap_grnd          => waterfluxbulk_inst%qflx_evap_grnd_patch     , & ! Output: [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
          qflx_sub_snow           => waterfluxbulk_inst%qflx_sub_snow_patch      , & ! Output: [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]
          qflx_dew_snow           => waterfluxbulk_inst%qflx_dew_snow_patch      , & ! Output: [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -16,7 +16,7 @@ module SoilHydrologyMod
   use column_varcon     , only : icol_roof, icol_sunwall, icol_shadewall
   use column_varcon     , only : icol_road_imperv
   use landunit_varcon   , only : istsoil, istcrop
-  use clm_time_manager  , only : get_step_size
+  use clm_time_manager  , only : get_step_size_real
   use EnergyFluxType    , only : energyflux_type
   use InfiltrationExcessRunoffMod, only : infiltration_excess_runoff_type
   use SoilHydrologyType , only : soilhydrology_type  
@@ -460,7 +460,7 @@ contains
           h2osoi_liq       =>    waterstatebulk_inst%h2osoi_liq_col        & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)                            
           )
 
-     dtime = get_step_size()
+     dtime = get_step_size_real()
 
      ! ------------------------------------------------------------------------
      ! Set qflx_surf for hydrologically-active columns
@@ -539,7 +539,7 @@ contains
          qflx_evap_grnd   =>    waterfluxbulk_inst%qflx_evap_grnd_col     & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]    
          )
 
-     dtime = get_step_size()
+     dtime = get_step_size_real()
 
      do fc = 1, num_urbanc
         c = filter_urbanc(fc)
@@ -659,7 +659,7 @@ contains
 
        ! Get time step
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Convert layer thicknesses from m to mm
 
@@ -994,7 +994,7 @@ contains
 
        ! Get time step
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Convert layer thicknesses from m to mm
 
@@ -1737,7 +1737,7 @@ contains
 
        ! Get time step
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Compute ice fraction in each layer
 
@@ -2034,7 +2034,7 @@ contains
 
        ! Get time step
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Convert layer thicknesses from m to mm
 
@@ -2286,7 +2286,7 @@ contains
 
        ! Get time step
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
@@ -2385,7 +2385,7 @@ contains
           zwt                =>    soilhydrology_inst%zwt_col              & ! Input:  [real(r8) (:)   ] water table depth (m)                             
           )
 
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        do j = 1, nlevsoi
           do fc = 1, num_soilc
@@ -2482,7 +2482,7 @@ contains
           h2osoi_liq         =>    waterstate_inst%h2osoi_liq_col          & ! Output: [real(r8) (:,:) ] liquid water (kg/m2)
           )
 
-     dtime = get_step_size()
+     dtime = get_step_size_real()
 
      do j = 1, nlevsoi
         do fc = 1, num_soilc

--- a/src/biogeophys/SoilTemperatureMod.F90
+++ b/src/biogeophys/SoilTemperatureMod.F90
@@ -142,7 +142,7 @@ contains
     !   results in a tridiagonal system equation.
     !
     ! !USES:
-    use clm_time_manager         , only : get_step_size
+    use clm_time_manager         , only : get_step_size_real
     use clm_varpar               , only : nlevsno, nlevgrnd, nlevurb
     use clm_varctl               , only : iulog
     use clm_varcon               , only : cnfac, cpice, cpliq, denh2o
@@ -276,7 +276,7 @@ contains
 
       ! Get step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       if ( IsSimpleBuildTemp() ) call BuildingHAC( bounds, num_urbanl, &
                                            filter_urbanl, temperature_inst, &
@@ -824,7 +824,7 @@ contains
     ! Only freezing is considered.  When water freezes, move ice to bottom snow layer.
     !
     ! !USES:
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use clm_varcon       , only : tfrz, hfus, grav, denice, cnfac, cpice, cpliq
     use clm_varpar       , only : nlevsno, nlevgrnd
     use clm_varctl       , only : iulog
@@ -885,7 +885,7 @@ contains
 
       ! Get step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Initialization
 
@@ -1062,7 +1062,7 @@ contains
     ! (3) Re-adjust the ice and liquid mass, and the layer temperature
     !
     ! !USES:
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use clm_varpar       , only : nlevsno, nlevgrnd,nlevurb
     use clm_varctl       , only : iulog
     use clm_varcon       , only : tfrz, hfus, grav
@@ -1137,7 +1137,7 @@ contains
 
       ! Get step size
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Initialization
 

--- a/src/biogeophys/SoilWaterMovementMod.F90
+++ b/src/biogeophys/SoilWaterMovementMod.F90
@@ -459,7 +459,7 @@ contains
     use clm_varcon                 , only : wimp,grav,hfus,tfrz
     use clm_varcon                 , only : e_ice,denh2o, denice
     use clm_varpar                 , only : nlevsoi, max_patch_per_col, nlevgrnd
-    use clm_time_manager           , only : get_step_size, get_nstep
+    use clm_time_manager           , only : get_step_size_real, get_nstep
     use column_varcon              , only : icol_roof, icol_road_imperv
     use clm_varctl                 , only : use_flexibleCN, use_hydrstress
     use TridiagonalMod             , only : Tridiagonal
@@ -581,7 +581,7 @@ contains
       ! Get time step
       
       nstep = get_nstep()
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
 
       ! Because the depths in this routine are in mm, use local
@@ -1047,7 +1047,7 @@ contains
     use clm_varctl           , only : iulog, use_hydrstress
     use clm_varcon           , only : denh2o, denice
     use clm_varpar           , only : nlevsoi
-    use clm_time_manager     , only : get_step_size, get_nstep
+    use clm_time_manager     , only : get_step_size_real, get_nstep
     use SoilStateType        , only : soilstate_type
     use SoilHydrologyType    , only : soilhydrology_type
     use TemperatureType      , only : temperature_type
@@ -1162,7 +1162,7 @@ contains
       ! Get time step
 
       nstep = get_nstep()
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! main spatial loop
       do fc = 1, num_hydrologyc
@@ -2011,7 +2011,7 @@ contains
     use shr_const_mod        , only : SHR_CONST_TKFRZ, SHR_CONST_LATICE, SHR_CONST_G
     use abortutils           , only : endrun
     use decompMod            , only : bounds_type
-    use clm_time_manager     , only : get_step_size
+    use clm_time_manager     , only : get_step_size_real
     use clm_varpar           , only : nlevsoi
     use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
     use SoilStateType        , only : soilstate_type
@@ -2068,7 +2068,7 @@ contains
 
       ! Get time step
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! compute flux of water to aquifer
       do fc = 1, num_hydrologyc

--- a/src/biogeophys/SurfaceRadiationMod.F90
+++ b/src/biogeophys/SurfaceRadiationMod.F90
@@ -479,7 +479,7 @@ contains
      use clm_varcon       , only : spval
      use landunit_varcon  , only : istsoil, istcrop 
      use clm_varctl       , only : use_subgrid_fluxes, use_snicar_frc, iulog, use_SSRE
-     use clm_time_manager , only : get_step_size, is_near_local_noon
+     use clm_time_manager , only : get_step_size_real, is_near_local_noon
      use SnowSnicarMod    , only : DO_SNO_OC
      use abortutils       , only : endrun
      !
@@ -642,7 +642,7 @@ contains
 
        ! Determine seconds off current time step
      
-       dtime = get_step_size()
+       dtime = get_step_size_real()
 
        ! Initialize fluxes
 

--- a/src/biogeophys/SurfaceWaterMod.F90
+++ b/src/biogeophys/SurfaceWaterMod.F90
@@ -12,7 +12,7 @@ module SurfaceWaterMod
   use shr_spfn_mod                , only : erf => shr_spfn_erf
   use clm_varcon                  , only : denh2o, denice, roverg, wimp, tfrz, pc, mu, rpi
   use clm_varpar                  , only : nlevsno, nlevgrnd
-  use clm_time_manager            , only : get_step_size
+  use clm_time_manager            , only : get_step_size_real
   use column_varcon               , only : icol_roof, icol_road_imperv, icol_sunwall, icol_shadewall, icol_road_perv
   use decompMod                   , only : bounds_type
   use ColumnType                  , only : col
@@ -85,7 +85,7 @@ contains
          b_waterdiagnostic_inst => water_inst%waterdiagnosticbulk_inst &
          )
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! ------------------------------------------------------------------------
     ! Update diagnostics for bulk water
@@ -354,7 +354,7 @@ contains
          h2osfcflag       =>    soilhydrology_inst%h2osfcflag         & ! Input:  integer
          )
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     call QflxH2osfcSurf(bounds, num_hydrologyc, filter_hydrologyc, &
          h2osfcflag = h2osfcflag, &
@@ -438,7 +438,7 @@ contains
     SHR_ASSERT_ALL((ubound(topo_slope) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
     SHR_ASSERT_ALL((ubound(qflx_h2osfc_surf) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     do fc = 1, num_hydrologyc
        c = filter_hydrologyc(fc)
@@ -504,7 +504,7 @@ contains
     SHR_ASSERT_ALL((ubound(qinmax) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
     SHR_ASSERT_ALL((ubound(qflx_h2osfc_drain) == (/bounds%endc/)), errMsg(sourcefile, __LINE__))
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     do fc = 1, num_hydrologyc
        c = filter_hydrologyc(fc)

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -1123,7 +1123,7 @@ contains
     !
     ! !USES
     use accumulMod       , only : init_accum_field
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     !
     ! !ARGUMENTS:
@@ -1135,7 +1135,7 @@ contains
     integer, parameter :: not_used = huge(1)
     !---------------------------------------------------------------------
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     this%t_veg24_patch(bounds%begp:bounds%endp) = spval
     call init_accum_field (name='T_VEG24', units='K',                                              &

--- a/src/biogeophys/UrbBuildTempOleson2015Mod.F90
+++ b/src/biogeophys/UrbBuildTempOleson2015Mod.F90
@@ -202,7 +202,7 @@ contains
 !
 ! !USES:
     use shr_kind_mod    , only : r8 => shr_kind_r8
-    use clm_time_manager, only : get_step_size
+    use clm_time_manager, only : get_step_size_real
     use clm_varcon      , only : rair, pstd, cpair, sb, hcv_roof, hcv_roof_enhanced, &
                                  hcv_floor, hcv_floor_enhanced, hcv_sunw, hcv_shdw, &
                                  em_roof_int, em_floor_int, em_sunw_int, em_shdw_int, &
@@ -334,7 +334,7 @@ contains
 
     ! Get step size
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
 
     ! 1. Save t_* at previous time step
     ! 2. Set convective heat transfer coefficients (Bueno et al. 2012, GMD).

--- a/src/biogeophys/UrbanFluxesMod.F90
+++ b/src/biogeophys/UrbanFluxesMod.F90
@@ -71,7 +71,7 @@ contains
     use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, frictionvel_parms_inst
     use QSatMod             , only : QSat
     use clm_varpar          , only : maxpatch_urb, nlevurb, nlevgrnd
-    use clm_time_manager    , only : get_step_size, get_nstep, is_near_local_noon
+    use clm_time_manager    , only : get_step_size_real, get_nstep, is_near_local_noon
     use HumanIndexMod       , only : all_human_stress_indices, fast_human_stress_indices, &
                                      Wet_Bulb, Wet_BulbS, HeatIndex, AppTemp, &
                                      swbgt, hmdex, dis_coi, dis_coiS, THIndex, &
@@ -321,7 +321,7 @@ contains
       zii(begl:endl)  = 1000._r8          ! Should be set to the same values as in Biogeophysics1Mod
 
       ! Get current date
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Compute canyontop wind using Masson (2000)
 

--- a/src/biogeophys/UrbanRadiationMod.F90
+++ b/src/biogeophys/UrbanRadiationMod.F90
@@ -61,7 +61,7 @@ contains
     use clm_varcon          , only : spval, sb, tfrz
     use column_varcon       , only : icol_road_perv, icol_road_imperv
     use column_varcon       , only : icol_roof, icol_sunwall, icol_shadewall
-    use clm_time_manager    , only : get_step_size
+    use clm_time_manager    , only : get_step_size_real
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds    
@@ -246,7 +246,7 @@ contains
               urbanparams_inst)
       end if
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ! Determine variables needed for history output and communication with atm
       ! Loop over urban patches in clump

--- a/src/cpl/lnd_import_export.F90
+++ b/src/cpl/lnd_import_export.F90
@@ -294,7 +294,7 @@ contains
     use shr_kind_mod       , only : r8 => shr_kind_r8
     use seq_flds_mod       , only : seq_flds_l2x_fields
     use clm_varctl         , only : iulog
-    use clm_time_manager   , only : get_nstep, get_step_size  
+    use clm_time_manager   , only : get_nstep
     use seq_drydep_mod     , only : n_drydep
     use shr_megan_mod      , only : shr_megan_mechcomps_n
     use shr_fire_emis_mod  , only : shr_fire_emis_mechcomps_n

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -272,7 +272,7 @@ contains
     use clm_varctl            , only : use_century_decomp, single_column, scmlat, scmlon, use_cn, use_fates
     use clm_varctl            , only : use_crop, ndep_from_cpl
     use clm_varorb            , only : eccen, mvelpp, lambm0, obliqr
-    use clm_time_manager      , only : get_step_size, get_curr_calday
+    use clm_time_manager      , only : get_step_size_real, get_curr_calday
     use clm_time_manager      , only : get_curr_date, get_nstep, advance_timestep 
     use clm_time_manager      , only : timemgr_init, timemgr_restart_io, timemgr_restart, is_restart
     use CIsoAtmTimeseriesMod  , only : C14_init_BombSpike, use_c14_bombspike, C13_init_TimeSeries, use_c13_timeseries
@@ -371,7 +371,7 @@ contains
     calday = get_curr_calday()
     call shr_orb_decl( calday, eccen, mvelpp, lambm0, obliqr, declin, eccf )
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
     caldaym1 = get_curr_calday(offset=-int(dtime))
     call shr_orb_decl( caldaym1, eccen, mvelpp, lambm0, obliqr, declinm1, eccf )
 

--- a/src/main/clm_instMod.F90
+++ b/src/main/clm_instMod.F90
@@ -369,7 +369,7 @@ contains
        ! Note that init_decompcascade_bgc and init_decompcascade_cn need 
        ! soilbiogeochem_state_inst to be initialized
 
-       call init_decomp_cascade_constants()
+       call init_decomp_cascade_constants( use_century_decomp )
        if (use_century_decomp) then
           call init_decompcascade_bgc(bounds, soilbiogeochem_state_inst, &
                                       soilstate_inst )

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -129,7 +129,6 @@ contains
     integer :: ierr                 ! error code
     integer :: unitn                ! unit for namelist file
     integer :: dtime                ! Integer time-step
-    integer :: override_nsrest      ! If want to override the startup type sent from driver
     logical :: use_init_interp      ! Apply initInterp to the file given by finidat
     !------------------------------------------------------------------------
 
@@ -202,7 +201,7 @@ contains
 
     namelist /clm_inparm/  &
          clump_pproc, wrtdia, &
-         create_crop_landunit, nsegspc, co2_ppmv, override_nsrest, &
+         create_crop_landunit, nsegspc, co2_ppmv, &
          albice, soil_layerstruct_predefined, soil_layerstruct_userdefined, &
          soil_layerstruct_userdefined_nlevsoi, use_subgrid_fluxes, snow_cover_fraction_method, &
          irrigate, run_zero_weight_urban, all_active, &
@@ -301,8 +300,6 @@ contains
     clump_pproc = 1
 #endif
 
-    override_nsrest = nsrest
-
     use_init_interp = .false.
 
     if (masterproc) then
@@ -355,17 +352,6 @@ contains
              hist_nhtfrq(i) = nint(-hist_nhtfrq(i)*SHR_CONST_CDAY/(24._r8*dtime))
           endif
        end do
-
-       ! Override start-type (can only override to branch (3)  and only 
-       ! if the driver is a startup type
-       if ( override_nsrest /= nsrest )then
-           if ( override_nsrest /= nsrBranch .and. nsrest /= nsrStartup )then
-              call endrun(msg= ' ERROR: can ONLY override clm start-type ' // &
-                   'to branch type and ONLY if driver is a startup type'// &
-                   errMsg(sourcefile, __LINE__))
-           end if
-           call clm_varctl_set( nsrest_in=override_nsrest )
-       end if
 
        if (maxpatch_glcmec <= 0) then
           call endrun(msg=' ERROR: maxpatch_glcmec must be at least 1 ' // &

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -39,7 +39,7 @@ module controlMod
   use UrbanParamsType                  , only: UrbanReadNML
   use HumanIndexMod                    , only: HumanIndexReadNML
   use CNPrecisionControlMod            , only: CNPrecisionControlReadNML
-  use CNSharedParamsMod                , only: anoxia_wtsat, use_fun
+  use CNSharedParamsMod                , only: use_fun
   use CIsoAtmTimeseriesMod             , only: use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
   use SoilBiogeochemCompetitionMod     , only: suplnitro, suplnNon
   use SoilBiogeochemLittVertTranspMod  , only: som_adv_flux, max_depth_cryoturb
@@ -185,7 +185,7 @@ contains
          perchroot, perchroot_alt
 
     namelist /clm_inparm / &
-         anoxia, anoxia_wtsat, use_fun
+         anoxia, use_fun
 
     namelist /clm_inparm / &
          deepmixing_depthcrit, deepmixing_mixfact, lake_melt_icealb
@@ -772,7 +772,6 @@ contains
     call mpi_bcast (perchroot_alt, 1, MPI_LOGICAL, 0, mpicom, ier)
     if (use_lch4) then
        call mpi_bcast (anoxia, 1, MPI_LOGICAL, 0, mpicom, ier)
-       call mpi_bcast (anoxia_wtsat, 1, MPI_LOGICAL, 0, mpicom, ier)
     end if
 
     ! lakes
@@ -1024,7 +1023,6 @@ contains
     write(iulog,*) ' perchroot (plant water stress based on time-integrated active layer only) = ',perchroot
     if (use_lch4) then
        write(iulog,*) ' anoxia (applied to soil decomposition)             = ',anoxia
-       write(iulog,*) ' anoxia_wtsat (weight anoxia by inundated fraction) = ',anoxia_wtsat
     end if
     ! Lakes
     write(iulog,*)

--- a/src/soilbiogeochem/SoilBiogeochemCompetitionMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemCompetitionMod.F90
@@ -129,7 +129,7 @@ contains
     !
     ! !USES:
     use clm_varcon      , only: secspday
-    use clm_time_manager, only: get_step_size
+    use clm_time_manager, only: get_step_size_real
     use clm_varctl      , only: iulog, cnallocate_carbon_only_set
     use shr_infnan_mod  , only: nan => shr_infnan_nan, assignment(=)
     !
@@ -142,7 +142,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! set time steps
-    dt = real( get_step_size(), r8 )
+    dt = get_step_size_real()
 
     ! set space-and-time parameters from parameter file
     bdnr = params_inst%bdnr * (dt/secspday)

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90
@@ -302,7 +302,6 @@ contains
     !  written by C. Koven 
     !
     ! !USES:
-    use clm_time_manager , only : get_step_size
     !
     ! !ARGUMENTS:
     type(bounds_type)               , intent(in)    :: bounds  

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90
@@ -548,7 +548,7 @@ contains
      ! written by C. Koven based on original CLM4 decomposition cascade by P. Thornton
      !
      ! !USES:
-     use clm_time_manager, only : get_step_size
+     use clm_time_manager, only : get_step_size_real
      use clm_varcon      , only : secspday
      use clm_varpar      , only : i_cwd
      !
@@ -626,7 +626,7 @@ contains
        mino2lim = CNParamsShareInst%mino2lim
 
        ! set time steps
-       dt = real( get_step_size(), r8 )
+       dt = get_step_size_real()
        dtd = dt/secspday
 
        ! set initial base rates for decomposition mass loss (1/day)

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90
@@ -224,6 +224,8 @@ contains
     !  initialize rate constants and decomposition pathways for the BGC model originally implemented in CLM-CN
     !  written by C. Koven based on original CLM4 decomposition cascade by P. Thornton
     !
+    ! !USES:
+    use SoilBiogeochemDecompCascadeConType, only : i_atm
     ! !ARGUMENTS:
     type(bounds_type)               , intent(in)    :: bounds  
     type(soilbiogeochem_state_type) , intent(inout) :: soilbiogeochem_state_inst
@@ -250,7 +252,6 @@ contains
     integer :: i_soil2
     integer :: i_soil3
     integer :: i_soil4
-    integer :: i_atm
     integer :: i_l1s1
     integer :: i_l2s2
     integer :: i_l3s3
@@ -439,7 +440,6 @@ contains
       is_cellulose(i_soil4) = .false.
       is_lignin(i_soil4) = .false.
 
-      i_atm = 0  !! for terminal pools (i.e. 100% respiration)
       floating_cn_ratio_decomp_pools(i_atm) = .false.
       decomp_cascade_con%decomp_pool_name_restart(i_atm) = 'atmosphere'
       decomp_cascade_con%decomp_pool_name_history(i_atm) = 'atmosphere'

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90
@@ -15,7 +15,7 @@ module SoilBiogeochemDecompCascadeCNMod
   use clm_varcon                         , only : zsoi
   use decompMod                          , only : bounds_type
   use abortutils                         , only : endrun
-  use CNSharedParamsMod                  , only : CNParamsShareInst, anoxia_wtsat, nlev_soildecomp_standard 
+  use CNSharedParamsMod                  , only : CNParamsShareInst, nlev_soildecomp_standard 
   use SoilBiogeochemDecompCascadeConType , only : decomp_cascade_con
   use SoilBiogeochemStateType            , only : soilbiogeochem_state_type
   use SoilBiogeochemCarbonFluxType       , only : soilbiogeochem_carbonflux_type
@@ -770,17 +770,6 @@ contains
           end do
 
           if (use_lch4) then
-             if (anoxia_wtsat) then ! Adjust for saturated fraction if unfrozen.
-                do fc = 1,num_soilc
-                   c = filter_soilc(fc)
-                   if (alt_indx(c) >= nlev_soildecomp_standard .and. t_soisno(c,1) > SHR_CONST_TKFRZ) then
-                      w_scalar(c,1) = w_scalar(c,1)*(1._r8 - finundated(c)) + finundated(c)
-                   end if
-                end do
-             end if
-          end if
-
-          if (use_lch4) then
              ! Calculate ANOXIA
              if (anoxia) then
                 ! Check for anoxia w/o LCH4 now done in controlMod.
@@ -791,13 +780,7 @@ contains
 
                       if (j==1) o_scalar(c,:) = 0._r8
 
-                      if (.not. anoxia_wtsat) then
-                         o_scalar(c,1) = o_scalar(c,1) + fr(c,j) * max(o2stress_unsat(c,j), mino2lim)
-                      else
-                         o_scalar(c,1) = o_scalar(c,1) + fr(c,j) * &
-                              (max(o2stress_unsat(c,j), mino2lim)*(1._r8 - finundated(c)) + &
-                              max(o2stress_sat(c,j), mino2lim)*finundated(c) )
-                      end if
+                      o_scalar(c,1) = o_scalar(c,1) + fr(c,j) * max(o2stress_unsat(c,j), mino2lim)
                    end do
                 end do
              else
@@ -852,11 +835,6 @@ contains
                 else
                    w_scalar(c,j) = 0._r8
                 end if
-                if (use_lch4) then
-                   if (anoxia_wtsat .and. t_soisno(c,j) > SHR_CONST_TKFRZ) then ! wet area will have w_scalar of 1 if unfrozen
-                      w_scalar(c,j) = w_scalar(c,j)*(1._r8 - finundated(c)) + finundated(c)
-                   end if
-                end if
              end do
           end do
 
@@ -871,12 +849,7 @@ contains
                 do fc = 1,num_soilc
                    c = filter_soilc(fc)
 
-                   if (.not. anoxia_wtsat) then
-                      o_scalar(c,j) = max(o2stress_unsat(c,j), mino2lim)
-                   else
-                      o_scalar(c,j) = max(o2stress_unsat(c,j), mino2lim) * (1._r8 - finundated(c)) + &
-                           max(o2stress_sat(c,j), mino2lim) * finundated(c)
-                   end if
+                   o_scalar(c,j) = max(o2stress_unsat(c,j), mino2lim)
                 end do
              end do
           else

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeConType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeConType.F90
@@ -57,24 +57,24 @@ contains
     allocate(decomp_cascade_con%cascade_receiver_pool(1:ndecomp_cascade_transitions))
 
     ! NOTE(bja, 2015-10) according to Dave Lawrence and Charlie Koven,
-    ! the indexing of decomposing pools from 0:ndecomp_pools is a
+    ! the indexing of decomposing pools from 1:ndecomp_pools is a
     ! bug. The lower bound should be 1. The index zero data shouldn't
     ! be used.
     
     !-- properties of each decomposing pool
-    allocate(decomp_cascade_con%floating_cn_ratio_decomp_pools(0:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_restart(0:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_history(0:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_long(0:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_short(0:ndecomp_pools))
-    allocate(decomp_cascade_con%is_litter(0:ndecomp_pools))
-    allocate(decomp_cascade_con%is_soil(0:ndecomp_pools))
-    allocate(decomp_cascade_con%is_cwd(0:ndecomp_pools))
-    allocate(decomp_cascade_con%initial_cn_ratio(0:ndecomp_pools))
-    allocate(decomp_cascade_con%initial_stock(0:ndecomp_pools))
-    allocate(decomp_cascade_con%is_metabolic(0:ndecomp_pools))
-    allocate(decomp_cascade_con%is_cellulose(0:ndecomp_pools))
-    allocate(decomp_cascade_con%is_lignin(0:ndecomp_pools))
+    allocate(decomp_cascade_con%floating_cn_ratio_decomp_pools(1:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_restart(1:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_history(1:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_long(1:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_short(1:ndecomp_pools))
+    allocate(decomp_cascade_con%is_litter(1:ndecomp_pools))
+    allocate(decomp_cascade_con%is_soil(1:ndecomp_pools))
+    allocate(decomp_cascade_con%is_cwd(1:ndecomp_pools))
+    allocate(decomp_cascade_con%initial_cn_ratio(1:ndecomp_pools))
+    allocate(decomp_cascade_con%initial_stock(1:ndecomp_pools))
+    allocate(decomp_cascade_con%is_metabolic(1:ndecomp_pools))
+    allocate(decomp_cascade_con%is_cellulose(1:ndecomp_pools))
+    allocate(decomp_cascade_con%is_lignin(1:ndecomp_pools))
     allocate(decomp_cascade_con%spinup_factor(1:ndecomp_pools))
 
     !-- properties of each pathway along decomposition cascade 
@@ -83,20 +83,20 @@ contains
     decomp_cascade_con%cascade_receiver_pool(1:ndecomp_cascade_transitions) = 0
 
     !-- first initialization of properties of each decomposing pool
-    decomp_cascade_con%floating_cn_ratio_decomp_pools(0:ndecomp_pools) = .false.
-    decomp_cascade_con%decomp_pool_name_history(0:ndecomp_pools)       = ''
-    decomp_cascade_con%decomp_pool_name_restart(0:ndecomp_pools)       = ''
-    decomp_cascade_con%decomp_pool_name_long(0:ndecomp_pools)          = ''
-    decomp_cascade_con%decomp_pool_name_short(0:ndecomp_pools)         = ''
-    decomp_cascade_con%is_litter(0:ndecomp_pools)                      = .false.
-    decomp_cascade_con%is_soil(0:ndecomp_pools)                        = .false.
-    decomp_cascade_con%is_cwd(0:ndecomp_pools)                         = .false.
-    decomp_cascade_con%initial_cn_ratio(0:ndecomp_pools)               = nan
-    decomp_cascade_con%initial_stock(0:ndecomp_pools)                  = nan
+    decomp_cascade_con%floating_cn_ratio_decomp_pools(1:ndecomp_pools) = .false.
+    decomp_cascade_con%decomp_pool_name_history(1:ndecomp_pools)       = ''
+    decomp_cascade_con%decomp_pool_name_restart(1:ndecomp_pools)       = ''
+    decomp_cascade_con%decomp_pool_name_long(1:ndecomp_pools)          = ''
+    decomp_cascade_con%decomp_pool_name_short(1:ndecomp_pools)         = ''
+    decomp_cascade_con%is_litter(1:ndecomp_pools)                      = .false.
+    decomp_cascade_con%is_soil(1:ndecomp_pools)                        = .false.
+    decomp_cascade_con%is_cwd(1:ndecomp_pools)                         = .false.
+    decomp_cascade_con%initial_cn_ratio(1:ndecomp_pools)               = nan
+    decomp_cascade_con%initial_stock(1:ndecomp_pools)                  = nan
     decomp_cascade_con%initial_stock_soildepth                         = 0.3
-    decomp_cascade_con%is_metabolic(0:ndecomp_pools)                   = .false.
-    decomp_cascade_con%is_cellulose(0:ndecomp_pools)                   = .false.
-    decomp_cascade_con%is_lignin(0:ndecomp_pools)                      = .false.
+    decomp_cascade_con%is_metabolic(1:ndecomp_pools)                   = .false.
+    decomp_cascade_con%is_cellulose(1:ndecomp_pools)                   = .false.
+    decomp_cascade_con%is_lignin(1:ndecomp_pools)                      = .false.
     decomp_cascade_con%spinup_factor(1:ndecomp_pools)                  = nan
 
   end subroutine init_decomp_cascade_constants

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeConType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeConType.F90
@@ -39,42 +39,47 @@ module SoilBiogeochemDecompCascadeConType
      real(r8)          , pointer  :: spinup_factor(:)                  ! factor by which to scale AD and relevant processes by
   end type decomp_cascade_type
 
+  integer, public, parameter :: i_atm = 0                              ! for terminal pools (i.e. 100% respiration) (only used for CN not for BGC)
   type(decomp_cascade_type), public :: decomp_cascade_con
   !------------------------------------------------------------------------
 
 contains
 
   !------------------------------------------------------------------------
-  subroutine init_decomp_cascade_constants()
+  subroutine init_decomp_cascade_constants( use_century_decomp )
     !
     ! !DESCRIPTION:
     ! Initialize decomposition cascade state
     !------------------------------------------------------------------------
+    ! !ARGUMENTS:
+    logical, intent(IN) :: use_century_decomp
+    ! !LOGAL VARIABLES:
+    integer :: ibeg    ! Beginning index for allocated arrays
 
+    if ( use_century_decomp ) then
+       ibeg = 1
+    else
+       ibeg = i_atm
+    end if
     !-- properties of each pathway along decomposition cascade 
     allocate(decomp_cascade_con%cascade_step_name(1:ndecomp_cascade_transitions))
     allocate(decomp_cascade_con%cascade_donor_pool(1:ndecomp_cascade_transitions))
     allocate(decomp_cascade_con%cascade_receiver_pool(1:ndecomp_cascade_transitions))
 
-    ! NOTE(bja, 2015-10) according to Dave Lawrence and Charlie Koven,
-    ! the indexing of decomposing pools from 1:ndecomp_pools is a
-    ! bug. The lower bound should be 1. The index zero data shouldn't
-    ! be used.
-    
     !-- properties of each decomposing pool
-    allocate(decomp_cascade_con%floating_cn_ratio_decomp_pools(1:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_restart(1:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_history(1:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_long(1:ndecomp_pools))
-    allocate(decomp_cascade_con%decomp_pool_name_short(1:ndecomp_pools))
-    allocate(decomp_cascade_con%is_litter(1:ndecomp_pools))
-    allocate(decomp_cascade_con%is_soil(1:ndecomp_pools))
-    allocate(decomp_cascade_con%is_cwd(1:ndecomp_pools))
-    allocate(decomp_cascade_con%initial_cn_ratio(1:ndecomp_pools))
-    allocate(decomp_cascade_con%initial_stock(1:ndecomp_pools))
-    allocate(decomp_cascade_con%is_metabolic(1:ndecomp_pools))
-    allocate(decomp_cascade_con%is_cellulose(1:ndecomp_pools))
-    allocate(decomp_cascade_con%is_lignin(1:ndecomp_pools))
+    allocate(decomp_cascade_con%floating_cn_ratio_decomp_pools(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_restart(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_history(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_long(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%decomp_pool_name_short(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%is_litter(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%is_soil(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%is_cwd(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%initial_cn_ratio(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%initial_stock(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%is_metabolic(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%is_cellulose(ibeg:ndecomp_pools))
+    allocate(decomp_cascade_con%is_lignin(ibeg:ndecomp_pools))
     allocate(decomp_cascade_con%spinup_factor(1:ndecomp_pools))
 
     !-- properties of each pathway along decomposition cascade 
@@ -83,21 +88,21 @@ contains
     decomp_cascade_con%cascade_receiver_pool(1:ndecomp_cascade_transitions) = 0
 
     !-- first initialization of properties of each decomposing pool
-    decomp_cascade_con%floating_cn_ratio_decomp_pools(1:ndecomp_pools) = .false.
-    decomp_cascade_con%decomp_pool_name_history(1:ndecomp_pools)       = ''
-    decomp_cascade_con%decomp_pool_name_restart(1:ndecomp_pools)       = ''
-    decomp_cascade_con%decomp_pool_name_long(1:ndecomp_pools)          = ''
-    decomp_cascade_con%decomp_pool_name_short(1:ndecomp_pools)         = ''
-    decomp_cascade_con%is_litter(1:ndecomp_pools)                      = .false.
-    decomp_cascade_con%is_soil(1:ndecomp_pools)                        = .false.
-    decomp_cascade_con%is_cwd(1:ndecomp_pools)                         = .false.
-    decomp_cascade_con%initial_cn_ratio(1:ndecomp_pools)               = nan
-    decomp_cascade_con%initial_stock(1:ndecomp_pools)                  = nan
-    decomp_cascade_con%initial_stock_soildepth                         = 0.3
-    decomp_cascade_con%is_metabolic(1:ndecomp_pools)                   = .false.
-    decomp_cascade_con%is_cellulose(1:ndecomp_pools)                   = .false.
-    decomp_cascade_con%is_lignin(1:ndecomp_pools)                      = .false.
-    decomp_cascade_con%spinup_factor(1:ndecomp_pools)                  = nan
+    decomp_cascade_con%floating_cn_ratio_decomp_pools(ibeg:ndecomp_pools) = .false.
+    decomp_cascade_con%decomp_pool_name_history(ibeg:ndecomp_pools)       = ''
+    decomp_cascade_con%decomp_pool_name_restart(ibeg:ndecomp_pools)       = ''
+    decomp_cascade_con%decomp_pool_name_long(ibeg:ndecomp_pools)          = ''
+    decomp_cascade_con%decomp_pool_name_short(ibeg:ndecomp_pools)         = ''
+    decomp_cascade_con%is_litter(ibeg:ndecomp_pools)                      = .false.
+    decomp_cascade_con%is_soil(ibeg:ndecomp_pools)                        = .false.
+    decomp_cascade_con%is_cwd(ibeg:ndecomp_pools)                         = .false.
+    decomp_cascade_con%initial_cn_ratio(ibeg:ndecomp_pools)               = nan
+    decomp_cascade_con%initial_stock(ibeg:ndecomp_pools)                  = nan
+    decomp_cascade_con%initial_stock_soildepth                            = 0.3
+    decomp_cascade_con%is_metabolic(ibeg:ndecomp_pools)                   = .false.
+    decomp_cascade_con%is_cellulose(ibeg:ndecomp_pools)                   = .false.
+    decomp_cascade_con%is_lignin(ibeg:ndecomp_pools)                      = .false.
+    decomp_cascade_con%spinup_factor(1:ndecomp_pools)                     = nan
 
   end subroutine init_decomp_cascade_constants
 

--- a/src/soilbiogeochem/SoilBiogeochemDecompMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompMod.F90
@@ -73,6 +73,7 @@ contains
        cn_decomp_pools, p_decomp_cpool_loss, pmnf_decomp_cascade)
     !
     ! !USES:
+    use SoilBiogeochemDecompCascadeConType, only : i_atm
     !
     ! !ARGUMENT:
     type(bounds_type)                       , intent(in)    :: bounds   
@@ -91,7 +92,6 @@ contains
     integer :: c,j,k,l,m                                    ! indices
     integer :: fc                                           ! lake filter column index
     integer :: begc,endc                                    ! bounds 
-    integer, parameter :: i_atm = 0 !TODO - this appears in two places - move it to 1
     !  For methane code
     real(r8):: hrsum(bounds%begc:bounds%endc,1:nlevdecomp)  ! sum of HR (gC/m2/s) 
     !-----------------------------------------------------------------------

--- a/src/soilbiogeochem/SoilBiogeochemLittVertTranspMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemLittVertTranspMod.F90
@@ -101,7 +101,7 @@ contains
     ! Initial code by C. Koven and W. Riley
     !
     ! !USES:
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     use clm_varpar       , only : nlevdecomp, ndecomp_pools, nlevdecomp_full
     use clm_varcon       , only : zsoi, dzsoi_decomp, zisoi
     use TridiagonalMod   , only : Tridiagonal
@@ -177,7 +177,7 @@ contains
       cryoturb_diffusion_k       = params_inst%cryoturb_diffusion_k 
       max_altdepth_cryoturbation = params_inst%max_altdepth_cryoturbation 
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
 
       ntype = 2
       if ( use_c13 ) then

--- a/src/soilbiogeochem/SoilBiogeochemNLeachingMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNLeachingMod.F90
@@ -82,7 +82,7 @@ contains
     !
     ! !USES:
     use clm_varpar       , only : nlevdecomp, nlevsoi
-    use clm_time_manager , only : get_step_size
+    use clm_time_manager , only : get_step_size_real
     !
     ! !ARGUMENTS:
     type(bounds_type)                       , intent(in)    :: bounds  
@@ -120,7 +120,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       if (.not. use_nitrif_denitrif) then
          ! set constant sf 

--- a/src/soilbiogeochem/SoilBiogeochemNStateUpdate1Mod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNStateUpdate1Mod.F90
@@ -6,7 +6,7 @@ module SoilBiogeochemNStateUpdate1Mod
   !
   ! !USES:
   use shr_kind_mod                       , only: r8 => shr_kind_r8
-  use clm_time_manager                   , only : get_step_size
+  use clm_time_manager                   , only : get_step_size_real
   use clm_varpar                         , only : nlevdecomp, ndecomp_pools, ndecomp_cascade_transitions
   use clm_varpar                         , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use clm_varctl                         , only : iulog, use_nitrif_denitrif, use_crop
@@ -61,7 +61,7 @@ contains
          )
 
       ! set time steps
-      dt = real( get_step_size(), r8 )
+      dt = get_step_size_real()
 
       do j = 1, nlevdecomp
          do fc = 1,num_soilc

--- a/src/soilbiogeochem/SoilBiogeochemNitrifDenitrifMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrifDenitrifMod.F90
@@ -193,7 +193,7 @@ contains
     !  calculate nitrification and denitrification rates
     !
     ! !USES:
-    use clm_time_manager  , only : get_curr_date, get_step_size
+    use clm_time_manager  , only : get_curr_date
     use CNSharedParamsMod , only : anoxia_wtsat, CNParamsShareInst
     !
     ! !ARGUMENTS:

--- a/src/soilbiogeochem/SoilBiogeochemNitrifDenitrifMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrifDenitrifMod.F90
@@ -194,7 +194,7 @@ contains
     !
     ! !USES:
     use clm_time_manager  , only : get_curr_date
-    use CNSharedParamsMod , only : anoxia_wtsat, CNParamsShareInst
+    use CNSharedParamsMod , only : CNParamsShareInst
     !
     ! !ARGUMENTS:
     type(bounds_type)                       , intent(in)    :: bounds  
@@ -349,20 +349,6 @@ contains
                   anaerobic_frac(c,j) = 0._r8
                endif
 
-               if (anoxia_wtsat) then ! Average saturated fraction values into anaerobic_frac(c,j).
-                  r_min_sat = 2._r8 * surface_tension_water / (rho_w * grav * abs(grav * 1.e-6_r8 * sucsat(c,j)))
-                  r_psi_sat = sqrt(r_min_sat * r_max)
-                  if (o2_decomp_depth_sat(c,j) > 0._r8) then
-                     anaerobic_frac_sat = exp(-rij_kro_a * r_psi_sat**(-rij_kro_alpha) * &
-                          o2_decomp_depth_sat(c,j)**(-rij_kro_beta) * &
-                          conc_o2_sat(c,j)**rij_kro_gamma * (watsat(c,j) + ratio_diffusivity_water_gas(c,j) * &
-                          watsat(c,j))**rij_kro_delta)
-                  else
-                     anaerobic_frac_sat = 0._r8
-                  endif
-                  anaerobic_frac(c,j) = (1._r8 - finundated(c))*anaerobic_frac(c,j) + finundated(c)*anaerobic_frac_sat
-               end if
-
             else
                ! NITRIF_DENITRIF requires Methane model to be active, 
                ! otherwise diffusivity will be zeroed out here. EBK CDK 10/18/2011
@@ -449,11 +435,6 @@ contains
             ! total water limitation function (Del Grosso et al., 2000, figure 7a)
             wfps_vr(c,j) = max(min(h2osoi_vol(c,j)/watsat(c, j), 1._r8), 0._r8) * 100._r8
             fr_WFPS(c,j) = max(0.1_r8, 0.015_r8 * wfps_vr(c,j) - 0.32_r8)
-            if (use_lch4) then
-               if (anoxia_wtsat) then
-                  fr_WFPS(c,j) = fr_WFPS(c,j)*(1._r8 - finundated(c)) + finundated(c)*1.18_r8
-               end if
-            end if
 
             ! final ratio expression 
             n2_n2o_ratio_denit_vr(c,j) = max(0.16*ratio_k1(c,j), ratio_k1(c,j)*exp(-0.8 * ratio_no3_co2(c,j))) * fr_WFPS(c,j)

--- a/src/soilbiogeochem/SoilBiogeochemPotentialMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemPotentialMod.F90
@@ -73,7 +73,8 @@ contains
        cn_decomp_pools, p_decomp_cpool_loss, pmnf_decomp_cascade)
     !
     ! !USES:
-    use shr_log_mod, only : errMsg => shr_log_errMsg
+    use shr_log_mod                       , only : errMsg => shr_log_errMsg
+    use SoilBiogeochemDecompCascadeConType, only : i_atm
     !
     ! !ARGUMENT:
     type(bounds_type)                       , intent(in)    :: bounds   
@@ -94,7 +95,6 @@ contains
     integer :: begc,endc                                    !bounds 
     real(r8):: immob(bounds%begc:bounds%endc,1:nlevdecomp)  !potential N immobilization
     real(r8):: ratio                                        !temporary variable
-    integer, parameter :: i_atm = 0 !TODO - this appears in two places - move it to 1
     !-----------------------------------------------------------------------
    
     begc = bounds%begc; endc = bounds%endc

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -82,7 +82,7 @@ module CLMFatesInterfaceMod
                                   get_ref_date,      &
                                   timemgr_datediff,  &
                                   is_beg_curr_day,   &
-                                  get_step_size,     &
+                                  get_step_size_real,&
                                   get_nstep
    use spmdMod           , only : masterproc
    use decompMod         , only : get_proc_bounds,   &
@@ -1608,7 +1608,7 @@ contains
          end do
       end do
 
-      dtime = get_step_size()
+      dtime = get_step_size_real()
       
       ! Call photosynthesis
       
@@ -1673,7 +1673,7 @@ contains
     end do
 
 
-    dtime = get_step_size()
+    dtime = get_step_size_real()
     call  AccumulateFluxes_ED(this%fates(nc)%nsites,  &
                                this%fates(nc)%sites, &
                                this%fates(nc)%bc_in,  &
@@ -1807,7 +1807,7 @@ contains
       end do
 
       is_beg_day = is_beg_curr_day()
-      dtime = get_step_size()
+      dtime = get_step_size_real()
       nstep = get_nstep()
 
       call SummarizeNetFluxes(this%fates(nc)%nsites,  &
@@ -2262,7 +2262,7 @@ contains
    if ( .not.use_fates_planthydro ) return
 
 
-   dtime = get_step_size()
+   dtime = get_step_size_real()
 
    ! Prepare Input Boundary Conditions
    ! ------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description of changes

New clm5 paramsfile that has the bad date of 631 changed to 701. Along with some simple bit for
bit changes. Removing some problematic options. Making Dynamic Vegetation a deprecated option that requires you to use -ignore_warnings with it.

### Specific notes

Contributors other than yourself, if any: 

New params file for clm45, clm50 -- simple bit for bit changes

CTSM Issues Fixed (include github issue #): #463 #79 #97 #98 #104 #122 #173 #794 #795 #796

 Fixes #463 bad date on params file that didn't allow using ESMF library with Crop
 Fixes #79 correct documentation of qflx_evap_tot
 Fixes #97 remove override_nsrest
 Fixes #98 add warning when using single instance of a startup file for multi-instance cases
 Fixes #104 use get_step_size_real when putting into a real variable
 Fixes #122 decomp pool arrays should not start at 0 but 1
 Fixes #173 remove psi_soil_ref as not used
 Fixes #794 remove anoxia_wtsat
 Fixes #795 Correct documentation of -light_res
 Fixes #796 Deprecate Dynamic Vegetation

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? Yes
  Some namelist items removed: anoxia_wtsat, override_nsrest
  Turning dynamic Vegetation on, now displays a warning, and requires using -ignore_warnings in CLM_BLDNML_OPTS.

Testing performed, if any: ran a few tests on cheyenne, will run standard testing
