### PR TITLE
Resolve Issue#118

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.8.15
+tag = branch_tags/cime5.8.15_a01
 externals = ../Externals_cime.cfg
 required = True
 

--- a/cime_config/usermods_dirs/_includes/output_base/user_nl_clm
+++ b/cime_config/usermods_dirs/_includes/output_base/user_nl_clm
@@ -29,7 +29,7 @@ hist_dov2xy(1) = .true.
 hist_nhtfrq(1) = 0
 hist_type1d_pertape(1) = ' '
 hist_fexcl1 += 'PCT_GLC_MEC','PCT_NAT_PFT'
-hist_fincl1 += 'EFLX_LH_TOT_ICE', 'FIRE_ICE', 'FLDS_ICE', 'FSH_ICE', 'FSNO_ICE', 'FSR_ICE', 'QFLX_SUB_SNOW_ICE', 'QRUNOFF_ICE', 'QSNOFRZ_ICE', 'QSNOMELT_ICE', 'RAIN_ICE', 'SNOW_ICE', 'SNOWICE_ICE', 'SNOWLIQ_ICE', 'SNOTXMASS_ICE', 'TG_ICE', 'TOPO_COL_ICE', 'TSA_ICE', 'TSOI_ICE'
+hist_fincl1 += 'EFLX_LH_TOT_ICE', 'FIRE_ICE', 'FLDS_ICE', 'FSH_ICE', 'FSNO_ICE', 'FSR_ICE', 'QFLX_SOLIDEVAP_FROM_TOP_LAYER_ICE', 'QRUNOFF_ICE', 'QSNOFRZ_ICE', 'QSNOMELT_ICE', 'RAIN_ICE', 'SNOW_ICE', 'SNOWICE_ICE', 'SNOWLIQ_ICE', 'SNOTXMASS_ICE', 'TG_ICE', 'TOPO_COL_ICE', 'TSA_ICE', 'TSOI_ICE'
 
 ! h1 stream (monthly average, finest sub-grid)
 ! Emon, Lmon 

--- a/cime_config/usermods_dirs/_includes/output_base_highfreq/user_nl_clm
+++ b/cime_config/usermods_dirs/_includes/output_base_highfreq/user_nl_clm
@@ -8,7 +8,7 @@ hist_mfilt(6) = 365
 hist_dov2xy(6) = .true.
 hist_nhtfrq(6) = -24
 hist_type1d_pertape(6) = ' '
-hist_fincl6 += 'SOILWATER_10CM', 'TOTSOILLIQ', 'TOTSOILICE', 'EFLX_LH_TOT', 'FSH', 'FGR12', 'FSM', 'QSNOEVAP', 'TLAI', 'QDRAI', 'QDRAI_PERCH', 'QOVER', 'QFLX_SUB_SNOW', 'FSA', 'FIRA', 'H2OSNO', 'SNOCAN', 'QSNOFRZ', 'QFLX_SNOW_DRAIN', 'SNOWDP', 'H2OSFC', 'TV', 'TG', 'TAUX', 'TAUY', 'QVEGT', 'TWS', 'H2OCAN', 'QVEGE', 'QSOIL', 'TSKIN', 'FSDS','FSNO','SNOFSRVD','SNOFSRVI','SNOFSRND','SNOFSRNI','FSDSVD','FSDSVI','FSDSND','FSDSNI','SNOWLIQ','SOILICE','SOILLIQ','QINTR','SNOBCMSL','TSOI','SNOTXMASS','SNOWICE','SNOWLIQ','QRUNOFF','RAIN','SNOW'
+hist_fincl6 += 'SOILWATER_10CM', 'TOTSOILLIQ', 'TOTSOILICE', 'EFLX_LH_TOT', 'FSH', 'FGR12', 'FSM', 'QSNOEVAP', 'TLAI', 'QDRAI', 'QDRAI_PERCH', 'QOVER', 'QFLX_SOLIDEVAP_FROM_TOP_LAYER', 'FSA', 'FIRA', 'H2OSNO', 'SNOCAN', 'QSNOFRZ', 'QFLX_SNOW_DRAIN', 'SNOWDP', 'H2OSFC', 'TV', 'TG', 'TAUX', 'TAUY', 'QVEGT', 'TWS', 'H2OCAN', 'QVEGE', 'QSOIL', 'TSKIN', 'FSDS','FSNO','SNOFSRVD','SNOFSRVI','SNOFSRND','SNOFSRNI','FSDSVD','FSDSVI','FSDSND','FSDSNI','SNOWLIQ','SOILICE','SOILLIQ','QINTR','SNOBCMSL','TSOI','SNOTXMASS','SNOWICE','SNOWLIQ','QRUNOFF','RAIN','SNOW'
 
 ! h6 stream (daily average, landunit-level)
 ! Eday
@@ -21,10 +21,10 @@ hist_fincl7 += 'TREFMXAV','TREFMNAV'
 ! h7 stream (3-hourly average, gridcell-level)
 ! 3hr, E3hr, CF3hr
 ! 3hr requires QRUNOFF for time mean, and SOILWATER_10CM, TSKIN for time point (I)
-! CF3hr requires QFLX_SUB_SNOW for time point (I)
+! CF3hr requires QFLX_SOLIDEVAP_FROM_TOP_LAYER for time point (I)
 hist_mfilt(8) = 2920
 hist_dov2xy(8) = .true.
 hist_nhtfrq(8) = -3
 hist_type1d_pertape(8) = ' '
-hist_fincl8 += 'TSA','RH2M','SOILWATER_10CM:I','FSH','EFLX_LH_TOT','FSDS','QRUNOFF','QFLX_SUB_SNOW:I','TSKIN:I'
+hist_fincl8 += 'TSA','RH2M','SOILWATER_10CM:I','FSH','EFLX_LH_TOT','FSDS','QRUNOFF','QFLX_SOLIDEVAP_FROM_TOP_LAYER:I','TSKIN:I'
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,140 @@
 ===============================================================
+Tag name:  ctsm1.0.dev082
+Originator(s):  oleson (Keith Oleson)
+Date:  Sat Feb  1 09:28:41 MST 2020
+One-line Summary: Rename variables to avoid confusion; fix QSNOEVAP diagnostic
+
+Purpose of changes
+------------------
+
+Renamed variables as discussed in ESCOMP/ctsm#118 throughout the code.
+
+Also made a couple of minor changes to fix a couple of potential
+problems with these variables as described in the branch commit logs.
+
+Tested for bfb before changing the history field variables
+themselves. These changes are all bfb (with the exception of QSNOEVAP)
+for a 1 month global 2deg simulation, but may not be bfb under all
+conditions. QSNOEVAP is not bfb because I've added in qflx_ev_snow for
+lakes.
+
+Also, update cime slightly with a fix for izumi machine updates
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+- Resolves ESCOMP/ctsm#118
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none expected (not checked)
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: none
+
+Code reviewed by: Bill Sacks
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run
+
+  tools-tests (test/tools):
+
+    cheyenne - not run
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - not run
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - not run
+
+  regular tests (aux_clm):
+
+    cheyenne ---- ok
+    izumi ------- ok
+
+    ok: tests pass, answer changes in QSNOEVAP but nothing else (as expected)
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: all
+    - what platforms/compilers: all
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+
+      Larger than roundoff, but only in the diagnostic field QSNOEVAP
+
+      Possibility of other answer changes in rare circumstances, not
+      observed in testing.
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff? N/A
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: N/A
+
+   URL for LMWG diagnostics output used to validate new climate: N/A
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+- cime: cime5.8.15 -> branch_tags/cime5.8.15_a01
+  Minor update for izumi machine changes
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/CTSM/pull/893
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev081
 Originator(s):  slevis (Samuel Levis,SLevis Consulting LLC,303-665-1310)
 Date:  Mon Jan 13 15:37:07 MST 2020

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev082   oleson 02/01/2020 Rename variables to avoid confusion; fix QSNOEVAP diagnostic
   ctsm1.0.dev081   slevis 01/13/2020 Speed up restart writes
   ctsm1.0.dev080    sacks 12/02/2019 Update externals, minor fixes to work with latest cime, get nuopc cap working
   ctsm1.0.dev079    sacks 11/04/2019 Change a few uses of shr_kind

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -315,10 +315,10 @@ contains
           qflx_snwcp_discarded_liq =>   waterflux_inst%qflx_snwcp_discarded_liq_col, & ! Input:  [real(r8) (:)   ]  excess liquid h2o due to snow capping, which we simply discard in order to reset the snow pack (mm H2O /s) [+]`
           qflx_snwcp_discarded_ice =>   waterflux_inst%qflx_snwcp_discarded_ice_col, & ! Input:  [real(r8) (:)   ]  excess solid h2o due to snow capping, which we simply discard in order to reset the snow pack (mm H2O /s) [+]`
           qflx_evap_tot           =>    waterflux_inst%qflx_evap_tot_col        , & ! Input:  [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
-          qflx_dew_snow           =>    waterflux_inst%qflx_dew_snow_col        , & ! Input:  [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]
-          qflx_sub_snow           =>    waterflux_inst%qflx_sub_snow_col        , & ! Input:  [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]
-          qflx_evap_grnd          =>    waterflux_inst%qflx_evap_grnd_col       , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
-          qflx_dew_grnd           =>    waterflux_inst%qflx_dew_grnd_col        , & ! Input:  [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]
+          qflx_liqdew_to_top_layer      => waterflux_inst%qflx_liqdew_to_top_layer_col     , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+          qflx_solidevap_from_top_layer => waterflux_inst%qflx_solidevap_from_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
+          qflx_liqevap_from_top_layer   => waterflux_inst%qflx_liqevap_from_top_layer_col  , & ! Input:  [real(r8) (:)   ]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
+          qflx_soliddew_to_top_layer    => waterflux_inst%qflx_soliddew_to_top_layer_col   , & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
           qflx_prec_grnd          =>    waterdiagnosticbulk_inst%qflx_prec_grnd_col, & ! Input:  [real(r8) (:)   ]  water onto ground including canopy runoff [kg/(m2 s)]
           qflx_snow_h2osfc        =>    waterflux_inst%qflx_snow_h2osfc_col     , & ! Input:  [real(r8) (:)   ]  snow falling on surface water (mm/s)
           qflx_h2osfc_to_ice      =>    waterflux_inst%qflx_h2osfc_to_ice_col   , & ! Input:  [real(r8) (:)   ]  conversion of h2osfc to ice             
@@ -490,18 +490,19 @@ contains
              ! only created if h2osno > 10mm).
 
              if (col%snl(c) < 0) then
-                snow_sources(c) = qflx_prec_grnd(c) + qflx_dew_snow(c) + qflx_dew_grnd(c)
-                snow_sinks(c)  = qflx_sub_snow(c) + qflx_evap_grnd(c) + qflx_snow_drain(c) &
-                     + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
+                snow_sources(c) = qflx_prec_grnd(c) + qflx_liqdew_to_top_layer(c) &
+                     + qflx_soliddew_to_top_layer(c)
+                snow_sinks(c)  = qflx_solidevap_from_top_layer(c) + qflx_liqevap_from_top_layer(c) &
+                     + qflx_snow_drain(c) + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
                      + qflx_snwcp_discarded_ice(c) + qflx_snwcp_discarded_liq(c) &
                      + qflx_sl_top_soil(c)
 
                 if (lun%itype(l) == istdlak) then 
                    snow_sources(c) = qflx_snow_grnd_col(c) &
                         + frac_sno_eff(c) * (qflx_liq_grnd_col(c) &
-                        +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) 
-                   snow_sinks(c)   = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c) ) &
-                        + qflx_snwcp_ice(c) + qflx_snwcp_liq(c)  &
+                        +  qflx_liqdew_to_top_layer(c) + qflx_soliddew_to_top_layer(c) ) 
+                   snow_sinks(c)   = frac_sno_eff(c) * (qflx_solidevap_from_top_layer(c) &
+                        + qflx_liqevap_from_top_layer(c) ) + qflx_snwcp_ice(c) + qflx_snwcp_liq(c)  &
                         + qflx_snwcp_discarded_ice(c) + qflx_snwcp_discarded_liq(c)  &
                         + qflx_snow_drain(c)  + qflx_sl_top_soil(c)
                 endif
@@ -511,9 +512,10 @@ contains
                       lun%itype(l) == istice_mec) then
                    snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
                           + frac_sno_eff(c) * (qflx_liq_grnd_col(c) &
-                          +  qflx_dew_snow(c) + qflx_dew_grnd(c) ) + qflx_h2osfc_to_ice(c)
-                   snow_sinks(c) = frac_sno_eff(c) * (qflx_sub_snow(c) + qflx_evap_grnd(c)) &
-                          + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
+                          + qflx_liqdew_to_top_layer(c) + qflx_soliddew_to_top_layer(c) ) &
+                          + qflx_h2osfc_to_ice(c)
+                   snow_sinks(c) = frac_sno_eff(c) * (qflx_solidevap_from_top_layer(c) &
+                          + qflx_liqevap_from_top_layer(c)) + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
                           + qflx_snwcp_discarded_ice(c) + qflx_snwcp_discarded_liq(c) &
                           + qflx_snow_drain(c) + qflx_sl_top_soil(c)
                 endif
@@ -556,11 +558,11 @@ contains
                  write(iulog,*)'qflx_prec_grnd     = ',qflx_prec_grnd(indexc)*dtime
                  write(iulog,*)'qflx_snow_grnd_col = ',qflx_snow_grnd_col(indexc)*dtime
                  write(iulog,*)'qflx_liq_grnd_col  = ',qflx_liq_grnd_col(indexc)*dtime
-                 write(iulog,*)'qflx_sub_snow      = ',qflx_sub_snow(indexc)*dtime
+                 write(iulog,*)'qflx_solidevap_from_top_layer = ',qflx_solidevap_from_top_layer(indexc)*dtime
                  write(iulog,*)'qflx_snow_drain    = ',qflx_snow_drain(indexc)*dtime
-                 write(iulog,*)'qflx_evap_grnd     = ',qflx_evap_grnd(indexc)*dtime
-                 write(iulog,*)'qflx_dew_snow      = ',qflx_dew_snow(indexc)*dtime
-                 write(iulog,*)'qflx_dew_grnd      = ',qflx_dew_grnd(indexc)*dtime
+                 write(iulog,*)'qflx_liqevap_from_top_layer   = ',qflx_liqevap_from_top_layer(indexc)*dtime
+                 write(iulog,*)'qflx_liqdew_to_top_layer      = ',qflx_liqdew_to_top_layer(indexc)*dtime
+                 write(iulog,*)'qflx_soliddew_to_top_layer    = ',qflx_soliddew_to_top_layer(indexc)*dtime
                  write(iulog,*)'qflx_snwcp_ice     = ',qflx_snwcp_ice(indexc)*dtime
                  write(iulog,*)'qflx_snwcp_liq     = ',qflx_snwcp_liq(indexc)*dtime
                  write(iulog,*)'qflx_snwcp_discarded_ice = ',qflx_snwcp_discarded_ice(indexc)*dtime

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -315,10 +315,10 @@ contains
           qflx_snwcp_discarded_liq =>   waterflux_inst%qflx_snwcp_discarded_liq_col, & ! Input:  [real(r8) (:)   ]  excess liquid h2o due to snow capping, which we simply discard in order to reset the snow pack (mm H2O /s) [+]`
           qflx_snwcp_discarded_ice =>   waterflux_inst%qflx_snwcp_discarded_ice_col, & ! Input:  [real(r8) (:)   ]  excess solid h2o due to snow capping, which we simply discard in order to reset the snow pack (mm H2O /s) [+]`
           qflx_evap_tot           =>    waterflux_inst%qflx_evap_tot_col        , & ! Input:  [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
-          qflx_liqdew_to_top_layer      => waterflux_inst%qflx_liqdew_to_top_layer_col     , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+          qflx_soliddew_to_top_layer    => waterflux_inst%qflx_soliddew_to_top_layer_col   , & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
           qflx_solidevap_from_top_layer => waterflux_inst%qflx_solidevap_from_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
           qflx_liqevap_from_top_layer   => waterflux_inst%qflx_liqevap_from_top_layer_col  , & ! Input:  [real(r8) (:)   ]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
-          qflx_soliddew_to_top_layer    => waterflux_inst%qflx_soliddew_to_top_layer_col   , & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
+          qflx_liqdew_to_top_layer      => waterflux_inst%qflx_liqdew_to_top_layer_col     , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
           qflx_prec_grnd          =>    waterdiagnosticbulk_inst%qflx_prec_grnd_col, & ! Input:  [real(r8) (:)   ]  water onto ground including canopy runoff [kg/(m2 s)]
           qflx_snow_h2osfc        =>    waterflux_inst%qflx_snow_h2osfc_col     , & ! Input:  [real(r8) (:)   ]  snow falling on surface water (mm/s)
           qflx_h2osfc_to_ice      =>    waterflux_inst%qflx_h2osfc_to_ice_col   , & ! Input:  [real(r8) (:)   ]  conversion of h2osfc to ice             
@@ -490,8 +490,8 @@ contains
              ! only created if h2osno > 10mm).
 
              if (col%snl(c) < 0) then
-                snow_sources(c) = qflx_prec_grnd(c) + qflx_liqdew_to_top_layer(c) &
-                     + qflx_soliddew_to_top_layer(c)
+                snow_sources(c) = qflx_prec_grnd(c) + qflx_soliddew_to_top_layer(c) &
+                     + qflx_liqdew_to_top_layer(c)
                 snow_sinks(c)  = qflx_solidevap_from_top_layer(c) + qflx_liqevap_from_top_layer(c) &
                      + qflx_snow_drain(c) + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
                      + qflx_snwcp_discarded_ice(c) + qflx_snwcp_discarded_liq(c) &
@@ -500,7 +500,7 @@ contains
                 if (lun%itype(l) == istdlak) then 
                    snow_sources(c) = qflx_snow_grnd_col(c) &
                         + frac_sno_eff(c) * (qflx_liq_grnd_col(c) &
-                        +  qflx_liqdew_to_top_layer(c) + qflx_soliddew_to_top_layer(c) ) 
+                        +  qflx_soliddew_to_top_layer(c) + qflx_liqdew_to_top_layer(c) ) 
                    snow_sinks(c)   = frac_sno_eff(c) * (qflx_solidevap_from_top_layer(c) &
                         + qflx_liqevap_from_top_layer(c) ) + qflx_snwcp_ice(c) + qflx_snwcp_liq(c)  &
                         + qflx_snwcp_discarded_ice(c) + qflx_snwcp_discarded_liq(c)  &
@@ -512,7 +512,7 @@ contains
                       lun%itype(l) == istice_mec) then
                    snow_sources(c) = (qflx_snow_grnd_col(c) - qflx_snow_h2osfc(c) ) &
                           + frac_sno_eff(c) * (qflx_liq_grnd_col(c) &
-                          + qflx_liqdew_to_top_layer(c) + qflx_soliddew_to_top_layer(c) ) &
+                          + qflx_soliddew_to_top_layer(c) + qflx_liqdew_to_top_layer(c) ) &
                           + qflx_h2osfc_to_ice(c)
                    snow_sinks(c) = frac_sno_eff(c) * (qflx_solidevap_from_top_layer(c) &
                           + qflx_liqevap_from_top_layer(c)) + qflx_snwcp_ice(c) + qflx_snwcp_liq(c) &
@@ -560,9 +560,9 @@ contains
                  write(iulog,*)'qflx_liq_grnd_col  = ',qflx_liq_grnd_col(indexc)*dtime
                  write(iulog,*)'qflx_solidevap_from_top_layer = ',qflx_solidevap_from_top_layer(indexc)*dtime
                  write(iulog,*)'qflx_snow_drain    = ',qflx_snow_drain(indexc)*dtime
-                 write(iulog,*)'qflx_liqevap_from_top_layer   = ',qflx_liqevap_from_top_layer(indexc)*dtime
-                 write(iulog,*)'qflx_liqdew_to_top_layer      = ',qflx_liqdew_to_top_layer(indexc)*dtime
-                 write(iulog,*)'qflx_soliddew_to_top_layer    = ',qflx_soliddew_to_top_layer(indexc)*dtime
+                 write(iulog,*)'qflx_liqevap_from_top_layer = ',qflx_liqevap_from_top_layer(indexc)*dtime
+                 write(iulog,*)'qflx_soliddew_to_top_layer  = ',qflx_soliddew_to_top_layer(indexc)*dtime
+                 write(iulog,*)'qflx_liqdew_to_top_layer    = ',qflx_liqdew_to_top_layer(indexc)*dtime
                  write(iulog,*)'qflx_snwcp_ice     = ',qflx_snwcp_ice(indexc)*dtime
                  write(iulog,*)'qflx_snwcp_liq     = ',qflx_snwcp_liq(indexc)*dtime
                  write(iulog,*)'qflx_snwcp_discarded_ice = ',qflx_snwcp_discarded_ice(indexc)*dtime

--- a/src/biogeophys/LakeHydrologyMod.F90
+++ b/src/biogeophys/LakeHydrologyMod.F90
@@ -122,7 +122,7 @@ contains
     logical  :: unfrozen(bounds%begc:bounds%endc)               ! true if top lake layer is unfrozen with snow layers above
     real(r8) :: heatrem                                         ! used in case above [J/m^2]
     real(r8) :: heatsum(bounds%begc:bounds%endc)                ! used in case above [J/m^2]
-    real(r8) :: qflx_dew_minus_sub_snow                         ! qflx_dew_snow - qflx_sub_snow [mm/s]
+    real(r8) :: qflx_dew_minus_sub_snow                         ! qflx_liqdew_to_top_layer - qflx_solidevap_from_top_layer [mm/s]
     real(r8), parameter :: frac_sno_small = 1.e-6_r8            ! small value of frac_sno used when initiating a snow pack due to frost
     real(r8), parameter :: snow_bd = 250._r8                    ! assumed snow bulk density (for lakes w/out resolved snow layers) [kg/m^3]
     ! Should only be used for frost below.
@@ -187,16 +187,16 @@ contains
          qflx_liq_grnd        =>  b_waterflux_inst%qflx_liq_grnd_col      , & ! Output: [real(r8) (:)   ]  liquid on ground after interception (mm H2O/s) [+]
          qflx_evap_tot        =>  b_waterflux_inst%qflx_evap_tot_patch    , & ! Output: [real(r8) (:)   ]  qflx_evap_soi + qflx_evap_can + qflx_tran_veg
          qflx_evap_soi        =>  b_waterflux_inst%qflx_evap_soi_patch    , & ! Output: [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
-         qflx_sub_snow        =>  b_waterflux_inst%qflx_sub_snow_patch    , & ! Output: [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]
-         qflx_evap_grnd       =>  b_waterflux_inst%qflx_evap_grnd_patch   , & ! Output: [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
-         qflx_dew_snow        =>  b_waterflux_inst%qflx_dew_snow_patch    , & ! Output: [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]
-         qflx_dew_grnd        =>  b_waterflux_inst%qflx_dew_grnd_patch    , & ! Output: [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]
+         qflx_solidevap_from_top_layer => b_waterflux_inst%qflx_solidevap_from_top_layer_patch, & ! Output: [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
+         qflx_liqevap_from_top_layer   => b_waterflux_inst%qflx_liqevap_from_top_layer_patch  , & ! Output: [real(r8) (:)   ]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
+         qflx_liqdew_to_top_layer      => b_waterflux_inst%qflx_liqdew_to_top_layer_patch     , & ! Output: [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+         qflx_soliddew_to_top_layer    =>  b_waterflux_inst%qflx_soliddew_to_top_layer_patch  , & ! Output: [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
          qflx_snomelt         =>  b_waterflux_inst%qflx_snomelt_col       , & ! Output: [real(r8) (:)   ]  snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>  b_waterflux_inst%qflx_snomelt_lyr_col   , & ! Output: [real(r8) (:)   ]  snow melt in each layer (mm H2O /s)
-         qflx_evap_grnd_col   =>  b_waterflux_inst%qflx_evap_grnd_col     , & ! Output: [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]
-         qflx_dew_grnd_col    =>  b_waterflux_inst%qflx_dew_grnd_col      , & ! Output: [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]
-         qflx_dew_snow_col    =>  b_waterflux_inst%qflx_dew_snow_col      , & ! Output: [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]
-         qflx_sub_snow_col    =>  b_waterflux_inst%qflx_sub_snow_col      , & ! Output: [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]
+         qflx_liqevap_from_top_layer_col   => b_waterflux_inst%qflx_liqevap_from_top_layer_col  , & ! Output: [real(r8) (:)   ]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
+         qflx_soliddew_to_top_layer_col    =>  b_waterflux_inst%qflx_soliddew_to_top_layer_col  , & ! Output: [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
+         qflx_liqdew_to_top_layer_col      => b_waterflux_inst%qflx_liqdew_to_top_layer_col     , & ! Output: [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+         qflx_solidevap_from_top_layer_col => b_waterflux_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
          qflx_evap_tot_col    =>  b_waterflux_inst%qflx_evap_tot_col      , & ! Output: [real(r8) (:)   ]  pft quantity averaged to the column (assuming one pft)
          qflx_snwcp_ice       =>  b_waterflux_inst%qflx_snwcp_ice_col     , & ! Output: [real(r8) (:)   ]  excess solid h2o due to snow capping (outgoing) (mm H2O /s) [+]
          qflx_snwcp_discarded_ice => b_waterflux_inst%qflx_snwcp_discarded_ice_col, & ! Input: [real(r8) (:)   ]  excess solid h2o due to snow capping, which we simply discard in order to reset the snow pack (mm H2O /s) [+]
@@ -274,10 +274,10 @@ contains
        c = pcolumn(p)
        jtop = snl(c)+1
 
-       qflx_evap_grnd(p) = 0._r8
-       qflx_sub_snow(p) = 0._r8
-       qflx_dew_snow(p) = 0._r8
-       qflx_dew_grnd(p) = 0._r8
+       qflx_liqevap_from_top_layer(p)   = 0._r8
+       qflx_solidevap_from_top_layer(p) = 0._r8
+       qflx_liqdew_to_top_layer(p)      = 0._r8
+       qflx_soliddew_to_top_layer(p)    = 0._r8
 
        if (jtop <= 0) then ! snow layers
           j = jtop
@@ -291,21 +291,22 @@ contains
              ! snow layer than there is there, create temp. limited evap_soi.
              qflx_evap_soi_lim = min(qflx_evap_soi(p), (h2osoi_liq(c,j)+h2osoi_ice(c,j))/dtime)
              if ((h2osoi_liq(c,j)+h2osoi_ice(c,j)) > 0._r8) then
-                qflx_evap_grnd(p) = max(qflx_evap_soi_lim*(h2osoi_liq(c,j)/(h2osoi_liq(c,j)+h2osoi_ice(c,j))), 0._r8)
+                qflx_liqevap_from_top_layer(p) = max(qflx_evap_soi_lim*(h2osoi_liq(c,j)/ &
+                     (h2osoi_liq(c,j)+h2osoi_ice(c,j))), 0._r8)
              else
-                qflx_evap_grnd(p) = 0._r8
+                qflx_liqevap_from_top_layer(p) = 0._r8
              end if
-             qflx_sub_snow(p) = qflx_evap_soi_lim - qflx_evap_grnd(p)     
+             qflx_solidevap_from_top_layer(p) = qflx_evap_soi_lim - qflx_liqevap_from_top_layer(p)     
           else
              ! if (t_grnd(c) < tfrz) then
              ! Causes rare blowup when thin snow layer should completely melt and has a high temp after thermal physics,
              ! but then is not eliminated in SnowHydrology because of this added frost. Also see below removal of
              ! completely melted single snow layer.
              if (t_grnd(c) < tfrz .and. t_soisno(c,j) < tfrz) then
-                qflx_dew_snow(p) = abs(qflx_evap_soi(p))
+                qflx_liqdew_to_top_layer(p) = abs(qflx_evap_soi(p))
                 ! If top layer is only snow layer, SnowHydrology won't eliminate it if dew is added.
              else if (j < 0 .or. (t_grnd(c) == tfrz .and. t_soisno(c,j) == tfrz)) then
-                qflx_dew_grnd(p) = abs(qflx_evap_soi(p))
+                qflx_soliddew_to_top_layer(p) = abs(qflx_evap_soi(p))
              end if
           end if
 
@@ -313,20 +314,20 @@ contains
           if (qflx_evap_soi(p) >= 0._r8) then
              ! Sublimation: do not allow for more sublimation than there is snow
              ! after melt.  Remaining surface evaporation used for infiltration.
-             qflx_sub_snow(p) = min(qflx_evap_soi(p), h2osno_no_layers(c)/dtime)
-             qflx_evap_grnd(p) = qflx_evap_soi(p) - qflx_sub_snow(p)
+             qflx_solidevap_from_top_layer(p) = min(qflx_evap_soi(p), h2osno_no_layers(c)/dtime)
+             qflx_liqevap_from_top_layer(p) = qflx_evap_soi(p) - qflx_solidevap_from_top_layer(p)
           else
              if (t_grnd(c) < tfrz-0.1_r8) then
-                qflx_dew_snow(p) = abs(qflx_evap_soi(p))
+                qflx_liqdew_to_top_layer(p) = abs(qflx_evap_soi(p))
              else
-                qflx_dew_grnd(p) = abs(qflx_evap_soi(p))
+                qflx_soliddew_to_top_layer(p) = abs(qflx_evap_soi(p))
              end if
           end if
 
           ! Update snow pack for dew & sub.
 
           h2osno_temp = h2osno_no_layers(c)
-          qflx_dew_minus_sub_snow = -qflx_sub_snow(p)+qflx_dew_snow(p)
+          qflx_dew_minus_sub_snow = -qflx_solidevap_from_top_layer(p)+qflx_liqdew_to_top_layer(p)
           h2osno_no_layers(c) = h2osno_no_layers(c) + qflx_dew_minus_sub_snow*dtime
           h2osno_no_layers(c) = max(h2osno_no_layers(c), 0._r8)
           if (qflx_dew_minus_sub_snow > 0._r8) then
@@ -373,10 +374,10 @@ contains
        c = pcolumn(p)
 
        qflx_evap_tot_col(c)  = qflx_evap_tot(p)
-       qflx_evap_grnd_col(c) = qflx_evap_grnd(p)
-       qflx_dew_grnd_col(c)  = qflx_dew_grnd(p)
-       qflx_dew_snow_col(c)  = qflx_dew_snow(p)
-       qflx_sub_snow_col(c)  = qflx_sub_snow(p)
+       qflx_liqevap_from_top_layer_col(c)   = qflx_liqevap_from_top_layer(p)
+       qflx_soliddew_to_top_layer_col(c)    = qflx_soliddew_to_top_layer(p)
+       qflx_liqdew_to_top_layer_col(c)      = qflx_liqdew_to_top_layer(p)
+       qflx_solidevap_from_top_layer_col(c) = qflx_solidevap_from_top_layer(p)
     enddo
 
     ! BUG(wjs, 2019-07-12, ESCOMP/ctsm#762) This is needed so that we can test the

--- a/src/biogeophys/LakeHydrologyMod.F90
+++ b/src/biogeophys/LakeHydrologyMod.F90
@@ -197,6 +197,8 @@ contains
          qflx_soliddew_to_top_layer_col    =>  b_waterflux_inst%qflx_soliddew_to_top_layer_col  , & ! Output: [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
          qflx_liqdew_to_top_layer_col      => b_waterflux_inst%qflx_liqdew_to_top_layer_col     , & ! Output: [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
          qflx_solidevap_from_top_layer_col => b_waterflux_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
+         qflx_ev_snow         =>  b_waterflux_inst%qflx_ev_snow_patch     , & ! Output: [real(r8) (:)   ]  evaporation flux from snow (mm H2O/s) [+ to atm]
+         qflx_ev_snow_col     =>  b_waterflux_inst%qflx_ev_snow_col       , & ! Output: [real(r8) (:)   ]  evaporation flux from snow (mm H2O/s) [+ to atm]
          qflx_evap_tot_col    =>  b_waterflux_inst%qflx_evap_tot_col      , & ! Output: [real(r8) (:)   ]  pft quantity averaged to the column (assuming one pft)
          qflx_snwcp_ice       =>  b_waterflux_inst%qflx_snwcp_ice_col     , & ! Output: [real(r8) (:)   ]  excess solid h2o due to snow capping (outgoing) (mm H2O /s) [+]
          qflx_snwcp_discarded_ice => b_waterflux_inst%qflx_snwcp_discarded_ice_col, & ! Input: [real(r8) (:)   ]  excess solid h2o due to snow capping, which we simply discard in order to reset the snow pack (mm H2O /s) [+]
@@ -278,6 +280,7 @@ contains
        qflx_solidevap_from_top_layer(p) = 0._r8
        qflx_liqdew_to_top_layer(p)      = 0._r8
        qflx_soliddew_to_top_layer(p)    = 0._r8
+       qflx_ev_snow(p)                  = qflx_evap_soi(p)
 
        if (jtop <= 0) then ! snow layers
           j = jtop
@@ -290,6 +293,7 @@ contains
              ! Since we're not limiting evap over lakes, but still can't remove more from top
              ! snow layer than there is there, create temp. limited evap_soi.
              qflx_evap_soi_lim = min(qflx_evap_soi(p), (h2osoi_liq(c,j)+h2osoi_ice(c,j))/dtime)
+             qflx_ev_snow(p) = qflx_evap_soi_lim
              if ((h2osoi_liq(c,j)+h2osoi_ice(c,j)) > 0._r8) then
                 qflx_liqevap_from_top_layer(p) = max(qflx_evap_soi_lim*(h2osoi_liq(c,j)/ &
                      (h2osoi_liq(c,j)+h2osoi_ice(c,j))), 0._r8)
@@ -378,6 +382,7 @@ contains
        qflx_soliddew_to_top_layer_col(c)    = qflx_soliddew_to_top_layer(p)
        qflx_liqdew_to_top_layer_col(c)      = qflx_liqdew_to_top_layer(p)
        qflx_solidevap_from_top_layer_col(c) = qflx_solidevap_from_top_layer(p)
+       qflx_ev_snow_col(c)                  = qflx_ev_snow(p)
     enddo
 
     ! BUG(wjs, 2019-07-12, ESCOMP/ctsm#762) This is needed so that we can test the

--- a/src/biogeophys/SnowHydrologyMod.F90
+++ b/src/biogeophys/SnowHydrologyMod.F90
@@ -989,11 +989,11 @@ contains
             dtime          = dtime, &
             snl            = col%snl(begc:endc), &
             frac_sno_eff   = b_waterdiagnostic_inst%frac_sno_eff_col(begc:endc), &
-            qflx_dew_snow  = w%waterflux_inst%qflx_dew_snow_col(begc:endc), &
-            qflx_sub_snow  = w%waterflux_inst%qflx_sub_snow_col(begc:endc), &
+            qflx_liqdew_to_top_layer      = w%waterflux_inst%qflx_liqdew_to_top_layer_col(begc:endc), &
+            qflx_solidevap_from_top_layer = w%waterflux_inst%qflx_solidevap_from_top_layer_col(begc:endc), &
             qflx_liq_grnd  = w%waterflux_inst%qflx_liq_grnd_col(begc:endc), &
-            qflx_dew_grnd  = w%waterflux_inst%qflx_dew_grnd_col(begc:endc), &
-            qflx_evap_grnd = w%waterflux_inst%qflx_evap_grnd_col(begc:endc), &
+            qflx_soliddew_to_top_layer  = w%waterflux_inst%qflx_soliddew_to_top_layer_col(begc:endc), &
+            qflx_liqevap_from_top_layer = w%waterflux_inst%qflx_liqevap_from_top_layer_col(begc:endc), &
             ! Outputs
             h2osoi_ice     = w%waterstate_inst%h2osoi_ice_col(begc:endc,:), &
             h2osoi_liq     = w%waterstate_inst%h2osoi_liq_col(begc:endc,:))
@@ -1060,8 +1060,8 @@ contains
          ! Inputs
          dtime            = dtime, &
          frac_sno_eff     = b_waterdiagnostic_inst%frac_sno_eff_col(begc:endc), &
-         qflx_dew_snow    = b_waterflux_inst%qflx_dew_snow_col(begc:endc), &
-         qflx_dew_grnd    = b_waterflux_inst%qflx_dew_grnd_col(begc:endc), &
+         qflx_liqdew_to_top_layer   = b_waterflux_inst%qflx_liqdew_to_top_layer_col(begc:endc), &
+         qflx_soliddew_to_top_layer = b_waterflux_inst%qflx_soliddew_to_top_layer_col(begc:endc), &
          qflx_liq_grnd    = b_waterflux_inst%qflx_liq_grnd_col(begc:endc), &
          h2osno_no_layers = b_waterstate_inst%h2osno_no_layers_col(begc:endc), &
          ! Outputs
@@ -1090,8 +1090,8 @@ contains
   !-----------------------------------------------------------------------
   subroutine UpdateState_TopLayerFluxes(bounds, num_snowc, filter_snowc, &
        name, dtime, snl, frac_sno_eff, &
-       qflx_dew_snow, qflx_sub_snow, qflx_liq_grnd, qflx_dew_grnd, qflx_evap_grnd, &
-       h2osoi_ice, h2osoi_liq)
+       qflx_liqdew_to_top_layer, qflx_solidevap_from_top_layer, qflx_liq_grnd, &
+       qflx_soliddew_to_top_layer, qflx_liqevap_from_top_layer, h2osoi_ice, h2osoi_liq)
     !
     ! !DESCRIPTION:
     ! Update top layer of snow pack with various fluxes into and out of the top layer,
@@ -1106,11 +1106,11 @@ contains
     real(r8)         , intent(in) :: dtime                          ! land model time step (sec)
     integer          , intent(in) :: snl( bounds%begc: )            ! negative number of snow layers
     real(r8)         , intent(in) :: frac_sno_eff( bounds%begc: )   ! eff. fraction of ground covered by snow (0 to 1)
-    real(r8)         , intent(in) :: qflx_dew_snow( bounds%begc: )  ! surface dew added to snow pack (mm H2O /s)
-    real(r8)         , intent(in) :: qflx_sub_snow( bounds%begc: )  ! sublimation rate from snow pack (mm H2O /s)
+    real(r8)         , intent(in) :: qflx_liqdew_to_top_layer( bounds%begc: ) ! rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s)
+    real(r8)         , intent(in) :: qflx_solidevap_from_top_layer( bounds%begc: ) ! rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s)
     real(r8)         , intent(in) :: qflx_liq_grnd( bounds%begc: )  ! liquid on ground after interception (mm H2O/s)
-    real(r8)         , intent(in) :: qflx_dew_grnd( bounds%begc: )  ! ground surface dew formation (mm H2O /s)
-    real(r8)         , intent(in) :: qflx_evap_grnd( bounds%begc: ) ! ground surface evaporation rate (mm H2O/s)
+    real(r8)         , intent(in) :: qflx_soliddew_to_top_layer( bounds%begc: ) ! rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s)
+    real(r8)         , intent(in) :: qflx_liqevap_from_top_layer( bounds%begc: ) ! rate of liquid water evaporated from top soil or snow layer (mm H2O/s)
 
     real(r8) , intent(inout) :: h2osoi_ice( bounds%begc: , -nlevsno+1: ) ! ice lens (kg/m2)
     real(r8) , intent(inout) :: h2osoi_liq( bounds%begc: , -nlevsno+1: ) ! liquid water (kg/m2)
@@ -1126,11 +1126,11 @@ contains
 
     SHR_ASSERT_FL((ubound(snl, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(frac_sno_eff, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_dew_snow, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_sub_snow, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_liqdew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_solidevap_from_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_liq_grnd, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_dew_grnd, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_evap_grnd, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_soliddew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_liqevap_from_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(h2osoi_ice, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(h2osoi_liq, 1) == bounds%endc), sourcefile, __LINE__)
 
@@ -1145,11 +1145,12 @@ contains
        h2osoi_liq_top_orig(c) = h2osoi_liq(c,lev_top(c))
 
        h2osoi_ice(c,lev_top(c)) = h2osoi_ice(c,lev_top(c)) &
-            + frac_sno_eff(c) * (qflx_dew_snow(c) - qflx_sub_snow(c)) * dtime
+            + frac_sno_eff(c) * (qflx_liqdew_to_top_layer(c) &
+            - qflx_solidevap_from_top_layer(c)) * dtime
 
        h2osoi_liq(c,lev_top(c)) = h2osoi_liq(c,lev_top(c)) +  &
-            frac_sno_eff(c) * (qflx_liq_grnd(c) + qflx_dew_grnd(c) &
-            - qflx_evap_grnd(c)) * dtime
+            frac_sno_eff(c) * (qflx_liq_grnd(c) + qflx_soliddew_to_top_layer(c) &
+            - qflx_liqevap_from_top_layer(c)) * dtime
     end do
 
     ! If states were supposed to go to 0 but instead ended up near-0 (positive or
@@ -1185,8 +1186,8 @@ contains
           write(iulog,*) "h2osoi_ice_top_orig = ", h2osoi_ice_top_orig(c)
           write(iulog,*) "h2osoi_ice          = ", h2osoi_ice(c,lev_top(c))
           write(iulog,*) "frac_sno_eff        = ", frac_sno_eff(c)
-          write(iulog,*) "qflx_dew_snow*dtime = ", qflx_dew_snow(c)*dtime
-          write(iulog,*) "qflx_sub_snow*dtime = ", qflx_sub_snow(c)*dtime
+          write(iulog,*) "qflx_liqdew_to_top_layer*dtime = ", qflx_liqdew_to_top_layer(c)*dtime
+          write(iulog,*) "qflx_solidevap_from_top_layer*dtime = ", qflx_solidevap_from_top_layer(c)*dtime
           call endrun("In UpdateState_TopLayerFluxes, h2osoi_ice has gone significantly negative")
        end if
 
@@ -1198,8 +1199,8 @@ contains
           write(iulog,*) "h2osoi_liq           = ", h2osoi_liq(c,lev_top(c))
           write(iulog,*) "frac_sno_eff         = ", frac_sno_eff(c)
           write(iulog,*) "qflx_liq_grnd*dtime  = ", qflx_liq_grnd(c)*dtime
-          write(iulog,*) "qflx_dew_grnd*dtime  = ", qflx_dew_grnd(c)*dtime
-          write(iulog,*) "qflx_evap_grnd*dtime = ", qflx_evap_grnd(c)*dtime
+          write(iulog,*) "qflx_soliddew_to_top_layer*dtime  = ", qflx_soliddew_to_top_layer(c)*dtime
+          write(iulog,*) "qflx_liqevap_from_top_layer*dtime = ", qflx_liqevap_from_top_layer(c)*dtime
           call endrun("In UpdateState_TopLayerFluxes, h2osoi_liq has gone significantly negative")
        end if
 
@@ -1645,8 +1646,8 @@ contains
   !-----------------------------------------------------------------------
   subroutine BulkDiag_SnowWaterAccumulatedSnow(bounds, &
        num_snowc, filter_snowc, num_nosnowc, filter_nosnowc, &
-       dtime, frac_sno_eff, qflx_dew_snow, qflx_dew_grnd, qflx_liq_grnd, h2osno_no_layers, &
-       int_snow, frac_sno, snow_depth)
+       dtime, frac_sno_eff, qflx_liqdew_to_top_layer, qflx_soliddew_to_top_layer, &
+       qflx_liq_grnd, h2osno_no_layers, int_snow, frac_sno, snow_depth)
     !
     ! !DESCRIPTION:
     ! Update int_snow, and reset accumulated snow when no snow present
@@ -1660,8 +1661,8 @@ contains
 
     real(r8) , intent(in)    :: dtime                            ! land model time step (sec)
     real(r8) , intent(in)    :: frac_sno_eff( bounds%begc: )     ! eff. fraction of ground covered by snow (0 to 1)
-    real(r8) , intent(in)    :: qflx_dew_snow( bounds%begc: )    ! surface dew added to snow pack (mm H2O /s)
-    real(r8) , intent(in)    :: qflx_dew_grnd( bounds%begc: )    ! ground surface dew formation (mm H2O /s)
+    real(r8) , intent(in)    :: qflx_liqdew_to_top_layer( bounds%begc: ) ! rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s)
+    real(r8) , intent(in)    :: qflx_soliddew_to_top_layer( bounds%begc: ) ! rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s)
     real(r8) , intent(in)    :: qflx_liq_grnd( bounds%begc: )    ! liquid on ground after interception (mm H2O/s)
     real(r8) , intent(in)    :: h2osno_no_layers( bounds%begc: ) ! snow that is not resolved into layers (kg/m2)
 
@@ -1676,8 +1677,8 @@ contains
     !-----------------------------------------------------------------------
 
     SHR_ASSERT_FL((ubound(frac_sno_eff, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_dew_snow, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_dew_grnd, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_liqdew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_soliddew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_liq_grnd, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(h2osno_no_layers, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(int_snow, 1) == bounds%endc), sourcefile, __LINE__)
@@ -1688,7 +1689,8 @@ contains
        c = filter_snowc(fc)
 
        int_snow(c) = int_snow(c) + frac_sno_eff(c) &
-            * (qflx_dew_snow(c) + qflx_dew_grnd(c) + qflx_liq_grnd(c)) * dtime
+            * (qflx_liqdew_to_top_layer(c) + qflx_soliddew_to_top_layer(c) &
+            + qflx_liq_grnd(c)) * dtime
     end do
 
     do fc = 1, num_nosnowc

--- a/src/biogeophys/SnowHydrologyMod.F90
+++ b/src/biogeophys/SnowHydrologyMod.F90
@@ -989,11 +989,11 @@ contains
             dtime          = dtime, &
             snl            = col%snl(begc:endc), &
             frac_sno_eff   = b_waterdiagnostic_inst%frac_sno_eff_col(begc:endc), &
-            qflx_liqdew_to_top_layer      = w%waterflux_inst%qflx_liqdew_to_top_layer_col(begc:endc), &
+            qflx_soliddew_to_top_layer    = w%waterflux_inst%qflx_soliddew_to_top_layer_col(begc:endc), &
             qflx_solidevap_from_top_layer = w%waterflux_inst%qflx_solidevap_from_top_layer_col(begc:endc), &
-            qflx_liq_grnd  = w%waterflux_inst%qflx_liq_grnd_col(begc:endc), &
-            qflx_soliddew_to_top_layer  = w%waterflux_inst%qflx_soliddew_to_top_layer_col(begc:endc), &
-            qflx_liqevap_from_top_layer = w%waterflux_inst%qflx_liqevap_from_top_layer_col(begc:endc), &
+            qflx_liq_grnd                 = w%waterflux_inst%qflx_liq_grnd_col(begc:endc), &
+            qflx_liqdew_to_top_layer      = w%waterflux_inst%qflx_liqdew_to_top_layer_col(begc:endc), &
+            qflx_liqevap_from_top_layer   = w%waterflux_inst%qflx_liqevap_from_top_layer_col(begc:endc), &
             ! Outputs
             h2osoi_ice     = w%waterstate_inst%h2osoi_ice_col(begc:endc,:), &
             h2osoi_liq     = w%waterstate_inst%h2osoi_liq_col(begc:endc,:))
@@ -1060,10 +1060,10 @@ contains
          ! Inputs
          dtime            = dtime, &
          frac_sno_eff     = b_waterdiagnostic_inst%frac_sno_eff_col(begc:endc), &
-         qflx_liqdew_to_top_layer   = b_waterflux_inst%qflx_liqdew_to_top_layer_col(begc:endc), &
          qflx_soliddew_to_top_layer = b_waterflux_inst%qflx_soliddew_to_top_layer_col(begc:endc), &
-         qflx_liq_grnd    = b_waterflux_inst%qflx_liq_grnd_col(begc:endc), &
-         h2osno_no_layers = b_waterstate_inst%h2osno_no_layers_col(begc:endc), &
+         qflx_liqdew_to_top_layer   = b_waterflux_inst%qflx_liqdew_to_top_layer_col(begc:endc), &
+         qflx_liq_grnd              = b_waterflux_inst%qflx_liq_grnd_col(begc:endc), &
+         h2osno_no_layers           = b_waterstate_inst%h2osno_no_layers_col(begc:endc), &
          ! Outputs
          int_snow         = b_waterstate_inst%int_snow_col(begc:endc), &
          frac_sno         = b_waterdiagnostic_inst%frac_sno_col(begc:endc), &
@@ -1090,8 +1090,8 @@ contains
   !-----------------------------------------------------------------------
   subroutine UpdateState_TopLayerFluxes(bounds, num_snowc, filter_snowc, &
        name, dtime, snl, frac_sno_eff, &
-       qflx_liqdew_to_top_layer, qflx_solidevap_from_top_layer, qflx_liq_grnd, &
-       qflx_soliddew_to_top_layer, qflx_liqevap_from_top_layer, h2osoi_ice, h2osoi_liq)
+       qflx_soliddew_to_top_layer, qflx_solidevap_from_top_layer, qflx_liq_grnd, &
+       qflx_liqdew_to_top_layer, qflx_liqevap_from_top_layer, h2osoi_ice, h2osoi_liq)
     !
     ! !DESCRIPTION:
     ! Update top layer of snow pack with various fluxes into and out of the top layer,
@@ -1126,10 +1126,10 @@ contains
 
     SHR_ASSERT_FL((ubound(snl, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(frac_sno_eff, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_liqdew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_soliddew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_solidevap_from_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_liq_grnd, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_soliddew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_liqdew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_liqevap_from_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(h2osoi_ice, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(h2osoi_liq, 1) == bounds%endc), sourcefile, __LINE__)
@@ -1145,11 +1145,11 @@ contains
        h2osoi_liq_top_orig(c) = h2osoi_liq(c,lev_top(c))
 
        h2osoi_ice(c,lev_top(c)) = h2osoi_ice(c,lev_top(c)) &
-            + frac_sno_eff(c) * (qflx_liqdew_to_top_layer(c) &
+            + frac_sno_eff(c) * (qflx_soliddew_to_top_layer(c) &
             - qflx_solidevap_from_top_layer(c)) * dtime
 
        h2osoi_liq(c,lev_top(c)) = h2osoi_liq(c,lev_top(c)) +  &
-            frac_sno_eff(c) * (qflx_liq_grnd(c) + qflx_soliddew_to_top_layer(c) &
+            frac_sno_eff(c) * (qflx_liq_grnd(c) + qflx_liqdew_to_top_layer(c) &
             - qflx_liqevap_from_top_layer(c)) * dtime
     end do
 
@@ -1186,7 +1186,7 @@ contains
           write(iulog,*) "h2osoi_ice_top_orig = ", h2osoi_ice_top_orig(c)
           write(iulog,*) "h2osoi_ice          = ", h2osoi_ice(c,lev_top(c))
           write(iulog,*) "frac_sno_eff        = ", frac_sno_eff(c)
-          write(iulog,*) "qflx_liqdew_to_top_layer*dtime = ", qflx_liqdew_to_top_layer(c)*dtime
+          write(iulog,*) "qflx_soliddew_to_top_layer*dtime = ", qflx_soliddew_to_top_layer(c)*dtime
           write(iulog,*) "qflx_solidevap_from_top_layer*dtime = ", qflx_solidevap_from_top_layer(c)*dtime
           call endrun("In UpdateState_TopLayerFluxes, h2osoi_ice has gone significantly negative")
        end if
@@ -1199,7 +1199,7 @@ contains
           write(iulog,*) "h2osoi_liq           = ", h2osoi_liq(c,lev_top(c))
           write(iulog,*) "frac_sno_eff         = ", frac_sno_eff(c)
           write(iulog,*) "qflx_liq_grnd*dtime  = ", qflx_liq_grnd(c)*dtime
-          write(iulog,*) "qflx_soliddew_to_top_layer*dtime  = ", qflx_soliddew_to_top_layer(c)*dtime
+          write(iulog,*) "qflx_liqdew_to_top_layer*dtime  = ", qflx_liqdew_to_top_layer(c)*dtime
           write(iulog,*) "qflx_liqevap_from_top_layer*dtime = ", qflx_liqevap_from_top_layer(c)*dtime
           call endrun("In UpdateState_TopLayerFluxes, h2osoi_liq has gone significantly negative")
        end if
@@ -1646,7 +1646,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine BulkDiag_SnowWaterAccumulatedSnow(bounds, &
        num_snowc, filter_snowc, num_nosnowc, filter_nosnowc, &
-       dtime, frac_sno_eff, qflx_liqdew_to_top_layer, qflx_soliddew_to_top_layer, &
+       dtime, frac_sno_eff, qflx_soliddew_to_top_layer, qflx_liqdew_to_top_layer, &
        qflx_liq_grnd, h2osno_no_layers, int_snow, frac_sno, snow_depth)
     !
     ! !DESCRIPTION:
@@ -1661,8 +1661,8 @@ contains
 
     real(r8) , intent(in)    :: dtime                            ! land model time step (sec)
     real(r8) , intent(in)    :: frac_sno_eff( bounds%begc: )     ! eff. fraction of ground covered by snow (0 to 1)
-    real(r8) , intent(in)    :: qflx_liqdew_to_top_layer( bounds%begc: ) ! rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s)
     real(r8) , intent(in)    :: qflx_soliddew_to_top_layer( bounds%begc: ) ! rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s)
+    real(r8) , intent(in)    :: qflx_liqdew_to_top_layer( bounds%begc: ) ! rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s)
     real(r8) , intent(in)    :: qflx_liq_grnd( bounds%begc: )    ! liquid on ground after interception (mm H2O/s)
     real(r8) , intent(in)    :: h2osno_no_layers( bounds%begc: ) ! snow that is not resolved into layers (kg/m2)
 
@@ -1677,8 +1677,8 @@ contains
     !-----------------------------------------------------------------------
 
     SHR_ASSERT_FL((ubound(frac_sno_eff, 1) == bounds%endc), sourcefile, __LINE__)
-    SHR_ASSERT_FL((ubound(qflx_liqdew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_soliddew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
+    SHR_ASSERT_FL((ubound(qflx_liqdew_to_top_layer, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(qflx_liq_grnd, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(h2osno_no_layers, 1) == bounds%endc), sourcefile, __LINE__)
     SHR_ASSERT_FL((ubound(int_snow, 1) == bounds%endc), sourcefile, __LINE__)
@@ -1689,7 +1689,7 @@ contains
        c = filter_snowc(fc)
 
        int_snow(c) = int_snow(c) + frac_sno_eff(c) &
-            * (qflx_liqdew_to_top_layer(c) + qflx_soliddew_to_top_layer(c) &
+            * (qflx_soliddew_to_top_layer(c) + qflx_liqdew_to_top_layer(c) &
             + qflx_liq_grnd(c)) * dtime
     end do
 

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -210,10 +210,9 @@ contains
          eflx_sh_grnd(p) = eflx_sh_grnd(p) + tinc(c)*cgrnds(p)
          qflx_evap_soi(p) = qflx_evap_soi(p) + tinc(c)*cgrndl(p)
 
-         ! set ev_snow, ev_soil, ev_h2osfc for urban landunits here
+         ! set ev_soil, ev_h2osfc for urban landunits here
          l = patch%landunit(p)
          if (lun%urbpoi(l)) then
-            qflx_ev_snow(p) = 0._r8
             qflx_ev_soil(p) = 0._r8
             qflx_ev_h2osfc(p) = 0._r8
          else
@@ -276,6 +275,11 @@ contains
             qflx_ev_h2osfc(p) = qflx_ev_h2osfc(p) * egirat(c)
          end if
 
+         ! set ev_snow for urban landunits here
+         if (lun%urbpoi(l)) then
+            qflx_ev_snow(p) = qflx_evap_soi(p)
+         end if
+
          ! Ground heat flux
          
          if (.not. lun%urbpoi(l)) then
@@ -320,14 +324,24 @@ contains
             eflx_sh_tot_u(p)= eflx_sh_tot(p)
          end if
 
-         ! Assign ground evaporation to sublimation from soil ice or to dew
-         ! on snow or ground
-
          qflx_liqevap_from_top_layer(p)   = 0._r8
          qflx_solidevap_from_top_layer(p) = 0._r8
          qflx_liqdew_to_top_layer(p)      = 0._r8
          qflx_soliddew_to_top_layer(p)    = 0._r8
 
+         ! Partition the evaporation from snow/soil surface into liquid evaporation, 
+         ! solid evaporation (sublimation), liquid dew, or solid dew.  Note that the variables
+         ! affected here are all related to the snow subgrid patch only because of the use of qflx_ev_snow.
+         ! In the situations where there are snow layers or there is snow without an explicit snow layer, 
+         ! the partitioned variables will represent the components of snow evaporation 
+         ! (qflx_ev_snow = qflx_liqevap_from_top_layer + qflx_solidevap_from_top_layer 
+         ! - qflx_liqdew_to_top_layer - qflx_soliddew_to_top_layer).
+         ! In the case of no snow, qflx_ev_snow has already been set equal to qflx_ev_soil (the evaporation 
+         ! from the subgrid soil patch) and the partitioned variables will then represent evaporation from the 
+         ! subgrid soil patch.
+         ! In the case of urban columns (and lake columns - see LakeHydrologyMod), there are no subgrid 
+         ! patches and qflx_evap_soi is used. qflx_evap_soi = qflx_liqevap_from_top_layer + qflx_solidevap_from_top_layer 
+         ! - qflx_liqdew_to_top_layer - qflx_soliddew_to_top_layer.
          if (.not. lun%urbpoi(l)) then
             if (qflx_ev_snow(p) >= 0._r8) then
                ! for evaporation partitioning between liquid evap and ice sublimation, 
@@ -355,11 +369,10 @@ contains
                if ((h2osoi_liq(c,j)+h2osoi_ice(c,j)) > 0._r8) then
                   qflx_liqevap_from_top_layer(p) = max(qflx_evap_soi(p)*(h2osoi_liq(c,j)/ &
                        (h2osoi_liq(c,j)+h2osoi_ice(c,j))), 0._r8)
-                  qflx_solidevap_from_top_layer(p) = qflx_evap_soi(p) - qflx_liqevap_from_top_layer(p)
                else
                   qflx_liqevap_from_top_layer(p) = 0._r8
-                  qflx_solidevap_from_top_layer(p) = 0._r8
                end if
+               qflx_solidevap_from_top_layer(p) = qflx_evap_soi(p) - qflx_liqevap_from_top_layer(p)
             else
                if (t_grnd(c) < tfrz) then
                   qflx_liqdew_to_top_layer(p) = abs(qflx_evap_soi(p))

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -326,8 +326,8 @@ contains
 
          qflx_liqevap_from_top_layer(p)   = 0._r8
          qflx_solidevap_from_top_layer(p) = 0._r8
-         qflx_liqdew_to_top_layer(p)      = 0._r8
          qflx_soliddew_to_top_layer(p)    = 0._r8
+         qflx_liqdew_to_top_layer(p)      = 0._r8
 
          ! Partition the evaporation from snow/soil surface into liquid evaporation, 
          ! solid evaporation (sublimation), liquid dew, or solid dew.  Note that the variables
@@ -355,9 +355,9 @@ contains
                qflx_solidevap_from_top_layer(p) = qflx_ev_snow(p) - qflx_liqevap_from_top_layer(p)
             else
                if (t_grnd(c) < tfrz) then
-                  qflx_liqdew_to_top_layer(p) = abs(qflx_ev_snow(p))
-               else
                   qflx_soliddew_to_top_layer(p) = abs(qflx_ev_snow(p))
+               else
+                  qflx_liqdew_to_top_layer(p) = abs(qflx_ev_snow(p))
                end if
             end if
 
@@ -375,9 +375,9 @@ contains
                qflx_solidevap_from_top_layer(p) = qflx_evap_soi(p) - qflx_liqevap_from_top_layer(p)
             else
                if (t_grnd(c) < tfrz) then
-                  qflx_liqdew_to_top_layer(p) = abs(qflx_evap_soi(p))
-               else
                   qflx_soliddew_to_top_layer(p) = abs(qflx_evap_soi(p))
+               else
+                  qflx_liqdew_to_top_layer(p) = abs(qflx_evap_soi(p))
                end if
             end if
 

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -210,9 +210,10 @@ contains
          eflx_sh_grnd(p) = eflx_sh_grnd(p) + tinc(c)*cgrnds(p)
          qflx_evap_soi(p) = qflx_evap_soi(p) + tinc(c)*cgrndl(p)
 
-         ! set ev_snow, ev_soil for urban landunits here
+         ! set ev_snow, ev_soil, ev_h2osfc for urban landunits here
          l = patch%landunit(p)
          if (lun%urbpoi(l)) then
+            qflx_ev_snow(p) = 0._r8
             qflx_ev_soil(p) = 0._r8
             qflx_ev_h2osfc(p) = 0._r8
          else

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -210,11 +210,12 @@ contains
          eflx_sh_grnd(p) = eflx_sh_grnd(p) + tinc(c)*cgrnds(p)
          qflx_evap_soi(p) = qflx_evap_soi(p) + tinc(c)*cgrndl(p)
 
-         ! set ev_soil, ev_h2osfc for urban landunits here
+         ! Set ev_soil, ev_h2osfc, ev_snow for urban landunits here
          l = patch%landunit(p)
          if (lun%urbpoi(l)) then
             qflx_ev_soil(p) = 0._r8
             qflx_ev_h2osfc(p) = 0._r8
+            qflx_ev_snow(p) = qflx_evap_soi(p)
          else
             qflx_ev_snow(p) = qflx_ev_snow(p) + tinc(c)*cgrndl(p)
             qflx_ev_soil(p) = qflx_ev_soil(p) + tinc(c)*cgrndl(p)
@@ -275,7 +276,7 @@ contains
             qflx_ev_h2osfc(p) = qflx_ev_h2osfc(p) * egirat(c)
          end if
 
-         ! set ev_snow for urban landunits here
+         ! Update ev_snow for urban landunits here
          if (lun%urbpoi(l)) then
             qflx_ev_snow(p) = qflx_evap_soi(p)
          end if

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -636,8 +636,8 @@ contains
           h2osoi_vol         =>    waterstatebulk_inst%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
           frac_h2osfc        =>    waterdiagnosticbulk_inst%frac_h2osfc_col       , & ! Input:  [real(r8) (:)   ]                                                    
 
-          qflx_soliddew_to_top_layer => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_liqdew_to_top_layer   => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col  , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_soliddew_to_top_layer => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_ev_snow       =>    waterfluxbulk_inst%qflx_ev_snow_col   , & ! In/Out: [real(r8) (:)   ]  evaporation flux from snow (mm H2O/s) [+ to atm]
           bsw                =>    soilstate_inst%bsw_col                , & ! Input:  [real(r8) (:,:) ]  Clapp and Hornberger "b"                        
           hksat              =>    soilstate_inst%hksat_col              , & ! Input:  [real(r8) (:,:) ]  hydraulic conductivity at saturation (mm H2O /s)
@@ -833,8 +833,8 @@ contains
           if (snl(c)+1 >= 1) then
 
              ! make consistent with how evap_grnd removed in infiltration
-             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
+             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
+             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
              if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
                 qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
                 qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
@@ -854,8 +854,8 @@ contains
 
           if (col%itype(c) == icol_roof .or. col%itype(c) == icol_road_imperv) then
              if (snl(c)+1 >= 1) then
-                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_soliddew_to_top_layer(c) * dtime
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_liqdew_to_top_layer(c) * dtime)
+                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_liqdew_to_top_layer(c) * dtime
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_soliddew_to_top_layer(c) * dtime)
                 if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
                    qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
                    qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
@@ -987,8 +987,8 @@ contains
           
           qflx_snwcp_liq     =>    waterfluxbulk_inst%qflx_snwcp_liq_col     , & ! Output: [real(r8) (:)   ] excess liquid h2o due to snow capping (outgoing) (mm H2O /s) [+]
           qflx_ice_runoff_xs =>    waterfluxbulk_inst%qflx_ice_runoff_xs_col , & ! Output: [real(r8) (:)   ] solid runoff from excess ice in soil (mm H2O /s) [+]
-          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col   , & ! Output: [real(r8) (:)   ] rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_liqdew_to_top_layer      => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col     , & ! Output: [real(r8) (:)   ] rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col   , & ! Output: [real(r8) (:)   ] rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ] rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           qflx_drain         =>    waterfluxbulk_inst%qflx_drain_col         , & ! Output: [real(r8) (:)   ] sub-surface runoff (mm H2O /s)                    
           qflx_qrgwl         =>    waterfluxbulk_inst%qflx_qrgwl_col         , & ! Output: [real(r8) (:)   ] qflx_surf at glaciers, wetlands, lakes (mm H2O /s)
@@ -2029,8 +2029,8 @@ contains
           
           qflx_snwcp_liq     =>    waterfluxbulk_inst%qflx_snwcp_liq_col     , & ! Output: [real(r8) (:)   ] excess rainfall due to snow capping (mm H2O /s) [+]
           qflx_ice_runoff_xs =>    waterfluxbulk_inst%qflx_ice_runoff_xs_col , & ! Output: [real(r8) (:)   ] solid runoff from excess ice in soil (mm H2O /s) [+]
-          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col   , & ! Output: [real(r8) (:)   ] rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_liqdew_to_top_layer      => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col     , & ! Output: [real(r8) (:)   ] rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col   , & ! Output: [real(r8) (:)   ] rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ] rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           qflx_drain         =>    waterfluxbulk_inst%qflx_drain_col         , & ! Output: [real(r8) (:)   ] sub-surface runoff (mm H2O /s)                    
           qflx_qrgwl         =>    waterfluxbulk_inst%qflx_qrgwl_col         , & ! Output: [real(r8) (:)   ] qflx_surf at glaciers, wetlands, lakes (mm H2O /s)
@@ -2287,8 +2287,8 @@ contains
           h2osoi_liq         =>    waterstatebulk_inst%h2osoi_liq_col        , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)                            
           h2osoi_ice         =>    waterstatebulk_inst%h2osoi_ice_col        , & ! Output: [real(r8) (:,:) ]  ice lens (kg/m2)                                
           frac_h2osfc        =>    waterdiagnosticbulk_inst%frac_h2osfc_col       , & ! Input:  [real(r8) (:)   ]                                                    
-          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_liqdew_to_top_layer      => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col  , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
           qflx_ev_snow                  => waterfluxbulk_inst%qflx_ev_snow_col    , & ! In/Out: [real(r8) (:)   ]  evaporation flux from snow (mm H2O/s) [+ to atm]
           qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col & ! Output: [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           )
@@ -2305,8 +2305,8 @@ contains
           if (snl(c)+1 >= 1) then
 
              ! make consistent with how evap_grnd removed in infiltration
-             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
+             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
+             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
              if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
                 qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
                 qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
@@ -2327,8 +2327,8 @@ contains
 
           if (col%itype(c) == icol_roof .or. col%itype(c) == icol_road_imperv) then
              if (snl(c)+1 >= 1) then
-                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_soliddew_to_top_layer(c) * dtime
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_liqdew_to_top_layer(c) * dtime)
+                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_liqdew_to_top_layer(c) * dtime
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_soliddew_to_top_layer(c) * dtime)
                 if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
                    qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
                    qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -283,7 +283,7 @@ contains
           qflx_snow_h2osfc        =>    waterfluxbulk_inst%qflx_snow_h2osfc_col       , & ! Input:  [real(r8) (:)]  snow falling on surface water (mm/s)
           qflx_floodc             =>    waterfluxbulk_inst%qflx_floodc_col            , & ! Input:  [real(r8) (:)]  column flux of flood water from RTM
           qflx_ev_soil            =>    waterfluxbulk_inst%qflx_ev_soil_col           , & ! Input:  [real(r8) (:)]  evaporation flux from soil (W/m**2) [+ to atm]
-          qflx_evap_grnd          =>    waterfluxbulk_inst%qflx_evap_grnd_col         , & ! Input:  [real(r8) (:)]  ground surface evaporation rate (mm H2O/s) [+]
+          qflx_liqevap_from_top_layer => waterfluxbulk_inst%qflx_liqevap_from_top_layer_col, & ! Input:  [real(r8) (:)]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
           qflx_ev_h2osfc          =>    waterfluxbulk_inst%qflx_ev_h2osfc_col         , & ! Input:  [real(r8) (:)]  evaporation flux from h2osfc (W/m**2) [+ to atm]
           qflx_sat_excess_surf    =>    waterfluxbulk_inst%qflx_sat_excess_surf_col   , & ! Input:  [real(r8) (:)]  surface runoff due to saturated surface (mm H2O /s)
 
@@ -303,7 +303,7 @@ contains
         if (snl(c) >= 0) then
            fsno=0._r8
            ! if no snow layers, sublimation is removed from h2osoi_ice in drainage
-           qflx_evap=qflx_evap_grnd(c)
+           qflx_evap=qflx_liqevap_from_top_layer(c)
         else
            fsno=frac_sno(c)
            qflx_evap=qflx_ev_soil(c)
@@ -451,7 +451,7 @@ contains
           qflx_infl_excess_surf => waterfluxbulk_inst%qflx_infl_excess_surf_col, & ! Input:  [real(r8) (:)   ]  surface runoff due to infiltration excess (mm H2O /s)
           qflx_h2osfc_surf =>    waterfluxbulk_inst%qflx_h2osfc_surf_col,  & ! Input:  [real(r8) (:)   ]  surface water runoff (mm H2O /s)
           qflx_rain_plus_snomelt => waterfluxbulk_inst%qflx_rain_plus_snomelt_col , & ! Input: [real(r8) (:)   ] rain plus snow melt falling on the soil (mm/s)
-          qflx_evap_grnd   =>    waterfluxbulk_inst%qflx_evap_grnd_col   , & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]    
+          qflx_liqevap_from_top_layer => waterfluxbulk_inst%qflx_liqevap_from_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]    
           qflx_floodc      =>    waterfluxbulk_inst%qflx_floodc_col      , & ! Input:  [real(r8) (:)   ]  column flux of flood water from RTM               
           qflx_sat_excess_surf => waterfluxbulk_inst%qflx_sat_excess_surf_col , & ! Input:  [real(r8) (:)   ]  surface runoff due to saturated surface (mm H2O /s)
 
@@ -491,7 +491,7 @@ contains
               ! h2osoi_liq(c,1) are roughly analogous to h2osfc in hydrologically-active
               ! columns. Why not use h2osfc for urban columns, too?
               xs_urban(c) = max(0._r8, &
-                   h2osoi_liq(c,1)/dtime + qflx_rain_plus_snomelt(c) - qflx_evap_grnd(c) - &
+                   h2osoi_liq(c,1)/dtime + qflx_rain_plus_snomelt(c) - qflx_liqevap_from_top_layer(c) - &
                    pondmx_urban/dtime)
               qflx_surf(c) = xs_urban(c)
            end if
@@ -536,7 +536,7 @@ contains
          xs_urban         =>    soilhydrology_inst%xs_urban_col     , & ! Input:  [real(r8) (:)   ]  excess soil water above urban ponding limit
 
          qflx_rain_plus_snomelt => waterfluxbulk_inst%qflx_rain_plus_snomelt_col , & ! Input: [real(r8) (:)   ] rain plus snow melt falling on the soil (mm/s)
-         qflx_evap_grnd   =>    waterfluxbulk_inst%qflx_evap_grnd_col     & ! Input:  [real(r8) (:)   ]  ground surface evaporation rate (mm H2O/s) [+]    
+         qflx_liqevap_from_top_layer => waterfluxbulk_inst%qflx_liqevap_from_top_layer_col & ! Input:  [real(r8) (:)   ]  rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]    
          )
 
      dtime = get_step_size_real()
@@ -550,7 +550,7 @@ contains
                  h2osoi_liq(c,1) = pondmx_urban
               else
                  h2osoi_liq(c,1) = max(0._r8,h2osoi_liq(c,1)+ &
-                      (qflx_rain_plus_snomelt(c)-qflx_evap_grnd(c))*dtime)
+                      (qflx_rain_plus_snomelt(c)-qflx_liqevap_from_top_layer(c))*dtime)
               end if
            end if
         end if
@@ -635,8 +635,8 @@ contains
           h2osoi_vol         =>    waterstatebulk_inst%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
           frac_h2osfc        =>    waterdiagnosticbulk_inst%frac_h2osfc_col       , & ! Input:  [real(r8) (:)   ]                                                    
 
-          qflx_dew_grnd      =>    waterfluxbulk_inst%qflx_dew_grnd_col      , & ! Input:  [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]      
-          qflx_dew_snow      =>    waterfluxbulk_inst%qflx_dew_snow_col      , & ! Input:  [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]    
+          qflx_soliddew_to_top_layer => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
+          qflx_liqdew_to_top_layer   => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col  , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
 
           bsw                =>    soilstate_inst%bsw_col                , & ! Input:  [real(r8) (:,:) ]  Clapp and Hornberger "b"                        
           hksat              =>    soilstate_inst%hksat_col              , & ! Input:  [real(r8) (:,:) ]  hydraulic conductivity at saturation (mm H2O /s)
@@ -651,7 +651,7 @@ contains
           qcharge            =>    soilhydrology_inst%qcharge_col        , & ! Input:  [real(r8) (:)   ]  aquifer recharge rate (mm/s)                      
           origflag           =>    soilhydrology_inst%origflag           , & ! Input:  logical  
           
-          qflx_sub_snow      =>    waterfluxbulk_inst%qflx_sub_snow_col      , & ! Output: [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]   
+          qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           qflx_drain         =>    waterfluxbulk_inst%qflx_drain_col         , & ! Output: [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)                    
           qflx_drain_perched =>    waterfluxbulk_inst%qflx_drain_perched_col , & ! Output: [real(r8) (:)   ]  perched wt sub-surface runoff (mm H2O /s)         
           qflx_rsub_sat      =>    waterfluxbulk_inst%qflx_rsub_sat_col        & ! Output: [real(r8) (:)   ]  soil saturation excess [mm h2o/s]                 
@@ -832,13 +832,13 @@ contains
           if (snl(c)+1 >= 1) then
 
              ! make consistent with how evap_grnd removed in infiltration
-             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_dew_grnd(c) * dtime
-             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_dew_snow(c) * dtime
-             if (qflx_sub_snow(c)*dtime > h2osoi_ice(c,1)) then
-                qflx_sub_snow(c) = h2osoi_ice(c,1)/dtime
+             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
+             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
+             if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
+                qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
                 h2osoi_ice(c,1) = 0._r8
              else
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_sub_snow(c) * dtime
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
              end if
           end if
        end do
@@ -850,13 +850,13 @@ contains
 
           if (col%itype(c) == icol_roof .or. col%itype(c) == icol_road_imperv) then
              if (snl(c)+1 >= 1) then
-                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_dew_grnd(c) * dtime
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_dew_snow(c) * dtime)
-                if (qflx_sub_snow(c)*dtime > h2osoi_ice(c,1)) then
-                   qflx_sub_snow(c) = h2osoi_ice(c,1)/dtime
+                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_soliddew_to_top_layer(c) * dtime
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_liqdew_to_top_layer(c) * dtime)
+                if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
+                   qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
                    h2osoi_ice(c,1) = 0._r8
                 else
-                   h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_sub_snow(c) * dtime)
+                   h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_solidevap_from_top_layer(c) * dtime)
                 end if
              end if
           end if
@@ -980,9 +980,9 @@ contains
           
           qflx_snwcp_liq     =>    waterfluxbulk_inst%qflx_snwcp_liq_col     , & ! Output: [real(r8) (:)   ] excess liquid h2o due to snow capping (outgoing) (mm H2O /s) [+]
           qflx_ice_runoff_xs =>    waterfluxbulk_inst%qflx_ice_runoff_xs_col , & ! Output: [real(r8) (:)   ] solid runoff from excess ice in soil (mm H2O /s) [+]
-          qflx_dew_grnd      =>    waterfluxbulk_inst%qflx_dew_grnd_col      , & ! Output: [real(r8) (:)   ] ground surface dew formation (mm H2O /s) [+]      
-          qflx_dew_snow      =>    waterfluxbulk_inst%qflx_dew_snow_col      , & ! Output: [real(r8) (:)   ] surface dew added to snow pack (mm H2O /s) [+]    
-          qflx_sub_snow      =>    waterfluxbulk_inst%qflx_sub_snow_col      , & ! Output: [real(r8) (:)   ] sublimation rate from snow pack (mm H2O /s) [+]   
+          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col   , & ! Output: [real(r8) (:)   ] rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
+          qflx_liqdew_to_top_layer      => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col     , & ! Output: [real(r8) (:)   ] rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ] rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           qflx_drain         =>    waterfluxbulk_inst%qflx_drain_col         , & ! Output: [real(r8) (:)   ] sub-surface runoff (mm H2O /s)                    
           qflx_qrgwl         =>    waterfluxbulk_inst%qflx_qrgwl_col         , & ! Output: [real(r8) (:)   ] qflx_surf at glaciers, wetlands, lakes (mm H2O /s)
           qflx_rsub_sat      =>    waterfluxbulk_inst%qflx_rsub_sat_col      , & ! Output: [real(r8) (:)   ] soil saturation excess [mm h2o/s]                 
@@ -2022,9 +2022,9 @@ contains
           
           qflx_snwcp_liq     =>    waterfluxbulk_inst%qflx_snwcp_liq_col     , & ! Output: [real(r8) (:)   ] excess rainfall due to snow capping (mm H2O /s) [+]
           qflx_ice_runoff_xs =>    waterfluxbulk_inst%qflx_ice_runoff_xs_col , & ! Output: [real(r8) (:)   ] solid runoff from excess ice in soil (mm H2O /s) [+]
-          qflx_dew_grnd      =>    waterfluxbulk_inst%qflx_dew_grnd_col      , & ! Output: [real(r8) (:)   ] ground surface dew formation (mm H2O /s) [+]      
-          qflx_dew_snow      =>    waterfluxbulk_inst%qflx_dew_snow_col      , & ! Output: [real(r8) (:)   ] surface dew added to snow pack (mm H2O /s) [+]    
-          qflx_sub_snow      =>    waterfluxbulk_inst%qflx_sub_snow_col      , & ! Output: [real(r8) (:)   ] sublimation rate from snow pack (mm H2O /s) [+]   
+          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col   , & ! Output: [real(r8) (:)   ] rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
+          qflx_liqdew_to_top_layer      => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col     , & ! Output: [real(r8) (:)   ] rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col, & ! Output: [real(r8) (:)   ] rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           qflx_drain         =>    waterfluxbulk_inst%qflx_drain_col         , & ! Output: [real(r8) (:)   ] sub-surface runoff (mm H2O /s)                    
           qflx_qrgwl         =>    waterfluxbulk_inst%qflx_qrgwl_col         , & ! Output: [real(r8) (:)   ] qflx_surf at glaciers, wetlands, lakes (mm H2O /s)
           qflx_rsub_sat      =>    waterfluxbulk_inst%qflx_rsub_sat_col      , & ! Output: [real(r8) (:)   ] soil saturation excess [mm h2o/s]                 
@@ -2279,9 +2279,9 @@ contains
           h2osoi_liq         =>    waterstatebulk_inst%h2osoi_liq_col        , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)                            
           h2osoi_ice         =>    waterstatebulk_inst%h2osoi_ice_col        , & ! Output: [real(r8) (:,:) ]  ice lens (kg/m2)                                
           frac_h2osfc        =>    waterdiagnosticbulk_inst%frac_h2osfc_col       , & ! Input:  [real(r8) (:)   ]                                                    
-          qflx_dew_grnd      =>    waterfluxbulk_inst%qflx_dew_grnd_col      , & ! Input:  [real(r8) (:)   ]  ground surface dew formation (mm H2O /s) [+]      
-          qflx_dew_snow      =>    waterfluxbulk_inst%qflx_dew_snow_col      , & ! Input:  [real(r8) (:)   ]  surface dew added to snow pack (mm H2O /s) [+]    
-          qflx_sub_snow      =>    waterfluxbulk_inst%qflx_sub_snow_col       & ! Output: [real(r8) (:)   ]  sublimation rate from snow pack (mm H2O /s) [+]   
+          qflx_soliddew_to_top_layer    => waterfluxbulk_inst%qflx_soliddew_to_top_layer_col, & ! Input:  [real(r8) (:)   ]  rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]      
+          qflx_liqdew_to_top_layer      => waterfluxbulk_inst%qflx_liqdew_to_top_layer_col  , & ! Input:  [real(r8) (:)   ]  rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]    
+          qflx_solidevap_from_top_layer => waterfluxbulk_inst%qflx_solidevap_from_top_layer_col & ! Output: [real(r8) (:)   ]  rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]   
           )
 
        ! Get time step
@@ -2296,13 +2296,13 @@ contains
           if (snl(c)+1 >= 1) then
 
              ! make consistent with how evap_grnd removed in infiltration
-             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_dew_grnd(c) * dtime
-             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_dew_snow(c) * dtime
-             if (qflx_sub_snow(c)*dtime > h2osoi_ice(c,1)) then
-                qflx_sub_snow(c) = h2osoi_ice(c,1)/dtime
+             h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
+             h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
+             if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
+                qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
                 h2osoi_ice(c,1) = 0._r8
              else
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_sub_snow(c) * dtime
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
              end if
           end if
 
@@ -2315,13 +2315,13 @@ contains
 
           if (col%itype(c) == icol_roof .or. col%itype(c) == icol_road_imperv) then
              if (snl(c)+1 >= 1) then
-                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_dew_grnd(c) * dtime
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_dew_snow(c) * dtime)
-                if (qflx_sub_snow(c)*dtime > h2osoi_ice(c,1)) then
-                   qflx_sub_snow(c) = h2osoi_ice(c,1)/dtime
+                h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_soliddew_to_top_layer(c) * dtime
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_liqdew_to_top_layer(c) * dtime)
+                if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
+                   qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
                    h2osoi_ice(c,1) = 0._r8
                 else
-                   h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_sub_snow(c) * dtime)
+                   h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_solidevap_from_top_layer(c) * dtime)
                 end if
              end if
           end if

--- a/src/biogeophys/WaterFluxBulkType.F90
+++ b/src/biogeophys/WaterFluxBulkType.F90
@@ -203,6 +203,16 @@ contains
          long_name=this%info%lname('canopy snow temp unloading'), &
          ptr_patch=this%qflx_snotempunload_patch, set_lake=0._r8, c2l_scale_type='urbanf')
 
+    ! QSNOEVAP is evaporation from snow but only when snow is present (snl<0), otherwise, it is 
+    ! equivalent to qflx_ev_soil   
+    this%qflx_ev_snow_col(begc:endc) = spval
+    call hist_addfld1d ( &
+         fname=this%info%fname('QSNOEVAP'), &
+         units='mm/s',  &
+         avgflag='A', &
+         long_name=this%info%lname('evaporation from snow'), &
+         ptr_col=this%qflx_ev_snow_col, c2l_scale_type='urbanf')
+
     this%qflx_h2osfc_surf_col(begc:endc) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QH2OSFC'),  &

--- a/src/biogeophys/WaterFluxBulkType.F90
+++ b/src/biogeophys/WaterFluxBulkType.F90
@@ -210,7 +210,7 @@ contains
          fname=this%info%fname('QSNOEVAP'), &
          units='mm/s',  &
          avgflag='A', &
-         long_name=this%info%lname('evaporation from snow'), &
+         long_name=this%info%lname('evaporation from snow (only when snl<0, otherwise it is equal to qflx_ev_soil'), &
          ptr_col=this%qflx_ev_snow_col, c2l_scale_type='urbanf')
 
     this%qflx_h2osfc_surf_col(begc:endc) = spval

--- a/src/biogeophys/WaterFluxBulkType.F90
+++ b/src/biogeophys/WaterFluxBulkType.F90
@@ -188,6 +188,20 @@ contains
          ptr_col=this%qflx_rootsoi_col, set_spec=spval, l2g_scale_type='veg', default='inactive')
 
     this%qflx_ev_snow_patch(begp:endp) = spval
+    call hist_addfld1d ( &
+         fname=this%info%fname('QSNOEVAP'), &
+         units='mm/s',  &
+         avgflag='A', &
+         long_name=this%info%lname('evaporation from snow'), &
+         ptr_patch=this%qflx_ev_snow_patch, set_lake=0._r8, c2l_scale_type='urbanf')
+
+    this%qflx_ev_soil_patch(begp:endp) = spval
+    call hist_addfld1d ( &
+         fname=this%info%fname('QSOILEVAP'), &
+         units='mm/s',  &
+         avgflag='A', &
+         long_name=this%info%lname('evaporation from soil'), &
+         ptr_patch=this%qflx_ev_soil_patch, set_lake=0._r8, c2l_scale_type='urbanf')
 
     this%qflx_snowindunload_patch(begp:endp) = spval
     call hist_addfld1d ( &

--- a/src/biogeophys/WaterFluxBulkType.F90
+++ b/src/biogeophys/WaterFluxBulkType.F90
@@ -210,7 +210,7 @@ contains
          fname=this%info%fname('QSNOEVAP'), &
          units='mm/s',  &
          avgflag='A', &
-         long_name=this%info%lname('evaporation from snow (only when snl<0, otherwise it is equal to qflx_ev_soil'), &
+         long_name=this%info%lname('evaporation from snow (only when snl<0, otherwise it is equal to qflx_ev_soil)'), &
          ptr_col=this%qflx_ev_snow_col, c2l_scale_type='urbanf')
 
     this%qflx_h2osfc_surf_col(begc:endc) = spval

--- a/src/biogeophys/WaterFluxBulkType.F90
+++ b/src/biogeophys/WaterFluxBulkType.F90
@@ -187,22 +187,6 @@ contains
          long_name=this%info%lname('water flux from soil to root in each soil-layer'), &
          ptr_col=this%qflx_rootsoi_col, set_spec=spval, l2g_scale_type='veg', default='inactive')
 
-    this%qflx_ev_snow_patch(begp:endp) = spval
-    call hist_addfld1d ( &
-         fname=this%info%fname('QSNOEVAP'), &
-         units='mm/s',  &
-         avgflag='A', &
-         long_name=this%info%lname('evaporation from snow'), &
-         ptr_patch=this%qflx_ev_snow_patch, set_lake=0._r8, c2l_scale_type='urbanf')
-
-    this%qflx_ev_soil_patch(begp:endp) = spval
-    call hist_addfld1d ( &
-         fname=this%info%fname('QSOILEVAP'), &
-         units='mm/s',  &
-         avgflag='A', &
-         long_name=this%info%lname('evaporation from soil'), &
-         ptr_patch=this%qflx_ev_soil_patch, set_lake=0._r8, c2l_scale_type='urbanf')
-
     this%qflx_snowindunload_patch(begp:endp) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QSNO_WINDUNLOAD'), &

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -631,13 +631,6 @@ contains
          long_name=this%info%lname('canopy transpiration'), &
          ptr_patch=this%qflx_tran_veg_patch, c2l_scale_type='urbanf')
 
-    call hist_addfld1d ( &
-         fname=this%info%fname('QSNOEVAP'), &
-         units='mm/s',  &
-         avgflag='A', &
-         long_name=this%info%lname('evaporation from snow'), &
-         ptr_patch=this%qflx_tran_veg_patch, set_lake=0._r8, c2l_scale_type='urbanf')
-
     this%qflx_snwcp_liq_col(begc:endc) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QSNOCPLIQ'), &

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -689,11 +689,11 @@ contains
 
     this%qflx_liqevap_from_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_EVAP_GRND'), &
+         fname=this%info%fname('QFLX_LIQEVAP_FROM_TOP_LAYER'), &
          units='mm H2O/s', &
          avgflag='A', &
          long_name=this%info%lname('rate of liquid water evaporated from top soil or snow layer'), &
-         ptr_patch=this%qflx_liqevap_from_top_layer_patch, default='inactive', c2l_scale_type='urbanf')
+         ptr_patch=this%qflx_liqevap_from_top_layer_patch, c2l_scale_type='urbanf')
 
     this%qflx_evap_veg_patch(begp:endp) = spval
     call hist_addfld1d ( &
@@ -713,7 +713,7 @@ contains
 
     this%qflx_soliddew_to_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_DEW_GRND'), &
+         fname=this%info%fname('QFLX_SOLIDDEW_TO_TOP_LAYER'), &
          units='mm H2O/s', &
          avgflag='A', &
          long_name=this%info%lname('rate of solid water deposited on top soil or snow layer (frost)'), &
@@ -721,14 +721,14 @@ contains
 
     this%qflx_solidevap_from_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_SUB_SNOW'), &
+         fname=this%info%fname('QFLX_SOLIDEVAP_FROM_TOP_LAYER'), &
          units='mm H2O/s', &
          avgflag='A', &
          long_name=this%info%lname('rate of ice evaporated from top soil or snow layer (sublimation) (also includes bare ice sublimation from glacier columns)'), &
          ptr_patch=this%qflx_solidevap_from_top_layer_patch, c2l_scale_type='urbanf')
 
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_SUB_SNOW_ICE'), &
+         fname=this%info%fname('QFLX_SOLIDEVAP_FROM_TOP_LAYER_ICE'), &
          units='mm H2O/s', &
          avgflag='A', &
          long_name=this%info%lname('rate of ice evaporated from top soil or snow layer (sublimation) (also includes bare ice sublimation from glacier columns) '// &
@@ -738,10 +738,10 @@ contains
 
     this%qflx_liqdew_to_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_DEW_SNOW'), &
+         fname=this%info%fname('QFLX_LIQDEW_TO_TOP_LAYER'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('surface dew added to snow pacK'), &
+         long_name=this%info%lname('rate of liquid water deposited on top soil or snow layer (dew)'), &
          ptr_patch=this%qflx_liqdew_to_top_layer_patch, c2l_scale_type='urbanf')
 
     this%qflx_rsub_sat_col(begc:endc) = spval

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -38,8 +38,8 @@ module WaterFluxType
      real(r8), pointer :: qflx_liq_grnd_col        (:)   ! col liquid (rain+irrigation) on ground after interception (mm H2O/s) [+]
      real(r8), pointer :: qflx_snow_grnd_col       (:)   ! col snow on ground after interception (mm H2O/s) [+]
      real(r8), pointer :: qflx_rain_plus_snomelt_col(:)  ! col rain plus snow melt falling on the soil (mm/s)
-     real(r8), pointer :: qflx_sub_snow_patch      (:)   ! patch sublimation rate from snow pack (mm H2O /s) [+]
-     real(r8), pointer :: qflx_sub_snow_col        (:)   ! col sublimation rate from snow pack (mm H2O /s) [+]
+     real(r8), pointer :: qflx_solidevap_from_top_layer_patch(:) ! patch rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
+     real(r8), pointer :: qflx_solidevap_from_top_layer_col(:)   ! col rate of ice evaporated from top soil or snow layer (sublimation) (mm H2O /s) [+]
      real(r8), pointer :: qflx_evap_soi_patch      (:)   ! patch soil evaporation (mm H2O/s) (+ = to atm)
      real(r8), pointer :: qflx_evap_soi_col        (:)   ! col soil evaporation (mm H2O/s) (+ = to atm)
      real(r8), pointer :: qflx_evap_veg_patch      (:)   ! patch vegetation evaporation (mm H2O/s) (+ = to atm)
@@ -48,8 +48,8 @@ module WaterFluxType
      real(r8), pointer :: qflx_evap_can_col        (:)   ! col evaporation from leaves and stems (mm H2O/s) (+ = to atm)
      real(r8), pointer :: qflx_evap_tot_patch      (:)   ! patch pft_qflx_evap_soi + pft_qflx_evap_veg + qflx_tran_veg
      real(r8), pointer :: qflx_evap_tot_col        (:)   ! col col_qflx_evap_soi + col_qflx_evap_veg + qflx_tran_veg
-     real(r8), pointer :: qflx_evap_grnd_patch     (:)   ! patch ground surface evaporation rate (mm H2O/s) [+]
-     real(r8), pointer :: qflx_evap_grnd_col       (:)   ! col ground surface evaporation rate (mm H2O/s) [+]
+     real(r8), pointer :: qflx_liqevap_from_top_layer_patch(:) ! patch rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
+     real(r8), pointer :: qflx_liqevap_from_top_layer_col(:)   ! col rate of liquid water evaporated from top soil or snow layer (mm H2O/s) [+]
 
      ! In the snow capping parametrization excess mass above h2osno_max is removed.  A breakdown of mass into liquid 
      ! and solid fluxes is done, these are represented by qflx_snwcp_liq_col and qflx_snwcp_ice_col. 
@@ -64,10 +64,10 @@ module WaterFluxType
 
      real(r8), pointer :: qflx_tran_veg_patch      (:)   ! patch vegetation transpiration (mm H2O/s) (+ = to atm)
      real(r8), pointer :: qflx_tran_veg_col        (:)   ! col vegetation transpiration (mm H2O/s) (+ = to atm)
-     real(r8), pointer :: qflx_dew_snow_patch      (:)   ! patch surface dew added to snow pack (mm H2O /s) [+]
-     real(r8), pointer :: qflx_dew_snow_col        (:)   ! col surface dew added to snow pack (mm H2O /s) [+]
-     real(r8), pointer :: qflx_dew_grnd_patch      (:)   ! patch ground surface dew formation (mm H2O /s) [+]
-     real(r8), pointer :: qflx_dew_grnd_col        (:)   ! col ground surface dew formation (mm H2O /s) [+] (+ = to atm); usually eflx_bot >= 0)
+     real(r8), pointer :: qflx_liqdew_to_top_layer_patch(:)   ! patch rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+     real(r8), pointer :: qflx_liqdew_to_top_layer_col(:)     ! col rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+     real(r8), pointer :: qflx_soliddew_to_top_layer_patch(:) ! patch rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
+     real(r8), pointer :: qflx_soliddew_to_top_layer_col(:)   ! col rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+] (+ = to atm); usually eflx_bot >= 0)
 
      real(r8), pointer :: qflx_infl_col            (:)   ! col infiltration (mm H2O /s)
      real(r8), pointer :: qflx_surf_col            (:)   ! col total surface runoff (mm H2O /s)
@@ -175,17 +175,17 @@ contains
     call AllocateVar1d(var = this%qflx_snow_unload_patch, name = 'qflx_snow_unload_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_sub_snow_patch, name = 'qflx_sub_snow_patch', &
+    call AllocateVar1d(var = this%qflx_solidevap_from_top_layer_patch, name = 'qflx_solidevap_from_top_layer_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH, &
          ival = 0.0_r8)
     call AllocateVar1d(var = this%qflx_tran_veg_patch, name = 'qflx_tran_veg_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_dew_grnd_patch, name = 'qflx_dew_grnd_patch', &
+    call AllocateVar1d(var = this%qflx_soliddew_to_top_layer_patch, name = 'qflx_soliddew_to_top_layer_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_dew_snow_patch, name = 'qflx_dew_snow_patch', &
+    call AllocateVar1d(var = this%qflx_liqdew_to_top_layer_patch, name = 'qflx_liqdew_to_top_layer_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
 
@@ -198,7 +198,7 @@ contains
     call AllocateVar1d(var = this%qflx_rain_plus_snomelt_col, name = 'qflx_rain_plus_snomelt_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
-    call AllocateVar1d(var = this%qflx_sub_snow_col, name = 'qflx_sub_snow_col', &
+    call AllocateVar1d(var = this%qflx_solidevap_from_top_layer_col, name = 'qflx_solidevap_from_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN, &
          ival = 0.0_r8)
@@ -241,13 +241,13 @@ contains
     call AllocateVar1d(var = this%qflx_evap_tot_col, name = 'qflx_evap_tot_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
-    call AllocateVar1d(var = this%qflx_evap_grnd_col, name = 'qflx_evap_grnd_col', &
+    call AllocateVar1d(var = this%qflx_liqevap_from_top_layer_col, name = 'qflx_liqevap_from_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
-    call AllocateVar1d(var = this%qflx_dew_grnd_col, name = 'qflx_dew_grnd_col', &
+    call AllocateVar1d(var = this%qflx_soliddew_to_top_layer_col, name = 'qflx_soliddew_to_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
-    call AllocateVar1d(var = this%qflx_dew_snow_col, name = 'qflx_dew_snow_col', &
+    call AllocateVar1d(var = this%qflx_liqdew_to_top_layer_col, name = 'qflx_liqdew_to_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
     call AllocateVar1d(var = this%qflx_evap_veg_patch, name = 'qflx_evap_veg_patch', &
@@ -262,7 +262,7 @@ contains
     call AllocateVar1d(var = this%qflx_evap_tot_patch, name = 'qflx_evap_tot_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_evap_grnd_patch, name = 'qflx_evap_grnd_patch', &
+    call AllocateVar1d(var = this%qflx_liqevap_from_top_layer_patch, name = 'qflx_liqevap_from_top_layer_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
 
@@ -687,13 +687,13 @@ contains
          long_name=this%info%lname('snow on ground after interception'), &
          ptr_col=this%qflx_snow_grnd_col, default='inactive', c2l_scale_type='urbanf')
 
-    this%qflx_evap_grnd_patch(begp:endp) = spval
+    this%qflx_liqevap_from_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QFLX_EVAP_GRND'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('ground surface evaporation'), &
-         ptr_patch=this%qflx_evap_grnd_patch, default='inactive', c2l_scale_type='urbanf')
+         long_name=this%info%lname('rate of liquid water evaporated from top soil or snow layer'), &
+         ptr_patch=this%qflx_liqevap_from_top_layer_patch, default='inactive', c2l_scale_type='urbanf')
 
     this%qflx_evap_veg_patch(begp:endp) = spval
     call hist_addfld1d ( &
@@ -711,38 +711,38 @@ contains
          long_name=this%info%lname('qflx_evap_soi + qflx_evap_can + qflx_tran_veg'), &
          ptr_patch=this%qflx_evap_tot_patch, c2l_scale_type='urbanf')
 
-    this%qflx_dew_grnd_patch(begp:endp) = spval
+    this%qflx_soliddew_to_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QFLX_DEW_GRND'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('ground surface dew formation'), &
-         ptr_patch=this%qflx_dew_grnd_patch, c2l_scale_type='urbanf')
+         long_name=this%info%lname('rate of solid water deposited on top soil or snow layer (frost)'), &
+         ptr_patch=this%qflx_soliddew_to_top_layer_patch, c2l_scale_type='urbanf')
 
-    this%qflx_sub_snow_patch(begp:endp) = spval
+    this%qflx_solidevap_from_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QFLX_SUB_SNOW'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('sublimation rate from snow pack (also includes bare ice sublimation from glacier columns)'), &
-         ptr_patch=this%qflx_sub_snow_patch, c2l_scale_type='urbanf')
+         long_name=this%info%lname('rate of ice evaporated from top soil or snow layer (sublimation) (also includes bare ice sublimation from glacier columns)'), &
+         ptr_patch=this%qflx_solidevap_from_top_layer_patch, c2l_scale_type='urbanf')
 
     call hist_addfld1d ( &
          fname=this%info%fname('QFLX_SUB_SNOW_ICE'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('sublimation rate from snow pack (also includes bare ice sublimation from glacier columns) '// &
+         long_name=this%info%lname('rate of ice evaporated from top soil or snow layer (sublimation) (also includes bare ice sublimation from glacier columns) '// &
          '(ice landunits only)'), &
-         ptr_patch=this%qflx_sub_snow_patch, c2l_scale_type='urbanf', l2g_scale_type='ice', &
+         ptr_patch=this%qflx_solidevap_from_top_layer_patch, c2l_scale_type='urbanf', l2g_scale_type='ice', &
          default='inactive')
 
-    this%qflx_dew_snow_patch(begp:endp) = spval
+    this%qflx_liqdew_to_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
          fname=this%info%fname('QFLX_DEW_SNOW'), &
          units='mm H2O/s', &
          avgflag='A', &
          long_name=this%info%lname('surface dew added to snow pacK'), &
-         ptr_patch=this%qflx_dew_snow_patch, c2l_scale_type='urbanf')
+         ptr_patch=this%qflx_liqdew_to_top_layer_patch, c2l_scale_type='urbanf')
 
     this%qflx_rsub_sat_col(begc:endc) = spval
     call hist_addfld1d ( &
@@ -823,9 +823,9 @@ contains
     this%qflx_liqcanfall_patch(bounds%begp:bounds%endp)       = 0.0_r8
     this%qflx_snow_unload_patch(bounds%begp:bounds%endp)      = 0.0_r8
 
-    this%qflx_evap_grnd_patch(bounds%begp:bounds%endp)        = 0.0_r8
-    this%qflx_dew_grnd_patch (bounds%begp:bounds%endp)        = 0.0_r8
-    this%qflx_dew_snow_patch (bounds%begp:bounds%endp)        = 0.0_r8
+    this%qflx_liqevap_from_top_layer_patch(bounds%begp:bounds%endp) = 0.0_r8
+    this%qflx_soliddew_to_top_layer_patch (bounds%begp:bounds%endp) = 0.0_r8
+    this%qflx_liqdew_to_top_layer_patch(bounds%begp:bounds%endp)    = 0.0_r8
 
     this%qflx_sfc_irrig_col (bounds%begc:bounds%endc)         = 0.0_r8
     this%qflx_gw_uncon_irrig_col (bounds%begc:bounds%endc)    = 0.0_r8
@@ -834,9 +834,9 @@ contains
     this%qflx_irrig_drip_patch (bounds%begp:bounds%endp)      = 0.0_r8
     this%qflx_irrig_sprinkler_patch (bounds%begp:bounds%endp) = 0.0_r8
     
-    this%qflx_evap_grnd_col(bounds%begc:bounds%endc) = 0.0_r8
-    this%qflx_dew_grnd_col (bounds%begc:bounds%endc) = 0.0_r8
-    this%qflx_dew_snow_col (bounds%begc:bounds%endc) = 0.0_r8
+    this%qflx_liqevap_from_top_layer_col(bounds%begc:bounds%endc) = 0.0_r8
+    this%qflx_soliddew_to_top_layer_col (bounds%begc:bounds%endc) = 0.0_r8
+    this%qflx_liqdew_to_top_layer_col(bounds%begc:bounds%endc)    = 0.0_r8
     this%qflx_snow_drain_col(bounds%begc:bounds%endc)  = 0._r8
 
     ! This variable only gets set in the hydrology filter; need to initialize it to 0 for

--- a/src/biogeophys/WaterFluxType.F90
+++ b/src/biogeophys/WaterFluxType.F90
@@ -64,10 +64,10 @@ module WaterFluxType
 
      real(r8), pointer :: qflx_tran_veg_patch      (:)   ! patch vegetation transpiration (mm H2O/s) (+ = to atm)
      real(r8), pointer :: qflx_tran_veg_col        (:)   ! col vegetation transpiration (mm H2O/s) (+ = to atm)
-     real(r8), pointer :: qflx_liqdew_to_top_layer_patch(:)   ! patch rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
-     real(r8), pointer :: qflx_liqdew_to_top_layer_col(:)     ! col rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
      real(r8), pointer :: qflx_soliddew_to_top_layer_patch(:) ! patch rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+]
      real(r8), pointer :: qflx_soliddew_to_top_layer_col(:)   ! col rate of solid water deposited on top soil or snow layer (frost) (mm H2O /s) [+] (+ = to atm); usually eflx_bot >= 0)
+     real(r8), pointer :: qflx_liqdew_to_top_layer_patch(:)   ! patch rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
+     real(r8), pointer :: qflx_liqdew_to_top_layer_col(:)     ! col rate of liquid water deposited on top soil or snow layer (dew) (mm H2O /s) [+]
 
      real(r8), pointer :: qflx_infl_col            (:)   ! col infiltration (mm H2O /s)
      real(r8), pointer :: qflx_surf_col            (:)   ! col total surface runoff (mm H2O /s)
@@ -182,10 +182,10 @@ contains
     call AllocateVar1d(var = this%qflx_tran_veg_patch, name = 'qflx_tran_veg_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_soliddew_to_top_layer_patch, name = 'qflx_soliddew_to_top_layer_patch', &
+    call AllocateVar1d(var = this%qflx_liqdew_to_top_layer_patch, name = 'qflx_liqdew_to_top_layer_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
-    call AllocateVar1d(var = this%qflx_liqdew_to_top_layer_patch, name = 'qflx_liqdew_to_top_layer_patch', &
+    call AllocateVar1d(var = this%qflx_soliddew_to_top_layer_patch, name = 'qflx_soliddew_to_top_layer_patch', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_PATCH)
 
@@ -244,10 +244,10 @@ contains
     call AllocateVar1d(var = this%qflx_liqevap_from_top_layer_col, name = 'qflx_liqevap_from_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
-    call AllocateVar1d(var = this%qflx_soliddew_to_top_layer_col, name = 'qflx_soliddew_to_top_layer_col', &
+    call AllocateVar1d(var = this%qflx_liqdew_to_top_layer_col, name = 'qflx_liqdew_to_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
-    call AllocateVar1d(var = this%qflx_liqdew_to_top_layer_col, name = 'qflx_liqdew_to_top_layer_col', &
+    call AllocateVar1d(var = this%qflx_soliddew_to_top_layer_col, name = 'qflx_soliddew_to_top_layer_col', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = BOUNDS_SUBGRID_COLUMN)
     call AllocateVar1d(var = this%qflx_evap_veg_patch, name = 'qflx_evap_veg_patch', &
@@ -711,13 +711,13 @@ contains
          long_name=this%info%lname('qflx_evap_soi + qflx_evap_can + qflx_tran_veg'), &
          ptr_patch=this%qflx_evap_tot_patch, c2l_scale_type='urbanf')
 
-    this%qflx_soliddew_to_top_layer_patch(begp:endp) = spval
+    this%qflx_liqdew_to_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_SOLIDDEW_TO_TOP_LAYER'), &
+         fname=this%info%fname('QFLX_LIQDEW_TO_TOP_LAYER'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('rate of solid water deposited on top soil or snow layer (frost)'), &
-         ptr_patch=this%qflx_soliddew_to_top_layer_patch, c2l_scale_type='urbanf')
+         long_name=this%info%lname('rate of liquid water deposited on top soil or snow layer (dew)'), &
+         ptr_patch=this%qflx_liqdew_to_top_layer_patch, c2l_scale_type='urbanf')
 
     this%qflx_solidevap_from_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
@@ -736,13 +736,13 @@ contains
          ptr_patch=this%qflx_solidevap_from_top_layer_patch, c2l_scale_type='urbanf', l2g_scale_type='ice', &
          default='inactive')
 
-    this%qflx_liqdew_to_top_layer_patch(begp:endp) = spval
+    this%qflx_soliddew_to_top_layer_patch(begp:endp) = spval
     call hist_addfld1d ( &
-         fname=this%info%fname('QFLX_LIQDEW_TO_TOP_LAYER'), &
+         fname=this%info%fname('QFLX_SOLIDDEW_TO_TOP_LAYER'), &
          units='mm H2O/s', &
          avgflag='A', &
-         long_name=this%info%lname('rate of liquid water deposited on top soil or snow layer (dew)'), &
-         ptr_patch=this%qflx_liqdew_to_top_layer_patch, c2l_scale_type='urbanf')
+         long_name=this%info%lname('rate of solid water deposited on top soil or snow layer (frost)'), &
+         ptr_patch=this%qflx_soliddew_to_top_layer_patch, c2l_scale_type='urbanf')
 
     this%qflx_rsub_sat_col(begc:endc) = spval
     call hist_addfld1d ( &
@@ -824,8 +824,8 @@ contains
     this%qflx_snow_unload_patch(bounds%begp:bounds%endp)      = 0.0_r8
 
     this%qflx_liqevap_from_top_layer_patch(bounds%begp:bounds%endp) = 0.0_r8
-    this%qflx_soliddew_to_top_layer_patch (bounds%begp:bounds%endp) = 0.0_r8
     this%qflx_liqdew_to_top_layer_patch(bounds%begp:bounds%endp)    = 0.0_r8
+    this%qflx_soliddew_to_top_layer_patch (bounds%begp:bounds%endp) = 0.0_r8
 
     this%qflx_sfc_irrig_col (bounds%begc:bounds%endc)         = 0.0_r8
     this%qflx_gw_uncon_irrig_col (bounds%begc:bounds%endc)    = 0.0_r8
@@ -835,8 +835,8 @@ contains
     this%qflx_irrig_sprinkler_patch (bounds%begp:bounds%endp) = 0.0_r8
     
     this%qflx_liqevap_from_top_layer_col(bounds%begc:bounds%endc) = 0.0_r8
-    this%qflx_soliddew_to_top_layer_col (bounds%begc:bounds%endc) = 0.0_r8
     this%qflx_liqdew_to_top_layer_col(bounds%begc:bounds%endc)    = 0.0_r8
+    this%qflx_soliddew_to_top_layer_col (bounds%begc:bounds%endc) = 0.0_r8
     this%qflx_snow_drain_col(bounds%begc:bounds%endc)  = 0._r8
 
     ! This variable only gets set in the hydrology filter; need to initialize it to 0 for

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1478,24 +1478,24 @@ contains
          waterfluxbulk_inst%qflx_tran_veg_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         waterfluxbulk_inst%qflx_evap_grnd_patch(bounds%begp:bounds%endp), &
-         waterfluxbulk_inst%qflx_evap_grnd_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst%qflx_liqevap_from_top_layer_patch(bounds%begp:bounds%endp), &
+         waterfluxbulk_inst%qflx_liqevap_from_top_layer_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_allc, filter_allc, &
          waterfluxbulk_inst%qflx_evap_soi_patch(bounds%begp:bounds%endp), &
          waterfluxbulk_inst%qflx_evap_soi_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         waterfluxbulk_inst%qflx_dew_grnd_patch(bounds%begp:bounds%endp), &
-         waterfluxbulk_inst%qflx_dew_grnd_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst%qflx_soliddew_to_top_layer_patch(bounds%begp:bounds%endp), &
+         waterfluxbulk_inst%qflx_soliddew_to_top_layer_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         waterfluxbulk_inst%qflx_sub_snow_patch(bounds%begp:bounds%endp), &
-         waterfluxbulk_inst%qflx_sub_snow_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst%qflx_solidevap_from_top_layer_patch(bounds%begp:bounds%endp), &
+         waterfluxbulk_inst%qflx_solidevap_from_top_layer_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         waterfluxbulk_inst%qflx_dew_snow_patch(bounds%begp:bounds%endp), &
-         waterfluxbulk_inst%qflx_dew_snow_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst%qflx_liqdew_to_top_layer_patch(bounds%begp:bounds%endp), &
+         waterfluxbulk_inst%qflx_liqdew_to_top_layer_col(bounds%begc:bounds%endc))
 
   end subroutine clm_drv_patch2col
 

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1486,16 +1486,16 @@ contains
          waterfluxbulk_inst%qflx_evap_soi_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         waterfluxbulk_inst%qflx_soliddew_to_top_layer_patch(bounds%begp:bounds%endp), &
-         waterfluxbulk_inst%qflx_soliddew_to_top_layer_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst%qflx_liqdew_to_top_layer_patch(bounds%begp:bounds%endp), &
+         waterfluxbulk_inst%qflx_liqdew_to_top_layer_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
          waterfluxbulk_inst%qflx_solidevap_from_top_layer_patch(bounds%begp:bounds%endp), &
          waterfluxbulk_inst%qflx_solidevap_from_top_layer_col(bounds%begc:bounds%endc))
 
     call p2c (bounds, num_nolakec, filter_nolakec, &
-         waterfluxbulk_inst%qflx_liqdew_to_top_layer_patch(bounds%begp:bounds%endp), &
-         waterfluxbulk_inst%qflx_liqdew_to_top_layer_col(bounds%begc:bounds%endc))
+         waterfluxbulk_inst%qflx_soliddew_to_top_layer_patch(bounds%begp:bounds%endp), &
+         waterfluxbulk_inst%qflx_soliddew_to_top_layer_col(bounds%begc:bounds%endc))
 
   end subroutine clm_drv_patch2col
 


### PR DESCRIPTION
### Description of changes
Resolve [issue#118](https://github.com/ESCOMP/CTSM/issues/118)
### Specific notes
I've renamed the variables as discussed in [issue#118](https://github.com/ESCOMP/CTSM/issues/118) throughout the code.
I've also made a couple of minor changes to fix a couple of potential problems with these variables as described in the branch commit logs.
I tested for bfb before changing the history field variables themselves. These changes are all bfb (with the exception of QSNOEVAP) for a 1 month global 2deg simulation, but may not be bfb under all conditions.  QSNOEVAP is not bfb because I've added in qflx_ev_snow for lakes.

Contributors other than yourself, if any:
Variable names discussed with Bill Sacks, variable functions discussed with Sean Swenson.

CTSM Issues Fixed (include github issue #):
[118](https://github.com/ESCOMP/CTSM/issues/118)

Are answers expected to change (and if so in what way)?
See specific notes above.

Any User Interface Changes (namelist or namelist defaults changes)?
No.

Testing performed, if any:
See specific notes above.
