### PR TITLE
Allow for resorbtion in transition from live to dead wood N

### DIFF
--- a/src/biogeochem/CNNStateUpdate1Mod.F90
+++ b/src/biogeochem/CNNStateUpdate1Mod.F90
@@ -184,11 +184,16 @@ contains
             ns_veg%livestemn_patch(p)    = ns_veg%livestemn_patch(p)  - nf_veg%livestemn_to_deadstemn_patch(p)*dt
             ns_veg%deadstemn_patch(p)    = ns_veg%deadstemn_patch(p)  + nf_veg%livestemn_to_deadstemn_patch(p)*dt
             ns_veg%livestemn_patch(p)    = ns_veg%livestemn_patch(p)  - nf_veg%livestemn_to_retransn_patch(p)*dt
-            ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livestemn_to_retransn_patch(p)*dt
+! WW        ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livestemn_to_retransn_patch(p)*dt
             ns_veg%livecrootn_patch(p)   = ns_veg%livecrootn_patch(p) - nf_veg%livecrootn_to_deadcrootn_patch(p)*dt
             ns_veg%deadcrootn_patch(p)   = ns_veg%deadcrootn_patch(p) + nf_veg%livecrootn_to_deadcrootn_patch(p)*dt
             ns_veg%livecrootn_patch(p)   = ns_veg%livecrootn_patch(p) - nf_veg%livecrootn_to_retransn_patch(p)*dt
-            ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livecrootn_to_retransn_patch(p)*dt
+! WW        ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livecrootn_to_retransn_patch(p)*dt
+            ! WW change logic so livestem_retrans goes to npool (via free_retrans flux)
+            ! this should likely be done more cleanly if it works, i.e. not update fluxes w/ states
+            ! additional considerations for crop?
+            nf_veg%free_retransn_to_npool_patch(p) = nf_veg%free_retransn_to_npool_patch(p) + nf_veg%livestemn_to_retransn_patch(p)
+            nf_veg%free_retransn_to_npool_patch(p) = nf_veg%free_retransn_to_npool_patch(p) + nf_veg%livecrootn_to_retransn_patch(p)
          end if
          if (ivt(p) >= npcropmin) then ! Beth adds retrans from froot
             ns_veg%frootn_patch(p)       = ns_veg%frootn_patch(p)     - nf_veg%frootn_to_retransn_patch(p)*dt

--- a/src/biogeochem/CNNStateUpdate1Mod.F90
+++ b/src/biogeochem/CNNStateUpdate1Mod.F90
@@ -184,11 +184,11 @@ contains
             ns_veg%livestemn_patch(p)    = ns_veg%livestemn_patch(p)  - nf_veg%livestemn_to_deadstemn_patch(p)*dt
             ns_veg%deadstemn_patch(p)    = ns_veg%deadstemn_patch(p)  + nf_veg%livestemn_to_deadstemn_patch(p)*dt
             ns_veg%livestemn_patch(p)    = ns_veg%livestemn_patch(p)  - nf_veg%livestemn_to_retransn_patch(p)*dt
-! WW        ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livestemn_to_retransn_patch(p)*dt
+            ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livestemn_to_retransn_patch(p)*dt
             ns_veg%livecrootn_patch(p)   = ns_veg%livecrootn_patch(p) - nf_veg%livecrootn_to_deadcrootn_patch(p)*dt
             ns_veg%deadcrootn_patch(p)   = ns_veg%deadcrootn_patch(p) + nf_veg%livecrootn_to_deadcrootn_patch(p)*dt
             ns_veg%livecrootn_patch(p)   = ns_veg%livecrootn_patch(p) - nf_veg%livecrootn_to_retransn_patch(p)*dt
-! WW        ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livecrootn_to_retransn_patch(p)*dt
+            ns_veg%retransn_patch(p)     = ns_veg%retransn_patch(p)   + nf_veg%livecrootn_to_retransn_patch(p)*dt
             ! WW change logic so livestem_retrans goes to npool (via free_retrans flux)
             ! this should likely be done more cleanly if it works, i.e. not update fluxes w/ states
             ! additional considerations for crop?

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2758,14 +2758,16 @@ contains
             
             if (CNratio_floating .eqv. .true.) then    
                if (livestemc(p) == 0.0_r8) then    
-                   ntovr = 0.0_r8    
+                   ntovr = 0.0_r8   
+                   livestemn_to_deadstemn(p) = 0.0_r8 !for tests 3,4 w/ resorbtion
                 else    
-                   ntovr = ctovr * (livestemn(p) / livestemc(p))   
+                   ntovr = ctovr * (livestemn(p) / livestemc(p))  
+                   livestemn_to_deadstemn(p) = ctovr / deadwdcn(ivt(p)) !for tests 3,4 w/ resorbtion
                 end if   
 
               ! WW mods for same target C:N of live & dead wood  
-                livestemn_to_deadstemn(p) = 0.5_r8 * ntovr   !orig. code, assuming 50% goes to deadstemn 
-              ! livestemn_to_deadstemn(p) =  ntovr   
+              ! livestemn_to_deadstemn(p) = 0.5_r8 * ntovr   !for test 0, 2, orig. code, assuming 50% goes to deadstemn 
+              ! livestemn_to_deadstemn(p) =  ntovr           !for test 1, with livewdCN = 500
             end if    
             
             livestemn_to_retransn(p)  = ntovr - livestemn_to_deadstemn(p)
@@ -2777,24 +2779,30 @@ contains
             livecrootc_to_deadcrootc(p) = ctovr
             livecrootn_to_deadcrootn(p) = ctovr / deadwdcn(ivt(p))
             
-            if (CNratio_floating .eqv. .true.) then    
-              if (livecrootc(p) == 0.0_r8) then    
-                  ntovr = 0.0_r8    
-               else    
-                  ntovr = ctovr * (livecrootn(p) / livecrootc(p))   
-               end if   
-              
+            if (CNratio_floating .eqv. .true.) then
+               if (livecrootc(p) == 0.0_r8) then
+                   ntovr = 0.0_r8
+                   livecrootn_to_deadcrootn(p) = 0.0_r8 !for tests 3,4 w/ resorbtion
+                else
+                   ntovr = ctovr * (livecrootn(p) / livecrootc(p))
+                   livecrootn_to_deadcrootn(p) = ctovr / deadwdcn(ivt(p)) !for tests 3,4 w/ resorbtion
+                end if
+
               ! WW mods for same target C:N of live & dead wood  
-                livecrootn_to_deadcrootn(p) = 0.5_r8 * ntovr   !oric code, assuming 50% goes to deadstemn 
-              ! livecrootn_to_deadcrootn(p) = ntovr    
-            end if    
+              ! livecrootn_to_deadcrootn(p) = 0.5_r8 * ntovr   !for test 0, 2, orig. code, assuming 50% goes to deadcrootn 
+              ! livecrootn_to_deadcrootn(p) =  ntovr           !for test 1, with livewdCN = 500
+            end if
             
             livecrootn_to_retransn(p)  = ntovr - livecrootn_to_deadcrootn(p)
-            if(use_fun)then
-               !TURNED OFF FLUXES TO CORRECT N ACCUMULATION ISSUE. RF. Oct 2015. 
-               livecrootn_to_retransn(p) = 0.0_r8
-               livestemn_to_retransn(p)  = 0.0_r8
-            endif
+
+! WW tests 3-4
+! allow resorbtion with FUN
+! not sure how this will effect FUN function 
+!           if(use_fun)then
+!              !TURNED OFF FLUXES TO CORRECT N ACCUMULATION ISSUE. RF. Oct 2015. 
+!              livecrootn_to_retransn(p) = 0.0_r8
+!              livestemn_to_retransn(p)  = 0.0_r8
+!           endif
 
          end if
 

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2763,7 +2763,9 @@ contains
                    ntovr = ctovr * (livestemn(p) / livestemc(p))   
                 end if   
 
-                livestemn_to_deadstemn(p) = 0.5_r8 * ntovr   ! assuming 50% goes to deadstemn 
+              ! WW mods for same target C:N of live & dead wood  
+              ! livestemn_to_deadstemn(p) = 0.5_r8 * ntovr   ! assuming 50% goes to deadstemn 
+                livestemn_to_deadstemn(p) =  ntovr   
             end if    
             
             livestemn_to_retransn(p)  = ntovr - livestemn_to_deadstemn(p)
@@ -2781,8 +2783,10 @@ contains
                else    
                   ntovr = ctovr * (livecrootn(p) / livecrootc(p))   
                end if   
-
-               livecrootn_to_deadcrootn(p) = 0.5_r8 * ntovr   ! assuming 50% goes to deadstemn 
+              
+              ! WW mods for same target C:N of live & dead wood  
+              ! livecrootn_to_deadcrootn(p) = 0.5_r8 * ntovr   ! assuming 50% goes to deadstemn 
+                livecrootn_to_deadcrootn(p) = ntovr    
             end if    
             
             livecrootn_to_retransn(p)  = ntovr - livecrootn_to_deadcrootn(p)

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2764,8 +2764,8 @@ contains
                 end if   
 
               ! WW mods for same target C:N of live & dead wood  
-              ! livestemn_to_deadstemn(p) = 0.5_r8 * ntovr   ! assuming 50% goes to deadstemn 
-                livestemn_to_deadstemn(p) =  ntovr   
+                livestemn_to_deadstemn(p) = 0.5_r8 * ntovr   !orig. code, assuming 50% goes to deadstemn 
+              ! livestemn_to_deadstemn(p) =  ntovr   
             end if    
             
             livestemn_to_retransn(p)  = ntovr - livestemn_to_deadstemn(p)
@@ -2785,8 +2785,8 @@ contains
                end if   
               
               ! WW mods for same target C:N of live & dead wood  
-              ! livecrootn_to_deadcrootn(p) = 0.5_r8 * ntovr   ! assuming 50% goes to deadstemn 
-                livecrootn_to_deadcrootn(p) = ntovr    
+                livecrootn_to_deadcrootn(p) = 0.5_r8 * ntovr   !oric code, assuming 50% goes to deadstemn 
+              ! livecrootn_to_deadcrootn(p) = ntovr    
             end if    
             
             livecrootn_to_retransn(p)  = ntovr - livecrootn_to_deadcrootn(p)

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -829,6 +829,21 @@ contains
                ptr_patch=this%grainc_to_seed_patch)
        end if
 
+! WW added these two fields
+    this%hrv_livestemc_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='HRV_LIVESTEMC_TO_LITTER', units='gC/m^2/s', &
+         avgflag='A', long_name='harvest livestem C mortality', &
+         ptr_patch=this%hrv_livestemc_to_litter_patch, default='active')
+
+    ! This may just be a crop variable
+    this%livestemc_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMC_TO_LITTER', units='gC/m^2/s', &
+         avgflag='A', long_name='livestem C mortality', &
+         ptr_patch=this%hrv_livestemc_to_litter_patch, default='active')
+
+
+! end WW additions
+
        this%litterc_loss_col(begc:endc) = spval
        call hist_addfld1d (fname='LITTERC_LOSS', units='gC/m^2/s', &
             avgflag='A', long_name='litter C loss', &
@@ -887,7 +902,7 @@ contains
        this%m_livestemc_storage_to_litter_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_STORAGE_TO_LITTER', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C storage mortality', &
-            ptr_patch=this%m_livestemc_storage_to_litter_patch, default='inactive')
+            ptr_patch=this%m_livestemc_storage_to_litter_patch, default='active')
 
        this%m_deadstemc_storage_to_litter_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_DEADSTEMC_STORAGE_TO_LITTER', units='gC/m^2/s', &
@@ -917,7 +932,7 @@ contains
        this%m_livestemc_xfer_to_litter_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_XFER_TO_LITTER', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C transfer mortality', &
-            ptr_patch=this%m_livestemc_xfer_to_litter_patch, default='inactive')
+            ptr_patch=this%m_livestemc_xfer_to_litter_patch, default='active')
 
        this%m_deadstemc_xfer_to_litter_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_DEADSTEMC_XFER_TO_LITTER', units='gC/m^2/s', &
@@ -937,7 +952,7 @@ contains
        this%m_livestemc_to_litter_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_TO_LITTER', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C mortality', &
-            ptr_patch=this%m_livestemc_to_litter_patch, default='inactive')
+            ptr_patch=this%m_livestemc_to_litter_patch, default='active')
 
        this%m_deadstemc_to_litter_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_DEADSTEMC_TO_LITTER', units='gC/m^2/s', &
@@ -982,17 +997,17 @@ contains
        this%m_livestemc_to_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_TO_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C fire loss', &
-            ptr_patch=this%m_livestemc_to_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_to_fire_patch, default='active')
 
        this%m_livestemc_storage_to_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_STORAGE_TO_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C storage fire loss', &
-            ptr_patch=this%m_livestemc_storage_to_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_storage_to_fire_patch, default='active')
 
        this%m_livestemc_xfer_to_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_XFER_TO_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C transfer fire loss', &
-            ptr_patch=this%m_livestemc_xfer_to_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_xfer_to_fire_patch, default='active')
 
        this%m_deadstemc_to_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_DEADSTEMC_TO_FIRE', units='gC/m^2/s', &
@@ -1083,22 +1098,22 @@ contains
        this%m_livestemc_to_litter_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_TO_LITTER_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C fire mortality to litter', &
-            ptr_patch=this%m_livestemc_to_litter_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_to_litter_fire_patch, default='active')
 
        this%m_livestemc_storage_to_litter_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_STORAGE_TO_LITTER_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C storage fire mortality to litter', &
-            ptr_patch=this%m_livestemc_storage_to_litter_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_storage_to_litter_fire_patch, default='active')
 
        this%m_livestemc_xfer_to_litter_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_XFER_TO_LITTER_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C transfer fire mortality to litter', &
-            ptr_patch=this%m_livestemc_xfer_to_litter_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_xfer_to_litter_fire_patch, default='active')
 
        this%m_livestemc_to_deadstemc_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_LIVESTEMC_TO_DEADSTEMC_FIRE', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C fire mortality to dead stem C', &
-            ptr_patch=this%m_livestemc_to_deadstemc_fire_patch, default='inactive')
+            ptr_patch=this%m_livestemc_to_deadstemc_fire_patch, default='active')
 
        this%m_deadstemc_to_litter_fire_patch(begp:endp) = spval
        call hist_addfld1d (fname='M_DEADSTEMC_TO_LITTER_FIRE', units='gC/m^2/s', &
@@ -1189,7 +1204,7 @@ contains
        this%leafc_xfer_to_leafc_patch(begp:endp) = spval
        call hist_addfld1d (fname='LEAFC_XFER_TO_LEAFC', units='gC/m^2/s', &
             avgflag='A', long_name='leaf C growth from storage', &
-            ptr_patch=this%leafc_xfer_to_leafc_patch, default='inactive')
+            ptr_patch=this%leafc_xfer_to_leafc_patch, default='active')
 
        this%frootc_xfer_to_frootc_patch(begp:endp) = spval
        call hist_addfld1d (fname='FROOTC_XFER_TO_FROOTC', units='gC/m^2/s', &
@@ -1199,7 +1214,7 @@ contains
        this%livestemc_xfer_to_livestemc_patch(begp:endp) = spval
        call hist_addfld1d (fname='LIVESTEMC_XFER_TO_LIVESTEMC', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C growth from storage', &
-            ptr_patch=this%livestemc_xfer_to_livestemc_patch, default='inactive')
+            ptr_patch=this%livestemc_xfer_to_livestemc_patch, default='active')
 
        this%deadstemc_xfer_to_deadstemc_patch(begp:endp) = spval
        call hist_addfld1d (fname='DEADSTEMC_XFER_TO_DEADSTEMC', units='gC/m^2/s', &
@@ -1236,7 +1251,7 @@ contains
        this%cpool_to_resp_patch(begp:endp) = spval
        call hist_addfld1d (fname='EXCESSC_MR', units='gC/m^2/s', &
             avgflag='A', long_name='excess C maintenance respiration', &
-            ptr_patch=this%cpool_to_resp_patch, default='inactive')
+            ptr_patch=this%cpool_to_resp_patch, default='active')
        this%leaf_mr_patch(begp:endp) = spval
        call hist_addfld1d (fname='LEAF_MR', units='gC/m^2/s', &
             avgflag='A', long_name='leaf maintenance respiration', &
@@ -1250,12 +1265,12 @@ contains
        this%livestem_mr_patch(begp:endp) = spval
        call hist_addfld1d (fname='LIVESTEM_MR', units='gC/m^2/s', &
             avgflag='A', long_name='live stem maintenance respiration', &
-            ptr_patch=this%livestem_mr_patch, default='inactive')
+            ptr_patch=this%livestem_mr_patch, default='active')
 
        this%livecroot_mr_patch(begp:endp) = spval
        call hist_addfld1d (fname='LIVECROOT_MR', units='gC/m^2/s', &
             avgflag='A', long_name='live coarse root maintenance respiration', &
-            ptr_patch=this%livecroot_mr_patch, default='inactive')
+            ptr_patch=this%livecroot_mr_patch, default='active')
 
        this%psnsun_to_cpool_patch(begp:endp) = spval
        call hist_addfld1d (fname='PSNSUN_TO_CPOOL', units='gC/m^2/s', &
@@ -1290,22 +1305,22 @@ contains
        this%cpool_to_livestemc_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_TO_LIVESTEMC', units='gC/m^2/s', &
             avgflag='A', long_name='allocation to live stem C', &
-            ptr_patch=this%cpool_to_livestemc_patch, default='inactive')
+            ptr_patch=this%cpool_to_livestemc_patch, default='active')
 
        this%cpool_to_livestemc_storage_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_TO_LIVESTEMC_STORAGE', units='gC/m^2/s', &
             avgflag='A', long_name='allocation to live stem C storage', &
-            ptr_patch=this%cpool_to_livestemc_storage_patch, default='inactive')
+            ptr_patch=this%cpool_to_livestemc_storage_patch, default='active')
 
        this%cpool_to_deadstemc_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_TO_DEADSTEMC', units='gC/m^2/s', &
             avgflag='A', long_name='allocation to dead stem C', &
-            ptr_patch=this%cpool_to_deadstemc_patch, default='inactive')
+            ptr_patch=this%cpool_to_deadstemc_patch, default='active')
 
        this%cpool_to_deadstemc_storage_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_TO_DEADSTEMC_STORAGE', units='gC/m^2/s', &
             avgflag='A', long_name='allocation to dead stem C storage', &
-            ptr_patch=this%cpool_to_deadstemc_storage_patch, default='inactive')
+            ptr_patch=this%cpool_to_deadstemc_storage_patch, default='active')
 
        this%cpool_to_livecrootc_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_TO_LIVECROOTC', units='gC/m^2/s', &
@@ -1365,27 +1380,27 @@ contains
        this%cpool_livestem_gr_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_LIVESTEM_GR', units='gC/m^2/s', &
             avgflag='A', long_name='live stem growth respiration', &
-            ptr_patch=this%cpool_livestem_gr_patch, default='inactive')
+            ptr_patch=this%cpool_livestem_gr_patch, default='active')
 
        this%cpool_livestem_storage_gr_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_LIVESTEM_STORAGE_GR', units='gC/m^2/s', &
             avgflag='A', long_name='live stem growth respiration to storage', &
-            ptr_patch=this%cpool_livestem_storage_gr_patch, default='inactive')
+            ptr_patch=this%cpool_livestem_storage_gr_patch, default='active')
 
        this%transfer_livestem_gr_patch(begp:endp) = spval
        call hist_addfld1d (fname='TRANSFER_LIVESTEM_GR', units='gC/m^2/s', &
             avgflag='A', long_name='live stem growth respiration from storage', &
-            ptr_patch=this%transfer_livestem_gr_patch, default='inactive')
+            ptr_patch=this%transfer_livestem_gr_patch, default='active')
 
        this%cpool_deadstem_gr_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_DEADSTEM_GR', units='gC/m^2/s', &
             avgflag='A', long_name='dead stem growth respiration', &
-            ptr_patch=this%cpool_deadstem_gr_patch, default='inactive')
+            ptr_patch=this%cpool_deadstem_gr_patch, default='active')
 
        this%cpool_deadstem_storage_gr_patch(begp:endp) = spval
        call hist_addfld1d (fname='CPOOL_DEADSTEM_STORAGE_GR', units='gC/m^2/s', &
             avgflag='A', long_name='dead stem growth respiration to storage', &
-            ptr_patch=this%cpool_deadstem_storage_gr_patch, default='inactive')
+            ptr_patch=this%cpool_deadstem_storage_gr_patch, default='active')
 
        this%transfer_deadstem_gr_patch(begp:endp) = spval
        call hist_addfld1d (fname='TRANSFER_DEADSTEM_GR', units='gC/m^2/s', &
@@ -1435,7 +1450,7 @@ contains
        this%livestemc_storage_to_xfer_patch(begp:endp) = spval
        call hist_addfld1d (fname='LIVESTEMC_STORAGE_TO_XFER', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C shift storage to transfer', &
-            ptr_patch=this%livestemc_storage_to_xfer_patch, default='inactive')
+            ptr_patch=this%livestemc_storage_to_xfer_patch, default='active')
 
        this%deadstemc_storage_to_xfer_patch(begp:endp) = spval
        call hist_addfld1d (fname='DEADSTEMC_STORAGE_TO_XFER', units='gC/m^2/s', &
@@ -1460,7 +1475,7 @@ contains
        this%livestemc_to_deadstemc_patch(begp:endp) = spval
        call hist_addfld1d (fname='LIVESTEMC_TO_DEADSTEMC', units='gC/m^2/s', &
             avgflag='A', long_name='live stem C turnover', &
-            ptr_patch=this%livestemc_to_deadstemc_patch, default='inactive')
+            ptr_patch=this%livestemc_to_deadstemc_patch, default='active')
 
        this%livecrootc_to_deadcrootc_patch(begp:endp) = spval
        call hist_addfld1d (fname='LIVECROOTC_TO_DEADCROOTC', units='gC/m^2/s', &

--- a/src/biogeochem/CNVegNitrogenFluxType.F90
+++ b/src/biogeochem/CNVegNitrogenFluxType.F90
@@ -818,12 +818,12 @@ contains
     this%leafn_to_retransn_patch(begp:endp) = spval
     call hist_addfld1d (fname='LEAFN_TO_RETRANSN', units='gN/m^2/s', &
          avgflag='A', long_name='leaf N to retranslocated N pool', &
-         ptr_patch=this%leafn_to_retransn_patch, default='inactive')
+         ptr_patch=this%leafn_to_retransn_patch, default='active')
 
     this%frootn_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='FROOTN_TO_LITTER', units='gN/m^2/s', &
          avgflag='A', long_name='fine root N litterfall', &
-         ptr_patch=this%frootn_to_litter_patch, default='inactive')
+         ptr_patch=this%frootn_to_litter_patch, default='active')
 
     this%retransn_to_npool_patch(begp:endp) = spval
     call hist_addfld1d (fname='RETRANSN_TO_NPOOL', units='gN/m^2/s', &

--- a/src/biogeochem/CNVegNitrogenFluxType.F90
+++ b/src/biogeochem/CNVegNitrogenFluxType.F90
@@ -557,7 +557,29 @@ contains
     else 
        vr_suffix = ""
     endif
+! WW added these two fields
+    ! This may just be a crop variable
+    this%livestemn_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMN_TO_LITTER', units='gN/m^2/s', &
+         avgflag='A', long_name='livestem N mortality', &
+         ptr_patch=this%livestemn_to_litter_patch, default='active')
 
+    this%hrv_livestemn_to_litter_patch(begp:endp) = spval
+    call hist_addfld1d (fname='HRV_LIVESTEMN_TO_LITTER', units='gN/m^2/s', &
+         avgflag='A', long_name='harvest livestem N mortality', &
+         ptr_patch=this%hrv_livestemn_to_litter_patch, default='active')
+
+    this%m_livestemn_to_litter_fire_patch(begp:endp) = spval
+    call hist_addfld1d (fname='M_LIVESTEMN_TO_LITTER_FIRE', units='gN/m^2/s', &
+         avgflag='A', long_name='live stem N fire mortality to litter', &
+         ptr_patch=this%m_livestemn_to_litter_fire_patch, default='active')
+
+       this%m_livestemn_to_deadstemn_fire_patch(begp:endp) = spval
+       call hist_addfld1d (fname='M_LIVESTEMN_TO_DEADSTEMN_FIRE', units='gN/m^2/s', &
+            avgflag='A', long_name='live stem N fire mortality to dead stem N', &
+            ptr_patch=this%m_livestemn_to_deadstemn_fire_patch, default='active')
+! end WW additions
+    
     this%m_leafn_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LEAFN_TO_LITTER', units='gN/m^2/s', &
          avgflag='A', long_name='leaf N mortality', &
@@ -581,7 +603,7 @@ contains
     this%m_livestemn_storage_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LIVESTEMN_STORAGE_TO_LITTER', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N storage mortality', &
-         ptr_patch=this%m_livestemn_storage_to_litter_patch, default='inactive')
+         ptr_patch=this%m_livestemn_storage_to_litter_patch, default='active')
 
     this%m_deadstemn_storage_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_DEADSTEMN_STORAGE_TO_LITTER', units='gN/m^2/s', &
@@ -611,7 +633,7 @@ contains
     this%m_livestemn_xfer_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LIVESTEMN_XFER_TO_LITTER', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N transfer mortality', &
-         ptr_patch=this%m_livestemn_xfer_to_litter_patch, default='inactive')
+         ptr_patch=this%m_livestemn_xfer_to_litter_patch, default='active')
 
     this%m_deadstemn_xfer_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_DEADSTEMN_XFER_TO_LITTER', units='gN/m^2/s', &
@@ -631,7 +653,7 @@ contains
     this%m_livestemn_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LIVESTEMN_TO_LITTER', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N mortality', &
-         ptr_patch=this%m_livestemn_to_litter_patch, default='inactive')
+         ptr_patch=this%m_livestemn_to_litter_patch, default='active')
 
     this%m_deadstemn_to_litter_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_DEADSTEMN_TO_LITTER', units='gN/m^2/s', &
@@ -676,7 +698,7 @@ contains
     this%m_livestemn_storage_to_fire_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LIVESTEMN_STORAGE_TO_FIRE', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N storage fire loss', &
-         ptr_patch=this%m_livestemn_storage_to_fire_patch, default='inactive')
+         ptr_patch=this%m_livestemn_storage_to_fire_patch, default='active')
 
     this%m_deadstemn_storage_to_fire_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_DEADSTEMN_STORAGE_TO_FIRE', units='gN/m^2/s', &
@@ -706,7 +728,7 @@ contains
     this%m_livestemn_xfer_to_fire_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LIVESTEMN_XFER_TO_FIRE', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N transfer fire loss', &
-         ptr_patch=this%m_livestemn_xfer_to_fire_patch, default='inactive')
+         ptr_patch=this%m_livestemn_xfer_to_fire_patch, default='active')
 
     this%m_deadstemn_xfer_to_fire_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_DEADSTEMN_XFER_TO_FIRE', units='gN/m^2/s', &
@@ -726,7 +748,7 @@ contains
     this%m_livestemn_to_fire_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_LIVESTEMN_TO_FIRE', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N fire loss', &
-         ptr_patch=this%m_livestemn_to_fire_patch, default='inactive')
+         ptr_patch=this%m_livestemn_to_fire_patch, default='active')
 
     this%m_deadstemn_to_fire_patch(begp:endp) = spval
     call hist_addfld1d (fname='M_DEADSTEMN_TO_FIRE', units='gN/m^2/s', &
@@ -761,7 +783,7 @@ contains
     this%leafn_xfer_to_leafn_patch(begp:endp) = spval
     call hist_addfld1d (fname='LEAFN_XFER_TO_LEAFN', units='gN/m^2/s', &
          avgflag='A', long_name='leaf N growth from storage', &
-         ptr_patch=this%leafn_xfer_to_leafn_patch, default='inactive')
+         ptr_patch=this%leafn_xfer_to_leafn_patch, default='active')
 
     this%frootn_xfer_to_frootn_patch(begp:endp) = spval
     call hist_addfld1d (fname='FROOTN_XFER_TO_FROOTN', units='gN/m^2/s', &
@@ -771,7 +793,7 @@ contains
     this%livestemn_xfer_to_livestemn_patch(begp:endp) = spval
     call hist_addfld1d (fname='LIVESTEMN_XFER_TO_LIVESTEMN', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N growth from storage', &
-         ptr_patch=this%livestemn_xfer_to_livestemn_patch, default='inactive')
+         ptr_patch=this%livestemn_xfer_to_livestemn_patch, default='active')
 
     this%deadstemn_xfer_to_deadstemn_patch(begp:endp) = spval
     call hist_addfld1d (fname='DEADSTEMN_XFER_TO_DEADSTEMN', units='gN/m^2/s', &
@@ -841,22 +863,22 @@ contains
     this%npool_to_livestemn_patch(begp:endp) = spval
     call hist_addfld1d (fname='NPOOL_TO_LIVESTEMN', units='gN/m^2/s', &
          avgflag='A', long_name='allocation to live stem N', &
-         ptr_patch=this%npool_to_livestemn_patch, default='inactive')
+         ptr_patch=this%npool_to_livestemn_patch, default='active')
 
     this%npool_to_livestemn_storage_patch(begp:endp) = spval
     call hist_addfld1d (fname='NPOOL_TO_LIVESTEMN_STORAGE', units='gN/m^2/s', &
          avgflag='A', long_name='allocation to live stem N storage', &
-         ptr_patch=this%npool_to_livestemn_storage_patch, default='inactive')
+         ptr_patch=this%npool_to_livestemn_storage_patch, default='active')
 
     this%npool_to_deadstemn_patch(begp:endp) = spval
     call hist_addfld1d (fname='NPOOL_TO_DEADSTEMN', units='gN/m^2/s', &
          avgflag='A', long_name='allocation to dead stem N', &
-         ptr_patch=this%npool_to_deadstemn_patch, default='inactive')
+         ptr_patch=this%npool_to_deadstemn_patch, default='active')
 
     this%npool_to_deadstemn_storage_patch(begp:endp) = spval
     call hist_addfld1d (fname='NPOOL_TO_DEADSTEMN_STORAGE', units='gN/m^2/s', &
          avgflag='A', long_name='allocation to dead stem N storage', &
-         ptr_patch=this%npool_to_deadstemn_storage_patch, default='inactive')
+         ptr_patch=this%npool_to_deadstemn_storage_patch, default='active')
 
     this%npool_to_livecrootn_patch(begp:endp) = spval
     call hist_addfld1d (fname='NPOOL_TO_LIVECROOTN', units='gN/m^2/s', &
@@ -891,7 +913,7 @@ contains
     this%livestemn_storage_to_xfer_patch(begp:endp) = spval
     call hist_addfld1d (fname='LIVESTEMN_STORAGE_TO_XFER', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N shift storage to transfer', &
-         ptr_patch=this%livestemn_storage_to_xfer_patch, default='inactive')
+         ptr_patch=this%livestemn_storage_to_xfer_patch, default='active')
 
     this%deadstemn_storage_to_xfer_patch(begp:endp) = spval
     call hist_addfld1d (fname='DEADSTEMN_STORAGE_TO_XFER', units='gN/m^2/s', &
@@ -911,12 +933,12 @@ contains
     this%livestemn_to_deadstemn_patch(begp:endp) = spval
     call hist_addfld1d (fname='LIVESTEMN_TO_DEADSTEMN', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N turnover', &
-         ptr_patch=this%livestemn_to_deadstemn_patch, default='inactive')
+         ptr_patch=this%livestemn_to_deadstemn_patch, default='active')
 
     this%livestemn_to_retransn_patch(begp:endp) = spval
     call hist_addfld1d (fname='LIVESTEMN_TO_RETRANSN', units='gN/m^2/s', &
          avgflag='A', long_name='live stem N to retranslocated N pool', &
-         ptr_patch=this%livestemn_to_retransn_patch, default='inactive')
+         ptr_patch=this%livestemn_to_retransn_patch, default='active')
 
     this%livecrootn_to_deadcrootn_patch(begp:endp) = spval
     call hist_addfld1d (fname='LIVECROOTN_TO_DEADCROOTN', units='gN/m^2/s', &

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -37,6 +37,10 @@ module NutrientCompetitionFlexibleCNMod
      private
      real(r8), pointer :: actual_leafcn(:)                    ! leaf CN ratio used by flexible CN
      real(r8), pointer :: actual_storage_leafcn(:)            ! storage leaf CN ratio used by flexible CN
+     real(r8), pointer :: actual_livestemcn(:)                ! live wood CN ratio used by flexible CN
+     real(r8), pointer :: actual_livestemcn_storage(:)        ! storage live wood CN ratio used by flexible CN
+     real(r8), pointer :: npool_to_livestemn(:)               ! npool to live stem n                    
+     real(r8), pointer :: npool_to_livestemn_storage(:)       ! npool to live stem storage n                   
    contains
      ! public methocs
      procedure, public :: Init                                ! Initialization
@@ -98,6 +102,10 @@ contains
 
     allocate(this%actual_leafcn(bounds%begp:bounds%endp))         ; this%actual_leafcn(:)         = nan
     allocate(this%actual_storage_leafcn(bounds%begp:bounds%endp)) ; this%actual_storage_leafcn(:) = nan
+    allocate(this%actual_livestemcn(bounds%begp:bounds%endp))         ; this%actual_livestemcn(:) = nan
+    allocate(this%actual_livestemcn_storage(bounds%begp:bounds%endp)) ; this%actual_livestemcn_storage(:) = nan
+    allocate(this%npool_to_livestemn(bounds%begp:bounds%endp))         ; this%npool_to_livestemn(:)         = nan
+    allocate(this%npool_to_livestemn_storage(bounds%begp:bounds%endp)) ; this%npool_to_livestemn_storage(:) = nan
 
   end subroutine InitAllocate
 
@@ -128,7 +136,25 @@ contains
     this%actual_storage_leafcn(begp:endp) = spval
     call hist_addfld1d (fname='LEAFCN_STORAGE', units='gC/gN', &
          avgflag='A', long_name='Storage Leaf CN ratio used for flexible CN', &
-         ptr_patch=this%actual_storage_leafcn, default='inactive')
+         ptr_patch=this%actual_storage_leafcn, default='active')
+
+    this%actual_livestemcn(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMCN', units='gC/gN', &
+         avgflag='A', long_name='Live wood CN ratio used for flexible CN', &
+         ptr_patch=this%actual_livestemcn )
+    this%actual_livestemcn_storage(begp:endp) = spval
+    call hist_addfld1d (fname='LIVESTEMCN_STORAGE', units='gC/gN', &
+         avgflag='A', long_name='Storage Live wood CN ratio used for flexible CN', &
+         ptr_patch=this%actual_livestemcn_storage, default='active')
+
+    this%npool_to_livestemn(begp:endp) = spval
+    call hist_addfld1d (fname='NPOOL_TO_LIVESTEM', units='gN m^-1 s^-1', &
+         avgflag='A', long_name='NPOOL to live stem N', &
+         ptr_patch=this%npool_to_livestemn )
+    this%npool_to_livestemn_storage(begp:endp) = spval
+    call hist_addfld1d (fname='NPOOL_TO_LIVESTEM_STORAGE', units='gN m^-1 s^-1', &
+         avgflag='A', long_name='NPOOL to live stem N storage', &
+         ptr_patch=this%npool_to_livestemn_storage )
 
   end subroutine InitHistory
 
@@ -767,6 +793,9 @@ contains
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          if (downreg_opt .eqv. .false. .AND. CN_partition_opt == 1) then
 
+         ! WW this is where demand could also be modified based on actual leaf and live wood C:N
+         ! allocation from npool to storage would also have to be modified?
+
             ! computing nitrogen demand for different pools based on carbon allocated and CN ratio
             npool_to_leafn_demand(p)          = (nlc / cnl) * fcur
             npool_to_leafn_storage_demand(p)  = (nlc / cnl) * (1._r8 - fcur)
@@ -944,7 +973,9 @@ contains
                   / cnveg_nitrogenstate_inst%leafn_storage_patch(p)
                end if
             end if
-            
+
+            !! WW none of this is done in CLM5 w/ FUN because carbon_resp_opt = 0 by default !!
+            !! WW remove this redundant code? 
             if (carbon_resp_opt == 1 .AND. laisun(p)+laisha(p) > 0.0_r8) then   
                ! computing carbon to nitrogen ratio of different plant parts 
 
@@ -1261,6 +1292,12 @@ contains
     SHR_ASSERT_ALL((ubound(arepr) == (/bounds%endp/)), errMsg(sourcefile, __LINE__))
     SHR_ASSERT_ALL((ubound(this%actual_leafcn) >= (/bounds%endp/)), errMsg(sourcefile, __LINE__))
     SHR_ASSERT_ALL((lbound(this%actual_leafcn) <= (/bounds%begp/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(this%actual_storage_leafcn) >= (/bounds%endp/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((lbound(this%actual_storage_leafcn) <= (/bounds%begp/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(this%actual_livestemcn) >= (/bounds%endp/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((lbound(this%actual_livestemcn) <= (/bounds%begp/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(this%actual_livestemcn_storage) >= (/bounds%endp/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((lbound(this%actual_livestemcn_storage) <= (/bounds%begp/)), errMsg(sourcefile, __LINE__))
 
     associate(                                                                        &
          ivt                   => patch%itype                                        ,  & ! Input:  [integer  (:) ]  patch vegetation type
@@ -1323,8 +1360,10 @@ contains
 
          xsmrpool              => cnveg_carbonstate_inst%xsmrpool_patch             , & ! Input:  [real(r8) (:)   ]  (gC/m2) temporary photosynthate C pool
          leafc                 => cnveg_carbonstate_inst%leafc_patch                , & ! Input:  [real(r8) (:)   ]
+         leafc_storage         => cnveg_carbonstate_inst%leafc_storage_patch        , & ! Input:  [real(r8) (:)   ]
          frootc                => cnveg_carbonstate_inst%frootc_patch               , & ! Input:  [real(r8) (:)   ]
          livestemc             => cnveg_carbonstate_inst%livestemc_patch            , & ! Input:  [real(r8) (:)   ]
+         livestemc_storage     => cnveg_carbonstate_inst%livestemc_storage_patch    , & ! Input:  [real(r8) (:)   ]
          livecrootc            => cnveg_carbonstate_inst%livecrootc_patch           , & ! Input:  [real(r8) (:)   ]
          retransn              => cnveg_nitrogenstate_inst%retransn_patch           , & ! Input:  [real(r8) (:)   ]  (gN/m2) plant pool of retranslocated N
 
@@ -1352,6 +1391,7 @@ contains
          cpool_to_xsmrpool     => cnveg_carbonflux_inst%cpool_to_xsmrpool_patch     , & ! Output: [real(r8) (:)   ]
 
          leafn                 => cnveg_nitrogenstate_inst%leafn_patch              , & ! Input:  [real(r8) (:)   ]  (gN/m2) leaf N
+         leafn_storage         => cnveg_nitrogenstate_inst%leafn_storage_patch      , & ! Input:  [real(r8) (:)   ]  (gN/m2) leaf N
          plant_ndemand         => cnveg_nitrogenflux_inst%plant_ndemand_patch       , & ! Output: [real(r8) (:)   ]  N flux required to support initial GPP (gN/m2/s)
          avail_retransn        => cnveg_nitrogenflux_inst%avail_retransn_patch      , & ! Output: [real(r8) (:)   ]  N flux available from retranslocation pool (gN/m2/s)
          retransn_to_npool     => cnveg_nitrogenflux_inst%retransn_to_npool_patch   , & ! Output: [real(r8) (:)   ]  deployment of retranslocated N (gN/m2/s)
@@ -1360,6 +1400,7 @@ contains
          frootn_to_retransn    => cnveg_nitrogenflux_inst%frootn_to_retransn_patch  , & ! Output: [real(r8) (:)   ]
          livestemn_to_retransn => cnveg_nitrogenflux_inst%livestemn_to_retransn_patch,& ! Output: [real(r8) (:)   ]
          livestemn             => cnveg_nitrogenstate_inst%livestemn_patch          , & ! Input:  [real(r8) (:)   ]  (gN/m2) livestem N
+         livestemn_storage     => cnveg_nitrogenstate_inst%livestemn_storage_patch          , & ! Input:  [real(r8) (:)   ]  (gN/m2) livestem N
          frootn                => cnveg_nitrogenstate_inst%frootn_patch             , & ! Input:  [real(r8) (:)   ]  (gN/m2) fine root N
          sminn_vr              => soilbiogeochem_nitrogenstate_inst%sminn_vr_col    , & ! Input:  [real(r8) (:,:) ]  (gN/m3) soil mineral N
          btran                 => energyflux_inst%btran_patch                       , & ! Input: [real(r8) (:)    ]  transpiration wetness factor (0 to 1)
@@ -1653,7 +1694,32 @@ contains
             ! leaf CN ratio 
             this%actual_leafcn(p) = leafc(p)  / leafn(p)
          end if
-            
+         ! WW added here to simplify diagnostics            
+         if (leafn_storage(p) < n_min ) then
+            this%actual_storage_leafcn(p) = spval
+         else
+            this%actual_storage_leafcn(p) = leafc_storage(p)  / leafn_storage(p)
+         end if
+
+
+         ! when we have "if (livestemn(p) == 0.0_r8)" below then we
+         ! have floating overflow (out of floating point range)
+         ! error in "actual_livestemcn(p) = livestemc(p) / livestemn(p)"
+         if (woody(ivt(p)) == 1.0_r8) then
+           if (livestemn(p) < n_min ) then
+              ! to avoid division by zero, and to set livestemcn to missing value for history files
+              this%actual_livestemcn(p) = spval
+           else
+              ! livestem CN ratio 
+              this%actual_livestemcn(p) = livestemc(p)  / livestemn(p)
+           end if
+
+          if (livestemn_storage(p) < n_min ) then
+              this%actual_livestemcn_storage(p) = spval
+           else
+              this%actual_livestemcn_storage(p) = livestemc(p)  / livestemn_storage(p)
+           end if
+         end if
 
          if (nscalar_opt) then
 


### PR DESCRIPTION
### Description of changes
allows for resorbtion in transition from live to dead wood N, which also move to NPOOL for free.

### Specific notes
allows resorbtion of live_to_dead wood N flux
moves live stem and root retranslocated N to NPOOL for free

Contributors other than yourself, if any:
This was first noticed in single point simulations by @susancheng. @rosiealice provided input & suggestions.

CTSM Issues Fixed (include github issue #):
#443 

Are answers expected to change (and if so in what way)?
All modifications increased GPP and CUE, resulting in higher LAI and VEG C pools, but the collateral changes to the C cycle seem minimized with these suggested changes here. Results seem to be behaving appropriately, with no excess N accumulating in RETRANSN and NPOOL, but is incorrectly being handled in CNNStateUpdate as presently implemented.

Any User Interface Changes (namelist or namelist defaults changes)?
none

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)
none

**NOTE: Be sure to check your Coding style against the standard:**
https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines
I'm sure I'll need to clean up some of this.
