### PR TITLE
[WIP] top-level cmake build for CTSM and CIME share code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required (VERSION 3.5.2)
+project (ctsm C Fortran)
+
+# Local CMake modules
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/CMakeModules)
+find_package(ESMF REQUIRED)
+
+# cime build
+set(CIME_ROOT "/glade/work/jhamman/lilac/cime")  # TDOO: generalize this
+file(GLOB CIME_SOURCES ${CIME_ROOT}/src/share/streams/*F90
+                       ${CIME_ROOT}/src/share/util/*F90
+                       ${CIME_ROOT}/src/share/esmf_wrf_timemgr/*F90
+                       ${CIME_ROOT}/src/share/streams/*.inc
+                       ${CIME_ROOT}/src/share/util/*.inc
+                       ${CIME_ROOT}/src/share/esmf_wrf_timemgr/*.inc
+                       ${CIME_ROOT}/src/share/streams/*.h
+                       ${CIME_ROOT}/src/share/util/*.h
+                       ${CIME_ROOT}/src/share/esmf_wrf_timemgr/*.h)
+add_library(cime SHARED ${CIME_SOURCES})
+target_link_libraries(cime ESMF)
+
+# ctsm build
+file(GLOB_RECURSE CTSM_SOURCES src/**/*.F90 src/**/*.h src/**/*.inc)
+add_library(ctsm SHARED ${CTSM_SOURCES})
+target_link_libraries(ctsm cime ESMF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,15 +9,16 @@ find_package(ESMF REQUIRED)
 set(CIME_ROOT "/glade/work/jhamman/lilac/cime")  # TDOO: generalize this
 file(GLOB CIME_SOURCES ${CIME_ROOT}/src/share/streams/*F90
                        ${CIME_ROOT}/src/share/util/*F90
+                       ${CIME_ROOT}/src/share/util/*F90.in
                        ${CIME_ROOT}/src/share/esmf_wrf_timemgr/*F90
-                       ${CIME_ROOT}/src/share/streams/*.inc
-                       ${CIME_ROOT}/src/share/util/*.inc
-                       ${CIME_ROOT}/src/share/esmf_wrf_timemgr/*.inc
                        ${CIME_ROOT}/src/share/streams/*.h
                        ${CIME_ROOT}/src/share/util/*.h
                        ${CIME_ROOT}/src/share/esmf_wrf_timemgr/*.h)
 add_library(cime SHARED ${CIME_SOURCES})
 target_link_libraries(cime ESMF)
+
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -I ${CIME_ROOT}/src/share/streams/ -I ${CIME_ROOT}/src/share/util/ -I ${CIME_ROOT}/src/share/esmf_wrf_timemgr/")
+
 
 # ctsm build
 file(GLOB_RECURSE CTSM_SOURCES src/**/*.F90 src/**/*.h src/**/*.inc)


### PR DESCRIPTION
### Description of changes
This PR adds a top-level cmake build script to the CTSM repository to support builds outside of the CIME system. 

The goal is to support a stand-alone build of the CTSM library, without having to create a CIME case (or interacting directly with any CIME utilities). The basic workflow would be:

```shell
cd ctsm
mkdir _build
cd _build
cmake ..
make
```

closes #799

### Specific notes

Contributors other than yourself, if any:  @billsacks @negin513 @mvertens 

CTSM Issues Fixed (include github issue #): #799

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

--------------------

Current (11/5) status:

```shell
cheyenne:~/projects/lilac/ctsm/_build (cmake_build)$ make 
...
[  4%] Building Fortran object CMakeFiles/cime.dir/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90.o
/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90(43): error #7002: Error in opening the compiled module file.  Check INCLUDE paths.   [SHR_INFNAN_MOD]
use shr_infnan_mod, only: &
----^
/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90(44): error #6581: Unresolved rename.   [ISNAN]
     isnan => shr_infnan_isnan
-----^
/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90(118): error #6498: The use-name for this local-name is not defined.   [ISNAN]
     if (.not. isnan(input) .and. all(buffer(1:1) /= ["-", "+"])) then
---------------^
/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90(143): error #6498: The use-name for this local-name is not defined.   [ISNAN]
     if (.not. isnan(input) .and. all(buffer(1:1) /= ["-", "+"])) then
---------------^
compilation aborted for /glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90 (code 1)
CMakeFiles/cime.dir/build.make:734: recipe for target 'CMakeFiles/cime.dir/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90.o' failed
make[3]: *** [CMakeFiles/cime.dir/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90.o] Error 1
CMakeFiles/cime.dir/build.make:750: recipe for target 'CMakeFiles/cime.dir/glade/u/home/jhamman/projects/lilac/cime/src/share/util/shr_strconvert_mod.F90.o.provides' failed
```

Primary TODOs include:

- Come up with a strategy for handling modules that include code injection of various kinds (e.g. `shr_infnan_mod`)
- Determine where to put the CIME code in the build (currently hard coded to my workspace)