### PR TITLE
FATES: Condition the zeroing of qflx bc_in upon having hydro on

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1407,9 +1407,9 @@ contains
 
         ! set transpiration input boundary condition to zero. The exposed
         ! vegetation filter may not even call every patch.
-
-        this%fates(nc)%bc_in(s)%qflx_transp_pa(:) = 0._r8
-
+        if (use_fates_planthydro) then
+            this%fates(nc)%bc_in(s)%qflx_transp_pa(:) = 0._r8
+        end if
 
      end do
   end subroutine prep_canopyfluxes


### PR DESCRIPTION
### Description of changes

This is a bug fix. The boundary condition to fates for tranpiration flux is only allocated when the hydraulics module is active.  This variable was being zero'd for cases where the array was not allocated.

### Specific notes

@serbinsh and  @Qianyuxuan found the error.

FATES issue fixed:  https://github.com/NGEET/fates/issues/605

Are answers expected to change (and if so in what way)?  No, but I don't know how the tests did not catch this!

Any User Interface Changes (namelist or namelist defaults changes)?

No

Testing performed, if any:

TBD

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
