### PR TITLE
Updated default fates parameter file for new api 8.1.0 format.

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.30.0_api.8.0.0
+tag = sci.1.31.1_api.8.1.0
 required = True
 
 [PTCLM]

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.4.0_12pft_c191213.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c191213.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c191216.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c191217.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.3.0_12pft_c190530.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.7.4.0_12pft_c191213.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c191213.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c191216.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -355,7 +355,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c191217.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.8.1.0_12pft_c200103.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->


### PR DESCRIPTION
### Description of changes

This PR is synced with https://github.com/NGEET/fates/pull/595
Changes here should only update the default fates parameter file location.

Tag info will be added last in Externals_CLM.cfg after tests pass and FATES side changes are integrated.


### Specific notes

See: https://github.com/NGEET/fates/pull/595

Are answers expected to change (and if so in what way)?

Since the parameter files are different, I don't think this will pass b4b tests, even though the values are all the same in the parameter file, and answers should not change.  The parameter names have changed, and new parameter entries have been added that are not used yet.

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:

fates test suite, results TBD
