### PR TITLE
Two answer changing fixes (fire, DWT_SLASH) and fix for urban streams for Clm45

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1129,7 +1129,11 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <stream_year_first_urbantv sim_year="constant" sim_year_range="2000-2100" >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  sim_year="constant" sim_year_range="2000-2100" >2106</stream_year_last_urbantv>
 
-<stream_fldfilename_urbantv hgrid="0.9x1.25" >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
+<stream_fldfilename_urbantv phys="clm5_0" hgrid="0.9x1.25"
+>lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
+
+<stream_fldfilename_urbantv phys="clm4_5" hgrid="0.9x1.25"
+>lnd/clm2/urbandata/CLM45_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
 
 <urbantvmapalgo >nn</urbantvmapalgo>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -365,7 +365,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190729.nc</paramfile>
+<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c190529.nc</paramfile>
 <paramfile phys="clm4_5">lnd/clm2/paramdata/clm_params.c190518.nc</paramfile>
 
 <!-- ================================================================== -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1105,36 +1105,31 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <popdensmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</popdensmapalgo>
 
 <!-- Urban time varying streams namelist defaults -->
-<stream_year_first_urbantv phys="clm4_5"  >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm4_5"  >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="2000" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="2000" >2000</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="2000" >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="2000" >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="1850" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="1850" >1850</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="1850" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="1850" >1850</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="1000" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="1000" >2000</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="1000" >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="1000" >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1850-2100" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
+<stream_year_first_urbantv sim_year="constant" sim_year_range="2000-2100" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  sim_year="constant" sim_year_range="2000-2100" >2106</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="2000-2100" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="2000-2100" >2106</stream_year_last_urbantv>
-
-<stream_fldfilename_urbantv phys="clm5_0" hgrid="0.9x1.25" >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
-
-<stream_fldfilename_urbantv phys="clm4_5" hgrid="0.9x1.25" >lnd/clm2/urbandata/CLM45_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
+<stream_fldfilename_urbantv hgrid="0.9x1.25" >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
 
 <urbantvmapalgo >nn</urbantvmapalgo>
 

--- a/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp2.6_transient.xml
@@ -40,6 +40,10 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2100</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2100</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>

--- a/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp4.5_transient.xml
@@ -40,6 +40,10 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2100</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2100</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>

--- a/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp6_transient.xml
@@ -41,6 +41,10 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2100</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2100</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>

--- a/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
+++ b/bld/namelist_files/use_cases/1850-2100_rcp8.5_transient.xml
@@ -40,6 +40,10 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2100</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2100</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -23,6 +23,9 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >1850</stream_year_last_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 

--- a/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
+++ b/bld/namelist_files/use_cases/2000-2100_rcp8.5_transient.xml
@@ -39,6 +39,10 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >2000</model_year_align_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2100</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >2000</model_year_align_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2100</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >2000</model_year_align_urbantv>

--- a/bld/namelist_files/use_cases/2000_control.xml
+++ b/bld/namelist_files/use_cases/2000_control.xml
@@ -24,6 +24,9 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >2000</stream_year_last_popdens>
 
+<stream_year_first_urbantv phys="clm4_5" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" >2000</stream_year_last_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" >2000</stream_year_last_urbantv>
 

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -34,6 +34,10 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2016</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2106</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>

--- a/cime_config/usermods_dirs/output_bgc/user_nl_clm
+++ b/cime_config/usermods_dirs/output_bgc/user_nl_clm
@@ -11,7 +11,7 @@ hist_fincl2 += 'GPP', 'NPP', 'AGNPP', 'TOTVEGC', 'NPP_NUPTAKE', 'AR', 'HR', 'HTO
 
 ! h2 stream (monthly average, landunit-level)
 ! TOT_WOODPRODC:I, CROPPROD1C:I, and NEE are not available at the landunit level
-hist_fincl3 += 'GPP', 'NPP', 'AR', 'HR', 'DWT_CONV_CFLUX_PATCH', 'WOOD_HARVESTC', 'DWT_WOOD_PRODUCTC_GAIN_PATCH', 'SLASH_HARVESTC', 'COL_FIRE_CLOSS', 'DWT_SLASH_CFLUX', 'FROOTC:I', 'HTOP'
+hist_fincl3 += 'GPP', 'NPP', 'AR', 'HR', 'DWT_CONV_CFLUX_PATCH', 'WOOD_HARVESTC', 'DWT_WOOD_PRODUCTC_GAIN_PATCH', 'SLASH_HARVESTC', 'COL_FIRE_CLOSS', 'FROOTC:I', 'HTOP'
 
 ! h3 stream (yearly average, gridcell-level)
 hist_fincl4 += 'SOILC_vr', 'SOILN_vr', 'CWDC_vr', 'LITR1C_vr', 'LITR2C_vr', 'LITR3C_vr', 'LITR1N_vr', 'LITR2N_vr', 'LITR3N_vr','CWDN_vr', 'TOTLITC:I', 'TOT_WOODPRODC:I', 'TOTSOMC:I','TOTVEGC:I'

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,125 @@
 ===============================================================
+Tag name:  ctsm1.0.dev063
+Originator(s):  erik (Erik Kluzek)
+Date: Thu Sep  5 21:28:02 MDT 2019
+One-line Summary: Two answer changing fixes (fire, DWT_SLASH) and fix for urban streams for Clm45
+
+Purpose of changes
+------------------
+
+Fire bug fix and DWT_SLASH change and fix urban stream years for clm4_5.
+The latitude used in an expression for Bgc-Fire model Li2016 (used in Clm50)
+had latitude in degrees rather than in radians as it should have been. The
+term is used for ignition and the cosine was being taken in degrees rather 
+than radians, hence the spatial pattern for ignition with latitude was incorrect.
+
+The history field DWT_SLASH_CFLUX was being calculated on the column, but 
+really should have been a patch level variable. In the same way other fields
+were handled we made DWT_SLASH_CFLUX a grid-cell variable, and added
+DWT_SLASH_CFLUX_PATCH on the patch level that could be added to output. The same
+is true of the C13_ and C14_ versions of it.
+
+Clm45 was setting urbantv to year 2000, rather than 1850 or historical as it should
+have. The urbantv file for Clm45 doesn't actually change, so this doesn't actually
+make a difference. But, it does make the namelist look wrong.
+
+Note, that SP cases, Vic cases and Fates cases do NOT change answers. Or if fire is
+off, or certain single-point cases. Some cold-start cases don't seem to be sensitive
+to it either.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): #175, #787, #780
+  fixes #175 urban stream years for clm4_5
+  fixes #787 DWT_SLASH field
+  fixes #780 Bug in CN Fire Li 2016 which used latitude in degrees rather than radians
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values): Defaults for urbantv for clm4_5
+
+Changes to the datasets (e.g., parameter, surface or initial files): None
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): None
+
+Changes to tests or testing: None
+
+Code reviewed by: self, @olywon
+
+
+CTSM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (62 compare fail due to namelist changes)
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    izumi ------- OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here: previous
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes!
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: Clm50Bgc and some Clm45Bgc cases
+    - what platforms/compilers: All
+    - nature of change: similar climate (but fire ignition pattern changes by latitude)
+        DWT_SLASH_* history fields change because moved to gridcell quantity (so change is relatively minor)
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: 
+           oleson/clm50_cesm20R_2deg_GSWP3V1_issue780_hist (for the fire change)
+
+   URL for LMWG diagnostics output used to validate new climate:
+http://webext.cgd.ucar.edu/I20TR/clm50_cesm20R_2deg_GSWP3V1_issue780_hist/lnd/clm50_cesm20R_2deg_GSWP3V1_issue780_hist.1995_2014-clm50_cesm20R_2deg_GSWP3V1_hist.1995_2014/setsIndex.html
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids): #802
+(https://github.com/ESCOMP/ctsm/pull)
+   #802 -- Three answer changing fixes (fire, DWT_SLASH, urban streams for clm4_5)
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev062
 Originator(s):  sacks (Bill Sacks)
 Date: Tue Sep  3 16:04:28 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev063     erik 09/05/2019 Two answer changing fixes (fire, DWT_SLASH) and fix for urban streams for Clm45
   ctsm1.0.dev062    sacks 09/03/2019 Move hobart tests to izumi
   ctsm1.0.dev061     erik 09/01/2019 Simple b4b fixes: new params file, remove override_nsrest/anoxia_wtsat, DV deprecated
   ctsm1.0.dev060    sacks 08/29/2019 In SnowWater, truncate small h2osoi residuals

--- a/src/biogeochem/CNFireLi2016Mod.F90
+++ b/src/biogeochem/CNFireLi2016Mod.F90
@@ -607,7 +607,7 @@ contains
               end if
               lh       = pot_hmn_ign_counts_alpha*6.8_r8*hdmlf**(0.43_r8)/30._r8/24._r8
               fs       = 1._r8-(0.01_r8+0.98_r8*exp(-0.025_r8*hdmlf))
-              ig       = (lh+this%forc_lnfm(g)/(5.16_r8+2.16_r8*cos(3*min(60._r8,abs(grc%latdeg(g)))))*0.22_r8)  &
+              ig       = (lh+this%forc_lnfm(g)/(5.16_r8+2.16_r8*cos(SHR_CONST_PI/180._r8*3*min(60._r8,abs(grc%latdeg(g)))))*0.22_r8)  &
                          *(1._r8-fs)*(1._r8-cropf_col(c))
               nfire(c) = ig/secsphr*fb*fire_m*lgdp_col(c) !fire counts/km2/sec
               Lb_lf    = 1._r8+10._r8*(1._r8-EXP(-0.06_r8*forc_wind(g)))

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -263,7 +263,8 @@ module CNVegCarbonFluxType
      real(r8), pointer :: dwt_conv_cflux_dribbled_grc               (:)     ! (gC/m2/s) dwt_conv_cflux_grc dribbled evenly throughout the year
      real(r8), pointer :: dwt_wood_productc_gain_patch              (:)     ! (gC/m2/s) addition to wood product pools from landcover change; although this is a patch-level flux, it is expressed per unit GRIDCELL area
      real(r8), pointer :: dwt_crop_productc_gain_patch              (:)     ! (gC/m2/s) addition to crop product pools from landcover change; although this is a patch-level flux, it is expressed per unit GRIDCELL area
-     real(r8), pointer :: dwt_slash_cflux_col                       (:)     ! (gC/m2/s) conversion slash flux due to landcover change
+     real(r8), pointer :: dwt_slash_cflux_patch                     (:)     ! (gC/m2/s) conversion slash flux due to landcover change
+     real(r8), pointer :: dwt_slash_cflux_grc                       (:)     ! (gC/m2/s) dwt_slash_cflux_patch summed to the gridcell-level
      real(r8), pointer :: dwt_frootc_to_litr_met_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_cel_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
      real(r8), pointer :: dwt_frootc_to_litr_lig_c_col              (:,:)   ! (gC/m3/s) fine root to litter due to landcover change
@@ -629,7 +630,8 @@ contains
     allocate(this%harvest_c_to_litr_lig_c_col       (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_litr_lig_c_col  (:,:)=nan
     allocate(this%harvest_c_to_cwdc_col             (begc:endc,1:nlevdecomp_full)); this%harvest_c_to_cwdc_col        (:,:)=nan
 
-    allocate(this%dwt_slash_cflux_col               (begc:endc))                  ; this%dwt_slash_cflux_col (:) =nan
+    allocate(this%dwt_slash_cflux_patch             (begp:endp))                  ; this%dwt_slash_cflux_patch        (:) =nan
+    allocate(this%dwt_slash_cflux_grc               (begg:endg))                  ; this%dwt_slash_cflux_grc          (:) =nan
     allocate(this%dwt_frootc_to_litr_met_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_met_c_col (:,:)=nan
     allocate(this%dwt_frootc_to_litr_cel_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_cel_c_col (:,:)=nan
     allocate(this%dwt_frootc_to_litr_lig_c_col      (begc:endc,1:nlevdecomp_full)); this%dwt_frootc_to_litr_lig_c_col (:,:)=nan
@@ -2876,10 +2878,19 @@ contains
             '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
             ptr_patch=this%dwt_wood_productc_gain_patch, default='inactive')
 
-        this%dwt_slash_cflux_col(begc:endc) = spval
-        call hist_addfld1d (fname='DWT_SLASH_CFLUX', units='gC/m^2/s', &
-             avgflag='A', long_name='slash C flux to litter and CWD due to land use', &
-             ptr_col=this%dwt_slash_cflux_col)
+       this%dwt_slash_cflux_grc(begg:endg) = spval
+       call hist_addfld1d (fname='DWT_SLASH_CFLUX', units='gC/m^2/s', &
+            avgflag='A', &
+            long_name='slash C flux (to litter diagnostic only) (0 at all times except first timestep of year)', &
+            ptr_gcell=this%dwt_slash_cflux_grc)
+
+       this%dwt_slash_cflux_patch(begp:endp) = spval
+       call hist_addfld1d (fname='DWT_SLASH_CFLUX_PATCH', units='gC/m^2/s', &
+            avgflag='A', &
+            long_name='patch-level slash C flux (to litter diagnostic only) ' // &
+            '(0 at all times except first timestep of year) ' // &
+            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='DWT_FROOTC_TO_LITR_MET_C', units='gC/m^2/s',  type2d='levdcmp', &
@@ -3050,10 +3061,19 @@ contains
             long_name='C13 conversion C flux (immediate loss to atm), dribbled throughout the year', &
             ptr_gcell=this%dwt_conv_cflux_dribbled_grc, default='inactive')
 
-       this%dwt_slash_cflux_col(begc:endc) = spval
-       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX', units='gC/m^2/s', &
-            avgflag='A', long_name='C13 slash C flux to litter and CWD due to land use', &
-            ptr_col=this%dwt_slash_cflux_col, default='inactive')
+       this%dwt_slash_cflux_grc(begg:endg) = spval
+       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX', units='gC13/m^2/s', &
+            avgflag='A', long_name='C13 slash C flux (to litter diagnostic only)' // &
+            '(0 at all times except first timestep of year)', &
+            ptr_gcell=this%dwt_slash_cflux_grc, default='inactive')
+
+       this%dwt_slash_cflux_patch(begp:endp) = spval
+       call hist_addfld1d (fname='C13_DWT_SLASH_CFLUX_PATCH', units='gC13/m^2/s', &
+            avgflag='A', &
+            long_name='patch-level C13 slash C flux (to litter diagnostic only) ' // &
+            '(0 at all times except first timestep of year) ' // &
+            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='C13_DWT_FROOTC_TO_LITR_MET_C', units='gC13/m^2/s',  type2d='levdcmp', &
@@ -3206,10 +3226,19 @@ contains
             long_name='C14 conversion C flux (immediate loss to atm), dribbled throughout the year', &
             ptr_gcell=this%dwt_conv_cflux_dribbled_grc, default='inactive')
 
-       this%dwt_slash_cflux_col(begc:endc) = spval
-       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX', units='gC/m^2/s', &
-            avgflag='A', long_name='C14 slash C flux to litter and CWD due to land use', &
-            ptr_col=this%dwt_slash_cflux_col, default='inactive')
+       this%dwt_slash_cflux_grc(begg:endg) = spval
+       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX', units='gC14/m^2/s', &
+            avgflag='A', long_name='C14 slash C flux (to litter diagnostic only)' // &
+            '(0 at all times except first timestep of year)', &
+            ptr_gcell=this%dwt_slash_cflux_grc, default='inactive')
+
+       this%dwt_slash_cflux_patch(begp:endp) = spval
+       call hist_addfld1d (fname='C14_DWT_SLASH_CFLUX_PATCH', units='gC14/m^2/s', &
+            avgflag='A', &
+            long_name='patch-level C14 slash C flux (to litter diagnostic only)' // &
+            '(0 at all times except first timestep of year) ' // &
+            '(per-area-gridcell; only makes sense with dov2xy=.false.)', &
+            ptr_patch=this%dwt_slash_cflux_patch, default='inactive')
 
        this%dwt_frootc_to_litr_met_c_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='C14_DWT_FROOTC_TO_LITR_MET_C', units='gC14/m^2/s',  type2d='levdcmp', &
@@ -3364,7 +3393,6 @@ contains
        ! also initialize dynamic landcover fluxes so that they have
        ! real values on first timestep, prior to calling pftdyn_cnbal
        if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
-          this%dwt_slash_cflux_col(c) = 0._r8
           do j = 1, nlevdecomp_full
              this%dwt_frootc_to_litr_met_c_col(c,j) = 0._r8
              this%dwt_frootc_to_litr_cel_c_col(c,j) = 0._r8
@@ -3965,10 +3993,7 @@ contains
        this%dwt_seedc_to_leaf_grc(g)        = 0._r8
        this%dwt_seedc_to_deadstem_grc(g)    = 0._r8
        this%dwt_conv_cflux_grc(g)           = 0._r8
-    end do
-
-    do c = bounds%begc,bounds%endc
-       this%dwt_slash_cflux_col(c)              = 0._r8
+       this%dwt_slash_cflux_grc(g)           = 0._r8
     end do
 
     do j = 1, nlevdecomp_full

--- a/src/biogeochem/dynConsBiogeochemMod.F90
+++ b/src/biogeochem/dynConsBiogeochemMod.F90
@@ -587,36 +587,6 @@ contains
     end do
     
 
-    ! calculate patch-to-column slash fluxes into litter and CWD pools
-    do p = bounds%begp, bounds%endp
-       c = patch%column(p)
-
-       ! fine and coarse root to litter and CWD slash carbon fluxes
-       cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
-               cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
-               dwt_frootc_to_litter(p)/dt + &
-               dwt_livecrootc_to_litter(p)/dt + &
-               dwt_deadcrootc_to_litter(p)/dt
-
-       if ( use_c13 ) then
-          c13_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
-                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
-                  dwt_frootc13_to_litter(p)/dt + &
-                  dwt_livecrootc13_to_litter(p)/dt + &
-                  dwt_deadcrootc13_to_litter(p)/dt
-       endif
-
-       if ( use_c14 ) then
-          c14_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) = &
-                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_col(c) + &
-                  dwt_frootc14_to_litter(p)/dt + &
-                  dwt_livecrootc14_to_litter(p)/dt + &
-                  dwt_deadcrootc14_to_litter(p)/dt
-       endif
-
-    end do
-
-    
     ! calculate patch-to-column for fluxes into litter and CWD pools
     do j = 1, nlevdecomp
        do p = bounds%begp, bounds%endp
@@ -787,6 +757,46 @@ contains
 
     end do
 
+       ! calculate patch-to-gridcell slash fluxes into litter and CWD pools
+       ! Note that patch-level fluxes are stored per unit GRIDCELL area - thus, we don't
+       ! need to multiply by the patch's gridcell weight when translating patch-level
+       ! fluxes into gridcell-level fluxes.
+       
+    do p = bounds%begp, bounds%endp
+       g = patch%gridcell(p)
+
+       ! fine and coarse root to litter and CWD slash carbon fluxes
+       cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
+               dwt_frootc_to_litter(p)/dt + &
+               dwt_livecrootc_to_litter(p)/dt + &
+               dwt_deadcrootc_to_litter(p)/dt
+       cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
+               cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
+               cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
+
+       if ( use_c13 ) then
+          c13_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
+                  dwt_frootc13_to_litter(p)/dt + &
+                  dwt_livecrootc13_to_litter(p)/dt + &
+                  dwt_deadcrootc13_to_litter(p)/dt
+          c13_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
+                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
+                  c13_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
+       endif
+
+       if ( use_c14 ) then
+          c14_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p) = &
+                  dwt_frootc14_to_litter(p)/dt + &
+                  dwt_livecrootc14_to_litter(p)/dt + &
+                  dwt_deadcrootc14_to_litter(p)/dt
+          c14_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) = &
+                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_grc(g) + &
+                  c14_cnveg_carbonflux_inst%dwt_slash_cflux_patch(p)
+       endif
+
+    end do
+
+    
     ! Deallocate patch-level flux arrays
     deallocate(dwt)
     deallocate(dwt_leafc_seed)


### PR DESCRIPTION
### Description of changes

Fire bug fix and DWT_SLASH change and fix urban stream years for clm4_5.

### Specific notes

Contributors other than yourself, if any: @lawrencepj1 @olyson 

CTSM Issues Fixed (include github issue #): #175, #787, #780
  fixes #175 urban stream years for clm4_5
  fixes #787 DWT_SLASH field
  fixes #780 Bug in CN Fire Li 2016 which used latitude in degrees rather than radians

Are answers expected to change (and if so in what way)? Yes
   clm5_0 BGC simulations fire ignition changes due to difference in cosine(lat) with
     latitude properly in radian's rather than in degrees
     A few fields associated with DWT_SLASH change by a small amount due to the averaging
     difference for a few cases

Any User Interface Changes (namelist or namelist defaults changes)? N

Testing performed, if any: regular
  Running standard testing on cheyenne and izumi
