### PR TITLE
Some answer changes for release branch

### DIFF
--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -1098,7 +1098,7 @@ lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_16pfts_Irrig_CMIP6_simyr18
 <stream_year_last_soilm   >1997</stream_year_last_soilm>
 <model_year_align_soilm   >1997</model_year_align_soilm>
 
-<stream_fldfilename_soilm hgrid="0.9x1.25">lnd/clm2/prescribed_data/LFMIP-pdLC-SST.H2OSOI.0.9x1.25.20levsoi.natveg.climo1980-2014.MONS_c190709.nc</stream_fldfilename_soilm>
+<stream_fldfilename_soilm hgrid="0.9x1.25">lnd/clm2/prescribed_data/LFMIP-pdLC-SST.H2OSOI.0.9x1.25.20levsoi.natveg.1980-2014.MONS_climo.c190716.nc</stream_fldfilename_soilm>
 
 <soilm_tintalgo>linear</soilm_tintalgo>
 <soilm_offset  >0</soilm_offset>

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -1211,23 +1211,39 @@ lnd/clm2/surfdata_map/landuse.timeseries_ne30np4_hist_16pfts_Irrig_CMIP6_simyr18
 <stream_year_last_urbantv  phys="clm5_0" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0" sim_year_range="1850-2100" >2015</model_year_align_urbantv>
 
-<stream_year_first_urbantv phys="clm4_5"  >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm4_5"  >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv phys="clm4_5" sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5" sim_year_range="1850-2100" >2015</model_year_align_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0" sim_year="2000" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" sim_year="2000" >2000</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5" sim_year="2000" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" sim_year="2000" >2000</stream_year_last_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0" sim_year="1850" >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" sim_year="1850" >1850</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5" sim_year="1850" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" sim_year="1850" >1850</stream_year_last_urbantv>
+
 <stream_year_first_urbantv phys="clm5_0" sim_year="1000" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" sim_year="1000" >2000</stream_year_last_urbantv>
+
+<stream_year_first_urbantv phys="clm4_5" sim_year="1000" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" sim_year="1000" >2000</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_urbantv>
+
+<stream_year_first_urbantv phys="clm4_5" sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" sim_year="constant" sim_year_range="1000-1002" >2000</stream_year_last_urbantv>
+
+<stream_year_first_urbantv phys="clm4_5" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_0" hgrid="0.9x1.25" >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
 

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -35,6 +35,9 @@
 <!-- Use single year ndep file for CLM50 as the new multi-year file has different times that change answers relative to control sims -->
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
+
+<stream_fldfilename_ndep phys="clm4_5" use_cn=".true."
+>lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
  
 <ndep_taxmode            phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
 

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -32,6 +32,9 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >1850</stream_year_last_urbantv>
+
 <!-- Use single year ndep file for CLM50 as the new multi-year file has different times that change answers relative to control sims -->
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>

--- a/bld/namelist_files/use_cases/1850_noanthro_control.xml
+++ b/bld/namelist_files/use_cases/1850_noanthro_control.xml
@@ -42,6 +42,9 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >1850</stream_year_last_urbantv>
+
 <!-- Turn calculation of human stress indices all the way off to save some CPU -->
 <calc_human_stress_indices     >NONE</calc_human_stress_indices>
 

--- a/bld/namelist_files/use_cases/2000_control.xml
+++ b/bld/namelist_files/use_cases/2000_control.xml
@@ -33,4 +33,7 @@
 <stream_year_first_urbantv phys="clm5_0" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" >2000</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" >2000</stream_year_last_urbantv>
+
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/2010_control.xml
+++ b/bld/namelist_files/use_cases/2010_control.xml
@@ -33,4 +33,7 @@
 <stream_year_first_urbantv phys="clm5_0" >2010</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" >2010</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5" >2010</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5" >2010</stream_year_last_urbantv>
+
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -49,4 +49,8 @@
 <stream_year_last_urbantv  phys="clm5_0"  >2106</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>
 
+<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+
 </namelist_defaults>

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -14,5 +14,7 @@
     <entry issue="667"              >FAIL ERS_D_Ld5.1x1_brazil.I2000Clm50FatesCruGs.cheyenne_intel.clm-FatesHydro COMPARE_base_rest</entry>
     <entry issue="667"              >FAIL ERS_D_Ld5.1x1_brazil.I2000Clm50FatesCruGs.hobart_nag.clm-FatesHydro RUN</entry>
     <entry issue="NGEET/fates/#510" >FAIL SMS_Lm3_D_Mmpi-serial.1x1_brazil.I2000Clm50FatesCruGs.hobart_nag.clm-FatesHydro MEMLEAK</entry>
+    <entry issue="667"              >FAIL ERS_D_Ld5.1x1_brazil.I2000Clm50FatesCruGs.izumi_nag.clm-FatesHydro RUN</entry>
+    <entry issue="NGEET/fates/#510" >FAIL SMS_Lm3_D_Mmpi-serial.1x1_brazil.I2000Clm50FatesCruGs.izumi_nag.clm-FatesHydro MEMLEAK</entry>
   </category>
 </expectedFails> 

--- a/cime_config/testdefs/testmods_dirs/clm/prescribed/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/prescribed/user_nl_clm
@@ -1,3 +1,5 @@
  use_soil_moisture_streams = .true.
  use_lai_streams = .true.
  hist_fincl1   += 'H2OSOI_PRESCRIBED_GRC'
+ soilm_tintalgo = 'lower'    ! set time interpolation to use lower value, so can compare to input dataset
+ lai_tintalgo = 'lower'      ! set time interpolation to use lower value, so can compare more directly to input dataset

--- a/cime_config/testdefs/testmods_dirs/clm/prescribed/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/prescribed/user_nl_clm
@@ -3,3 +3,4 @@
  hist_fincl1   += 'H2OSOI_PRESCRIBED_GRC'
  soilm_tintalgo = 'lower'    ! set time interpolation to use lower value, so can compare to input dataset
  lai_tintalgo = 'lower'      ! set time interpolation to use lower value, so can compare more directly to input dataset
+ soilm_ignore_data_if_missing = .true.

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+release-clm5.0.29     erik 11/19/2019 Some answer changes needed for prescribed soil-moisture and clm4_5 defaults (1850-ndep, and urbantv settings)
 release-clm5.0.28     erik 11/14/2019 Several bit-for-bit fixes especially around soil-moisture streams
 release-clm5.0.27     erik 08/13/2019 Add presoribed soil moisture streams as an option, and a few fixes
 release-clm5.0.26    sacks 07/29/2019 Add a CN precision control call to fix problems related to small negative values

--- a/doc/release-clm5.0.ChangeLog
+++ b/doc/release-clm5.0.ChangeLog
@@ -1,4 +1,118 @@
 ===============================================================
+Tag name:  release-clm5.0.29
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date: Tue Nov 19 12:14:02 MST 2019
+One-line Summary: Some answer changes needed for prescribed soil-moisture and clm4_5 defaults (1850-ndep, and urbantv settings)
+
+Purpose of this version:
+------------------------
+
+Some answer changes needed for prescribed soil-moisture. And clm4_5 defaults for 1850 Nitrogen deposition and or urbantv
+settings were made to be consistent with clm5_0.
+
+
+CTSM Master Tag This Corresponds To: ctsm1.0.dev025 (with many other changes)
+
+Summary of changes:
+-------------------
+
+Issues fixed (include CTSM Issue #): #175, #817, #832 #833
+
+   Fixes #817 -- Have clm4_5 use the same ndep file as clm5_0 for 1850
+   Fixes #175 -- Have clm4_5 use the same settings for urbantv years as clm5_0
+   Fixes #832 -- don't override with missing value, let the model set it
+   Fixes #833 -- time interpolation of soilm causes bad values for some missing points
+
+Science changes since: release-clm5.0.28
+
+   Defaults for clm4_5, prescribed soil-moisture
+
+   Some defaults were changed for clm4_5 to be consistent with clm5_0 (use of the same 1850-ndep file, 
+   and changes in the urbantv year settings)
+
+   Prescribed soil-moisture was changes so that if time-interpolation produces large values, they
+   will be marked as missing (spval). Also points where the input prescribed soil moisture is missing
+   are now ignored (and run normally).
+
+Software changes since:  release-clm5.0.28
+
+
+Changes to User Interface since: release-clm5.0.28
+
+  Behavior of soilm_ignore_data_if_missing changes!
+
+  Behavior of soilm_ignore_data_if_missing changes. Now if true will ignore any points
+  where the prescribed soil moisture dataset is missing. So for these points the model
+  will run normally (as if prescribed soil moisture was off). Before it would mark them
+  as missing, but modify h2osoi_ice/liq in an odd fashion.
+
+Testing:
+--------
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (10 tests are different)
+
+  unit-tests (components/clm/src):
+
+    cheyenne - PASS
+    hobart --- PASS
+
+  tools-tests (components/clm/test/tools):
+
+    cheyenne - NOT run
+    hobart --- NOT run
+
+  PTCLM testing (components/clm/tools/shared/PTCLM/test):
+
+     cheyenne - NOT run
+     hobart --- NOT run
+
+  regular tests (aux_clm):
+
+    cheyenne_intel ---- OK
+    cheyenne_gnu ------ OK
+    izumi_nag --------- OK
+    izumi_pgi --------- OK
+    izumi_intel ------- OK
+
+Summary of Answer changes:
+-------------------------
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here: previous
+
+Changes answers relative to baseline: Yes for some! prescribed soil-moisture and clm4_5 (1850-ndep, and urbantv settings)
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: prescribed soil-moisture, or clm4_5 due to default changes in 1850-ndep and urbantv
+    - what platforms/compilers: all
+    - nature of change:  similar climate
+
+  Will new REFCASES need to be made for cesm and/or CAM?: No
+
+Detailed list of changes:
+------------------------
+
+Externals being used: No changes
+
+   cism:   release-cesm2.0.04
+   rtm:    release-cesm2.0.03
+   mosart: release-cesm2.0.03
+   cime:   cim5.6.25
+   FATES:  fates_s1.21.0_a7.0.0_br_rev2
+   PTCLM:  PTCLM2_180611
+
+CTSM Tag versions pulled over from master development branch: None
+
+Pull Requests that document the changes (include PR ids): #841
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #841 -- Some answer changes for release branch
+
+===============================================================
+===============================================================
 Tag name:  release-clm5.0.28
 Originator(s):  erik (Erik Kluzek)
 Date: Thu Nov 14 23:03:39 MST 2019

--- a/src/biogeophys/SoilMoistureStreamMod.F90
+++ b/src/biogeophys/SoilMoistureStreamMod.F90
@@ -344,9 +344,9 @@ contains
 
              ! If soil moiture is being interpolated in time and the result is
              ! large that probably means one of the two data points is missing (set to spval)
-             !if ( h2osoi_vol_prs(g,j) > 10.0_r8 .and. (h2osoi_vol_prs(g,j) /= spval) )then
-                !h2osoi_vol_prs(g,j) = spval
-             !end if
+             if ( h2osoi_vol_prs(g,j) > 10.0_r8 .and. (h2osoi_vol_prs(g,j) /= spval) )then
+                h2osoi_vol_prs(g,j) = spval
+             end if
 
          end do
       end do
@@ -375,7 +375,7 @@ contains
                   ! file is different
                   if ( (h2osoi_vol_prs(g,j) == spval) .and. (h2osoi_vol_initial /= spval) )then
                      if ( soilm_ignore_data_if_missing )then
-                        !cycle
+                        cycle
                      else
                         write(iulog,*) 'Input soil moisture dataset is not vegetated as expected: gridcell=', &
                                         g, ' active = ', col%active(c)

--- a/src/biogeophys/SoilMoistureStreamMod.F90
+++ b/src/biogeophys/SoilMoistureStreamMod.F90
@@ -358,8 +358,7 @@ contains
          g = col%gridcell(c)
          ig = g_to_ig(g)
             
-         if (lun%itype(col%landunit(c)) == istsoil ) then
-         !if ( (lun%itype(col%landunit(c)) == istsoil) .or. (lun%itype(col%landunit(c)) == istcrop) ) then
+         if ( (lun%itype(col%landunit(c)) == istsoil) .or. (lun%itype(col%landunit(c)) == istcrop) ) then
             !       this is a 2d field (gridcell/nlevsoi) !
             do j = 1, nlevsoi
                


### PR DESCRIPTION
### Description of changes

 answer changes needed. Move prescribed soil moisture dataset being used.

For soil moisture streams apply over both nat-veg and crop.

This is answer changing.

Point to $CSMDATA/lnd/clm2/prescribed_data/LFMIP-pdLC-SST.H2OSOI.0.9x1.25.20levsoi.natveg.1980-2014.MONS_climo.c190716.nc

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #): #175, #817, #832 #833

Fixes #817 -- Have clm4_5 use the same ndep file as clm5_0 for 1850
Fixes #175 -- Have clm4_5 use the same settings for urbantv years as clm5_0
Fixes #832 -- don't override with missing value, let the model set it
Fixes #833 -- time interpolation of soilm causes bad values for some missing points

Are answers expected to change (and if so in what way)? Yes!

prescribed soil moisture changes, so that grid points that are missing on the input dataset, just run CLM normally, time interpolation might show that more points are missing, and prescribed soil moisture is also done for crops.

For clm4_5, the same ndep file is used for 1850 as for clm5_0, and same settings for urbantv are now used as well (rather than present day).

Any User Interface Changes (namelist or namelist defaults changes)? Yes namelist defaults

clm4_5 defaults for ndep and urbantv years mirror clm5_0

Testing performed, if any: regular, running standard testing on cheyenne and izumi
