### PR TITLE
Add DOI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 CTSM
 ====
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3739617.svg
+   :target: https://doi.org/10.5281/zenodo.3739617
+
 The Community Terrestrial Systems Model.
 
 This includes the Community Land Model (CLM5.0 and CLM4.5) of the Community Earth System Model.


### PR DESCRIPTION
### Description of changes

See README file in https://github.com/billsacks/ctsm/tree/doi_badge for how this renders.

### Specific notes

This uses the "all versions" DOI, which resolves to the latest release, rather than a specific release, because it seems like the latter would be a maintenance headache. When it comes time to actually cite the code, though, people should use the DOI for the release that they actually used, so they are pointing to a stable version... so I'm not sure if using this generic doi version on the README file does more harm than good.

If we do use this generic link, I'm torn between wanting to keep the README short and sweet (i.e., just adding this image with nothing else) vs. adding a bunch of explanatory text like, "This is the generic CTSM DOI, but don't actually use this one: you should use the DOI of the specific version that you ran."

By the way, it's standard to have a bunch of badges like this at the top of a GitHub readme file (https://github.com/numpy/numpy is just one example of many). This makes me slightly inclined to have this badge without any extra explanatory text, but I'm open to others' thoughts.

Contributors other than yourself, if any: @ekluzek @danicalombardozzi 

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? none

Testing performed, if any: none
