### PR TITLE
For mct, run land with a subset of global threads if desired

### DIFF
--- a/src/cpl/mct/lnd_comp_mct.F90
+++ b/src/cpl/mct/lnd_comp_mct.F90
@@ -67,7 +67,9 @@ contains
     use clm_cpl_indices  , only : clm_cpl_indices_set
     use mct_mod          , only : mct_aVect_init, mct_aVect_zero, mct_gsMap_lsize
     use ESMF
-!$  use omp_lib         , only : omp_set_num_threads
+#ifdef _OPENMP
+    use omp_lib          , only : omp_set_num_threads
+#endif
     !
     ! !ARGUMENTS:
     type(ESMF_Clock),           intent(inout) :: EClock           ! Input synchronization clock
@@ -84,7 +86,7 @@ contains
     integer  :: g,i,j                                ! indices
     integer  :: dtime_sync                           ! coupling time-step from the input synchronization clock
     integer  :: dtime_clm                            ! clm time-step
-    integer  :: nthreads
+    integer  :: nthreads_lnd                         ! number of OpenMP threads for the land model
     logical  :: exists                               ! true if file exists
     logical  :: atm_aero                             ! Flag if aerosol data sent from atm model
     real(r8) :: scmlat                               ! single-column latitude
@@ -117,8 +119,10 @@ contains
     call seq_cdata_setptrs(cdata_l, ID=LNDID, mpicom=mpicom_lnd, &
          gsMap=GSMap_lnd, dom=dom_l, infodata=infodata)
 
-    call seq_comm_setptrs(LNDID, nthreads=nthreads)
-!$  call omp_set_num_threads(nthreads)
+#ifdef _OPENMP
+    call seq_comm_setptrs(LNDID, nthreads=nthreads_lnd)
+    call omp_set_num_threads(nthreads_lnd)
+#endif
 
     ! Determine attriute vector indices
 
@@ -313,7 +317,9 @@ contains
     use shr_orb_mod     ,  only : shr_orb_decl
     use ESMF
     use seq_comm_mct    , only : seq_comm_setptrs
-!$  use omp_lib         , only : omp_set_num_threads
+#ifdef _OPENMP
+    use omp_lib         , only : omp_set_num_threads
+#endif
     !
     ! !ARGUMENTS:
     type(ESMF_Clock) , intent(inout) :: EClock    ! Input synchronization clock from driver
@@ -347,7 +353,7 @@ contains
     integer      :: shrlogunit,shrloglev ! old values for share log unit and log level
     integer      :: lbnum                ! input to memory diagnostic
     integer      :: g,i,lsize            ! counters
-    integer      :: nthreads             ! number of threads in a task
+    integer      :: nthreads_lnd         ! number of OpenMP threads for the land model
     real(r8)     :: calday               ! calendar day for nstep
     real(r8)     :: declin               ! solar declination angle in radians for nstep
     real(r8)     :: declinp1             ! solar declination angle in radians for nstep+1
@@ -360,9 +366,11 @@ contains
     character(len=32)               :: rdate                ! date char string for restart file names
     character(len=32), parameter    :: sub = "lnd_run_mct"
     !---------------------------------------------------------------------------
+#ifdef _OPENMP
     ! set number of openmp threads
-    call seq_comm_setptrs(LNDID, nthreads=nthreads)
-!$  call omp_set_num_threads(nthreads)
+    call seq_comm_setptrs(LNDID, nthreads=nthreads_lnd)
+    call omp_set_num_threads(nthreads_lnd)
+#endif
 
     ! Determine processor bounds
 

--- a/src/cpl/mct/lnd_comp_mct.F90
+++ b/src/cpl/mct/lnd_comp_mct.F90
@@ -68,7 +68,7 @@ contains
     use mct_mod          , only : mct_aVect_init, mct_aVect_zero, mct_gsMap_lsize
     use ESMF
 #ifdef _OPENMP
-    use omp_lib          , only : omp_set_num_threads
+    use omp_lib          , only : omp_set_num_threads, omp_get_max_threads
 #endif
     !
     ! !ARGUMENTS:
@@ -86,6 +86,7 @@ contains
     integer  :: g,i,j                                ! indices
     integer  :: dtime_sync                           ! coupling time-step from the input synchronization clock
     integer  :: dtime_clm                            ! clm time-step
+    integer  :: nthreads_orig                        ! original number of threads at start of call
     integer  :: nthreads_lnd                         ! number of OpenMP threads for the land model
     logical  :: exists                               ! true if file exists
     logical  :: atm_aero                             ! Flag if aerosol data sent from atm model
@@ -120,6 +121,7 @@ contains
          gsMap=GSMap_lnd, dom=dom_l, infodata=infodata)
 
 #ifdef _OPENMP
+    nthreads_orig = omp_get_max_threads()
     call seq_comm_setptrs(LNDID, nthreads=nthreads_lnd)
     call omp_set_num_threads(nthreads_lnd)
 #endif
@@ -287,6 +289,10 @@ contains
     endif
 #endif
 
+#ifdef _OPENMP
+    call omp_set_num_threads(nthreads_orig)
+#endif
+
   end subroutine lnd_init_mct
 
   !====================================================================================
@@ -318,7 +324,7 @@ contains
     use ESMF
     use seq_comm_mct    , only : seq_comm_setptrs
 #ifdef _OPENMP
-    use omp_lib         , only : omp_set_num_threads
+    use omp_lib         , only : omp_set_num_threads, omp_get_max_threads
 #endif
     !
     ! !ARGUMENTS:
@@ -353,6 +359,7 @@ contains
     integer      :: shrlogunit,shrloglev ! old values for share log unit and log level
     integer      :: lbnum                ! input to memory diagnostic
     integer      :: g,i,lsize            ! counters
+    integer      :: nthreads_orig        ! original number of threads at start of call
     integer      :: nthreads_lnd         ! number of OpenMP threads for the land model
     real(r8)     :: calday               ! calendar day for nstep
     real(r8)     :: declin               ! solar declination angle in radians for nstep
@@ -368,6 +375,7 @@ contains
     !---------------------------------------------------------------------------
 #ifdef _OPENMP
     ! set number of openmp threads
+    nthreads_orig = omp_get_max_threads()
     call seq_comm_setptrs(LNDID, nthreads=nthreads_lnd)
     call omp_set_num_threads(nthreads_lnd)
 #endif
@@ -519,6 +527,10 @@ contains
 #endif
 
     first_call  = .false.
+
+#ifdef _OPENMP
+    call omp_set_num_threads(nthreads_orig)
+#endif
 
   end subroutine lnd_run_mct
 

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -50,6 +50,9 @@ module controlMod
   use CanopyFluxesMod                  , only: CanopyFluxesReadNML
   use seq_drydep_mod                   , only: drydep_method, DD_XLND, n_drydep
   use clm_varctl
+#ifdef _OPENMP
+  use omp_lib                          , only: omp_get_max_threads
+#endif
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -66,10 +69,6 @@ module controlMod
   ! !PRIVATE TYPES:
   character(len=  7) :: runtyp(4)                        ! run type
   character(len=SHR_KIND_CL) :: NLFilename = 'lnd.stdin' ! Namelist filename
-
-#if (defined _OPENMP)
-  integer, external :: omp_get_max_threads  ! max number of threads that can execute concurrently in a single parallel region
-#endif
 
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
@@ -293,7 +292,7 @@ contains
 
     ! Set clumps per procoessor
 
-#if (defined _OPENMP)
+#ifdef _OPENMP
     clump_pproc = omp_get_max_threads()
 #else
     clump_pproc = 1

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -21,8 +21,8 @@ module controlMod
   use clm_varcon                       , only: h2osno_max
   use clm_varpar                       , only: maxpatch_pft, maxpatch_glcmec, numrad, nlevsno
   use fileutils                        , only: getavu, relavu, get_filename
-  use histFileMod                      , only: max_tapes, max_namlen
-  use histFileMod                      , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape
+  use histFileMod                      , only: max_tapes, max_namlen 
+  use histFileMod                      , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape 
   use histFileMod                      , only: hist_nhtfrq, hist_ndens, hist_mfilt, hist_fincl1, hist_fincl2, hist_fincl3
   use histFileMod                      , only: hist_fincl4, hist_fincl5, hist_fincl6, hist_fincl7, hist_fincl8
   use histFileMod                      , only: hist_fincl9, hist_fincl10
@@ -43,16 +43,13 @@ module controlMod
   use CIsoAtmTimeseriesMod             , only: use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
   use SoilBiogeochemCompetitionMod     , only: suplnitro, suplnNon
   use SoilBiogeochemLittVertTranspMod  , only: som_adv_flux, max_depth_cryoturb
-  use SoilBiogeochemVerticalProfileMod , only: surfprof_exp
+  use SoilBiogeochemVerticalProfileMod , only: surfprof_exp 
   use SoilBiogeochemNitrifDenitrifMod  , only: no_frozen_nitrif_denitrif, nitrifReadNML
   use SoilHydrologyMod                 , only: soilHydReadNML
   use CNFireFactoryMod                 , only: CNFireReadNML
   use CanopyFluxesMod                  , only: CanopyFluxesReadNML
   use seq_drydep_mod                   , only: drydep_method, DD_XLND, n_drydep
   use clm_varctl
-#ifdef _OPENMP
-  use omp_lib                          , only: omp_get_num_threads
-#endif
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -69,6 +66,11 @@ module controlMod
   ! !PRIVATE TYPES:
   character(len=  7) :: runtyp(4)                        ! run type
   character(len=SHR_KIND_CL) :: NLFilename = 'lnd.stdin' ! Namelist filename
+
+#if (defined _OPENMP)
+  integer, external :: omp_get_max_threads  ! max number of threads that can execute concurrently in a single parallel region
+#endif
+
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
   !-----------------------------------------------------------------------
@@ -189,7 +191,7 @@ contains
     ! lake_melt_icealb is of dimension numrad
 
     ! Glacier_mec info
-    namelist /clm_inparm/ &
+    namelist /clm_inparm/ &    
          maxpatch_glcmec, glc_do_dynglacier, &
          glc_snow_persistence_max_days, &
          nlevsno, h2osno_max
@@ -203,13 +205,13 @@ contains
          soil_layerstruct_userdefined_nlevsoi, use_subgrid_fluxes, snow_cover_fraction_method, &
          irrigate, run_zero_weight_urban, all_active, &
          crop_fsat_equals_zero
-
+    
     ! vertical soil mixing variables
     namelist /clm_inparm/  &
          som_adv_flux, max_depth_cryoturb
 
     ! C and N input vertical profiles
-    namelist /clm_inparm/  &
+    namelist /clm_inparm/  & 
           surfprof_exp
 
     namelist /clm_inparm/ no_frozen_nitrif_denitrif
@@ -232,7 +234,7 @@ contains
     namelist /clm_nitrogen/ MM_Nuptake_opt, downreg_opt, &
          plant_ndemand_opt, substrate_term_opt, nscalar_opt, temp_scalar_opt, &
          CNratio_floating, lnc_opt, reduce_dayl_factor, vcmax_opt, CN_residual_opt, &
-         CN_partition_opt, CN_evergreen_phenology_opt, carbon_resp_opt
+         CN_partition_opt, CN_evergreen_phenology_opt, carbon_resp_opt  
 
     namelist /clm_inparm/ use_lai_streams
 
@@ -244,8 +246,8 @@ contains
 
     namelist /clm_inparm/  &
          use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
-
-    ! All old cpp-ifdefs are below and have been converted to namelist variables
+		 
+    ! All old cpp-ifdefs are below and have been converted to namelist variables 
 
     ! maxpatch_pft is obsolete and has been replaced with maxsoil_patches
     ! maxpatch_pft will eventually be removed from the perl and the namelist
@@ -292,11 +294,7 @@ contains
     ! Set clumps per procoessor
 
 #if (defined _OPENMP)
-!$omp parallel
-!$omp critical
-    clump_pproc = omp_get_num_threads()
-!$omp end critical
-!$omp end parallel
+    clump_pproc = omp_get_max_threads()
 #else
     clump_pproc = 1
 #endif
@@ -306,7 +304,7 @@ contains
     if (masterproc) then
 
        ! ----------------------------------------------------------------------
-       ! Read namelist from standard input.
+       ! Read namelist from standard input. 
        ! ----------------------------------------------------------------------
 
        if ( len_trim(NLFilename) == 0  )then
@@ -422,22 +420,22 @@ contains
           call endrun(msg=' ERROR: prognostic crop Patches require create_crop_landunit=.true.'//&
             errMsg(sourcefile, __LINE__))
        end if
-
-       if (use_lch4 .and. use_vertsoilc) then
+       
+       if (use_lch4 .and. use_vertsoilc) then 
           anoxia = .true.
        else
           anoxia = .false.
        end if
 
        ! ----------------------------------------------------------------------
-       ! Check compatibility with the FATES model
+       ! Check compatibility with the FATES model 
        if ( use_fates ) then
 
           if ( use_cn) then
              call endrun(msg=' ERROR: use_cn and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
           end if
-
+          
           if ( use_hydrstress) then
              call endrun(msg=' ERROR: use_hydrstress and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
@@ -447,7 +445,7 @@ contains
              call endrun(msg=' ERROR: use_crop and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
           end if
-
+          
           if( use_lch4 ) then
              call endrun(msg=' ERROR: use_lch4 (methane) and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
@@ -470,7 +468,7 @@ contains
        end if
 
        ! If nfix_timeconst is equal to the junk default value, then it was not specified
-       ! by the user namelist and we need to assign it the correct default value. If the
+       ! by the user namelist and we need to assign it the correct default value. If the 
        ! user specified it in the namelist, we leave it alone.
 
        if (nfix_timeconst == -1.2345_r8) then
@@ -525,7 +523,7 @@ contains
     ! ----------------------------------------------------------------------
 
     call control_spmd()
-
+    
     ! ----------------------------------------------------------------------
     ! Read in other namelists that are dependent on other namelist setttings
     ! ----------------------------------------------------------------------
@@ -564,7 +562,7 @@ contains
 
     ! Check on run type
     if (nsrest == iundef) then
-       call endrun(msg=' ERROR:: must set nsrest'//&
+       call endrun(msg=' ERROR:: must set nsrest'//& 
             errMsg(sourcefile, __LINE__))
     end if
     if (nsrest == nsrBranch .and. nrevsn == ' ') then
@@ -574,7 +572,7 @@ contains
 
     ! Consistency settings for co2_ppvm
     if ( (co2_ppmv <= 0.0_r8) .or. (co2_ppmv > 3000.0_r8) ) then
-       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//&
+       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//& 
             errMsg(sourcefile, __LINE__))
     end if
 
@@ -608,9 +606,9 @@ contains
   subroutine control_spmd()
     !
     ! !DESCRIPTION:
-    ! Distribute namelist data all processors. All program i/o is
-    ! funnelled through the master processor. Processor 0 either
-    ! reads restart/history data from the disk and distributes
+    ! Distribute namelist data all processors. All program i/o is 
+    ! funnelled through the master processor. Processor 0 either 
+    ! reads restart/history data from the disk and distributes 
     ! it to all processors, or collects data from
     ! all processors and writes it to disk.
     !
@@ -722,20 +720,20 @@ contains
     ! flexibleCN nitrogen model
     call mpi_bcast (use_flexibleCN, 1, MPI_LOGICAL, 0, mpicom, ier)
     ! TODO(bja, 2015-08) need to move some of these into a module with limited scope.
-    call mpi_bcast (MM_Nuptake_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (downreg_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (plant_ndemand_opt, 1, MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (substrate_term_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (nscalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (temp_scalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (CNratio_floating, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (lnc_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (reduce_dayl_factor, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (vcmax_opt, 1, MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (CN_residual_opt, 1, MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (CN_partition_opt, 1, MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (CN_evergreen_phenology_opt, 1, MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (carbon_resp_opt, 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (MM_Nuptake_opt, 1, MPI_LOGICAL, 0, mpicom, ier)             
+    call mpi_bcast (downreg_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                
+    call mpi_bcast (plant_ndemand_opt, 1, MPI_INTEGER, 0, mpicom, ier)          
+    call mpi_bcast (substrate_term_opt, 1, MPI_LOGICAL, 0, mpicom, ier)         
+    call mpi_bcast (nscalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                
+    call mpi_bcast (temp_scalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)            
+    call mpi_bcast (CNratio_floating, 1, MPI_LOGICAL, 0, mpicom, ier)           
+    call mpi_bcast (lnc_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                    
+    call mpi_bcast (reduce_dayl_factor, 1, MPI_LOGICAL, 0, mpicom, ier)         
+    call mpi_bcast (vcmax_opt, 1, MPI_INTEGER, 0, mpicom, ier)                  
+    call mpi_bcast (CN_residual_opt, 1, MPI_INTEGER, 0, mpicom, ier)            
+    call mpi_bcast (CN_partition_opt, 1, MPI_INTEGER, 0, mpicom, ier)           
+    call mpi_bcast (CN_evergreen_phenology_opt, 1, MPI_INTEGER, 0, mpicom, ier) 
+    call mpi_bcast (carbon_resp_opt, 1, MPI_INTEGER, 0, mpicom, ier) 
 
     call mpi_bcast (use_luna, 1, MPI_LOGICAL, 0, mpicom, ier)
 
@@ -756,7 +754,7 @@ contains
        call mpi_bcast (surfprof_exp,            1, MPI_REAL8,  0, mpicom, ier)
     end if
 
-    if (use_cn .and. use_nitrif_denitrif) then
+    if (use_cn .and. use_nitrif_denitrif) then 
        call mpi_bcast (no_frozen_nitrif_denitrif,  1, MPI_LOGICAL, 0, mpicom, ier)
     end if
 
@@ -909,13 +907,13 @@ contains
           write(iulog,*) '   Supplemental Nitrogen mode is set to run over Patches: ', &
                trim(suplnitro)
        end if
-
+       
        if (nfix_timeconst /= 0._r8) then
           write(iulog,*) '   nfix_timeconst, timescale for smoothing npp in N fixation term: ', nfix_timeconst
        else
           write(iulog,*) '   nfix_timeconst == zero, use standard N fixation scheme. '
        end if
-
+       
        write(iulog,*) '   spinup_state, (0 = normal mode; 1 = AD spinup; 2 AAD)         : ', spinup_state
        if ( spinup_state .eq. 0 ) then
           write(iulog,*) '   model is currently NOT in AD spinup mode.'
@@ -931,7 +929,7 @@ contains
        if ( use_fun ) then
           write(iulog,*) '   Fixation and Uptake of Nitrogen Model Version 2 (FUN2) is turned on for Nitrogen Competition'
        end if
-
+       
        write(iulog,*) '   override_bgc_restart_mismatch_dump                     : ', override_bgc_restart_mismatch_dump
     end if
 
@@ -940,7 +938,7 @@ contains
        write(iulog, *) '   max_depth_cryoturb (m)                                : ', max_depth_cryoturb
        write(iulog, *) '   surfprof_exp                                          : ', surfprof_exp
     end if
-
+       
     if (use_cn .and. .not. use_nitrif_denitrif) then
        write(iulog, *) '   no_frozen_nitrif_denitrif                             : ', no_frozen_nitrif_denitrif
     end if
@@ -1034,18 +1032,18 @@ contains
                    'as compared with 0.60, 0.40 for cold frozen lakes with no snow.'
 
     write(iulog, *) 'plant nitrogen model namelists:'
-    write(iulog, *) '  use_flexibleCN = ', use_flexibleCN
+    write(iulog, *) '  use_flexibleCN = ', use_flexibleCN                       
     if (use_flexibleCN) then
-       write(iulog, *) '    MM_Nuptake_opt = ', MM_Nuptake_opt
-       write(iulog, *) '    downreg_opt = ', downreg_opt
-       write(iulog, *) '    plant_ndemand_opt = ', plant_ndemand_opt
-       write(iulog, *) '    substrate_term_opt = ', substrate_term_opt
-       write(iulog, *) '    nscalar_opt = ', nscalar_opt
-       write(iulog, *) '    temp_scalar_opt = ', temp_scalar_opt
-       write(iulog, *) '    CNratio_floating = ', CNratio_floating
-       write(iulog, *) '    lnc_opt = ', lnc_opt
-       write(iulog, *) '    reduce_dayl_factor = ', reduce_dayl_factor
-       write(iulog, *) '    vcmax_opt = ', vcmax_opt
+       write(iulog, *) '    MM_Nuptake_opt = ', MM_Nuptake_opt                       
+       write(iulog, *) '    downreg_opt = ', downreg_opt                       	  
+       write(iulog, *) '    plant_ndemand_opt = ', plant_ndemand_opt           
+       write(iulog, *) '    substrate_term_opt = ', substrate_term_opt                   
+       write(iulog, *) '    nscalar_opt = ', nscalar_opt                
+       write(iulog, *) '    temp_scalar_opt = ', temp_scalar_opt                      
+       write(iulog, *) '    CNratio_floating = ', CNratio_floating            
+       write(iulog, *) '    lnc_opt = ', lnc_opt                              
+       write(iulog, *) '    reduce_dayl_factor = ', reduce_dayl_factor          
+       write(iulog, *) '    vcmax_opt = ', vcmax_opt                            
        write(iulog, *) '    CN_residual_opt = ', CN_residual_opt
        write(iulog, *) '    CN_partition_opt = ', CN_partition_opt
        write(iulog, *) '    CN_evergreen_phenology_opt = ', CN_evergreen_phenology_opt

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -21,8 +21,8 @@ module controlMod
   use clm_varcon                       , only: h2osno_max
   use clm_varpar                       , only: maxpatch_pft, maxpatch_glcmec, numrad, nlevsno
   use fileutils                        , only: getavu, relavu, get_filename
-  use histFileMod                      , only: max_tapes, max_namlen 
-  use histFileMod                      , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape 
+  use histFileMod                      , only: max_tapes, max_namlen
+  use histFileMod                      , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape
   use histFileMod                      , only: hist_nhtfrq, hist_ndens, hist_mfilt, hist_fincl1, hist_fincl2, hist_fincl3
   use histFileMod                      , only: hist_fincl4, hist_fincl5, hist_fincl6, hist_fincl7, hist_fincl8
   use histFileMod                      , only: hist_fincl9, hist_fincl10
@@ -43,13 +43,16 @@ module controlMod
   use CIsoAtmTimeseriesMod             , only: use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
   use SoilBiogeochemCompetitionMod     , only: suplnitro, suplnNon
   use SoilBiogeochemLittVertTranspMod  , only: som_adv_flux, max_depth_cryoturb
-  use SoilBiogeochemVerticalProfileMod , only: surfprof_exp 
+  use SoilBiogeochemVerticalProfileMod , only: surfprof_exp
   use SoilBiogeochemNitrifDenitrifMod  , only: no_frozen_nitrif_denitrif, nitrifReadNML
   use SoilHydrologyMod                 , only: soilHydReadNML
   use CNFireFactoryMod                 , only: CNFireReadNML
   use CanopyFluxesMod                  , only: CanopyFluxesReadNML
   use seq_drydep_mod                   , only: drydep_method, DD_XLND, n_drydep
   use clm_varctl
+#ifdef _OPENMP
+  use omp_lib                          , only: omp_get_num_threads
+#endif
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -66,11 +69,6 @@ module controlMod
   ! !PRIVATE TYPES:
   character(len=  7) :: runtyp(4)                        ! run type
   character(len=SHR_KIND_CL) :: NLFilename = 'lnd.stdin' ! Namelist filename
-
-#if (defined _OPENMP)
-  integer, external :: omp_get_max_threads  ! max number of threads that can execute concurrently in a single parallel region
-#endif
-
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
   !-----------------------------------------------------------------------
@@ -191,7 +189,7 @@ contains
     ! lake_melt_icealb is of dimension numrad
 
     ! Glacier_mec info
-    namelist /clm_inparm/ &    
+    namelist /clm_inparm/ &
          maxpatch_glcmec, glc_do_dynglacier, &
          glc_snow_persistence_max_days, &
          nlevsno, h2osno_max
@@ -205,13 +203,13 @@ contains
          soil_layerstruct_userdefined_nlevsoi, use_subgrid_fluxes, snow_cover_fraction_method, &
          irrigate, run_zero_weight_urban, all_active, &
          crop_fsat_equals_zero
-    
+
     ! vertical soil mixing variables
     namelist /clm_inparm/  &
          som_adv_flux, max_depth_cryoturb
 
     ! C and N input vertical profiles
-    namelist /clm_inparm/  & 
+    namelist /clm_inparm/  &
           surfprof_exp
 
     namelist /clm_inparm/ no_frozen_nitrif_denitrif
@@ -234,7 +232,7 @@ contains
     namelist /clm_nitrogen/ MM_Nuptake_opt, downreg_opt, &
          plant_ndemand_opt, substrate_term_opt, nscalar_opt, temp_scalar_opt, &
          CNratio_floating, lnc_opt, reduce_dayl_factor, vcmax_opt, CN_residual_opt, &
-         CN_partition_opt, CN_evergreen_phenology_opt, carbon_resp_opt  
+         CN_partition_opt, CN_evergreen_phenology_opt, carbon_resp_opt
 
     namelist /clm_inparm/ use_lai_streams
 
@@ -246,8 +244,8 @@ contains
 
     namelist /clm_inparm/  &
          use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
-		 
-    ! All old cpp-ifdefs are below and have been converted to namelist variables 
+
+    ! All old cpp-ifdefs are below and have been converted to namelist variables
 
     ! maxpatch_pft is obsolete and has been replaced with maxsoil_patches
     ! maxpatch_pft will eventually be removed from the perl and the namelist
@@ -294,7 +292,11 @@ contains
     ! Set clumps per procoessor
 
 #if (defined _OPENMP)
-    clump_pproc = omp_get_max_threads()
+!$omp parallel
+!$omp critical
+    clump_pproc = omp_get_num_threads()
+!$omp end critical
+!$omp end parallel
 #else
     clump_pproc = 1
 #endif
@@ -304,7 +306,7 @@ contains
     if (masterproc) then
 
        ! ----------------------------------------------------------------------
-       ! Read namelist from standard input. 
+       ! Read namelist from standard input.
        ! ----------------------------------------------------------------------
 
        if ( len_trim(NLFilename) == 0  )then
@@ -420,22 +422,22 @@ contains
           call endrun(msg=' ERROR: prognostic crop Patches require create_crop_landunit=.true.'//&
             errMsg(sourcefile, __LINE__))
        end if
-       
-       if (use_lch4 .and. use_vertsoilc) then 
+
+       if (use_lch4 .and. use_vertsoilc) then
           anoxia = .true.
        else
           anoxia = .false.
        end if
 
        ! ----------------------------------------------------------------------
-       ! Check compatibility with the FATES model 
+       ! Check compatibility with the FATES model
        if ( use_fates ) then
 
           if ( use_cn) then
              call endrun(msg=' ERROR: use_cn and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
           end if
-          
+
           if ( use_hydrstress) then
              call endrun(msg=' ERROR: use_hydrstress and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
@@ -445,7 +447,7 @@ contains
              call endrun(msg=' ERROR: use_crop and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
           end if
-          
+
           if( use_lch4 ) then
              call endrun(msg=' ERROR: use_lch4 (methane) and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
@@ -468,7 +470,7 @@ contains
        end if
 
        ! If nfix_timeconst is equal to the junk default value, then it was not specified
-       ! by the user namelist and we need to assign it the correct default value. If the 
+       ! by the user namelist and we need to assign it the correct default value. If the
        ! user specified it in the namelist, we leave it alone.
 
        if (nfix_timeconst == -1.2345_r8) then
@@ -523,7 +525,7 @@ contains
     ! ----------------------------------------------------------------------
 
     call control_spmd()
-    
+
     ! ----------------------------------------------------------------------
     ! Read in other namelists that are dependent on other namelist setttings
     ! ----------------------------------------------------------------------
@@ -562,7 +564,7 @@ contains
 
     ! Check on run type
     if (nsrest == iundef) then
-       call endrun(msg=' ERROR:: must set nsrest'//& 
+       call endrun(msg=' ERROR:: must set nsrest'//&
             errMsg(sourcefile, __LINE__))
     end if
     if (nsrest == nsrBranch .and. nrevsn == ' ') then
@@ -572,7 +574,7 @@ contains
 
     ! Consistency settings for co2_ppvm
     if ( (co2_ppmv <= 0.0_r8) .or. (co2_ppmv > 3000.0_r8) ) then
-       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//& 
+       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//&
             errMsg(sourcefile, __LINE__))
     end if
 
@@ -606,9 +608,9 @@ contains
   subroutine control_spmd()
     !
     ! !DESCRIPTION:
-    ! Distribute namelist data all processors. All program i/o is 
-    ! funnelled through the master processor. Processor 0 either 
-    ! reads restart/history data from the disk and distributes 
+    ! Distribute namelist data all processors. All program i/o is
+    ! funnelled through the master processor. Processor 0 either
+    ! reads restart/history data from the disk and distributes
     ! it to all processors, or collects data from
     ! all processors and writes it to disk.
     !
@@ -720,20 +722,20 @@ contains
     ! flexibleCN nitrogen model
     call mpi_bcast (use_flexibleCN, 1, MPI_LOGICAL, 0, mpicom, ier)
     ! TODO(bja, 2015-08) need to move some of these into a module with limited scope.
-    call mpi_bcast (MM_Nuptake_opt, 1, MPI_LOGICAL, 0, mpicom, ier)             
-    call mpi_bcast (downreg_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                
-    call mpi_bcast (plant_ndemand_opt, 1, MPI_INTEGER, 0, mpicom, ier)          
-    call mpi_bcast (substrate_term_opt, 1, MPI_LOGICAL, 0, mpicom, ier)         
-    call mpi_bcast (nscalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                
-    call mpi_bcast (temp_scalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)            
-    call mpi_bcast (CNratio_floating, 1, MPI_LOGICAL, 0, mpicom, ier)           
-    call mpi_bcast (lnc_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                    
-    call mpi_bcast (reduce_dayl_factor, 1, MPI_LOGICAL, 0, mpicom, ier)         
-    call mpi_bcast (vcmax_opt, 1, MPI_INTEGER, 0, mpicom, ier)                  
-    call mpi_bcast (CN_residual_opt, 1, MPI_INTEGER, 0, mpicom, ier)            
-    call mpi_bcast (CN_partition_opt, 1, MPI_INTEGER, 0, mpicom, ier)           
-    call mpi_bcast (CN_evergreen_phenology_opt, 1, MPI_INTEGER, 0, mpicom, ier) 
-    call mpi_bcast (carbon_resp_opt, 1, MPI_INTEGER, 0, mpicom, ier) 
+    call mpi_bcast (MM_Nuptake_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (downreg_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (plant_ndemand_opt, 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (substrate_term_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (nscalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (temp_scalar_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (CNratio_floating, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (lnc_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (reduce_dayl_factor, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (vcmax_opt, 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (CN_residual_opt, 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (CN_partition_opt, 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (CN_evergreen_phenology_opt, 1, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (carbon_resp_opt, 1, MPI_INTEGER, 0, mpicom, ier)
 
     call mpi_bcast (use_luna, 1, MPI_LOGICAL, 0, mpicom, ier)
 
@@ -754,7 +756,7 @@ contains
        call mpi_bcast (surfprof_exp,            1, MPI_REAL8,  0, mpicom, ier)
     end if
 
-    if (use_cn .and. use_nitrif_denitrif) then 
+    if (use_cn .and. use_nitrif_denitrif) then
        call mpi_bcast (no_frozen_nitrif_denitrif,  1, MPI_LOGICAL, 0, mpicom, ier)
     end if
 
@@ -907,13 +909,13 @@ contains
           write(iulog,*) '   Supplemental Nitrogen mode is set to run over Patches: ', &
                trim(suplnitro)
        end if
-       
+
        if (nfix_timeconst /= 0._r8) then
           write(iulog,*) '   nfix_timeconst, timescale for smoothing npp in N fixation term: ', nfix_timeconst
        else
           write(iulog,*) '   nfix_timeconst == zero, use standard N fixation scheme. '
        end if
-       
+
        write(iulog,*) '   spinup_state, (0 = normal mode; 1 = AD spinup; 2 AAD)         : ', spinup_state
        if ( spinup_state .eq. 0 ) then
           write(iulog,*) '   model is currently NOT in AD spinup mode.'
@@ -929,7 +931,7 @@ contains
        if ( use_fun ) then
           write(iulog,*) '   Fixation and Uptake of Nitrogen Model Version 2 (FUN2) is turned on for Nitrogen Competition'
        end if
-       
+
        write(iulog,*) '   override_bgc_restart_mismatch_dump                     : ', override_bgc_restart_mismatch_dump
     end if
 
@@ -938,7 +940,7 @@ contains
        write(iulog, *) '   max_depth_cryoturb (m)                                : ', max_depth_cryoturb
        write(iulog, *) '   surfprof_exp                                          : ', surfprof_exp
     end if
-       
+
     if (use_cn .and. .not. use_nitrif_denitrif) then
        write(iulog, *) '   no_frozen_nitrif_denitrif                             : ', no_frozen_nitrif_denitrif
     end if
@@ -1032,18 +1034,18 @@ contains
                    'as compared with 0.60, 0.40 for cold frozen lakes with no snow.'
 
     write(iulog, *) 'plant nitrogen model namelists:'
-    write(iulog, *) '  use_flexibleCN = ', use_flexibleCN                       
+    write(iulog, *) '  use_flexibleCN = ', use_flexibleCN
     if (use_flexibleCN) then
-       write(iulog, *) '    MM_Nuptake_opt = ', MM_Nuptake_opt                       
-       write(iulog, *) '    downreg_opt = ', downreg_opt                       	  
-       write(iulog, *) '    plant_ndemand_opt = ', plant_ndemand_opt           
-       write(iulog, *) '    substrate_term_opt = ', substrate_term_opt                   
-       write(iulog, *) '    nscalar_opt = ', nscalar_opt                
-       write(iulog, *) '    temp_scalar_opt = ', temp_scalar_opt                      
-       write(iulog, *) '    CNratio_floating = ', CNratio_floating            
-       write(iulog, *) '    lnc_opt = ', lnc_opt                              
-       write(iulog, *) '    reduce_dayl_factor = ', reduce_dayl_factor          
-       write(iulog, *) '    vcmax_opt = ', vcmax_opt                            
+       write(iulog, *) '    MM_Nuptake_opt = ', MM_Nuptake_opt
+       write(iulog, *) '    downreg_opt = ', downreg_opt
+       write(iulog, *) '    plant_ndemand_opt = ', plant_ndemand_opt
+       write(iulog, *) '    substrate_term_opt = ', substrate_term_opt
+       write(iulog, *) '    nscalar_opt = ', nscalar_opt
+       write(iulog, *) '    temp_scalar_opt = ', temp_scalar_opt
+       write(iulog, *) '    CNratio_floating = ', CNratio_floating
+       write(iulog, *) '    lnc_opt = ', lnc_opt
+       write(iulog, *) '    reduce_dayl_factor = ', reduce_dayl_factor
+       write(iulog, *) '    vcmax_opt = ', vcmax_opt
        write(iulog, *) '    CN_residual_opt = ', CN_residual_opt
        write(iulog, *) '    CN_partition_opt = ', CN_partition_opt
        write(iulog, *) '    CN_evergreen_phenology_opt = ', CN_evergreen_phenology_opt


### PR DESCRIPTION
### Description of changes

Listen to the land thread number set in the mct driver rather than running on the full global number of threads.

This started from @jedwards4b 's PR #967 and supersedes that one. See comments there for more details.

However, I'm wondering if this is really the right way to do it: It feels to me like a better solution would be to set the number of threads in the driver rather than requiring all components to do this in their caps. The mct driver already has code to do this in `component_mod`:

```Fortran
             if (drv_threading) call seq_comm_setnthreads(comp(1)%nthreads_compid)
```

but maybe the `drv_threading` conditional needs to be removed for this to work right.

### Specific notes

Contributors other than yourself, if any: @jedwards4b 

CTSM Issues Fixed (include github issue #):
- Resolves #163 

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None yet
