### PR TITLE
Add mizuRoute

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -26,11 +26,18 @@ repo_url = https://github.com/ESCOMP/mosart
 tag = mosart1_0_35
 required = True
 
+[mizuRoute]
+local_path = components/mizuRoute
+protocol = git
+repo_url = https://github.com/ekluzek/mizuRoute
+branch = ctsm-coupling
+required = True
+
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/ESMCI/cime
-tag = branch_tags/cime5.8.15_a01
+repo_url = https://github.com/ekluzek/cime
+branch = mizuRoute
 externals = ../Externals_cime.cfg
 required = True
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -66,6 +66,11 @@
   </compset>
 
   <compset>
+    <alias>I2000Clm50SpMizGs</alias>
+    <lname>2000_DATM%GSWP3v1_CLM50%SP_SICE_SOCN_MIZUROUTE_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>I2000Clm50BgcCru</alias>
     <lname>2000_DATM%CRUv7_CLM50%BGC_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>


### PR DESCRIPTION
### Description of changes

Start bringing in mizuRoute as an external and a compset that will exercise it.

### Specific notes

Contributors other than yourself, if any: @serbinsh nmizukami

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)? No (unless running with mizuRoute)

Any User Interface Changes (namelist or namelist defaults changes)? New compset

Testing performed, if any:
SMS_D_Vnuopc.f90_g17.I2000Clm50SpMizGs.cheyenne_intel can be setup and create namelists. It doesn't currently build however.


**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
