### PR TITLE
Document authorship and CTSM code management team, release branch

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,7 @@
+{
+    "creators": [
+        {
+            "name": "CTSM Development Team"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3739617.svg)](https://doi.org/10.5281/zenodo.3739617)
 
 ## Overview and resources
+
 The Community Terrestrial Systems Model.
 
 This includes the Community Land Model (CLM5.0 and CLM4.5) of the Community Earth System Model.
@@ -23,6 +24,11 @@ https://github.com/ESCOMP/CTSM/wiki/Quick-start-to-CTSM-development-with-git
 and
 
 https://github.com/ESCOMP/ctsm/wiki/Recommended-git-setup
+
+For support with model use, troubleshooting, etc., please use the CTSM forum (or other
+appropriate forum) here:
+
+https://xenforo.cgd.ucar.edu/cesm/
 
 To get updates on CTSM tags and important notes on CTSM developments
 join our low traffic email list:

--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Science team:
 - [Sean Swenson](https://github.com/swensosc)
 - [Mike Barlage](https://github.com/barlage)
 - [Rosie Fisher](https://github.com/rosiealice)
+- [Peter Lawrence](https://github.com/lawrencepj1)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3739617.svg)](https://doi.org/10.5281/zenodo.3739617)
 
-## Overview and Resources
+## Overview and resources
 The Community Terrestrial Systems Model.
 
 This includes the Community Land Model (CLM5.0 and CLM4.5) of the Community Earth System Model.
@@ -30,3 +30,23 @@ join our low traffic email list:
 https://groups.google.com/a/ucar.edu/forum/#!forum/ctsm-dev
 
 (Send email to ctsm-software@ucar.edu if you have problems with any of this)
+
+## CTSM code management team
+
+CTSM code management is provided primarily by:
+
+Software engineering team:
+- [Erik Kluzek](https://github.com/ekluzek)
+- [Bill Sacks](https://github.com/billsacks)
+- [Mariana Vertenstein](https://github.com/mvertens)
+- [Negin Sobhani](https://github.com/negin513)
+- [Sam Levis](https://github.com/slevisconsulting)
+
+Science team:
+- [Dave Lawrence](https://github.com/dlawrenncar)
+- [Will Wieder](https://github.com/wwieder)
+- [Danica Lombardozzi](https://github.com/danicalombardozzi)
+- [Keith Oleson](https://github.com/olyson)
+- [Sean Swenson](https://github.com/swensosc)
+- [Mike Barlage](https://github.com/barlage)
+- [Rosie Fisher](https://github.com/rosiealice)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://escomp.github.io/ctsm-docs/
 
 For help with how to work with CTSM in git, see
 
-https://github.com/ESCOMP/ctsm/wiki/Getting-started-with-CTSM-in-git
+https://github.com/ESCOMP/CTSM/wiki/Quick-start-to-CTSM-development-with-git
 
 and
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-====
-CTSM
-====
+# CTSM
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3739617.svg)](https://doi.org/10.5281/zenodo.3739617)
+
+## Overview and Resources
 The Community Terrestrial Systems Model.
 
 This includes the Community Land Model (CLM5.0 and CLM4.5) of the Community Earth System Model.


### PR DESCRIPTION
**Same as #1006 but for the release branch**

### Description of changes

- Add zenodo metadata file so that the Zenodo authorship is given simply as "CTSM Development Team", rather than trying to harvest authorship information from the list of git contributors.

- Document primary CTSM code management team members in the README

- Convert README to markdown, because I find it a little easier to work with than restructuredText. (Other than the addition of the CTSM code management team and fixing a link, content is the same as before.)

- Bring in a few other changes from the README file on master (making the README file on the release branch identical to that on master)

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
- Addresses #1005 for release branch

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None
