### PR TITLE
Resolve Issue #811: Bounds assertion for ciso when threading is on

### DIFF
--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -432,7 +432,7 @@
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
-      <option name="wallclock">0:20:00</option>
+      <option name="wallclock">00:20:00</option>
       <option name="comment"  >Do a test with RTM and flooding on as that also impacts CLM code</option>
     </options>
   </test>
@@ -740,7 +740,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Want an ERP test covering some non-default irrigation options. Long enough so that we're likely to exercise the various groundwater irrigation code.</option>
         </options>
       </machine>
@@ -1646,7 +1646,7 @@
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm">
         <options>
-          <option name="wallclock">0:20:00</option>
+          <option name="wallclock">00:20:00</option>
           <option name="comment">Debug test covering some non-default irrigation options.</option>
         </options>
       </machine>
@@ -1657,7 +1657,7 @@
 
       <machine name="izumi" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Include a tracer consistency check in debug mode.</option>
         </options>
       </machine>
@@ -1669,7 +1669,7 @@
 
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">A debug ERP test of the NWP configuration with active BGC and CROP.</option>
         </options>
       </machine>
@@ -1680,7 +1680,7 @@
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Ensure that turning on water tracers doesn't change answers. Cold start for now, until we can use initial conditions from a non-isotope case in an isotope case; once we can do that, this should be changed to not be cold start (e.g., 5-day decStart transient test: see also https://github.com/ESCOMP/ctsm/issues/495#issuecomment-516619853).</option>
         </options>
       </machine>
@@ -1691,7 +1691,7 @@
 
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Include a debug ERP test of the NWP configuration.</option>
         </options>
       </machine>
@@ -1703,7 +1703,7 @@
 
       <machine name="cheyenne" compiler="gnu" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Include a short smoke test covering the nldas2 grid and the I2000Ctsm50NwpSpNldasGs compset, which uses NLDAS datm forcing.</option>
         </options>
       </machine>
@@ -1715,7 +1715,7 @@
 
       <machine name="cheyenne" compiler="gnu" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Include a short smoke test covering the nldas2 grid and the I2000Ctsm50NwpSpNldasRsGs compset, which uses NLDAS datm forcing.</option>
         </options>
       </machine>
@@ -1910,7 +1910,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Can use this test to determine if there are significant throughput changes, at least for this common and important configuration. Note that this deliberately doesn't have any testmods in order to (1) avoid doing history output (because the timing of output can be very variable, and mixing output timing with other aspects of model time can be confusing), and (2) generally keep the test replicating a production configuration as closely as possible (so, for example, we do NOT set BFBFLAG=TRUE for this test).</option>
         </options>
       </machine>
@@ -1920,7 +1920,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30:00</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">This test runs CTSM's Fortran unit tests. We're abusing the system test infrastructure to run these, so that a run of the test suite results in the unit tests being run as well. Grid and compset are irrelevant here, except that compset must be one that includes CTSM in order for CIME to find the test definition.</option>
         </options>
       </machine>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1900,7 +1900,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm">
         <options>
-          <option name="wallclock">0:30</option>
+          <option name="wallclock">00:30:00</option>
           <option name="comment">Include a test of the NUOPC cap</option>
         </options>
       </machine>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,109 @@
 ===============================================================
+Tag name:  ctsm1.0.dev084
+Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
+Date: Wed Feb 19 15:05:03 MST 2020
+One-line Summary: Bounds assertion for C istopoes when threading is on
+
+Purpose of changes
+------------------
+
+Previously, the bounds of c13 and c14 in subroutines TruncateCStates and
+TruncateCandNStates were not checked when threading was on. This PR allows us
+to handle c13 and c14 arrays like everything else in CTSM including (bounds
+checking).
+
+This PR resolves issue ESCOMP/ctsm#811
+
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #):
+	-ESCOMP/ctsm#811
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): none
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): none
+
+Changes made to namelist defaults (e.g., changed parameter values): none
+
+Changes to the datasets (e.g., parameter, surface or initial files): none
+
+Substantial timing or memory changes: none
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): none
+
+Changes to tests or testing: 
+	- There was an issue (wrong wallclock time ) for one of the tests in the test
+	  definitions which got fixed:  (SMS_D_Vnuopc.f10_f10_musgs.I2000Clm50SpRsGs..)
+	- Also, I tried making the wallclocktime for all tests in
+	  cime_config/testdefs/testlist_clm.xml consistent in the format of hh:mm:ss. 
+
+Code reviewed by: Bill Sacks
+
+
+CTSM testing:
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - not run 
+
+  tools-tests (test/tools):
+
+    cheyenne - not run 
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - not run 
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    (any machine) - not run 
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK 
+    izumi ------- PASS
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: NO
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): none
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/CTSM/pull/923)
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev083
 Originator(s):  negins (Negin Sobhani,UCAR/CSEG,303-497-1224)
 Date: Thu Feb  6 12:12:26 MST 2020

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev084   negins 02/19/2020 Bounds assertion for C istopoes when threading is on
   ctsm1.0.dev083   negins 02/06/2020 Some BFB Fixes: Resolve issues #683, # 874, #878, # 885, # 745, #838
   ctsm1.0.dev082   oleson 02/01/2020 Rename variables to avoid confusion; fix QSNOEVAP diagnostic
   ctsm1.0.dev081   slevis 01/13/2020 Speed up restart writes

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -747,6 +747,8 @@ contains
     if ( present(allowneg) )then
       if (  allowneg ) lallowneg = .true.
     end if
+
+    num_truncatep = 0
     do fp = 1,num_soilp
        p = filter_soilp(fp)
 
@@ -756,6 +758,10 @@ contains
              write(iulog,*) 'ERROR: limit = ', cnegcrit
              call endrun(msg='ERROR: carbon state critically negative '//errMsg(sourcefile, lineno))
           else if ( abs(carbon_patch(p)) < ccrit) then
+
+             num_truncatep = num_truncatep + 1
+             filter_truncatep(num_truncatep) = p
+
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
           end if

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -706,7 +706,7 @@ contains
  end subroutine TruncateCandNStates
 
  subroutine TruncateCStates( bounds, filter_soilp, num_soilp, carbon_patch, pc, lineno,  &
-                                 num_truncatep, filter_truncatep, croponly, allowneg )
+                             num_truncatep, filter_truncatep, croponly, allowneg )
     !
     ! !DESCRIPTION:
     ! Truncate Carbon states. If a carbon state is too small truncate it to
@@ -808,8 +808,8 @@ contains
  end subroutine TruncateNStates
 
  !-----------------------------------------------------------------------
- subroutine TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-      state_patch, truncation_patch, lineno)
+ subroutine TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                state_patch, truncation_patch, lineno)
    !
    ! !DESCRIPTION:
    ! Given a filter of points for which we have already determined that truncation should
@@ -819,20 +819,19 @@ contains
    use decompMod  , only : bounds_type
    ! !ARGUMENTS:
    implicit none
-   type(bounds_type)              , intent(in)    :: bounds          ! bounds
-   integer, intent(in) :: num_truncatep       ! number of points in filter_truncatep
-   integer, intent(in) :: filter_truncatep(:) ! filter for points that need truncation
-   real(r8), intent(inout) :: state_patch(bounds%begp: )
-   real(r8), intent(inout) :: truncation_patch(bounds%begp: )
-   integer, intent(in) :: lineno
+   type(bounds_type) , intent (in)    :: bounds              ! bounds
+   integer           , intent (in)    :: num_truncatep       ! number of points in filter_truncatep
+   integer           , intent (in)    :: filter_truncatep(:) ! filter for points that need truncation
+   real(r8)          , intent (inout) :: state_patch(bounds%begp: )
+   real(r8)          , intent (inout) :: truncation_patch(bounds%begp: )
+   integer           , intent (in)    :: lineno
    !
    ! !LOCAL VARIABLES:
-
-   integer :: fp, p
+   integer                     :: fp, p
    character(len=*), parameter :: subname = 'TruncateAdditional'
    !-----------------------------------------------------------------------
 
-   SHR_ASSERT_FL((ubound(state_patch, 1) == bounds%endp), 'state_patch '//sourcefile, lineno)
+   SHR_ASSERT_FL((ubound(state_patch, 1)      == bounds%endp), 'state_patch '     //sourcefile, lineno)
    SHR_ASSERT_FL((ubound(truncation_patch, 1) == bounds%endp), 'truncation_patch '//sourcefile, lineno)
 
    do fp = 1, num_truncatep

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -208,15 +208,16 @@ contains
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
                                 pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
+
       if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%leafc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
-      end if
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%leafc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+                         end if
       if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%leafc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%leafc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
 
 
@@ -225,14 +226,14 @@ contains
                                 ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
       if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%leafc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%leafc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
       if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%leafc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                 c14cs%leafc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                 __LINE__)
       end if
 
       ! leaf transfer C and N
@@ -240,14 +241,14 @@ contains
                                 ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
       if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
       if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
 
       ! froot C and N
@@ -258,30 +259,30 @@ contains
                                    ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                    num_truncatep, filter_truncatep, allowneg=.true.)
           if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%frootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c13cs%frootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                      __LINE__)
           end if
           if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%frootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c14cs%frootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                      __LINE__)
           end if
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
+                                ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
       if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%frootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%frootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
       if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%frootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%frootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
 
       ! froot transfer C and N
@@ -289,14 +290,14 @@ contains
                                 ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
       if (use_c13) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
       if (use_c14) then
-         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-              c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-              __LINE__)
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
       end if
 
       if ( use_crop )then
@@ -304,47 +305,47 @@ contains
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                    num_truncatep, filter_truncatep, croponly=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%grainc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%grainc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+         if (use_c13) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c13cs%grainc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
+         if (use_c14) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c14cs%grainc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
                                    __LINE__, num_truncatep, filter_truncatep, croponly=.true. )
 
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%grainc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%grainc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+         if (use_c13) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c13cs%grainc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
+         if (use_c14) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c14cs%grainc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                    num_truncatep, filter_truncatep, croponly=.true.)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+         if (use_c13) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
+         if (use_c14) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
@@ -353,14 +354,14 @@ contains
                                    num_truncatep, filter_truncatep, &
                                    allowneg=.true., croponly=.true. )
           if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                      __LINE__)
           end if
           if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                      __LINE__)
           end if
 
       end if
@@ -369,229 +370,223 @@ contains
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
                                 ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livestemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livestemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%livestemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%livestemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
+                                ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
 
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
                                 ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadstemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadstemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%deadstemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%deadstemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
                                 ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livecrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livecrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%livecrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%livecrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
+                                ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
 
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
                                 ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
                                 num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadcrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadcrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%deadcrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%deadcrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
-                      ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, num_truncatep, filter_truncatep)
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                                ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
+                                __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep) 
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%gresp_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%gresp_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                            pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%gresp_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%gresp_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! gresp_xfer(c only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_xfer_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep) 
-                            !pc(bounds%begp:), __LINE__, &
-                            !c13=c13cs%gresp_xfer_patch, c14=c14cs%gresp_xfer_patch, &
-                            !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                            pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%gresp_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%gresp_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       ! cpool (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%cpool_patch(bounds%begp:bounds%endp), &
-                            pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep) 
-                            !pc(bounds%begp:), __LINE__, &
-                            !c13=c13cs%cpool_patch, c14=c14cs%cpool_patch, &
-                            !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%cpool_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%cpool_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+                            pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c13cs%cpool_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                  c14cs%cpool_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                  __LINE__)
+      end if
 
       if ( use_crop )then
          ! xsmrpool (C only)
@@ -599,19 +594,16 @@ contains
          call TruncateCStates( bounds, filter_soilp, num_soilp, cs%xsmrpool_patch(bounds%begp:bounds%endp), &
                                 pc(bounds%begp:), __LINE__, num_truncatep, filter_truncatep, &
                                 allowneg=.true., croponly=.true. )
-                               !pc(bounds%begp:), __LINE__, &
-                               !c13=c13cs%xsmrpool_patch, c14=c14cs%xsmrpool_patch, &
-                               !pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
-          if (use_c13) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c13cs%xsmrpool_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
-          if (use_c14) then
-             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
-                  c14cs%xsmrpool_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
-                  __LINE__)
-          end if
+         if (use_c13) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c13cs%xsmrpool_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
+         if (use_c14) then
+             call TruncateAdditional( bounds, num_truncatep, filter_truncatep, &
+                                      c14cs%xsmrpool_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                                      __LINE__)
+         end if
 
       end if
 
@@ -763,8 +755,8 @@ contains
     real(r8)         , intent(inout) :: carbon_patch(bounds%begp:)
     real(r8)         , intent(inout) :: pc(bounds%begp:)
     integer          , intent(in)    :: lineno
-    integer          ,  intent(out)  :: num_truncatep       ! number of points in filter_truncatep
-    integer          ,  intent(out)  :: filter_truncatep(:) ! filter for points that need truncation
+    integer          , intent(out)   :: num_truncatep       ! number of points in filter_truncatep
+    integer          , intent(out)   :: filter_truncatep(:) ! filter for points that need truncation
     logical          , intent(in)   , optional :: croponly
     logical          , intent(in)   , optional :: allowneg
 

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -674,22 +674,7 @@ contains
     SHR_ASSERT_ALL_FL((ubound(nitrogen_patch) == (/bounds%endp/)), 'ubnd(nitro)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
-!#ifndef _OPENMP
-!    if ( present(c13) .and. use_c13 )then
-!       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
-!       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
-!    end if
-!    if ( present(c14) .and. use_c14 )then
-!       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
-!       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
-!    end if
-!#endif
-!    if ( present(pc13) )then
-!       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
-!    end if
-!    if ( present(pc14) )then
-!       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
-!    end if
+
     ! patch loop
     lcroponly = .false.
     if ( present(croponly) )then
@@ -718,15 +703,6 @@ contains
 
              pn(p) = pn(p) + nitrogen_patch(p)
              nitrogen_patch(p) = 0._r8
-   
-             !if ( use_c13 .and. present(c13) .and. present(pc13) ) then
-             !   pc13(p) = pc13(p) + c13(p)
-             !   c13(p) = 0._r8
-             !endif
-             !if ( use_c14 .and. present(c14) .and. present(pc14)) then
-             !   pc14(p) = pc14(p) + c14(p)
-             !   c14(p) = 0._r8
-             !endif
           end if
        end if
     end do
@@ -765,25 +741,7 @@ contains
 
     SHR_ASSERT_ALL_FL((ubound(carbon_patch)   == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), sourcefile, __LINE__)
-!#ifndef _OPENMP
-!    if ( present(c13) .and. use_c13 )then
-!       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), sourcefile, __LINE__)
-!       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), sourcefile, __LINE__)
-!    end if
-!    if ( present(c14) .and. use_c14 )then
-!       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), sourcefile, __LINE__)
-!       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), sourcefile, __LINE__)
-!    end if
-!#endif
-!    if ( present(pc13) )then
-!       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), sourcefile, __LINE__)
-!    end if
-!    if ( present(pc14) )then
-!       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), sourcefile, __LINE__)
-!    end if
-!    if ( -ccrit < cnegcrit )then
-!        call endrun(msg='ERROR: cnegcrit should be less than -ccrit: '//errMsg(sourcefile, lineno))
-!    end if
+
     lcroponly = .false.
     if ( present(croponly) )then
       if ( croponly ) lcroponly = .true.
@@ -803,15 +761,6 @@ contains
           else if ( abs(carbon_patch(p)) < ccrit) then
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
-   
-             !if ( use_c13 .and. present(c13) .and. present(pc13) ) then
-             !   pc13(p) = pc13(p) + c13(p)
-             !   c13(p) = 0._r8
-             !endif
-             !if ( use_c14 .and. present(c14)  .and. present(pc14)) then
-             !   pc14(p) = pc14(p) + c14(p)
-             !   c14(p) = 0._r8
-             !endif
           end if
        end if
     end do

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -120,6 +120,8 @@ contains
     ! !LOCAL VARIABLES:
     integer :: p,j,k                             ! indices
     integer :: fp                                ! filter indices
+    integer :: num_truncatep                     ! number of points in filter_truncatep
+    integer :: filter_truncatep(bounds%endp-bounds%begp+1) ! filter for points that need truncation
     real(r8):: pc(bounds%begp:bounds%endp)       ! truncation terms for patch-level corrections Carbon
     real(r8):: pn(bounds%begp:bounds%endp)       ! truncation terms for patch-level corrections nitrogen
     real(r8):: pc13(bounds%begp:bounds%endp)     ! truncation terms for patch-level corrections
@@ -205,20 +207,48 @@ contains
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_patch(bounds%begp:bounds%endp), &
                                 pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_patch, c14=c14cs%leafc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%leafc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%leafc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+
 
       ! leaf storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_storage_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_storage_patch, c14=c14cs%leafc_storage_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%leafc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%leafc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       ! leaf transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%leafc_xfer_patch(bounds%begp:bounds%endp), &
                                 ns%leafn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%leafc_xfer_patch, c14=c14cs%leafc_xfer_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%leafc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       ! froot C and N
       ! EBK KO DML: For some reason frootc/frootn can go negative and allowing
@@ -226,120 +256,294 @@ contains
       if ( prec_control_for_froot ) then
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_patch(bounds%begp:bounds%endp),  &
                                    ns%frootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%frootc_patch, c14=c14cs%frootc_patch,  &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true. )
+                                   num_truncatep, filter_truncatep, allowneg=.true.)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%frootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%frootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
       end if
 
       ! froot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%frootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%frootc_storage_patch, c14=c14cs%frootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%frootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%frootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       ! froot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%frootc_xfer_patch(bounds%begp:bounds%endp), &
                                 ns%frootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%frootc_xfer_patch, c14=c14cs%frootc_xfer_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+      if (use_c13) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c13cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
+      if (use_c14) then
+         call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+              c14cs%frootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+              __LINE__)
+      end if
 
       if ( use_crop )then
          ! grain C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%grainc_patch, c14=c14cs%grainc_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   num_truncatep, filter_truncatep, croponly=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%grainc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%grainc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
          ! grain storage C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_storage_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                                   __LINE__, c13=c13cs%grainc_storage_patch, c14=c14cs%grainc_storage_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   __LINE__, num_truncatep, filter_truncatep, croponly=.true. )
+
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%grainc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%grainc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%grainc_xfer_patch(bounds%begp:bounds%endp), &
                                    ns%grainn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%grainc_xfer_patch, c14=c14cs%grainc_xfer_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), croponly=.true. )
+                                   num_truncatep, filter_truncatep, croponly=.true.)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%grainc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
          ! grain transfer C and N
          call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), &
                                    ns%cropseedn_deficit_patch(bounds%begp:bounds%endp), pc(bounds%begp:), &
                                    pn(bounds%begp:), __LINE__, &
-                                   c13=c13cs%cropseedc_deficit_patch, c14=c14cs%cropseedc_deficit_patch, &
-                                   pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:), allowneg=.true., croponly=.true. )
+                                   num_truncatep, filter_truncatep, &
+                                   allowneg=.true., croponly=.true. )
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%cropseedc_deficit_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       end if
 
       ! livestem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_patch(bounds%begp:bounds%endp), &
                                 ns%livestemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%livestemc_patch, c14=c14cs%livestemc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livestemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livestemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livestem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_storage_patch(bounds%begp:bounds%endp), &
                       ns%livestemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livestemc_storage_patch, c14=c14cs%livestemc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
 
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livestemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
       ! livestem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livestemc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%livestemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livestemc_xfer_patch, c14=c14cs%livestemc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livestemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadstem C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_patch(bounds%begp:bounds%endp), &
                                 ns%deadstemn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%deadstemc_patch, c14=c14cs%deadstemc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadstemc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadstemc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
       ! deadstem storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_storage_patch(bounds%begp:bounds%endp), &
                       ns%deadstemn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadstemc_storage_patch, c14=c14cs%deadstemc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadstemc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadstem transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%deadstemn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadstemc_xfer_patch, c14=c14cs%deadstemc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadstemc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livecroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_patch(bounds%begp:bounds%endp), &
                                 ns%livecrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%livecrootc_patch, c14=c14cs%livecrootc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                   num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livecrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livecrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livecroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%livecrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livecrootc_storage_patch, c14=c14cs%livecrootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livecrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! livecroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%livecrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%livecrootc_xfer_patch, c14=c14cs%livecrootc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%livecrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadcroot C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_patch(bounds%begp:bounds%endp), &
                                 ns%deadcrootn_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), __LINE__, &
-                                c13=c13cs%deadcrootc_patch, c14=c14cs%deadcrootc_patch, &
-                                pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                                num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadcrootc_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadcrootc_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadcroot storage C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), &
                       ns%deadcrootn_storage_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadcrootc_storage_patch, c14=c14cs%deadcrootc_storage_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadcrootc_storage_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! deadcroot transfer C and N
       call TruncateCandNStates( bounds, filter_soilp, num_soilp, cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), &
                       ns%deadcrootn_xfer_patch(bounds%begp:bounds%endp), pc(bounds%begp:), pn(bounds%begp:), &
-                      __LINE__, c13=c13cs%deadcrootc_xfer_patch, c14=c14cs%deadcrootc_xfer_patch, &
-                      pc13=pc13(bounds%begp:), pc14=pc14(bounds%begp:) )
+                      __LINE__, num_truncatep, filter_truncatep)
+          if (use_c13) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c13cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc13(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
+          if (use_c14) then
+             call TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+                  c14cs%deadcrootc_xfer_patch(bounds%begp:bounds%endp), pc14(bounds%begp:bounds%endp), &
+                  __LINE__)
+          end if
 
       ! gresp_storage (C only)
       call TruncateCStates( bounds, filter_soilp, num_soilp, cs%gresp_storage_patch(bounds%begp:bounds%endp), &
@@ -397,8 +601,11 @@ contains
 
  end subroutine CNPrecisionControl
 
- subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
-                                 pc13, pc14, croponly, allowneg )
+ subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, &
+                                 num_truncatep, filter_truncatep, croponly, allowneg )
+
+ !subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
+ !                                pc13, pc14, croponly, allowneg )
     !
     ! !DESCRIPTION:
     ! Truncate paired Carbon and Nitrogen states. If a paired carbon and nitrogen state iare too small truncate 
@@ -421,10 +628,8 @@ contains
     real(r8), intent(inout) :: pc(bounds%begp:)
     real(r8), intent(inout) :: pn(bounds%begp:)
     integer,  intent(in)    :: lineno
-    real(r8), intent(inout), optional, pointer :: c13(:)
-    real(r8), intent(inout), optional, pointer :: c14(:)
-    real(r8), intent(inout), optional :: pc13(bounds%begp:)
-    real(r8), intent(inout), optional :: pc14(bounds%begp:)
+    integer,  intent(out)   :: num_truncatep       ! number of points in filter_truncatep
+    integer,  intent(out)   :: filter_truncatep(:) ! filter for points that need truncation
     logical , intent(in)   , optional :: croponly
     logical , intent(in)   , optional :: allowneg
 
@@ -435,22 +640,22 @@ contains
     SHR_ASSERT_ALL_FL((ubound(nitrogen_patch) == (/bounds%endp/)), 'ubnd(nitro)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), 'ubnd(pc)'//sourcefile, lineno)
     SHR_ASSERT_ALL_FL((ubound(pn)             == (/bounds%endp/)), 'ubnd(pn)'//sourcefile, lineno)
-#ifndef _OPENMP
-    if ( present(c13) .and. use_c13 )then
-       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
-       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
-    end if
-    if ( present(c14) .and. use_c14 )then
-       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
-       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
-    end if
-#endif
-    if ( present(pc13) )then
-       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
-    end if
-    if ( present(pc14) )then
-       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
-    end if
+!#ifndef _OPENMP
+!    if ( present(c13) .and. use_c13 )then
+!       SHR_ASSERT_ALL_FL((lbound(c13)         == (/bounds%begp/)), 'lbnd(c13)'//sourcefile, lineno)
+!       SHR_ASSERT_ALL_FL((ubound(c13)         == (/bounds%endp/)), 'ubnd(c13)'//sourcefile, lineno)
+!    end if
+!    if ( present(c14) .and. use_c14 )then
+!       SHR_ASSERT_ALL_FL((lbound(c14)         == (/bounds%begp/)), 'lbnd(c14)'//sourcefile, lineno)
+!       SHR_ASSERT_ALL_FL((ubound(c14)         == (/bounds%endp/)), 'ubnd(c14)'//sourcefile, lineno)
+!    end if
+!#endif
+!    if ( present(pc13) )then
+!       SHR_ASSERT_ALL_FL((ubound(pc13)        == (/bounds%endp/)), 'ubnd(pc13)'//sourcefile, lineno)
+!    end if
+!    if ( present(pc14) )then
+!       SHR_ASSERT_ALL_FL((ubound(pc14)        == (/bounds%endp/)), 'ubnd(pc14)'//sourcefile, lineno)
+!    end if
     ! patch loop
     lcroponly = .false.
     if ( present(croponly) )then
@@ -460,6 +665,8 @@ contains
     if ( present(allowneg) )then
       if (  allowneg ) lallowneg = .true.
     end if
+
+    num_truncatep = 0
     do fp = 1,num_soilp
        p = filter_soilp(fp)
 
@@ -469,20 +676,23 @@ contains
              write(iulog,*) 'ERROR: limits = ', cnegcrit, nnegcrit
              call endrun(msg='ERROR: carbon or nitrogen state critically negative '//errMsg(sourcefile, lineno))
           else if ( abs(carbon_patch(p)) < ccrit .or. (use_nguardrail .and. abs(nitrogen_patch(p)) < ncrit) ) then
+             num_truncatep = num_truncatep + 1
+             filter_truncatep(num_truncatep) = p
+
              pc(p) = pc(p) + carbon_patch(p)
              carbon_patch(p) = 0._r8
-      
+
              pn(p) = pn(p) + nitrogen_patch(p)
              nitrogen_patch(p) = 0._r8
    
-             if ( use_c13 .and. present(c13) .and. present(pc13) ) then
-                pc13(p) = pc13(p) + c13(p)
-                c13(p) = 0._r8
-             endif
-             if ( use_c14 .and. present(c14) .and. present(pc14)) then
-                pc14(p) = pc14(p) + c14(p)
-                c14(p) = 0._r8
-             endif
+             !if ( use_c13 .and. present(c13) .and. present(pc13) ) then
+             !   pc13(p) = pc13(p) + c13(p)
+             !   c13(p) = 0._r8
+             !endif
+             !if ( use_c14 .and. present(c14) .and. present(pc14)) then
+             !   pc14(p) = pc14(p) + c14(p)
+             !   c14(p) = 0._r8
+             !endif
           end if
        end if
     end do
@@ -611,5 +821,41 @@ contains
        end if
     end do
  end subroutine TruncateNStates
+
+ !-----------------------------------------------------------------------
+ subroutine TruncateAdditional(bounds, num_truncatep, filter_truncatep, &
+      state_patch, truncation_patch, lineno)
+   !
+   ! !DESCRIPTION:
+   ! Given a filter of points for which we have already determined that truncation should
+   ! occur, do the truncation for the given patch-level state, putting the truncation
+   ! amount in truncation_patch.
+   !
+   use decompMod  , only : bounds_type
+   ! !ARGUMENTS:
+   implicit none
+   type(bounds_type)              , intent(in)    :: bounds          ! bounds
+   integer, intent(in) :: num_truncatep       ! number of points in filter_truncatep
+   integer, intent(in) :: filter_truncatep(:) ! filter for points that need truncation
+   real(r8), intent(inout) :: state_patch(bounds%begp: )
+   real(r8), intent(inout) :: truncation_patch(bounds%begp: )
+   integer, intent(in) :: lineno
+   !
+   ! !LOCAL VARIABLES:
+
+   integer :: fp, p
+   character(len=*), parameter :: subname = 'TruncateAdditional'
+   !-----------------------------------------------------------------------
+
+   SHR_ASSERT_FL((ubound(state_patch, 1) == bounds%endp), 'state_patch '//sourcefile, lineno)
+   SHR_ASSERT_FL((ubound(truncation_patch, 1) == bounds%endp), 'truncation_patch '//sourcefile, lineno)
+
+   do fp = 1, num_truncatep
+      p = filter_truncatep(fp)
+      truncation_patch(p) = truncation_patch(p) + state_patch(p)
+      state_patch(p) = 0._r8
+   end do
+
+ end subroutine TruncateAdditional
 
 end module CNPrecisionControlMod

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -637,9 +637,6 @@ contains
 
  subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, &
                                  num_truncatep, filter_truncatep, croponly, allowneg )
-
- !subroutine TruncateCandNStates( bounds, filter_soilp, num_soilp, carbon_patch, nitrogen_patch, pc, pn, lineno, c13, c14, &
- !                                pc13, pc14, croponly, allowneg )
     !
     ! !DESCRIPTION:
     ! Truncate paired Carbon and Nitrogen states. If a paired carbon and nitrogen state iare too small truncate 

--- a/src/biogeochem/CNPrecisionControlMod.F90
+++ b/src/biogeochem/CNPrecisionControlMod.F90
@@ -739,6 +739,9 @@ contains
     SHR_ASSERT_ALL_FL((ubound(carbon_patch)   == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(pc)             == (/bounds%endp/)), sourcefile, __LINE__)
 
+    if ( -ccrit < cnegcrit )then
+        call endrun(msg='ERROR: cnegcrit should be less than -ccrit: '//errMsg(sourcefile, lineno))
+    end if
     lcroponly = .false.
     if ( present(croponly) )then
       if ( croponly ) lcroponly = .true.


### PR DESCRIPTION
### Description of changes
This PR request resolves issue #811 . 
The bounds of arguments in subroutines `TruncateCStates` and `TruncateCandNStates` 
are not getting checked when threading is on for c13 and c14. 
Removing `#ifndef _OPENMP` was causing problems since c13 and c14 are not always allocated. 
@billsacks  suggested using a similar method that is used for handling water isotopes here.
 Based on this method the isotopes (i.e. c13 and c14) are being handled separately from the bulk and in another subroutine. Here we use `TruncateAdditional` for c13 and c14 only when they are allocated ( `if (use_c13)` or ` if (use_c14)`). 


### Specific notes

Contributors other than yourself, if any: @billsacks

CTSM Issues Fixed (include github issue #):  #811 

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? None

Testing performed, if any:
Tested `clm_short` on Cheyenne. I will run standard testing ( `aux_clm`) for Cheyenne and Izumi.
