### PR TITLE
fix for 0D variable pio interface

### DIFF
--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -1291,7 +1291,6 @@ contains
        else
           idata1d(1) = 0
        end if
-!       status = pio_put_var(ncid, varid, start(1:1), count(1:1), idata1d)
        status = pio_put_var(ncid, varid, idata1d)
        deallocate(idata1d)
 #elif ({DIMS}==1)

--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -1291,7 +1291,8 @@ contains
        else
           idata1d(1) = 0
        end if
-       status = pio_put_var(ncid, varid, start(1:1), count(1:1), idata1d)
+!       status = pio_put_var(ncid, varid, start(1:1), count(1:1), idata1d)
+       status = pio_put_var(ncid, varid, idata1d)
        deallocate(idata1d)
 #elif ({DIMS}==1)
        start(1) = 1 ; count(1) = size(data)
@@ -1393,7 +1394,7 @@ contains
        start(1) = 1  ; count(1) = 1
        if (present(nt)) start(1) = nt
        temp(1) = data
-       status = pio_put_var(ncid, varid, start(1:1), count(1:1), temp)
+       status = pio_put_var(ncid, varid, temp)
 #elif ({DIMS}==1)
        start(1) = 1 ; count(1) = size(data)
        start(2) = 1 ; count(2) = 1


### PR DESCRIPTION
### 
remove start and count arguments from 0D variable interface to PIO

### 
This bug shows up when using PIO_VERSION=2 and DEBUG=TRUE

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)? NO

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
Tested with case f19_f19_mg17.I2000Clm50SpGs using both PIO versions and with and without DEBUG=TRUE

(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
