### PR TITLE
Some BFB Fixes: Resolve issues #683, # 874,  #878, # 885, # 745, #838.

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -954,7 +954,7 @@ lnd/clm2/surfdata_map/surfdata_ne120np4_78pfts_CMIP6_simyr1850_c170824.nc</fsurd
 <use_fun phys="clm5_0" use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
 <use_fun                                                           >.false.</use_fun>
 
-<br_root phys="clm5_0" use_cn=".true." use_fun=".true.">0.83d-06</br_root>
+<br_root>0.83d-06</br_root>
 
 <!-- Scalar of leaf respiration to vcmax (used for SP mode and with luna)-->
 <leaf_mr_vcm phys="clm5_0" >0.015d00</leaf_mr_vcm>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1900,7 +1900,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30</option>
+          <option name="wallclock">0:30:00</option>
           <option name="comment">Include a test of the NUOPC cap</option>
         </options>
       </machine>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -256,7 +256,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="SMS_P720x1_Ln3" grid="hcru_hcru" compset="I2000Clm50BgcCruGs" testmods="clm/coldStart">
+  <test name="SMS_P720x1_Ln6" grid="hcru_hcru" compset="I2000Clm50BgcCruGs" testmods="clm/coldStart">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -11,11 +11,11 @@ Resolved issues:
 
 ESCOMP/ctsm#683 :  Writing out FATES parameters only on masterproc.
 ESCOMP/ctsm#874 :  Changing the number of timesteps to run for
-				   SMS_P720x1_Ln3.hcru_hcru.I2000Clm50BgcCruGs.cheyenne_intel.clm-coldStar
-				   to prevent failing with CMEPS.
+                   SMS_P720x1_Ln3.hcru_hcru.I2000Clm50BgcCruGs.cheyenne_intel.clm-coldStar
+                   to prevent failing with CMEPS.
 ESCOMP/ctsm#878 :  Removing the unused atm2lnd field.
 ESCOMP/ctsm#885 :  Changing the defaults for br_root in namelist_defaults to
-				   enable FUN with CLM4.5.
+                   enable FUN with CLM4.5.
 ESCOMP/ctsm#745 :  Removing ReadNL private subroutine from initVerticalMod.F90.
 ESCOMP/ctsm#838 :  Clarifying ZISNO in the variable long name.
 
@@ -52,14 +52,14 @@ Notes of particular relevance for users
 
 Caveats for users (e.g., need to interpolate initial conditions): none
 
-Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
 
-Changes made to namelist defaults (e.g., changed parameter values): 
+Changes made to namelist defaults (e.g., changed parameter values):
 	Not any changes in parameter values.
 	changing the default for br_root in namelist_defaults to enable FUN with
 	CLM4.5.
 
-Changes to the datasets (e.g., parameter, surface or initial files):
+Changes to the datasets (e.g., parameter, surface or initial files): none
 
 Substantial timing or memory changes: none
 
@@ -67,7 +67,7 @@ Notes of particular relevance for developers: (including Code reviews and testin
 ---------------------------------------------
 NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
 
-Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
 
 Changes to tests or testing: 
 	Changed the number of timesteps from Ln3 to Ln6 for
@@ -82,19 +82,19 @@ CTSM testing:
 
   build-namelist tests:
 
-    cheyenne - 
+    cheyenne - not run
 
   tools-tests (test/tools):
 
-    cheyenne - 
+    cheyenne - not run
 
   PTCLM testing (tools/shared/PTCLM/test):
 
-    cheyenne - 
+    cheyenne - not run
 
   python testing (see instructions in python/README.md; document testing done):
 
-    (any machine) - 
+    (any machine) - not run
 
   regular tests (aux_clm):
 
@@ -107,33 +107,15 @@ If the tag used for baseline comparisons was NOT the previous tag, note that her
 Answer changes
 --------------
 
-Changes answers relative to baseline:
-
-  If a tag changes answers relative to baseline comparison the
-  following should be filled in (otherwise remove this section):
-
-  Summarize any changes to answers, i.e.,
-    - what code configurations:
-    - what platforms/compilers:
-    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
-
-   If bitwise differences were observed, how did you show they were no worse
-   than roundoff?
-
-   If this tag changes climate describe the run(s) done to evaluate the new
-   climate (put details of the simulations in the experiment database)
-       - casename: 
-
-   URL for LMWG diagnostics output used to validate new climate:
-	
+Changes answers relative to baseline: NO
 
 Detailed list of changes
 ------------------------
 
-List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
 
 Pull Requests that document the changes (include PR ids):
-(https://github.com/ESCOMP/ctsm/pull)
+https://github.com/ESCOMP/CTSM/pull/897
 
 ===============================================================
 ===============================================================

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,142 @@
 ===============================================================
+Tag name:  ctsm1.0.dev083
+Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
+Date: Thu Feb  6 12:12:26 MST 2020
+One-line Summary: Some BFB Fixes: Resolve issues #683, # 874, #878, # 885, # 745, #838
+
+Purpose of changes
+------------------
+
+Resolved issues: 
+
+ESCOMP/ctsm#683 :  Writing out FATES parameters only on masterproc.
+ESCOMP/ctsm#874 :  Changing the number of timesteps to run for
+				   SMS_P720x1_Ln3.hcru_hcru.I2000Clm50BgcCruGs.cheyenne_intel.clm-coldStar
+				   to prevent failing with CMEPS.
+ESCOMP/ctsm#878 :  Removing the unused atm2lnd field.
+ESCOMP/ctsm#885 :  Changing the defaults for br_root in namelist_defaults to
+				   enable FUN with CLM4.5.
+ESCOMP/ctsm#745 :  Removing ReadNL private subroutine from initVerticalMod.F90.
+ESCOMP/ctsm#838 :  Clarifying ZISNO in the variable long name.
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+Resolves :
+	- ESCOMP/ctsm#683
+	- ESCOMP/ctsm#874
+	- ESCOMP/ctsm#878
+	- ESCOMP/ctsm#885
+	- ESCOMP/ctsm#745
+	- ESCOMP/ctsm#838
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+
+Changes made to namelist defaults (e.g., changed parameter values): 
+	Not any changes in parameter values.
+	changing the default for br_root in namelist_defaults to enable FUN with
+	CLM4.5.
+
+Changes to the datasets (e.g., parameter, surface or initial files):
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+
+Changes to tests or testing: 
+	Changed the number of timesteps from Ln3 to Ln6 for
+	SMS_P720x1_Ln3.hcru_hcru.I2000Clm50BgcCruGs.cheyenne_intel.clm-coldStar
+
+Code reviewed by: Bill Sacks
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - 
+
+  tools-tests (test/tools):
+
+    cheyenne - 
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - 
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - 
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    izumi ------- PASS
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline:
+
+  If a tag changes answers relative to baseline comparison the
+  following should be filled in (otherwise remove this section):
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations:
+    - what platforms/compilers:
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): 
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff?
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+       - casename: 
+
+   URL for LMWG diagnostics output used to validate new climate:
+	
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev082
 Originator(s):  oleson (Keith Oleson)
 Date:  Sat Feb  1 09:28:41 MST 2020

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev083   negins 02/06/2020 Some BFB Fixes: Resolve issues #683, # 874, #878, # 885, # 745, #838
   ctsm1.0.dev082   oleson 02/01/2020 Rename variables to avoid confusion; fix QSNOEVAP diagnostic
   ctsm1.0.dev081   slevis 01/13/2020 Speed up restart writes
   ctsm1.0.dev080    sacks 12/02/2019 Update externals, minor fixes to work with latest cime, get nuopc cap working

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -436,11 +436,9 @@ contains
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
     if ( present(c13) .and. use_c13 )then
-       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
        SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
     end if
     if ( present(c14) .and. use_c14 )then
-       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
        SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
     end if
     if ( present(pc13) )then

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -413,20 +413,20 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type)              , intent (in) :: bounds          ! bounds
-    integer  , intent (in) :: num_soilp       ! number of soil patchs in filter
-    integer  , intent (in) :: filter_soilp(:) ! filter for soil patches
-    real(r8) , intent (inout)                     :: carbon_patch(bounds%begp:)
-    real(r8) , intent (inout)                     :: nitrogen_patch(bounds%begp:)
-    real(r8) , intent (inout)                     :: pc(bounds%begp:)
-    real(r8) , intent (inout)                     :: pn(bounds%begp:)
-    integer  , intent (in)                        :: lineno
-    real(r8) , intent (inout), optional           :: c13 (bounds%begp:)
-    real(r8) , intent (inout), optional           :: c14 (bounds%begp:)
-    real(r8) , intent (inout), optional           :: pc13(bounds%begp:)
-    real(r8) , intent (inout), optional           :: pc14(bounds%begp:)
-    logical  , intent (in)   , optional           :: croponly
-    logical  , intent (in)   , optional           :: allowneg
+    type(bounds_type), intent (in)      :: bounds          ! bounds
+    integer  ,         intent (in)      :: num_soilp       ! number of soil patchs in filter
+    integer  ,         intent (in)      :: filter_soilp(:) ! filter for soil patches
+    real(r8) , intent (inout)           :: carbon_patch(bounds%begp:)
+    real(r8) , intent (inout)           :: nitrogen_patch(bounds%begp:)
+    real(r8) , intent (inout)           :: pc(bounds%begp:)
+    real(r8) , intent (inout)           :: pn(bounds%begp:)
+    integer  , intent (in)              :: lineno
+    real(r8) , intent (inout), optional :: c13 (bounds%begp:)
+    real(r8) , intent (inout), optional :: c14 (bounds%begp:)
+    real(r8) , intent (inout), optional :: pc13(bounds%begp:)
+    real(r8) , intent (inout), optional :: pc14(bounds%begp:)
+    logical  , intent (in)   , optional :: croponly
+    logical  , intent (in)   , optional :: allowneg
 
     logical :: lcroponly, lallowneg
     integer :: fp, p
@@ -521,11 +521,9 @@ contains
     SHR_ASSERT_ALL_FL((ubound(carbon_patch)   == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), sourcefile, __LINE__)
     if ( present(c13) .and. use_c13 )then
-       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), sourcefile, __LINE__)
        SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), sourcefile, __LINE__)
     end if
     if ( present(c14) .and. use_c14 )then
-       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), sourcefile, __LINE__)
        SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), sourcefile, __LINE__)
     end if
     if ( present(pc13) )then

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -204,225 +204,178 @@ contains
       ! leaf C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%leafc_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%leafc_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_storage_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%leafc_storage_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%leafc_storage_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! froot C and N
       ! EBK KO DML: For some reason frootc/frootn can go negative and allowing
       ! it to be negative is important for C4 crops (otherwise they die) Jun/3/2016
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
-                                   ns%frootn_patch(bounds%begp:bounds%endp), &
-                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%frootc_patch(bounds%begp:bounds%endp),  &
-                                   c14=c14cs%frootc_patch(bounds%begp:bounds%endp),  &
-                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true. )
+                                   ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                   c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%frootn_storage_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_patch(bounds%begp:bounds%endp), &
-                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%grainc_patch(bounds%begp:bounds%endp), &
-                                   c14=c14cs%grainc_patch(bounds%begp:bounds%endp), &
-                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
+                                   ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                   c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), &
-                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%grainc_storage_patch(bounds%begp:bounds%endp), &
-                                   c14=c14cs%grainc_storage_patch(bounds%begp:bounds%endp), &
-                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
+                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                   __LINE__, c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), &
-                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
-                                   c14=c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
-                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
+                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                   c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), &
-                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   c14=c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
+                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
+                                   pn(bounds%begp:), __LINE__, &
+                                   c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
 
       end if
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
-                                ns%livestemn_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livestemc_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%livestemc_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%livestemn_storage_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%livestemn_xfer_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
-                                ns%deadstemn_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadstemc_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%deadstemc_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%deadstemn_storage_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%deadstemc_storage_patch, c14=c14cs%deadstemc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
-                                ns%livecrootn_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livecrootc_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%livecrootc_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%livecrootn_storage_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
-                                ns%deadcrootn_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadcrootc_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%deadcrootc_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
+                                c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                                c14=c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                      __LINE__, c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:bounds%endp), __LINE__, &
-                            c13=c13cs%gresp_storage_patch(bounds%begp:bounds%endp),&
-                            c14=c14cs%gresp_storage_patch(bounds%begp:bounds%endp), &
-                            pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                            pc(bounds%begp:), __LINE__, &
+                            c13=c13cs%gresp_storage_patch, c14=c14cs%gresp_storage_patch, &
+                            pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! gresp_xfer(c only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:bounds%endp), __LINE__, &
-                            c13=c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
-                            c14=c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
-                            pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                            pc(bounds%begp:), __LINE__, &
+                            c13=c13cs%gresp_xfer_patch, c14=c14cs%gresp_xfer_patch, &
+                            pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! cpool (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%cpool_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:bounds%endp), __LINE__, &
-                            c13=c13cs%cpool_patch(bounds%begp:bounds%endp), &
-                            c14=c14cs%cpool_patch(bounds%begp:bounds%endp), &
-                            pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                            pc(bounds%begp:), __LINE__, &
+                            c13=c13cs%cpool_patch, c14=c14cs%cpool_patch, &
+                            pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       if ( use_crop )then
          ! xsmrpool (C only)
          ! xsmr is a pool to balance the budget and as such can be freely negative
          call TruncateCStates( bounds, filter_soilp, num_soilp, cs%xsmrpool_patch(bounds%begp:bounds%endp), &
-                               pc(bounds%begp:bounds%endp), __LINE__, &
-                               c13=c13cs%xsmrpool_patch(bounds%begp:bounds%endp), &
-                               c14=c14cs%xsmrpool_patch(bounds%begp:bounds%endp), &
-                               pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), &
-                               allowneg=.true., croponly=.true. )
+                               pc(bounds%begp:), __LINE__, &
+                               c13=c13cs%xsmrpool_patch, c14=c14cs%xsmrpool_patch, &
+                               pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
 
       end if
 
       ! retransn (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), &
-                            pn(bounds%begp:bounds%endp), __LINE__ )
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), pn(bounds%begp:), &
+                            __LINE__ )
 
       ! npool (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), &
-                            pn(bounds%begp:bounds%endp), __LINE__ )
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), pn(bounds%begp:), &
+                            __LINE__ )
 
       ! patch loop
       do fp = 1,num_soilp
@@ -460,20 +413,20 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type), intent (in)      :: bounds          ! bounds
-    integer  ,         intent (in)      :: num_soilp       ! number of soil patchs in filter
-    integer  ,         intent (in)      :: filter_soilp(:) ! filter for soil patches
-    real(r8) , intent (inout)           :: carbon_patch(bounds%begp:)
-    real(r8) , intent (inout)           :: nitrogen_patch(bounds%begp:)
-    real(r8) , intent (inout)           :: pc(bounds%begp:)
-    real(r8) , intent (inout)           :: pn(bounds%begp:)
-    integer  , intent (in)              :: lineno
-    real(r8) , intent (inout), optional :: c13 (bounds%begp:)
-    real(r8) , intent (inout), optional :: c14 (bounds%begp:)
-    real(r8) , intent (inout), optional :: pc13(bounds%begp:)
-    real(r8) , intent (inout), optional :: pc14(bounds%begp:)
-    logical  , intent (in)   , optional :: croponly
-    logical  , intent (in)   , optional :: allowneg
+    type(bounds_type)              , intent(in)    :: bounds          ! bounds
+    integer                        , intent(in)    :: num_soilp       ! number of soil patchs in filter
+    integer                        , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    real(r8), intent(inout) :: carbon_patch(bounds%begp:)
+    real(r8), intent(inout) :: nitrogen_patch(bounds%begp:)
+    real(r8), intent(inout) :: pc(bounds%begp:)
+    real(r8), intent(inout) :: pn(bounds%begp:)
+    integer,  intent(in)    :: lineno
+    real(r8), intent(inout), optional, pointer :: c13(:)
+    real(r8), intent(inout), optional, pointer :: c14(:)
+    real(r8), intent(inout), optional :: pc13(bounds%begp:)
+    real(r8), intent(inout), optional :: pc14(bounds%begp:)
+    logical , intent(in)   , optional :: croponly
+    logical , intent(in)   , optional :: allowneg
 
     logical :: lcroponly, lallowneg
     integer :: fp, p
@@ -482,12 +435,16 @@ contains
     SHR_ASSERT_ALL_FL((ubound(nitrogen_patch) == (/bounds%endp/)), 'ubnd(nitro)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
+#ifndef _OPENMP
     if ( present(c13) .and. use_c13 )then
+       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
        SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
     end if
     if ( present(c14) .and. use_c14 )then
+       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
        SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
     end if
+#endif
     if ( present(pc13) )then
        SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
     end if
@@ -547,30 +504,34 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type), intent (in)              :: bounds          ! bounds
-    integer          , intent (in)              :: num_soilp       ! number of soil patchs in filter
-    integer          , intent (in)              :: filter_soilp(:) ! filter for soil patches
-    real(r8)         , intent (inout)           :: carbon_patch(bounds%begp:)
-    real(r8)         , intent (inout)           :: pc(bounds%begp:)
-    integer          , intent (in)              :: lineno
-    real(r8)         , intent (inout), optional :: c13 (bounds%begp:)
-    real(r8)         , intent (inout), optional :: c14 (bounds%begp:)
-    real(r8)         , intent (inout), optional :: pc13(bounds%begp:)
-    real(r8)         , intent (inout), optional :: pc14(bounds%begp:)
-    logical          , intent (in)   , optional :: croponly
-    logical          , intent (in)   , optional :: allowneg
+    type(bounds_type), intent(in)    :: bounds          ! bounds
+    integer          , intent(in)    :: num_soilp       ! number of soil patchs in filter
+    integer          , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    real(r8)         , intent(inout) :: carbon_patch(bounds%begp:)
+    real(r8)         , intent(inout) :: pc(bounds%begp:)
+    integer          , intent(in)    :: lineno
+    real(r8)         , intent(inout), optional, pointer :: c13(:)
+    real(r8)         , intent(inout), optional, pointer :: c14(:)
+    real(r8)         , intent(inout), optional :: pc13(bounds%begp:)
+    real(r8)         , intent(inout), optional :: pc14(bounds%begp:)
+    logical          , intent(in)   , optional :: croponly
+    logical          , intent(in)   , optional :: allowneg
 
     logical :: lcroponly, lallowneg
     integer :: fp, p
 
     SHR_ASSERT_ALL_FL((ubound(carbon_patch)   == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), sourcefile, __LINE__)
+#ifndef _OPENMP
     if ( present(c13) .and. use_c13 )then
+       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), sourcefile, __LINE__)
        SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), sourcefile, __LINE__)
     end if
     if ( present(c14) .and. use_c14 )then
+       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), sourcefile, __LINE__)
        SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), sourcefile, __LINE__)
     end if
+#endif
     if ( present(pc13) )then
        SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), sourcefile, __LINE__)
     end if
@@ -599,7 +560,7 @@ contains
           else if ( abs(carbon_patch(p)) < ccrit) then
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
- 
+   
              if ( use_c13 .and. present(c13) .and. present(pc13) ) then
                 pc13(p) = pc13(p) + c13(p)
                 c13(p) = 0._r8

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -120,6 +120,8 @@ contains
     ! !LOCAL VARIABLES:
     integer :: p,j,k                             ! indices
     integer :: fp                                ! filter indices
+    integer :: num_truncatep                     ! number of points in filter_truncatep
+    integer :: filter_truncatep(bounds%endp-bounds%begp+1) ! filter for points that need truncation
     real(r8):: pc(bounds%begp:bounds%endp)       ! truncation terms for patch-level corrections Carbon
     real(r8):: pn(bounds%begp:bounds%endp)       ! truncation terms for patch-level corrections nitrogen
     real(r8):: pc13(bounds%begp:bounds%endp)     ! truncation terms for patch-level corrections
@@ -205,20 +207,54 @@ contains
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
                                 pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+           !                     c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
+           !                     pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%leafc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%leafc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+                                !c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%leafc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%leafc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+                                !c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       ! froot C and N
       ! EBK KO DML: For some reason frootc/frootn can go negative and allowing
@@ -226,120 +262,331 @@ contains
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
                                    ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
+                                   num_truncatep, filter_truncatep)
+                                   !c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
+                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%frootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%frootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+                      !c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
+                      !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%frootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%frootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
                                 ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                   num_truncatep, filter_truncatep)
+                                !c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   num_truncatep, filter_truncatep)
+                                   !c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
+                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%grainc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%grainc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                                   __LINE__, c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   __LINE__, num_truncatep, filter_truncatep)
+
+                               !c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
+                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%grainc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%grainc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   num_truncatep, filter_truncatep)
+                                   !c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
+                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
          ! grain transfer C and N
-         call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
-                                   pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
+!         call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
+!                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
+!                                   pn(bounds%begp:), __LINE__, &
+!                                   num_truncatep, filter_truncatep)
+                                   !c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
+                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       end if
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
                                 ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+                                !c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livestemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livestemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
                       ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+                  !c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
+                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+                  !c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
+                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
                                 ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+                                !c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadstemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadstemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
                       ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadstemc_storage_patch, c14=c14cs%deadstemc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+!                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+!                  c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
+!                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
                                 ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                   num_truncatep, filter_truncatep)
+                                !c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livecrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livecrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+                  !c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
+                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+!                  c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
+!                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
                                 ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+                                !c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
+                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadcrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadcrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+
+                  !c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
+                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+                  !c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
+                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
@@ -397,8 +644,11 @@ contains
 
  end subroutine CNPrecisionControl
 
- subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
-                                 pc13, pc14, croponly, allowneg )
+ subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, &
+                                 num_truncatep, filter_truncatep, croponly, allowneg )
+
+ !subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
+ !                                pc13, pc14, croponly, allowneg )
     !
     ! !DESCRIPTION:
     ! Truncate paired Carbon and Nitrogen states. If a paired carbon and nitrogen state iare too small truncate 
@@ -421,10 +671,8 @@ contains
     real(r8), intent(inout) :: pc(bounds%begp:)
     real(r8), intent(inout) :: pn(bounds%begp:)
     integer,  intent(in)    :: lineno
-    real(r8), intent(inout), optional, pointer :: c13(:)
-    real(r8), intent(inout), optional, pointer :: c14(:)
-    real(r8), intent(inout), optional :: pc13(bounds%begp:)
-    real(r8), intent(inout), optional :: pc14(bounds%begp:)
+    integer,  intent(out)   :: num_truncatep       ! number of points in filter_truncatep
+    integer,  intent(out)   :: filter_truncatep(:) ! filter for points that need truncation
     logical , intent(in)   , optional :: croponly
     logical , intent(in)   , optional :: allowneg
 
@@ -435,22 +683,22 @@ contains
     SHR_ASSERT_ALL_FL((ubound(nitrogen_patch) == (/bounds%endp/)), 'ubnd(nitro)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
-#ifndef _OPENMP
-    if ( present(c13) .and. use_c13 )then
-       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
-       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
-    end if
-    if ( present(c14) .and. use_c14 )then
-       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
-       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
-    end if
-#endif
-    if ( present(pc13) )then
-       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
-    end if
-    if ( present(pc14) )then
-       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
-    end if
+!#ifndef _OPENMP
+!    if ( present(c13) .and. use_c13 )then
+!       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
+!       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
+!    end if
+!    if ( present(c14) .and. use_c14 )then
+!       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
+!       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
+!    end if
+!#endif
+!    if ( present(pc13) )then
+!       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
+!    end if
+!    if ( present(pc14) )then
+!       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
+!    end if
     ! patch loop
     lcroponly = .false.
     if ( present(croponly) )then
@@ -460,6 +708,8 @@ contains
     if ( present(allowneg) )then
       if (  allowneg ) lallowneg = .true.
     end if
+
+    num_truncatep = 0
     do fp = 1,num_soilp
        p = filter_soilp(fp)
 
@@ -469,20 +719,23 @@ contains
              write(iulog,*) 'ERROR: limits = ', cnegcrit, nnegcrit
              call endrun(msg='ERROR: carbon or nitrogen state critically negative '//errMsg(sourcefile, lineno))
           else if ( abs(carbon_patch(p)) < ccrit .or. (use_nguardrail .and. abs(nitrogen_patch(p)) < ncrit) ) then
+             num_truncatep = num_truncatep + 1
+             filter_truncatep(num_truncatep) = p
+
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
-      
+
              pn(p) = pn(p) + nitrogen_patch(p)
              nitrogen_patch(p) = 0._r8
    
-             if ( use_c13 .and. present(c13) .and. present(pc13) ) then
-                pc13(p) = pc13(p) + c13(p)
-                c13(p) = 0._r8
-             endif
-             if ( use_c14 .and. present(c14) .and. present(pc14)) then
-                pc14(p) = pc14(p) + c14(p)
-                c14(p) = 0._r8
-             endif
+             !if ( use_c13 .and. present(c13) .and. present(pc13) ) then
+             !   pc13(p) = pc13(p) + c13(p)
+             !   c13(p) = 0._r8
+             !endif
+             !if ( use_c14 .and. present(c14) .and. present(pc14)) then
+             !   pc14(p) = pc14(p) + c14(p)
+             !   c14(p) = 0._r8
+             !endif
           end if
        end if
     end do
@@ -611,5 +864,41 @@ contains
        end if
     end do
  end subroutine TruncateNStates
+
+ !-----------------------------------------------------------------------
+ subroutine TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+      state_patch, truncation_patch, lineno)
+   !
+   ! !DESCRIPTION:
+   ! Given a filter of points for which we have already determined that truncation should
+   ! occur, do the truncation for the given patch-level state, putting the truncation
+   ! amount in truncation_patch.
+   !
+   use decompMod  , only : bounds_type
+   ! !ARGUMENTS:
+   implicit none
+   type(bounds_type)              , intent(in)    :: bounds          ! bounds
+   integer, intent(in) :: num_truncatep       ! number of points in filter_truncatep
+   integer, intent(in) :: filter_truncatep(:) ! filter for points that need truncation
+   real(r8), intent(inout) :: state_patch(bounds%begp: )
+   real(r8), intent(inout) :: truncation_patch(bounds%begp: )
+   integer, intent(in) :: lineno
+   !
+   ! !LOCAL VARIABLES:
+
+   integer :: fp, p
+   character(len=*), parameter :: subname = 'TruncateAdditional'
+   !-----------------------------------------------------------------------
+
+   SHR_ASSERT_FL((ubound(state_patch, 1) == bounds%endp), 'state_patch '//sourcefile, lineno)
+   SHR_ASSERT_FL((ubound(truncation_patch, 1) == bounds%endp), 'truncation_patch '//sourcefile, lineno)
+
+   do fp = 1, num_truncatep
+      p = filter_truncatep(fp)
+      truncation_patch(p) = truncation_patch(p) + state_patch(p)
+      state_patch(p) = 0._r8
+   end do
+
+ end subroutine TruncateAdditional
 
 end module CNPrecisionControlMod

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -210,13 +210,13 @@ contains
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%leafc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_storage_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
@@ -225,46 +225,46 @@ contains
       ! it to be negative is important for C4 crops (otherwise they die) Jun/3/2016
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
-                                   ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                   ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                    c13=c13cs%frootc_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_patch(bounds%begp:bounds%endp),  &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true. )
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%frootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_storage_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                   ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                    c13=c13cs%grainc_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                                    __LINE__, c13=c13cs%grainc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_storage_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                    c13=c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), &
-                                   pn(bounds%begc:bounds%endc), __LINE__, &
+                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), &
+                                   pn(bounds%begp:bounds%endp), __LINE__, &
                                    c13=c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), c14=c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
 
@@ -272,90 +272,90 @@ contains
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
-                                ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%livestemc_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
-                                ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%deadstemc_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
-                                ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%livecrootc_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
-                                ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
                                 c13=c13cs%deadcrootc_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                       __LINE__, c13=c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
                       pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begc:bounds%endc), __LINE__, &
+                            pc(bounds%begp:bounds%endp), __LINE__, &
                             c13=c13cs%gresp_storage_patch(bounds%begp:bounds%endp), c14=c14cs%gresp_storage_patch(bounds%begp:bounds%endp), &
                             pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! gresp_xfer(c only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begc:bounds%endc), __LINE__, &
+                            pc(bounds%begp:bounds%endp), __LINE__, &
                             c13=c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
                             pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! cpool (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%cpool_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begc:bounds%endc), __LINE__, &
+                            pc(bounds%begp:bounds%endp), __LINE__, &
                             c13=c13cs%cpool_patch(bounds%begp:bounds%endp), c14=c14cs%cpool_patch(bounds%begp:bounds%endp), &
                             pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
@@ -363,18 +363,18 @@ contains
          ! xsmrpool (C only)
          ! xsmr is a pool to balance the budget and as such can be freely negative
          call TruncateCStates( bounds, filter_soilp, num_soilp, cs%xsmrpool_patch(bounds%begp:bounds%endp), &
-                               pc(bounds%begc:bounds%endc), __LINE__, &
+                               pc(bounds%begp:bounds%endp), __LINE__, &
                                c13=c13cs%xsmrpool_patch(bounds%begp:bounds%endp), c14=c14cs%xsmrpool_patch(bounds%begp:bounds%endp), &
                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
 
       end if
 
       ! retransn (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), pn(bounds%begc:bounds%endc), &
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                             __LINE__ )
 
       ! npool (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), pn(bounds%begc:bounds%endc), &
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
                             __LINE__ )
 
       ! patch loop

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -413,20 +413,20 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type)              , intent(in)    :: bounds          ! bounds
-    integer                        , intent(in)    :: num_soilp       ! number of soil patchs in filter
-    integer                        , intent(in)    :: filter_soilp(:) ! filter for soil patches
-    real(r8), intent(inout) :: carbon_patch(bounds%begp:)
-    real(r8), intent(inout) :: nitrogen_patch(bounds%begp:)
-    real(r8), intent(inout) :: pc(bounds%begp:)
-    real(r8), intent(inout) :: pn(bounds%begp:)
-    integer,  intent(in)    :: lineno
-    real(r8), intent(inout), optional, pointer :: c13(:)
-    real(r8), intent(inout), optional, pointer :: c14(:)
-    real(r8), intent(inout), optional :: pc13(bounds%begp:)
-    real(r8), intent(inout), optional :: pc14(bounds%begp:)
-    logical , intent(in)   , optional :: croponly
-    logical , intent(in)   , optional :: allowneg
+    type(bounds_type)              , intent(in) :: bounds          ! bounds
+    integer                        , intent(in) :: num_soilp       ! number of soil patchs in filter
+    integer                        , intent(in) :: filter_soilp(:) ! filter for soil patches
+    real(r8), intent(inout)                     :: carbon_patch(bounds%begp:)
+    real(r8), intent(inout)                     :: nitrogen_patch(bounds%begp:)
+    real(r8), intent(inout)                     :: pc(bounds%begp:)
+    real(r8), intent(inout)                     :: pn(bounds%begp:)
+    integer,  intent(in)                        :: lineno
+    real(r8), intent(inout), optional           :: c13 (bounds%begp:)
+    real(r8), intent(inout), optional           :: c14 (bounds%begp:)
+    real(r8), intent(inout), optional           :: pc13(bounds%begp:)
+    real(r8), intent(inout), optional           :: pc14(bounds%begp:)
+    logical , intent(in)   , optional           :: croponly
+    logical , intent(in)   , optional           :: allowneg
 
     logical :: lcroponly, lallowneg
     integer :: fp, p
@@ -502,18 +502,18 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type), intent(in)    :: bounds          ! bounds
-    integer          , intent(in)    :: num_soilp       ! number of soil patchs in filter
-    integer          , intent(in)    :: filter_soilp(:) ! filter for soil patches
-    real(r8)         , intent(inout) :: carbon_patch(bounds%begp:)
-    real(r8)         , intent(inout) :: pc(bounds%begp:)
-    integer          , intent(in)    :: lineno
-    real(r8)         , intent(inout), optional, pointer :: c13(:)
-    real(r8)         , intent(inout), optional, pointer :: c14(:)
-    real(r8)         , intent(inout), optional :: pc13(bounds%begp:)
-    real(r8)         , intent(inout), optional :: pc14(bounds%begp:)
-    logical          , intent(in)   , optional :: croponly
-    logical          , intent(in)   , optional :: allowneg
+    type(bounds_type), intent (in)              :: bounds          ! bounds
+    integer          , intent (in)              :: num_soilp       ! number of soil patchs in filter
+    integer          , intent (in)              :: filter_soilp(:) ! filter for soil patches
+    real(r8)         , intent (inout)           :: carbon_patch(bounds%begp:)
+    real(r8)         , intent (inout)           :: pc(bounds%begp:)
+    integer          , intent (in)              :: lineno
+    real(r8)         , intent (inout), optional :: c13 (bounds%begp:)
+    real(r8)         , intent (inout), optional :: c14 (bounds%begp:)
+    real(r8)         , intent (inout), optional :: pc13(bounds%begp:)
+    real(r8)         , intent (inout), optional :: pc14(bounds%begp:)
+    logical          , intent (in)   , optional :: croponly
+    logical          , intent (in)   , optional :: allowneg
 
     logical :: lcroponly, lallowneg
     integer :: fp, p

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -435,7 +435,6 @@ contains
     SHR_ASSERT_ALL_FL((ubound(nitrogen_patch) == (/bounds%endp/)), 'ubnd(nitro)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
-#ifndef _OPENMP
     if ( present(c13) .and. use_c13 )then
        SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
        SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
@@ -444,7 +443,6 @@ contains
        SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
        SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
     end if
-#endif
     if ( present(pc13) )then
        SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
     end if
@@ -522,7 +520,6 @@ contains
 
     SHR_ASSERT_ALL_FL((ubound(carbon_patch)   == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), sourcefile, __LINE__)
-#ifndef _OPENMP
     if ( present(c13) .and. use_c13 )then
        SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), sourcefile, __LINE__)
        SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), sourcefile, __LINE__)
@@ -531,7 +528,6 @@ contains
        SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), sourcefile, __LINE__)
        SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), sourcefile, __LINE__)
     end if
-#endif
     if ( present(pc13) )then
        SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), sourcefile, __LINE__)
     end if

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -204,177 +204,177 @@ contains
       ! leaf C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
-                                pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%leafc_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%leafc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_storage_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! froot C and N
       ! EBK KO DML: For some reason frootc/frootn can go negative and allowing
       ! it to be negative is important for C4 crops (otherwise they die) Jun/3/2016
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
-                                   ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
+                                   ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                   c13=c13cs%frootc_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_patch(bounds%begp:bounds%endp),  &
+                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true. )
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%frootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_storage_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                   c13=c13cs%grainc_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_patch(bounds%begp:bounds%endp), &
+                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                                   __LINE__, c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                                   __LINE__, c13=c13cs%grainc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_storage_patch(bounds%begp:bounds%endp), &
+                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                   c13=c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
+                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
-                                   pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
+                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), &
+                                   pn(bounds%begc:bounds%endc), __LINE__, &
+                                   c13=c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), c14=c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
+                                   pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
 
       end if
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
-                                ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%livestemc_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
-                                ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%deadstemc_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadstemc_storage_patch, c14=c14cs%deadstemc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
-                                ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%livecrootc_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
-                                ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), __LINE__, &
+                                c13=c13cs%deadcrootc_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begc:bounds%endc), pn(bounds%begc:bounds%endc), &
+                      __LINE__, c13=c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
+                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:), __LINE__, &
-                            c13=c13cs%gresp_storage_patch, c14=c14cs%gresp_storage_patch, &
-                            pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                            pc(bounds%begc:bounds%endc), __LINE__, &
+                            c13=c13cs%gresp_storage_patch(bounds%begp:bounds%endp), c14=c14cs%gresp_storage_patch(bounds%begp:bounds%endp), &
+                            pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! gresp_xfer(c only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:), __LINE__, &
-                            c13=c13cs%gresp_xfer_patch, c14=c14cs%gresp_xfer_patch, &
-                            pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                            pc(bounds%begc:bounds%endc), __LINE__, &
+                            c13=c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
+                            pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! cpool (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%cpool_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:), __LINE__, &
-                            c13=c13cs%cpool_patch, c14=c14cs%cpool_patch, &
-                            pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                            pc(bounds%begc:bounds%endc), __LINE__, &
+                            c13=c13cs%cpool_patch(bounds%begp:bounds%endp), c14=c14cs%cpool_patch(bounds%begp:bounds%endp), &
+                            pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       if ( use_crop )then
          ! xsmrpool (C only)
          ! xsmr is a pool to balance the budget and as such can be freely negative
          call TruncateCStates( bounds, filter_soilp, num_soilp, cs%xsmrpool_patch(bounds%begp:bounds%endp), &
-                               pc(bounds%begp:), __LINE__, &
-                               c13=c13cs%xsmrpool_patch, c14=c14cs%xsmrpool_patch, &
-                               pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
+                               pc(bounds%begc:bounds%endc), __LINE__, &
+                               c13=c13cs%xsmrpool_patch(bounds%begp:bounds%endp), c14=c14cs%xsmrpool_patch(bounds%begp:bounds%endp), &
+                               pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
 
       end if
 
       ! retransn (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), pn(bounds%begp:), &
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), pn(bounds%begc:bounds%endc), &
                             __LINE__ )
 
       ! npool (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), pn(bounds%begp:), &
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), pn(bounds%begc:bounds%endc), &
                             __LINE__ )
 
       ! patch loop

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -413,20 +413,20 @@ contains
     !
     ! !ARGUMENTS:
     implicit none
-    type(bounds_type)              , intent(in) :: bounds          ! bounds
-    integer                        , intent(in) :: num_soilp       ! number of soil patchs in filter
-    integer                        , intent(in) :: filter_soilp(:) ! filter for soil patches
-    real(r8), intent(inout)                     :: carbon_patch(bounds%begp:)
-    real(r8), intent(inout)                     :: nitrogen_patch(bounds%begp:)
-    real(r8), intent(inout)                     :: pc(bounds%begp:)
-    real(r8), intent(inout)                     :: pn(bounds%begp:)
-    integer,  intent(in)                        :: lineno
-    real(r8), intent(inout), optional           :: c13 (bounds%begp:)
-    real(r8), intent(inout), optional           :: c14 (bounds%begp:)
-    real(r8), intent(inout), optional           :: pc13(bounds%begp:)
-    real(r8), intent(inout), optional           :: pc14(bounds%begp:)
-    logical , intent(in)   , optional           :: croponly
-    logical , intent(in)   , optional           :: allowneg
+    type(bounds_type)              , intent (in) :: bounds          ! bounds
+    integer  , intent (in) :: num_soilp       ! number of soil patchs in filter
+    integer  , intent (in) :: filter_soilp(:) ! filter for soil patches
+    real(r8) , intent (inout)                     :: carbon_patch(bounds%begp:)
+    real(r8) , intent (inout)                     :: nitrogen_patch(bounds%begp:)
+    real(r8) , intent (inout)                     :: pc(bounds%begp:)
+    real(r8) , intent (inout)                     :: pn(bounds%begp:)
+    integer  , intent (in)                        :: lineno
+    real(r8) , intent (inout), optional           :: c13 (bounds%begp:)
+    real(r8) , intent (inout), optional           :: c14 (bounds%begp:)
+    real(r8) , intent (inout), optional           :: pc13(bounds%begp:)
+    real(r8) , intent (inout), optional           :: pc14(bounds%begp:)
+    logical  , intent (in)   , optional           :: croponly
+    logical  , intent (in)   , optional           :: allowneg
 
     logical :: lcroponly, lallowneg
     integer :: fp, p

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -205,19 +205,24 @@ contains
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
                                 pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%leafc_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_patch(bounds%begp:bounds%endp), &
+                                c13=c13cs%leafc_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%leafc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%leafc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_storage_patch(bounds%begp:bounds%endp), &
+                                ns%leafn_storage_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%leafc_storage_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%leafc_storage_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
+                                ns%leafn_xfer_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! froot C and N
@@ -225,138 +230,178 @@ contains
       ! it to be negative is important for C4 crops (otherwise they die) Jun/3/2016
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
-                                   ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%frootc_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_patch(bounds%begp:bounds%endp),  &
+                                   ns%frootn_patch(bounds%begp:bounds%endp), &
+                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                   c13=c13cs%frootc_patch(bounds%begp:bounds%endp),  &
+                                   c14=c14cs%frootc_patch(bounds%begp:bounds%endp),  &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true. )
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%frootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%frootn_storage_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%frootc_storage_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%frootc_storage_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
-                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
+                                ns%frootn_xfer_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%grainc_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_patch(bounds%begp:bounds%endp), &
+                                   ns%grainn_patch(bounds%begp:bounds%endp), &
+                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                   c13=c13cs%grainc_patch(bounds%begp:bounds%endp), &
+                                   c14=c14cs%grainc_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                                   __LINE__, c13=c13cs%grainc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_storage_patch(bounds%begp:bounds%endp), &
+                                   ns%grainn_storage_patch(bounds%begp:bounds%endp), &
+                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                   c13=c13cs%grainc_storage_patch(bounds%begp:bounds%endp), &
+                                   c14=c14cs%grainc_storage_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
-                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
+                                   ns%grainn_xfer_patch(bounds%begp:bounds%endp), &
+                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                   c13=c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
+                                   c14=c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), &
-                                   pn(bounds%begp:bounds%endp), __LINE__, &
-                                   c13=c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), c14=c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
+                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), &
+                                   pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                   c13=c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
+                                   c14=c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
                                    pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
 
       end if
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
-                                ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livestemc_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_patch(bounds%begp:bounds%endp), &
+                                ns%livestemn_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%livestemc_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%livestemc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%livestemn_storage_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%livestemn_xfer_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
-                                ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadstemc_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_patch(bounds%begp:bounds%endp), &
+                                ns%deadstemn_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%deadstemc_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%deadstemc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%deadstemn_storage_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
-                                ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%livecrootc_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_patch(bounds%begp:bounds%endp), &
+                                ns%livecrootn_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%livecrootc_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%livecrootc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%livecrootn_storage_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
-                                ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
-                                c13=c13cs%deadcrootc_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_patch(bounds%begp:bounds%endp), &
+                                ns%deadcrootn_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%deadcrootc_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%deadcrootc_patch(bounds%begp:bounds%endp), &
                                 pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                      __LINE__, c13=c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
+                                ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), &
+                                pc(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), __LINE__, &
+                                c13=c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
+                                c14=c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
+                                pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
                             pc(bounds%begp:bounds%endp), __LINE__, &
-                            c13=c13cs%gresp_storage_patch(bounds%begp:bounds%endp), c14=c14cs%gresp_storage_patch(bounds%begp:bounds%endp), &
+                            c13=c13cs%gresp_storage_patch(bounds%begp:bounds%endp),&
+                            c14=c14cs%gresp_storage_patch(bounds%begp:bounds%endp), &
                             pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! gresp_xfer(c only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
                             pc(bounds%begp:bounds%endp), __LINE__, &
-                            c13=c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), c14=c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
+                            c13=c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
+                            c14=c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
                             pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       ! cpool (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%cpool_patch(bounds%begp:bounds%endp), &
                             pc(bounds%begp:bounds%endp), __LINE__, &
-                            c13=c13cs%cpool_patch(bounds%begp:bounds%endp), c14=c14cs%cpool_patch(bounds%begp:bounds%endp), &
+                            c13=c13cs%cpool_patch(bounds%begp:bounds%endp), &
+                            c14=c14cs%cpool_patch(bounds%begp:bounds%endp), &
                             pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp) )
 
       if ( use_crop )then
@@ -364,18 +409,20 @@ contains
          ! xsmr is a pool to balance the budget and as such can be freely negative
          call TruncateCStates( bounds, filter_soilp, num_soilp, cs%xsmrpool_patch(bounds%begp:bounds%endp), &
                                pc(bounds%begp:bounds%endp), __LINE__, &
-                               c13=c13cs%xsmrpool_patch(bounds%begp:bounds%endp), c14=c14cs%xsmrpool_patch(bounds%begp:bounds%endp), &
-                               pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), allowneg=.true., croponly=.true. )
+                               c13=c13cs%xsmrpool_patch(bounds%begp:bounds%endp), &
+                               c14=c14cs%xsmrpool_patch(bounds%begp:bounds%endp), &
+                               pc13=pc13(bounds%begp:bounds%endp), pc14=pc14(bounds%begp:bounds%endp), &
+                               allowneg=.true., croponly=.true. )
 
       end if
 
       ! retransn (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                            __LINE__ )
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%retransn_patch(bounds%begp:bounds%endp), &
+                            pn(bounds%begp:bounds%endp), __LINE__ )
 
       ! npool (N only)
-      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), pn(bounds%begp:bounds%endp), &
-                            __LINE__ )
+      call TruncateNStates( bounds, filter_soilp, num_soilp, ns%npool_patch(bounds%begp:bounds%endp), &
+                            pn(bounds%begp:bounds%endp), __LINE__ )
 
       ! patch loop
       do fp = 1,num_soilp
@@ -552,7 +599,7 @@ contains
           else if ( abs(carbon_patch(p)) < ccrit) then
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
-   
+ 
              if ( use_c13 .and. present(c13) .and. present(pc13) ) then
                 pc13(p) = pc13(p) + c13(p)
                 c13(p) = 0._r8

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -365,10 +365,10 @@ contains
           end if
 
          ! grain transfer C and N
-!         call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
-!                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
-!                                   pn(bounds%begp:), __LINE__, &
-!                                   num_truncatep, filter_truncatep)
+         call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
+                                   ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
+                                   pn(bounds%begp:), __LINE__, &
+                                   num_truncatep, filter_truncatep)
                                    !c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
                                    !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
           if (use_c13) then

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -120,8 +120,6 @@ contains
     ! !LOCAL VARIABLES:
     integer :: p,j,k                             ! indices
     integer :: fp                                ! filter indices
-    integer :: num_truncatep                     ! number of points in filter_truncatep
-    integer :: filter_truncatep(bounds%endp-bounds%begp+1) ! filter for points that need truncation
     real(r8):: pc(bounds%begp:bounds%endp)       ! truncation terms for patch-level corrections Carbon
     real(r8):: pn(bounds%begp:bounds%endp)       ! truncation terms for patch-level corrections nitrogen
     real(r8):: pc13(bounds%begp:bounds%endp)     ! truncation terms for patch-level corrections
@@ -207,54 +205,20 @@ contains
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
                                 pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                num_truncatep, filter_truncatep)
-           !                     c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
-           !                     pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-      if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%leafc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
-      if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%leafc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
-
+                                c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                num_truncatep, filter_truncatep)
-                                !c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-      if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%leafc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
-      if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%leafc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
+                                c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                num_truncatep, filter_truncatep)
-                                !c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-      if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
-      if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
+                                c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! froot C and N
       ! EBK KO DML: For some reason frootc/frootn can go negative and allowing
@@ -262,331 +226,120 @@ contains
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
                                    ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-                                   !c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
-                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%frootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%frootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                   c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-                      !c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
-                      !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-      if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%frootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
-      if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%frootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
+                      __LINE__, c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
                                 ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-                                !c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-      if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
-      if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
+                                c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-                                   !c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
-                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%grainc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%grainc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                   c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                                   __LINE__, num_truncatep, filter_truncatep)
-
-                               !c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
-                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%grainc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%grainc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                   __LINE__, c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-                                   !c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
-                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                   c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
                                    ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
                                    pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-                                   !c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
-                                   !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                   c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
+                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
 
       end if
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
                                 ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                num_truncatep, filter_truncatep)
-                                !c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livestemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livestemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
                       ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-                  !c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
-                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-                  !c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
-                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
                                 ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                num_truncatep, filter_truncatep)
-                                !c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadstemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadstemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
                       ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-!                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%deadstemc_storage_patch, c14=c14cs%deadstemc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-!                  c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
-!                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
                                 ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-                                !c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livecrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livecrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-                  !c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
-                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-!                  c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
-!                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
                                 ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                num_truncatep, filter_truncatep)
-                                !c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
-                                !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadcrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadcrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
+                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-
-                  !c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
-                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-                  !c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
-                  !    pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                      __LINE__, c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
+                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
@@ -644,11 +397,8 @@ contains
 
  end subroutine CNPrecisionControl
 
- subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, &
-                                 num_truncatep, filter_truncatep, croponly, allowneg )
-
- !subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
- !                                pc13, pc14, croponly, allowneg )
+ subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
+                                 pc13, pc14, croponly, allowneg )
     !
     ! !DESCRIPTION:
     ! Truncate paired Carbon and Nitrogen states. If a paired carbon and nitrogen state iare too small truncate 
@@ -671,8 +421,10 @@ contains
     real(r8), intent(inout) :: pc(bounds%begp:)
     real(r8), intent(inout) :: pn(bounds%begp:)
     integer,  intent(in)    :: lineno
-    integer,  intent(out)   :: num_truncatep       ! number of points in filter_truncatep
-    integer,  intent(out)   :: filter_truncatep(:) ! filter for points that need truncation
+    real(r8), intent(inout), optional, pointer :: c13(:)
+    real(r8), intent(inout), optional, pointer :: c14(:)
+    real(r8), intent(inout), optional :: pc13(bounds%begp:)
+    real(r8), intent(inout), optional :: pc14(bounds%begp:)
     logical , intent(in)   , optional :: croponly
     logical , intent(in)   , optional :: allowneg
 
@@ -683,22 +435,22 @@ contains
     SHR_ASSERT_ALL_FL((ubound(nitrogen_patch) == (/bounds%endp/)), 'ubnd(nitro)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
-!#ifndef _OPENMP
-!    if ( present(c13) .and. use_c13 )then
-!       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
-!       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
-!    end if
-!    if ( present(c14) .and. use_c14 )then
-!       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
-!       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
-!    end if
-!#endif
-!    if ( present(pc13) )then
-!       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
-!    end if
-!    if ( present(pc14) )then
-!       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
-!    end if
+#ifndef _OPENMP
+    if ( present(c13) .and. use_c13 )then
+       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
+       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
+    end if
+    if ( present(c14) .and. use_c14 )then
+       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
+       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
+    end if
+#endif
+    if ( present(pc13) )then
+       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
+    end if
+    if ( present(pc14) )then
+       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
+    end if
     ! patch loop
     lcroponly = .false.
     if ( present(croponly) )then
@@ -708,8 +460,6 @@ contains
     if ( present(allowneg) )then
       if (  allowneg ) lallowneg = .true.
     end if
-
-    num_truncatep = 0
     do fp = 1,num_soilp
        p = filter_soilp(fp)
 
@@ -719,23 +469,20 @@ contains
              write(iulog,*) 'ERROR: limits = ', cnegcrit, nnegcrit
              call endrun(msg='ERROR: carbon or nitrogen state critically negative '//errMsg(sourcefile, lineno))
           else if ( abs(carbon_patch(p)) < ccrit .or. (use_nguardrail .and. abs(nitrogen_patch(p)) < ncrit) ) then
-             num_truncatep = num_truncatep + 1
-             filter_truncatep(num_truncatep) = p
-
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
-
+      
              pn(p) = pn(p) + nitrogen_patch(p)
              nitrogen_patch(p) = 0._r8
    
-             !if ( use_c13 .and. present(c13) .and. present(pc13) ) then
-             !   pc13(p) = pc13(p) + c13(p)
-             !   c13(p) = 0._r8
-             !endif
-             !if ( use_c14 .and. present(c14) .and. present(pc14)) then
-             !   pc14(p) = pc14(p) + c14(p)
-             !   c14(p) = 0._r8
-             !endif
+             if ( use_c13 .and. present(c13) .and. present(pc13) ) then
+                pc13(p) = pc13(p) + c13(p)
+                c13(p) = 0._r8
+             endif
+             if ( use_c14 .and. present(c14) .and. present(pc14)) then
+                pc14(p) = pc14(p) + c14(p)
+                c14(p) = 0._r8
+             endif
           end if
        end if
     end do
@@ -864,41 +611,5 @@ contains
        end if
     end do
  end subroutine TruncateNStates
-
- !-----------------------------------------------------------------------
- subroutine TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-      state_patch, truncation_patch, lineno)
-   !
-   ! !DESCRIPTION:
-   ! Given a filter of points for which we have already determined that truncation should
-   ! occur, do the truncation for the given patch-level state, putting the truncation
-   ! amount in truncation_patch.
-   !
-   use decompMod  , only : bounds_type
-   ! !ARGUMENTS:
-   implicit none
-   type(bounds_type)              , intent(in)    :: bounds          ! bounds
-   integer, intent(in) :: num_truncatep       ! number of points in filter_truncatep
-   integer, intent(in) :: filter_truncatep(:) ! filter for points that need truncation
-   real(r8), intent(inout) :: state_patch(bounds%begp: )
-   real(r8), intent(inout) :: truncation_patch(bounds%begp: )
-   integer, intent(in) :: lineno
-   !
-   ! !LOCAL VARIABLES:
-
-   integer :: fp, p
-   character(len=*), parameter :: subname = 'TruncateAdditional'
-   !-----------------------------------------------------------------------
-
-   SHR_ASSERT_FL((ubound(state_patch, 1) == bounds%endp), 'state_patch '//sourcefile, lineno)
-   SHR_ASSERT_FL((ubound(truncation_patch, 1) == bounds%endp), 'truncation_patch '//sourcefile, lineno)
-
-   do fp = 1, num_truncatep
-      p = filter_truncatep(fp)
-      truncation_patch(p) = truncation_patch(p) + state_patch(p)
-      state_patch(p) = 0._r8
-   end do
-
- end subroutine TruncateAdditional
 
 end module CNPrecisionControlMod

--- a/src/biogeochem/DryDepVelocity.F90
+++ b/src/biogeochem/DryDepVelocity.F90
@@ -286,7 +286,7 @@ CONTAINS
          forc_solad =>    atm2lnd_inst%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
          forc_t     =>    atm2lnd_inst%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric temperature (Kelvin)                   
          forc_q     =>    wateratm2lndbulk_inst%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric specific humidity (kg/kg)              
-         forc_psrf  =>    atm2lnd_inst%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled surface pressure (Pa)                              
+         forc_pbot  =>    atm2lnd_inst%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled surface pressure (Pa)                              
          forc_rain  =>    wateratm2lndbulk_inst%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]                                   
 
          h2osoi_vol =>    waterstatebulk_inst%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ] volumetric soil water (0<=h2osoi_vol<=watsat)   
@@ -318,7 +318,7 @@ CONTAINS
 
             c = patch%column(pi)
             g = patch%gridcell(pi)
-            pg         = forc_psrf(c)  
+            pg         = forc_pbot(c)  
             spec_hum   = forc_q(c)
             rain       = forc_rain(c) 
             sfc_temp   = forc_t(c) 

--- a/src/main/atm2lndType.F90
+++ b/src/main/atm2lndType.F90
@@ -78,7 +78,6 @@ module atm2lndType
      real(r8), pointer :: forc_hgt_t_grc                (:)   => null() ! obs height of temperature [m] (new)
      real(r8), pointer :: forc_hgt_q_grc                (:)   => null() ! obs height of humidity [m] (new)
      real(r8), pointer :: forc_vp_grc                   (:)   => null() ! atmospheric vapor pressure (Pa)
-     real(r8), pointer :: forc_psrf_grc                 (:)   => null() ! surface pressure (Pa)
      real(r8), pointer :: forc_pco2_grc                 (:)   => null() ! CO2 partial pressure (Pa)
      real(r8), pointer :: forc_pco2_240_patch           (:)   => null() ! 10-day mean CO2 partial pressure (Pa)
      real(r8), pointer :: forc_solad_grc                (:,:) => null() ! direct beam radiation (numrad) (vis=forc_sols , nir=forc_soll )
@@ -474,7 +473,6 @@ contains
     allocate(this%forc_hgt_t_grc                (begg:endg))        ; this%forc_hgt_t_grc                (:)   = ival
     allocate(this%forc_hgt_q_grc                (begg:endg))        ; this%forc_hgt_q_grc                (:)   = ival
     allocate(this%forc_vp_grc                   (begg:endg))        ; this%forc_vp_grc                   (:)   = ival
-    allocate(this%forc_psrf_grc                 (begg:endg))        ; this%forc_psrf_grc                 (:)   = ival
     allocate(this%forc_pco2_grc                 (begg:endg))        ; this%forc_pco2_grc                 (:)   = ival
     allocate(this%forc_solad_grc                (begg:endg,numrad)) ; this%forc_solad_grc                (:,:) = ival
     allocate(this%forc_solai_grc                (begg:endg,numrad)) ; this%forc_solai_grc                (:,:) = ival
@@ -992,7 +990,6 @@ contains
     deallocate(this%forc_hgt_t_grc)
     deallocate(this%forc_hgt_q_grc)
     deallocate(this%forc_vp_grc)
-    deallocate(this%forc_psrf_grc)
     deallocate(this%forc_pco2_grc)
     deallocate(this%forc_solad_grc)
     deallocate(this%forc_solai_grc)

--- a/src/main/initVerticalMod.F90
+++ b/src/main/initVerticalMod.F90
@@ -41,7 +41,6 @@ module initVerticalMod
   public :: initVertical
 
   ! !PRIVATE MEMBER FUNCTIONS:
-  private :: ReadNL
   private :: hasBedrock  ! true if the given column type includes bedrock layers
   !
 
@@ -52,60 +51,6 @@ module initVerticalMod
   !------------------------------------------------------------------------
 
 contains
-
-  !------------------------------------------------------------------------
-  subroutine ReadNL( )
-    !
-    ! !DESCRIPTION:
-    ! Read namelist for SoilStateType
-    !
-    ! !USES:
-    use shr_mpi_mod    , only : shr_mpi_bcast
-    use shr_log_mod    , only : errMsg => shr_log_errMsg
-    use fileutils      , only : getavu, relavu, opnfil
-    use clm_nlUtilsMod , only : find_nlgroup_name
-    use clm_varctl     , only : iulog
-    use spmdMod        , only : mpicom, masterproc
-    use controlMod     , only : NLFilename
-    !
-    ! !ARGUMENTS:
-    !
-    ! !LOCAL VARIABLES:
-    integer :: ierr                 ! error code
-    integer :: unitn                ! unit for namelist file
-    character(len=32) :: subname = 'InitVertical_readnl'  ! subroutine name
-    !-----------------------------------------------------------------------
-
-    character(len=*), parameter :: nl_name  = 'clm_inparm'  ! Namelist name
-                                                                      
-    ! MUST agree with name in namelist and read
-    namelist /clm_inparm/ use_bedrock
-
-    ! preset values
-
-    use_bedrock = .false.
-
-    if ( masterproc )then
-
-       unitn = getavu()
-       write(iulog,*) 'Read in '//nl_name//' namelist'
-       call opnfil (NLFilename, unitn, 'F')
-       call find_nlgroup_name(unitn, nl_name, status=ierr)
-       if (ierr == 0) then
-          read(unit=unitn, nml=clm_inparm, iostat=ierr)
-          if (ierr /= 0) then
-             call endrun(msg="ERROR reading '//nl_name//' namelist"//errmsg(sourcefile, __LINE__))
-          end if
-       else
-          call endrun(msg="ERROR finding '//nl_name//' namelist"//errmsg(sourcefile, __LINE__))
-       end if
-       call relavu( unitn )
-
-    end if
-
-    call shr_mpi_bcast(use_bedrock, mpicom)
-
-  end subroutine ReadNL
 
   !------------------------------------------------------------------------
   subroutine initVertical(bounds, glc_behavior, snow_depth, thick_wall, thick_roof)

--- a/src/main/subgridRestMod.F90
+++ b/src/main/subgridRestMod.F90
@@ -532,7 +532,7 @@ contains
     end if
     call restartvar(ncid=ncid, flag=flag, varname='ZISNO', xtype=ncd_double,  & 
          dim1name='column', dim2name='levsno', switchdim=.true., lowerb2=-nlevsno, upperb2=-1, &
-         long_name='snow interface depth', units='m', &
+         long_name='snow interface depth at the top of layer j', units='m', &
          interpinic_flag='interp', readvar=readvar, data=temp2d)
     if (flag == 'read') then
        col%zi(bounds%begc:bounds%endc,-nlevsno:-1) = temp2d(bounds%begc:bounds%endc,-nlevsno:-1) 

--- a/src/main/subgridRestMod.F90
+++ b/src/main/subgridRestMod.F90
@@ -532,7 +532,7 @@ contains
     end if
     call restartvar(ncid=ncid, flag=flag, varname='ZISNO', xtype=ncd_double,  & 
          dim1name='column', dim2name='levsno', switchdim=.true., lowerb2=-nlevsno, upperb2=-1, &
-         long_name='snow interface depth at the top of layer j', units='m', &
+         long_name='snow interface depth at the top of the given layer', units='m', &
          interpinic_flag='interp', readvar=readvar, data=temp2d)
     if (flag == 'read') then
        col%zi(bounds%begc:bounds%endc,-nlevsno:-1) = temp2d(bounds%begc:bounds%endc,-nlevsno:-1) 

--- a/src/utils/clmfates_paraminterfaceMod.F90
+++ b/src/utils/clmfates_paraminterfaceMod.F90
@@ -172,11 +172,12 @@ contains
  !-----------------------------------------------------------------------
  subroutine ParametersFromNetCDF(filename, is_host_file, fates_params)
 
-   use shr_kind_mod, only: r8 => shr_kind_r8
-   use abortutils, only : endrun
-   use fileutils  , only : getfil
-   use ncdio_pio  , only : file_desc_t, ncd_pio_closefile, ncd_pio_openfile
-   use paramUtilMod, only : readNcdio
+   use shr_kind_mod , only : r8 => shr_kind_r8
+   use abortutils   , only : endrun
+   use fileutils    , only : getfil
+   use ncdio_pio    , only : file_desc_t , ncd_pio_closefile , ncd_pio_openfile
+   use paramUtilMod , only : readNcdio
+   use spmdMod      , only : masterproc
 
    use FatesParametersInterface, only : fates_parameters_type
    use FatesParametersInterface, only : param_string_length, max_dimensions, max_used_dimensions
@@ -227,7 +228,9 @@ contains
             call endrun(msg='unsupported number of dimensions reading parameters.')
 
          end select
-         write(fates_log(), *) 'clmfates_interfaceMod.F90:: reading '//trim(name)
+         if (masterproc) then
+            write(fates_log(), *) 'clmfates_interfaceMod.F90:: reading '//trim(name)
+         end if
          call readNcdio(ncid, name, dimension_shape, dimension_names, subname, data(1:size_dim_1, 1:size_dim_2))
          call fates_params%SetData(i, data(1:size_dim_1, 1:size_dim_2))
       end if


### PR DESCRIPTION
### Description of changes
Resolve issues #683, #874,  #878 , #885, #745 , #838

Fixes #683: writing out FATES parameters only on `masterproc`.
Fixes #874: Changing the number of timesteps to run for `SMS_P720x1_Ln3.hcru_hcru.I2000Clm50BgcCruGs.cheyenne_intel.clm-coldStar`
to prevent failing with CMEPS.
Fixes #878: Removing the unused atm2lnd field. 
Fixes #885: Changing the defaults for `br_root` in `namelist_defaults` to enable FUN with CLM4.5.
Fixes  #745: Removing `ReadNL` private subroutine from `initVerticalMod.F90`.
Fixes #838: Clarifying `ZISNO` in the variable long name.


### Specific notes

Contributors other than yourself, if any: @billsacks 

CTSM Issues Fixed (include github issue #):
#683, #874,  #878 , #885, #745 , #838 


Are answers expected to change (and if so in what way)?
No.

Any User Interface Changes (namelist or namelist defaults changes)?
The namelist_defaults for br_root were too specific. The default for br_root in namelist_defaults  has changed to enable FUN with CLM4.5. 

Testing performed, if any:
    cheyenne ---- OK
    izumi ------- PASS

