### PR TITLE
Correct frac_sno = 0 for lakes on old initial conditions files

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,167 @@
 ===============================================================
+Tag name:  ctsm1.0.dev074
+Originator(s):  sacks (Bill Sacks)
+Date:  Wed Oct 23 19:25:21 MDT 2019
+One-line Summary: For lakes: when reading finidat, set frac_sno=1 if h2osno_total > 0
+
+Purpose of changes
+------------------
+
+Due to ESCOMP/ctsm#783, frac_sno used to be 0 for all lake points. That
+was mostly fixed, but the issue is still present on initial conditions
+files that were generated prior to that fix (which includes most or all
+of our out-of-the-box restart files). This causes frac_sno to be 0 for
+lake points at the start of the simulation, even if there is a snow pack
+present. Currently this doesn't cause significant problems, but I'd like
+to change the calculation of frac_sno_eff so that it is 0 if frac_sno is
+0 - and then this frac_sno problem becomes an issue (causing divide by 0
+in at least one place).
+
+However, further problems were introduced if I tried to always apply
+this correction: It appears that sometimes the restart file legitimately
+has frac_sno == 0 for lake columns with non-zero snow cover. To avoid
+changing answers for newer restart files, I am writing metadata to the
+restart file documenting whether the fix has already been applied on
+that restart file, and if so, we avoid reapplying the fix.
+
+Getting this restart metadata correct was tricky, especially when
+running init_interp. I have introduced a new module to encapsulate this
+complexity. This can be used in general for writing / reading metadata
+on which issues have been fixed on a given restart file.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): [If none, remove this line]
+- Resolves ESCOMP/ctsm#783
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+- The setting of initial lake frac_sno to 1 isn't exactly correct, but
+  it's better than the old value of 0.
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+- I didn't check the PFS test, but the only change that could have
+  likely led to performance changes was the addition of a metadata copy
+  in init_interp. I checked the timing of this piece, and found it to be
+  a negligible portion of the total init_interp time
+  (https://github.com/ESCOMP/CTSM/pull/825#issuecomment-545219601).
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by: Erik Kluzek gave this an initial look and gave general
+approval for the restart file metadata mechanism I have added. He may
+give it a more careful look, possibly accompanied by a further cleanup
+tag addressing any issues he finds.
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  tools-tests (test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - not run
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - not run
+
+  regular tests (aux_clm):
+
+    cheyenne ---- ok
+    izumi ------- ok
+
+    ok means tests passed, baselines fail as expected.
+
+    Note that the FUNIT test failed initially; I got it passing on my
+    Mac, but didn't rerun it on cheyenne.
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: all
+    - what platforms/compilers: all
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+      Larger than roundoff/same climate
+
+      The only change is in initial lake frac_sno. This should only
+      affect the start of the simulation, and only over lake points. I
+      verified that changes are only over lake points via: For both
+      SMS_D_Ld1.f09_g17.I1850Clm50Sp.cheyenne_intel.clm-default (which
+      doesn't use init_interp) and
+      SMS_D_Ld3.f10_f10_musgs.I2000Clm50BgcCruGs.cheyenne_gnu.clm-default
+      (which uses init_interp): I checked which points have differences
+      in FSH in the h1 (vector) history file. Diffs were only over lake
+      points.
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff? N/A
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: N/A
+
+   URL for LMWG diagnostics output used to validate new climate: N/A
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/CTSM/pull/825
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev073
 Originator(s):  sacks (Bill Sacks)
 Date:  Tue Oct 22 06:14:24 MDT 2019

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev074    sacks 10/23/2019 For lakes: when reading finidat, set frac_sno=1 if h2osno_total > 0
   ctsm1.0.dev073    sacks 10/22/2019 Fix bug in calculation of dqgdT
   ctsm1.0.dev072 mvertens 10/15/2019 Add NUOPC cap
   ctsm1.0.dev071    sacks 10/11/2019 Split CanopyTemperature into separate pieces

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -775,7 +775,7 @@ contains
     character(len=*), parameter :: subname = 'RestartBackcompatIssue783'
     !-----------------------------------------------------------------------
 
-    if (flag == 'write') then
+    if (flag == 'define') then
        call ncd_putatt(ncid, ncd_global, att_name, 1)
 
     else if (flag == 'read' .and. .not. is_restart()) then

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -615,6 +615,7 @@ contains
     use clm_time_manager , only : is_first_step, is_restart
     use clm_varctl       , only : bound_h2osoi
     use ncdio_pio        , only : file_desc_t, ncd_io, ncd_double
+    use ncdio_pio        , only : ncd_putatt, ncd_getatt, check_att, ncd_global
     use restUtilMod
     !
     ! !ARGUMENTS:
@@ -627,6 +628,9 @@ contains
     ! !LOCAL VARIABLES:
     logical  :: readvar
     integer  :: fc, c
+    logical  :: issue_783_att_found
+    integer  :: issue_783_fixed_val
+    logical  :: issue_783_do_correction
     real(r8) :: h2osno_total(bounds%begc:bounds%endc)  ! total snow water (mm H2O)
     type(filter_col_type) :: filter_lakec  ! filter for lake columns
     !------------------------------------------------------------------------
@@ -680,35 +684,58 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%frac_sno_col)
     ! BACKWARDS_COMPATIBILITY(wjs, 2019-10-15) Due to ESCOMP/ctsm#783, old restart files
     ! can have frac_sno == 0 for lake points despite having a snow pack. This can cause
-    ! other problems, so fix that here. (This mainly impacts restart files produced by
-    ! versions prior to the initial fix of ESCOMP/ctsm#783 - i.e., prior to
-    ! ctsm1.0.dev057. However, in principle, restart files produced by versions after that
-    ! tag could still have this issue, since this backwards compatibility code wasn't in
-    ! place at that point, so frac_sno could have persisted at 0 if there were no new snow
-    ! since the last restart file was written. So, to be safe, this backwards
-    ! compatibility code should be left in place until we can rely on all restart files
-    ! being from versions later than the tag where this backwards compatibility was first
-    ! implemented.)
-    if (flag == 'read' .and. .not. is_restart()) then
-       filter_lakec = col_filter_from_ltypes( &
-            bounds = bounds, &
-            ltypes = [istdlak], &
-            include_inactive = .true.)
-       call waterstatebulk_inst%CalculateTotalH2osno( &
-            bounds = bounds, &
-            num_c = filter_lakec%num, &
-            filter_c = filter_lakec%indices, &
-            caller = 'WaterDiagnosticBulkType_RestartBulk', &
-            h2osno_total = h2osno_total(bounds%begc:bounds%endc))
-       do fc = 1, filter_lakec%num
-          c = filter_lakec%indices(fc)
-          if (this%frac_sno_col(c) == 0._r8 .and. h2osno_total(c) > 0._r8) then
-             ! Often the value should be between 0 and 1 rather than being 1, but 1 is at
-             ! least better than 0 in this case, and it would be tricky or impossible to
-             ! figure out the "correct" value.
-             this%frac_sno_col(c) = 1._r8
+    ! other problems, so fix that here. However, it is apparently possible for frac_sno to
+    ! be 0 legitimately when h2osno_total > 0. So if we apply this correction always, then
+    ! we sometimes introduce unintentional changes to newer restart files where we don't
+    ! actually need to apply this correction. We avoid this by writing metadata to the
+    ! restart file indicating that it's new enough to have this correction already in
+    ! place, then avoiding doing the correction here if we find we're working with a
+    ! new-enough restart file.
+    !
+    ! This backwards compatibility code can be removed once we can rely on all restart
+    ! files being new enough. i.e., we can remove this code once we can rely all restart
+    ! files having this new piece of metadata (at which point we can also stop writing
+    ! this metadata, as long as we don't need to use newer restart files with older code
+    ! versions).
+    if (flag == 'write') then
+       call ncd_putatt(ncid, ncd_global, 'issue_783_fixed', 1)
+    else if (flag == 'read' .and. .not. is_restart()) then
+       call check_att(ncid, ncd_global, 'issue_783_fixed', issue_783_att_found)
+       if (issue_783_att_found) then
+          ! It's probably sufficient just to know that the issue_783_fixed attribute is
+          ! on the file. But since this feels like a logical variable, it feels best to
+          ! also make sure that its value is true.
+          call ncd_getatt(ncid, ncd_global, 'issue_783_fixed', issue_783_fixed_val)
+          if (issue_783_fixed_val == 0) then
+             issue_783_do_correction = .true.
+          else
+             issue_783_do_correction = .false.
           end if
-       end do
+       else
+          issue_783_do_correction = .true.
+       end if
+
+       if (issue_783_do_correction) then
+          filter_lakec = col_filter_from_ltypes( &
+               bounds = bounds, &
+               ltypes = [istdlak], &
+               include_inactive = .true.)
+          call waterstatebulk_inst%CalculateTotalH2osno( &
+               bounds = bounds, &
+               num_c = filter_lakec%num, &
+               filter_c = filter_lakec%indices, &
+               caller = 'WaterDiagnosticBulkType_RestartBulk', &
+               h2osno_total = h2osno_total(bounds%begc:bounds%endc))
+          do fc = 1, filter_lakec%num
+             c = filter_lakec%indices(fc)
+             if (this%frac_sno_col(c) == 0._r8 .and. h2osno_total(c) > 0._r8) then
+                ! Often the value should be between 0 and 1 rather than being 1, but 1 is at
+                ! least better than 0 in this case, and it would be tricky or impossible to
+                ! figure out the "correct" value.
+                this%frac_sno_col(c) = 1._r8
+             end if
+          end do
+       end if
     end if
 
     call restartvar(ncid=ncid, flag=flag, &

--- a/src/biogeophys/WaterType.F90
+++ b/src/biogeophys/WaterType.F90
@@ -712,7 +712,7 @@ contains
 
 
   !-----------------------------------------------------------------------
-  subroutine Restart(this, bounds, ncid, flag, &
+  subroutine Restart(this, bounds, ncid, flag, writing_finidat_interp_dest_file, &
        watsat_col)
     !
     ! !DESCRIPTION:
@@ -723,6 +723,7 @@ contains
     type(bounds_type), intent(in)    :: bounds
     type(file_desc_t), intent(inout) :: ncid   ! netcdf id
     character(len=*) , intent(in)    :: flag   ! 'read', 'write' or 'define'
+    logical          , intent(in)    :: writing_finidat_interp_dest_file ! true if we are writing a finidat_interp_dest file (ignored for flag=='read')
     real(r8)         , intent(in)    :: watsat_col (bounds%begc:, 1:)  ! volumetric soil water at saturation (porosity)
     !
     ! !LOCAL VARIABLES:
@@ -739,6 +740,7 @@ contains
          watsat_col=watsat_col(bounds%begc:bounds%endc,:))
 
     call this%waterdiagnosticbulk_inst%restartBulk (bounds, ncid, flag=flag, &
+         writing_finidat_interp_dest_file=writing_finidat_interp_dest_file, &
          waterstatebulk_inst = this%waterstatebulk_inst)
 
     do i = this%tracers_beg, this%tracers_end

--- a/src/biogeophys/WaterType.F90
+++ b/src/biogeophys/WaterType.F90
@@ -738,7 +738,8 @@ contains
     call this%waterstatebulk_inst%restartBulk (bounds, ncid, flag=flag, &
          watsat_col=watsat_col(bounds%begc:bounds%endc,:))
 
-    call this%waterdiagnosticbulk_inst%restartBulk (bounds, ncid, flag=flag)
+    call this%waterdiagnosticbulk_inst%restartBulk (bounds, ncid, flag=flag, &
+         waterstatebulk_inst = this%waterstatebulk_inst)
 
     do i = this%tracers_beg, this%tracers_end
 

--- a/src/init_interp/initInterp.F90
+++ b/src/init_interp/initInterp.F90
@@ -23,6 +23,7 @@ module initInterpMod
   use abortutils     , only: endrun
   use spmdMod        , only: masterproc
   use restUtilMod    , only: iflag_interp, iflag_copy, iflag_skip, iflag_area
+  use IssueFixedMetadataHandler, only : copy_issue_fixed_metadata
   use glcBehaviorMod , only: glc_behavior_type
   use ncdio_utils    , only: find_var_on_file
   use ncdio_pio
@@ -39,6 +40,7 @@ module initInterpMod
 
   ! Private methods
 
+  private :: copy_metadata
   private :: check_dim_subgrid
   private :: check_dim_level
   private :: skip_var
@@ -233,6 +235,8 @@ contains
 
     call ncd_pio_openfile (ncidi, trim(filei) , 0)
     call ncd_pio_openfile (ncido, trim(fileo),  ncd_write)
+
+    call copy_metadata(ncidi, ncido)
 
     call check_interp_non_ciso_to_ciso(ncidi)
 
@@ -695,6 +699,28 @@ contains
     end if
 
   end subroutine initInterp
+
+  !-----------------------------------------------------------------------
+  subroutine copy_metadata(ncidi, ncido)
+    !
+    ! !DESCRIPTION:
+    ! Copy any necessary global metadata from the input file to the output file
+    !
+    ! !ARGUMENTS:
+    type(file_desc_t), intent(inout) :: ncidi ! input (source) file
+    type(file_desc_t), intent(inout) :: ncido ! output (destination) file
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'copy_metadata'
+    !-----------------------------------------------------------------------
+
+    call ncd_redef(ncido)
+    call copy_issue_fixed_metadata(ncidi, ncido)
+    call ncd_enddef(ncido)
+
+  end subroutine copy_metadata
+
 
   !-----------------------------------------------------------------------
   function skip_var(iflag_interpinic)

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1294,7 +1294,8 @@ contains
           call t_startf('clm_drv_io_wrest')
           filer = restFile_filename(rdate=rdate)
 
-          call restFile_write( bounds_proc, filer, rdate=rdate )
+          call restFile_write( bounds_proc, filer, &
+               writing_finidat_interp_dest_file=.false., rdate=rdate )
 
           call t_stopf('clm_drv_io_wrest')
        end if

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -575,7 +575,7 @@ contains
        end if
 
        ! Create new template file using cold start
-       call restFile_write(bounds_proc, finidat_interp_dest)
+       call restFile_write(bounds_proc, finidat_interp_dest, writing_finidat_interp_dest_file=.true.)
 
        ! Interpolate finidat onto new template file
        call getfil( finidat_interp_source, fnamer,  0 )

--- a/src/main/clm_instMod.F90
+++ b/src/main/clm_instMod.F90
@@ -471,7 +471,7 @@ contains
   end subroutine clm_instInit
 
   !-----------------------------------------------------------------------
-  subroutine clm_instRest(bounds, ncid, flag)
+  subroutine clm_instRest(bounds, ncid, flag, writing_finidat_interp_dest_file)
     !
     ! !USES:
     use ncdio_pio       , only : file_desc_t
@@ -487,6 +487,7 @@ contains
     
     type(file_desc_t) , intent(inout) :: ncid ! netcdf id
     character(len=*)  , intent(in)    :: flag ! 'define', 'write', 'read' 
+    logical           , intent(in)    :: writing_finidat_interp_dest_file ! true if we are writing a finidat_interp_dest file (ignored for flag=='read')
 
     ! Local variables
     integer                           :: nc, nclumps
@@ -521,6 +522,7 @@ contains
     call soilstate_inst%restart (bounds, ncid, flag=flag)
 
     call water_inst%restart(bounds, ncid, flag=flag, &
+         writing_finidat_interp_dest_file = writing_finidat_interp_dest_file, &
          watsat_col = soilstate_inst%watsat_col(bounds%begc:bounds%endc,:))
 
     call irrigation_inst%restart (bounds, ncid, flag=flag)

--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -26,9 +26,9 @@ module ncdio_pio
   use mct_mod        , only : mct_gsMap, mct_gsMap_lsize, mct_gsMap_gsize, mct_gsMap_orderedPoints
   use pio            , only : file_desc_t, io_desc_t, iosystem_desc_t
   use pio            , only : pio_bcast_error, pio_char, pio_clobber, pio_closefile, pio_createfile, pio_def_dim
-  use pio            , only : pio_def_var, pio_double, pio_enddef, pio_get_att, pio_get_var, pio_global, pio_initdecomp
+  use pio            , only : pio_def_var, pio_double, pio_redef, pio_enddef, pio_get_att, pio_get_var, pio_global, pio_initdecomp
   use pio            , only : pio_inq_att, pio_inq_dimid, pio_inq_dimlen, pio_inq_dimname, pio_inq_vardimid, pio_inq_varid
-  use pio            , only : pio_inq_varname, pio_inq_varndims, pio_inquire, pio_int, pio_internal_error
+  use pio            , only : pio_inq_attname, pio_inq_varname, pio_inq_varndims, pio_inquire, pio_int, pio_internal_error
   use pio            , only : pio_noclobber, pio_noerr, pio_nofill, pio_nowrite, pio_offset_kind, pio_openfile
   use pio            , only : pio_put_att, pio_put_var, pio_read_darray, pio_real, pio_seterrorhandling
   use pio            , only : pio_setframe, pio_unlimited, pio_write, pio_write_darray, var_desc_t
@@ -48,7 +48,10 @@ module ncdio_pio
   public :: ncd_pio_createfile ! create a new file
   public :: ncd_pio_closefile  ! close a file
   public :: ncd_pio_init       ! called from clm_comp
+  public :: ncd_redef          ! re-enter define mode
   public :: ncd_enddef         ! end define mode
+  public :: ncd_inqnatts       ! inquire number of global attributes
+  public :: ncd_inqattname     ! inquire attribute name, given attribute number
   public :: ncd_putatt         ! put attribute
   public :: ncd_getatt         ! get attribute
   public :: ncd_defdim         ! define dimension
@@ -369,6 +372,25 @@ contains
     end if
 
   end subroutine check_dim
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_redef(ncid)
+    !
+    ! !DESCRIPTION:
+    ! Re-enter define mode for this netcdf file
+    !
+    ! Remember to call ncd_enddef when finished
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t),intent(inout) :: ncid      ! netcdf file id
+    !
+    ! !LOCAL VARIABLES:
+    integer :: status   ! error status
+    !-----------------------------------------------------------------------
+
+    status = PIO_redef(ncid)
+
+  end subroutine ncd_redef
 
   !-----------------------------------------------------------------------
   subroutine ncd_enddef(ncid)
@@ -803,6 +825,47 @@ contains
 
   end subroutine ncd_inqvdname_byName
 
+  !-----------------------------------------------------------------------
+  subroutine ncd_inqnatts(ncid, nattributes)
+    !
+    ! !DESCRIPTION:
+    ! Inquire number of global attributes
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t), intent(inout) :: ncid ! netcdf file id
+    integer           , intent(out)   :: nattributes ! number of global attributes
+    !
+    ! !LOCAL VARIABLES:
+    integer :: status
+
+    character(len=*), parameter :: subname = 'ncd_inqnatts'
+    !-----------------------------------------------------------------------
+
+    status = PIO_inquire(ncid, nattributes=nattributes)
+
+  end subroutine ncd_inqnatts
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_inqattname(ncid, varid, attnum, attname)
+    !
+    ! !DESCRIPTION:
+    ! Inquire attribute name, given attribute number
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t) , intent(inout) :: ncid   ! netcdf file id
+    integer            , intent(in)    :: varid  ! netcdf var id (can be ncd_global)
+    integer            , intent(in)    :: attnum ! attribute number
+    character(len=*)   , intent(out) :: attname
+    !
+    ! !LOCAL VARIABLES:
+    integer :: status
+
+    character(len=*), parameter :: subname = 'ncd_inqattname'
+    !-----------------------------------------------------------------------
+
+    status = PIO_inq_attname(ncid, varid, attnum, attname)
+
+  end subroutine ncd_inqattname
 
   !-----------------------------------------------------------------------
   subroutine ncd_putatt_int(ncid,varid,attrib,value,xtype)

--- a/src/main/restFileMod.F90
+++ b/src/main/restFileMod.F90
@@ -63,7 +63,7 @@ module restFileMod
 contains
 
   !-----------------------------------------------------------------------
-  subroutine restFile_write( bounds, file, rdate, noptr)
+  subroutine restFile_write( bounds, file, writing_finidat_interp_dest_file, rdate, noptr)
     !
     ! !DESCRIPTION:
     ! Define/write CLM restart file.
@@ -71,6 +71,7 @@ contains
     ! !ARGUMENTS:
     type(bounds_type) , intent(in)           :: bounds          
     character(len=*)  , intent(in)           :: file  ! output netcdf restart file
+    logical           , intent(in)           :: writing_finidat_interp_dest_file ! true if we are writing a finidat_interp_dest file
     character(len=*)  , intent(in), optional :: rdate ! restart file time stamp for name
     logical           , intent(in), optional :: noptr ! if should NOT write to the restart pointer file
     !
@@ -100,7 +101,8 @@ contains
 
     call accumulRest( ncid, flag='define' )
 
-    call clm_instRest(bounds, ncid, flag='define')
+    call clm_instRest(bounds, ncid, flag='define', &
+         writing_finidat_interp_dest_file=writing_finidat_interp_dest_file)
 
     if (present(rdate)) then 
        call hist_restart_ncd (bounds, ncid, flag='define', rdate=rdate )
@@ -116,7 +118,8 @@ contains
 
     call accumulRest( ncid, flag='write' )
 
-    call clm_instRest(bounds, ncid, flag='write')
+    call clm_instRest(bounds, ncid, flag='write', &
+         writing_finidat_interp_dest_file=writing_finidat_interp_dest_file)
 
     call hist_restart_ncd (bounds, ncid, flag='write' )
 
@@ -191,7 +194,8 @@ contains
 
     call accumulRest( ncid, flag='read' )
 
-    call clm_instRest( bounds_proc, ncid, flag='read' )
+    call clm_instRest( bounds_proc, ncid, flag='read', &
+         writing_finidat_interp_dest_file=.false.)
 
     call restFile_set_derived(bounds_proc, glc_behavior)
 

--- a/src/unit_test_stubs/main/ncdio_pio_fake.F90.in
+++ b/src/unit_test_stubs/main/ncdio_pio_fake.F90.in
@@ -61,8 +61,11 @@ module ncdio_pio
   public :: ncd_inqdlen           ! stub: inquire size of a dimension
   public :: ncd_defvar            ! define variables
   public :: ncd_inqfdims          ! stub: inquire file dimensions
+  public :: ncd_inqnatts          ! stub: inquire number of global attributes
+  public :: ncd_inqattname        ! stub: inquire attribute name
   public :: ncd_getatt            ! stub: get attribute
   public :: ncd_putatt            ! stub: put attribute
+  public :: check_att             ! stub: check attribute
 
   interface file_desc_t
      module procedure constructor  ! initialize a new file_desc_t object
@@ -672,6 +675,47 @@ contains
   end subroutine ncd_inqfdims
 
   !-----------------------------------------------------------------------
+  subroutine ncd_inqnatts(ncid, nattributes)
+    !
+    ! !DESCRIPTION:
+    ! Stub replacement for ncd_inqnatts. This just returns 0.
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t), intent(inout) :: ncid ! netcdf file id
+    integer           , intent(out)   :: nattributes ! number of global attributes
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'ncd_inqnatts'
+    !-----------------------------------------------------------------------
+
+    nattributes = 0
+
+  end subroutine ncd_inqnatts
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_inqattname(ncid, varid, attnum, attname)
+    !
+    ! !DESCRIPTION:
+    ! Stub replacement for ncd_inqattname. This just returns an empty string.
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t) , intent(inout) :: ncid   ! netcdf file id
+    integer            , intent(in)    :: varid  ! netcdf var id (can be ncd_global)
+    integer            , intent(in)    :: attnum ! attribute number
+    character(len=*)   , intent(out) :: attname
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'ncd_inqattname'
+    !-----------------------------------------------------------------------
+
+    attname = ' '
+
+  end subroutine ncd_inqattname
+
+
+  !-----------------------------------------------------------------------
   subroutine ncd_getatt_char(ncid,varid,attrib,value)
     !
     ! !DESCRIPTION:
@@ -768,6 +812,28 @@ contains
 
     ! Do nothing
   end subroutine ncd_putatt_real
+
+
+  !-----------------------------------------------------------------------
+  subroutine check_att(ncid, varid, attrib, att_found)
+    !
+    ! !DESCRIPTION:
+    ! Stub replacement for check_att. This just returns false.
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t),intent(inout) :: ncid      ! netcdf file id
+    integer           ,intent(in)    :: varid     ! netcdf var id
+    character(len=*)  ,intent(in)    :: attrib    ! netcdf attrib
+    logical           ,intent(out)   :: att_found ! true if the attribute was found
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'check_att'
+    !-----------------------------------------------------------------------
+
+    att_found = .false.
+
+  end subroutine check_att
 
 
   ! ======================================================================

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND clm_sources
   clm_time_manager.F90
   quadraticMod.F90
   fileutils.F90
+  IssueFixedMetadataHandler.F90
   NumericsMod.F90
   )
 

--- a/src/utils/IssueFixedMetadataHandler.F90
+++ b/src/utils/IssueFixedMetadataHandler.F90
@@ -1,0 +1,189 @@
+module IssueFixedMetadataHandler
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Handles the writing and reading of netCDF metadata saying whether a given issue has
+  ! been fixed as of the writing of this file.
+  !
+  ! !USES:
+  use clm_varctl , only : iulog
+  use abortutils , only : endrun
+  use ncdio_pio  , only : file_desc_t, ncd_global
+  use ncdio_pio  , only : ncd_putatt, ncd_getatt, check_att
+  use ncdio_pio  , only : ncd_inqnatts, ncd_inqattname
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+  private
+  !
+  ! !PUBLIC MEMBER FUNCTIONS:
+  public :: write_issue_fixed_metadata ! write metadata to a netCDF file indicating that a given issue has been fixed
+  public :: read_issue_fixed_metadata  ! read metadata from a netCDF file indicating whether a given issue has been fixed
+  public :: copy_issue_fixed_metadata  ! copy all issue_fixed metadata from one netCDF file to another
+  !
+  ! !PRIVATE MEMBER FUNCTIONS:
+  private :: issue_fixed_attname  ! get the attribute name indicating whether a given issue has been fixed
+
+  !
+  ! !PRIVATE DATA:
+  character(len=*), parameter, private :: issue_fixed_att_prefix = 'issue_fixed_'  ! all attributes written by this module start with this prefix
+
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine write_issue_fixed_metadata(ncid, writing_finidat_interp_dest_file, &
+       issue_num, attribute_value)
+    !
+    ! !DESCRIPTION:
+    ! Write a global attribute to the given netcdf file, indicating that the given issue has been fixed
+    !
+    ! The netcdf file must be open and in define mode. If this is a finidat_interp_dest
+    ! file, nothing is written: Whether this issue has been fixed will be determined by
+    ! the presence of the attribute on the input file to init_interp.
+    !
+    ! !ARGUMENTS:
+    type(file_desc_t) , intent(inout) :: ncid                             ! netcdf id; must be open in define mode
+    logical           , intent(in)    :: writing_finidat_interp_dest_file ! true if this is a finidat_interp_dest file; if so, we don't write anything to it
+    integer           , intent(in)    :: issue_num                        ! number of the issue for which we're writing metadata
+
+    ! Value to write; if not specified, write 1
+    !
+    ! Note that a 0 value is used in read_issue_fixed_metadata to indicate that the
+    ! attribute wasn't found on the file at all. So you should generally avoid setting
+    ! attribute_value = 0 unless you want the behavior to be the same as if the attribute
+    ! wasn't on the file at all.
+    integer , intent(in), optional   :: attribute_value
+    !
+    ! !LOCAL VARIABLES:
+    integer :: l_attribute_value  ! local version of attribute_value
+    character(len=:), allocatable :: attname
+
+    character(len=*), parameter :: subname = 'write_issue_fixed_metadata'
+    !-----------------------------------------------------------------------
+
+    if (present(attribute_value)) then
+       l_attribute_value = attribute_value
+    else
+       l_attribute_value = 1
+    end if
+
+    attname = issue_fixed_attname(issue_num)
+
+    ! In principle, the caller could do this check. But we do it here because it can be
+    ! very important to avoid writing the metadata to the finidat_interp_dest file, and
+    ! we don't want to rely on the caller remembering to do this check.
+    if (.not. writing_finidat_interp_dest_file) then
+       call ncd_putatt(ncid, ncd_global, attname, l_attribute_value)
+    end if
+
+  end subroutine write_issue_fixed_metadata
+
+  !-----------------------------------------------------------------------
+  subroutine read_issue_fixed_metadata(ncid, issue_num, attribute_value)
+    !
+    ! !DESCRIPTION:
+    ! Read metadata from a netCDF file indicating whether a given issue has been fixed
+    !
+    ! If the given attribute isn't found, returns 0; if it is found, returns the attribute's value
+    !
+    ! Typically, then, the caller can check whether the issue is fixed on the given file
+    ! by checking whether the attribute's value is 0: if it is 0, the issue has NOT been
+    ! fixed; if it is non-zero, the issue has been fixed. (But a particular attribute may
+    ! have more nuanced meanings as well, indicated by different integer values.)
+    !
+    ! !ARGUMENTS:
+    type(file_desc_t), intent(inout) :: ncid ! netcdf id
+    integer          , intent(in)    :: issue_num ! number of the issue for which we're reading metadata
+    integer          , intent(out)   :: attribute_value ! value of the given issue fixed attribute; 0 if not present on file
+    !
+    ! !LOCAL VARIABLES:
+    character(len=:), allocatable :: attname
+    logical :: att_found
+
+    character(len=*), parameter :: subname = 'read_issue_fixed_metadata'
+    !-----------------------------------------------------------------------
+
+    attname = issue_fixed_attname(issue_num)
+    call check_att(ncid, ncd_global, attname, att_found)
+    if (att_found) then
+       call ncd_getatt(ncid, ncd_global, attname, attribute_value)
+    else
+       attribute_value = 0
+    end if
+
+  end subroutine read_issue_fixed_metadata
+
+  !-----------------------------------------------------------------------
+  subroutine copy_issue_fixed_metadata(ncidi, ncido)
+    !
+    ! !DESCRIPTION:
+    ! Copy all issue_fixed metadata from one netCDF file to another
+    !
+    ! !ARGUMENTS:
+    type(file_desc_t), intent(inout) :: ncidi ! input file (source)
+    type(file_desc_t), intent(inout) :: ncido ! output file (destination); must be open in define mode
+    !
+    ! !LOCAL VARIABLES:
+    integer :: input_natts  ! number of attributes on the input file
+    integer :: i
+    character(len=256) :: attname
+    integer :: attribute_value_input
+    integer :: attribute_value_output
+    logical :: already_exists_on_output ! whether the given attribute already exists on the output file
+
+    character(len=*), parameter :: subname = 'copy_issue_fixed_metadata'
+    !-----------------------------------------------------------------------
+
+    call ncd_inqnatts(ncidi, input_natts)
+    do i = 1, input_natts
+       call ncd_inqattname(ncidi, ncd_global, i, attname)
+       if (attname(1:len_trim(issue_fixed_att_prefix)) == trim(issue_fixed_att_prefix)) then
+          call ncd_getatt(ncidi, ncd_global, attname, attribute_value_input)
+          call check_att(ncido, ncd_global, attname, already_exists_on_output)
+          if (already_exists_on_output) then
+             ! Avoid trying to overwrite an existing attribute on the output file. If the
+             ! existing value is the same as the value in the input file, there's nothing
+             ! to do; if the existing value differed, it's unclear what we should do, so
+             ! abort.
+             call ncd_getatt(ncido, ncd_global, attname, attribute_value_output)
+             if (attribute_value_output /= attribute_value_input) then
+                write(iulog,*) subname//' ERROR: Attribute already exists on output file with a different value'
+                write(iulog,*) 'Attribute, input value, output value = ', &
+                     attname, attribute_value_input, attribute_value_output
+                call endrun(subname//' ERROR: Attribute already exists on output file with a different value')
+             end if
+
+          else
+             ! If the attribute doesn't already exist on the output, create it there
+             call ncd_putatt(ncido, ncd_global, attname, attribute_value_input)
+          end if
+       end if
+    end do
+
+  end subroutine copy_issue_fixed_metadata
+
+  !-----------------------------------------------------------------------
+  function issue_fixed_attname(issue_num) result(attname)
+    !
+    ! !DESCRIPTION:
+    ! Get the attribute name indicating whether a given issue has been fixed
+    !
+    ! !ARGUMENTS:
+    character(len=:), allocatable :: attname  ! function result
+    integer, intent(in) :: issue_num
+    !
+    ! !LOCAL VARIABLES:
+    character(len=32) :: issue_num_str
+
+    character(len=*), parameter :: subname = 'issue_fixed_attname'
+    !-----------------------------------------------------------------------
+
+    write(issue_num_str, '(i0)') issue_num
+    attname = issue_fixed_att_prefix // trim(issue_num_str)
+
+  end function issue_fixed_attname
+
+end module IssueFixedMetadataHandler


### PR DESCRIPTION
### Description of changes

Due to #783 , frac_sno used to be 0 for all lake points. That was mostly fixed, but the issue is still present on initial conditions files that were generated prior to that fix (which includes most or all of our out-of-the-box restart files). This causes frac_sno to be 0 for lake points at the start of the simulation, even if there is a snow pack present. Currently this doesn't cause significant problems, but I'd like to change the calculation of frac_sno_eff so that it is 0 if frac_sno is 0 - and then this frac_sno problem becomes an issue (causing divide by 0 in at least one place).

I struggled with how to fix this problem. My initial attempts involved setting frac_sno to 1 for lake points that had frac_sno = 0 on the restart file despite having either (attempt 1) snow_depth > 0 or (attempt 2) h2osno_total > 0. However, both of these attempts led to failures in ERI tests. Presumably there are legitimate cases where frac_sno can be 0 even when snow_depth and/or h2osno_total are > 0, so trying to fix this issue for already-fixed restart files can change answers.

This led me to introduce some metadata on the restart file saying whether this is a new enough restart file to already have the fix in place, and if so, to avoid reapplying the fix. I first thought I'd use the existing version number metadata on the restart file, but I came to feel that that would be less robust due to (1) the need to parse this version number, and more importantly (2) if you haven't fetched recent tags in your local clone (which is often the case for me), then the version number makes it look like you're using an older version of the code than you really are. So I settled on putting a new piece of global metadata on the file specifically saying whether this restart file is new enough to fix this particular issue.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed:
- Fixes #783 

Are answers expected to change (and if so in what way)? YES: Answers will change over lake points due to changing initial frac_sno

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None yet (due to cheyenne being down)
