### PR TITLE
Speed up restart writes

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm1.0.dev081
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
-Date:  Tue Jan  7 15:17:50 MST 2020
+Date:  Tue Jan  7 21:24:54 MST 2020
 One-line Summary: Speed up restart writes
 
 Purpose of changes
@@ -90,8 +90,8 @@ CTSM testing:
 
   regular tests (aux_clm):
 
-    cheyenne ---- 
-    izumi ------- 
+    cheyenne ---- OK 
+    izumi ------- PASS
 
 If the tag used for baseline comparisons was NOT the previous tag, note that here:
 
@@ -100,18 +100,7 @@ Answer changes
 --------------
 
 Changes answers relative to baseline:
-
-  If a tag changes answers relative to baseline comparison the
-  following should be filled in (otherwise remove this section):
-
-  Summarize any changes to answers, i.e.,
-    - what code configurations:
-    - what platforms/compilers:
-    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
-
-   If bitwise differences were observed, how did you show they were no worse
-   than roundoff?
-
+ No
 
 Detailed list of changes
 ------------------------

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,128 @@
 ===============================================================
+Tag name:  ctsm1.0.dev081
+Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
+Date:  Tue Jan  7 15:17:50 MST 2020
+One-line Summary: Speed up restart writes
+
+Purpose of changes
+------------------
+
+ E3SM#3163 makes some changes to speed up restart writes. I use E3SM#3163
+ function GetGlobalIndexArray in place of GetGlobalIndex so as to get
+ global indices by array rather than looping over every element.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): #801
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: [For timing changes, can check PFS test(s) in the test suite]
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by:
+
+
+CTSM testing:
+
+[... Remove before making master tag.  Available test levels:
+
+    a) regular (must be run before handing off a tag to SEs and must be run
+     before committing a tag)
+    b) build_namelist (if namelists and/or build_system changed))
+    c) tools (only if tools are modified and no CTSM source is modified)
+    d) short (for use during development and in rare cases where only a small
+          change with known behavior is added ... eg. a minor bug fix)
+    e) doc (no source testing required)
+
+... ]
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - 
+
+  tools-tests (test/tools):
+
+    cheyenne - 
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - 
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - 
+
+  regular tests (aux_clm):
+
+    cheyenne ---- 
+    izumi ------- 
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline:
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations:
+    - what platforms/compilers:
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff?
+
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
+
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/880
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev080
 Originator(s):  sacks (Bill Sacks)
 Date:  Mon Dec  2 12:23:22 MST 2019

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,13 +1,13 @@
 ===============================================================
 Tag name:  ctsm1.0.dev081
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
-Date:  Tue Jan  7 21:24:54 MST 2020
+Date:  Mon Jan 13 15:37:07 MST 2020
 One-line Summary: Speed up restart writes
 
 Purpose of changes
 ------------------
 
- E3SM#3163 makes some changes to speed up restart writes. I use E3SM#3163
+ E3SM#3163 made some changes to speed up restart writes. I use E3SM#3163
  function GetGlobalIndexArray in place of GetGlobalIndex so as to get
  global indices by array rather than looping over every element.
 
@@ -43,7 +43,7 @@ Changes made to namelist defaults (e.g., changed parameter values): none
 
 Changes to the datasets (e.g., parameter, surface or initial files): none
 
-Substantial timing or memory changes: [For timing changes, can check PFS test(s) in the test suite]
+Substantial timing or memory changes: Limited testing did not show substantial timing changes
 
 Notes of particular relevance for developers: (including Code reviews and testing)
 ---------------------------------------------
@@ -54,21 +54,10 @@ Caveats for developers (e.g., code that is duplicated that requires double maint
 Changes to tests or testing: none
 
 Code reviewed by:
-
+ @billsacks
+ @bishtgautam
 
 CTSM testing:
-
-[... Remove before making master tag.  Available test levels:
-
-    a) regular (must be run before handing off a tag to SEs and must be run
-     before committing a tag)
-    b) build_namelist (if namelists and/or build_system changed))
-    c) tools (only if tools are modified and no CTSM source is modified)
-    d) short (for use during development and in rare cases where only a small
-          change with known behavior is added ... eg. a minor bug fix)
-    e) doc (no source testing required)
-
-... ]
 
  [PASS means all tests PASS and OK means tests PASS other than expected fails.]
 
@@ -101,6 +90,13 @@ Answer changes
 
 Changes answers relative to baseline:
  No
+
+ @billsacks recommended running a global test in the branch vs. in master (i.e.
+ with vs. without the code mods) to compare restart files because the test suite
+ does not compare restart files and an error in the subgrid indices on the
+ restart file might go undetected. I ran this test:
+ ERS_D_Ld6.f10_f10_musgs.I1850Clm45BgcCrop.cheyenne_intel.clm-clm50CMIP6frc
+ and got identical values for all variables in the two restart files.
 
 Detailed list of changes
 ------------------------

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev081   slevis 01/07/2020 Speed up restart writes
   ctsm1.0.dev080    sacks 12/02/2019 Update externals, minor fixes to work with latest cime, get nuopc cap working
   ctsm1.0.dev079    sacks 11/04/2019 Change a few uses of shr_kind
   ctsm1.0.dev078   oleson 10/31/2019 Fix rootr calculation with use_hydrstress true

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm1.0.dev081   slevis 01/07/2020 Speed up restart writes
+  ctsm1.0.dev081   slevis 01/13/2020 Speed up restart writes
   ctsm1.0.dev080    sacks 12/02/2019 Update externals, minor fixes to work with latest cime, get nuopc cap working
   ctsm1.0.dev079    sacks 11/04/2019 Change a few uses of shr_kind
   ctsm1.0.dev078   oleson 10/31/2019 Fix rootr calculation with use_hydrstress true

--- a/src/main/GetGlobalValuesMod.F90
+++ b/src/main/GetGlobalValuesMod.F90
@@ -9,6 +9,7 @@ module GetGlobalValuesMod
   ! PUBLIC MEMBER FUNCTIONS:
 
   public :: GetGlobalIndex
+  public :: GetGlobalIndexArray
   public :: GetGlobalWrite
 
   character(len=*), parameter, private :: sourcefile = &
@@ -65,6 +66,60 @@ contains
     deallocate(gsmap_ordered)
 
   end function GetGlobalIndex
+
+  !-----------------------------------------------------------------------
+  function GetGlobalIndexArray(decomp_index, bounds1, bounds2, clmlevel)
+
+    !----------------------------------------------------------------
+    ! Description
+    ! Determine global index space value for target array at given clmlevel
+    !
+    ! Uses:
+    use shr_log_mod, only: errMsg => shr_log_errMsg
+    use decompMod  , only: bounds_type, get_clmlevel_gsmap, get_proc_bounds
+    use spmdMod    , only: iam
+    use clm_varcon , only: nameg, namel, namec, namep
+    use clm_varctl , only: iulog
+    use mct_mod
+    !
+    ! Arguments 
+    integer                 , intent(in) :: bounds1
+    integer                 , intent(in) :: bounds2
+    integer, dimension(bounds1:bounds2), intent(in) :: decomp_index
+    character(len=*)        , intent(in) :: clmlevel
+    integer, dimension(bounds1:bounds2)  :: GetGlobalIndexArray
+    !
+    ! Local Variables:
+    type(bounds_type)             :: bounds_proc   ! processor bounds
+    type(mct_gsMap),pointer       :: gsmap         ! global seg map
+    integer, pointer,dimension(:) :: gsmap_ordered ! gsmap ordered points
+    integer                       :: beg_index     ! beginning proc index for clmlevel
+    integer                       :: i
+    !----------------------------------------------------------------
+
+    call get_proc_bounds(bounds_proc)
+
+    if (trim(clmlevel) == nameg) then
+       beg_index = bounds_proc%begg
+    else if (trim(clmlevel) == namel) then
+       beg_index = bounds_proc%begl
+    else if (trim(clmlevel) == namec) then
+       beg_index = bounds_proc%begc
+    else if (trim(clmlevel) == namep) then
+       beg_index = bounds_proc%begp
+    else
+       call shr_sys_abort('clmlevel of '//trim(clmlevel)//' not supported' // &
+            errmsg(__FILE__, __LINE__))
+    end if
+
+    call get_clmlevel_gsmap(clmlevel=trim(clmlevel), gsmap=gsmap)
+    call mct_gsMap_orderedPoints(gsmap, iam, gsmap_ordered)
+    do i=bounds1,bounds2
+       GetGlobalIndexArray(i) = gsmap_ordered(decomp_index(i) - beg_index + 1)
+    enddo
+    deallocate(gsmap_ordered)
+
+  end function GetGlobalIndexArray
 
   !-----------------------------------------------------------------------
   subroutine GetGlobalWrite(decomp_index, clmlevel)

--- a/src/main/GetGlobalValuesMod.F90
+++ b/src/main/GetGlobalValuesMod.F90
@@ -74,7 +74,13 @@ contains
     ! Description
     ! Determine global index space value for target array at given clmlevel
     !
+    ! Example from histFileMod.F90:
+    ! ilarr = GetGlobalIndexArray(lun%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
+    ! Note that the last argument (clmlevel) is set to nameg, which corresponds
+    ! to the "gridcell" not the "lun" of the first argument.
+    !
     ! Uses:
+#include "shr_assert.h"
     use shr_log_mod, only: errMsg => shr_log_errMsg
     use decompMod  , only: bounds_type, get_clmlevel_gsmap, get_proc_bounds
     use spmdMod    , only: iam
@@ -83,11 +89,11 @@ contains
     use mct_mod
     !
     ! Arguments 
-    integer                 , intent(in) :: bounds1
-    integer                 , intent(in) :: bounds2
-    integer, dimension(bounds1:bounds2), intent(in) :: decomp_index
+    integer, intent(in) :: bounds1  ! lower bound of the input & returned arrays
+    integer, intent(in) :: bounds2  ! upper bound of the input & returned arrays
+    integer, intent(in) :: decomp_index(bounds1:)
     character(len=*)        , intent(in) :: clmlevel
-    integer, dimension(bounds1:bounds2)  :: GetGlobalIndexArray
+    integer :: GetGlobalIndexArray(bounds1:bounds2)
     !
     ! Local Variables:
     type(bounds_type)             :: bounds_proc   ! processor bounds
@@ -97,6 +103,7 @@ contains
     integer                       :: i
     !----------------------------------------------------------------
 
+    SHR_ASSERT_ALL_FL((ubound(decomp_index) == (/bounds2/)), sourcefile, __LINE__)
     call get_proc_bounds(bounds_proc)
 
     if (trim(clmlevel) == nameg) then

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -16,7 +16,7 @@ module histFileMod
   use clm_varcon     , only : spval, ispval, dzsoi_decomp 
   use clm_varcon     , only : grlnd, nameg, namel, namec, namep, nameCohort
   use decompMod      , only : get_proc_bounds, get_proc_global, bounds_type
-  use GetGlobalValuesMod , only : GetGlobalIndex
+  use GetGlobalValuesMod , only : GetGlobalIndexArray
   use GridcellType   , only : grc                
   use LandunitType   , only : lun                
   use ColumnType     , only : col                
@@ -3207,9 +3207,7 @@ contains
          ilarr(l) = (ldecomp%gdc2glo(lun%gridcell(l))-1)/ldomain%ni + 1
        enddo
        call ncd_io(varname='land1d_jxy'      , data=ilarr        , dim1name=namel, ncid=ncid, flag='write')
-       do l=bounds%begl,bounds%endl
-          ilarr(l) = GetGlobalIndex(decomp_index=lun%gridcell(l), clmlevel=nameg)
-       end do
+       ilarr = GetGlobalIndexArray(lun%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
        call ncd_io(varname='land1d_gi'       , data=ilarr, dim1name=namel, ncid=ncid, flag='write')
        call ncd_io(varname='land1d_wtgcell'  , data=lun%wtgcell , dim1name=namel, ncid=ncid, flag='write')
        call ncd_io(varname='land1d_ityplunit', data=lun%itype   , dim1name=namel, ncid=ncid, flag='write')
@@ -3233,13 +3231,9 @@ contains
          icarr(c) = (ldecomp%gdc2glo(col%gridcell(c))-1)/ldomain%ni + 1
        enddo
        call ncd_io(varname='cols1d_jxy'    , data=icarr         ,dim1name=namec, ncid=ncid, flag='write')
-       do c = bounds%begc,bounds%endc
-         icarr(c) =  GetGlobalIndex(decomp_index=col%gridcell(c), clmlevel=nameg)
-       enddo
+       icarr = GetGlobalIndexArray(col%gridcell(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=nameg)
        call ncd_io(varname='cols1d_gi'     , data=icarr, dim1name=namec, ncid=ncid, flag='write')
-       do c = bounds%begc,bounds%endc
-         icarr(c) =  GetGlobalIndex(decomp_index=col%landunit(c), clmlevel=namel)
-       enddo
+       icarr = GetGlobalIndexArray(col%landunit(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=namel)
        call ncd_io(varname='cols1d_li', data=icarr            , dim1name=namec, ncid=ncid, flag='write')
 
        call ncd_io(varname='cols1d_wtgcell', data=col%wtgcell , dim1name=namec, ncid=ncid, flag='write')
@@ -3272,17 +3266,11 @@ contains
        enddo
        call ncd_io(varname='pfts1d_jxy'      , data=iparr        , dim1name=namep, ncid=ncid, flag='write')
 
-       do p=bounds%begp,bounds%endp
-          iparr(p) = GetGlobalIndex(decomp_index=patch%gridcell(p), clmlevel=nameg)
-       enddo
+       iparr = GetGlobalIndexArray(patch%gridcell(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=nameg)
        call ncd_io(varname='pfts1d_gi'       , data=iparr, dim1name=namep, ncid=ncid, flag='write')
-       do p=bounds%begp,bounds%endp
-          iparr(p) = GetGlobalIndex(decomp_index=patch%landunit(p), clmlevel=namel)
-       enddo
+       iparr = GetGlobalIndexArray(patch%landunit(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namel)
        call ncd_io(varname='pfts1d_li'       , data=iparr, dim1name=namep, ncid=ncid, flag='write')
-       do p=bounds%begp,bounds%endp
-          iparr(p) = GetGlobalIndex(decomp_index=patch%column(p), clmlevel=namec)
-       enddo
+       iparr = GetGlobalIndexArray(patch%column(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namec)
        call ncd_io(varname='pfts1d_ci'  , data=iparr              , dim1name=namep, ncid=ncid, flag='write')
 
        call ncd_io(varname='pfts1d_wtgcell'  , data=patch%wtgcell , dim1name=namep, ncid=ncid, flag='write')

--- a/src/main/subgridRestMod.F90
+++ b/src/main/subgridRestMod.F90
@@ -15,7 +15,7 @@ module subgridRestMod
   use clm_varpar         , only : nlevsno, nlevgrnd
   use pio                , only : file_desc_t
   use ncdio_pio          , only : ncd_int, ncd_double
-  use GetGlobalValuesMod , only : GetGlobalIndex
+  use GetGlobalValuesMod , only : GetGlobalIndexArray
   use GridcellType       , only : grc                
   use LandunitType       , only : lun                
   use ColumnType         , only : col                
@@ -197,9 +197,7 @@ contains
          long_name='2d latitude index of corresponding landunit',                  &
          interpinic_flag='skip', readvar=readvar, data=ilarr)
 
-    do l=bounds%begl,bounds%endl
-       ilarr(l) = GetGlobalIndex(decomp_index=lun%gridcell(l), clmlevel=nameg)
-    end do
+    ilarr = GetGlobalIndexArray(lun%gridcell(bounds%begl:bounds%endl), bounds%begl, bounds%endl, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='land1d_gridcell_index', xtype=ncd_int, &
          dim1name='landunit',                                                             &
          long_name='gridcell index of corresponding landunit',                            &
@@ -262,17 +260,13 @@ contains
          long_name='2d latitude index of corresponding column', units=' ',          &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    do c= bounds%begc, bounds%endc
-       icarr(c) = GetGlobalIndex(decomp_index=col%gridcell(c), clmlevel=nameg)
-    end do
+    icarr = GetGlobalIndexArray(col%gridcell(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_gridcell_index', xtype=ncd_int, &
          dim1name='column',                                                               &
          long_name='gridcell index of corresponding column',                              &
          interpinic_flag='skip', readvar=readvar, data=icarr)
 
-    do c= bounds%begc, bounds%endc
-       icarr(c) = GetGlobalIndex(decomp_index=col%landunit(c), clmlevel=namel)
-    end do
+    icarr = GetGlobalIndexArray(col%landunit(bounds%begc:bounds%endc), bounds%begc, bounds%endc, clmlevel=namel)
     call restartvar(ncid=ncid, flag=flag, varname='cols1d_landunit_index', xtype=ncd_int, &
          dim1name='column',                                                               &
          long_name='landunit index of corresponding column',                              &
@@ -356,25 +350,19 @@ contains
          long_name='2d latitude index of corresponding pft', units='',         &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    do p=bounds%begp,bounds%endp
-       iparr(p) = GetGlobalIndex(decomp_index=patch%gridcell(p), clmlevel=nameg)
-    enddo
+    iparr = GetGlobalIndexArray(patch%gridcell(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=nameg)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_gridcell_index', xtype=ncd_int, &
          dim1name='pft',                                                                  &
          long_name='gridcell index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    do p=bounds%begp,bounds%endp
-       iparr(p) = GetGlobalIndex(decomp_index=patch%landunit(p), clmlevel=namel)
-    enddo
+    iparr = GetGlobalIndexArray(patch%landunit(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namel)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_landunit_index', xtype=ncd_int, &
          dim1name='pft',                                                                  &
          long_name='landunit index of corresponding pft',                                 &
          interpinic_flag='skip', readvar=readvar, data=iparr)
 
-    do p=bounds%begp,bounds%endp
-       iparr(p) = GetGlobalIndex(decomp_index=patch%column(p), clmlevel=namec)
-    enddo
+    iparr = GetGlobalIndexArray(patch%column(bounds%begp:bounds%endp), bounds%begp, bounds%endp, clmlevel=namec)
     call restartvar(ncid=ncid, flag=flag, varname='pfts1d_column_index', xtype=ncd_int,   &
          dim1name='pft',                                                                  &
          long_name='column index of corresponding pft',                                   &


### PR DESCRIPTION
### Description of changes
[E3SM#3163](https://github.com/E3SM-Project/E3SM/pull/3163) makes some changes to speed up restart writes.

As a first step I use E3SM#3163 function GetGlobalIndexArray in place of GetGlobalIndex so as to get global indices by array rather than looping over every element.

### Specific notes

Contributors other than yourself, if any:
@billsacks 

CTSM Issues Fixed (include github issue #):
#801 

Are answers expected to change (and if so in what way)?
No.

Any User Interface Changes (namelist or namelist defaults changes)?
No.

Testing performed, if any:
./create_test ERS_D_Ld6.f10_f10_musgs.I1850Clm45BgcCrop.cheyenne_intel.clm-clm50CMIP6frc -c /glade/p/cgd/tss/ctsm_baselines/ctsm1.0.dev080 -p P93300041 &	**PASS**