### PR TITLE
Fix harvest-related values on surface datasets for smallville and other cases with all_veg

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -33,7 +33,7 @@
   <test name="ERS_Lm20_Mmpi-serial.1x1_smallvilleIA.I2000Clm50BgcCropQianGs.cheyenne_gnu.clm-monthly">
     <phase name="RUN">
       <status>FAIL</status>
-      <issue>#158</issue>
+      <issue>#203</issue>
     </phase>
   </test>
 

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -93,6 +93,7 @@ program mksurfdat
     type(pct_pft_type), allocatable :: pctnatpft_max(:) ! % of grid cell maximum PFTs of the time series
     type(pct_pft_type), allocatable :: pctcft(:)        ! % of grid cell that is crop, and breakdown into CFTs
     type(pct_pft_type), allocatable :: pctcft_max(:)    ! % of grid cell maximum CFTs of the time series
+    real(r8)               :: harvest_initval    ! initial value for harvest variables
     real(r8), pointer      :: harvest1D(:)       ! harvest 1D data: normalized harvesting
     real(r8), pointer      :: harvest2D(:,:)     ! harvest 1D data: normalized harvesting
     real(r8), allocatable  :: pctgla(:)          ! percent of grid cell that is glacier  
@@ -568,7 +569,14 @@ program mksurfdat
          ndiag=ndiag, pctlnd_o=pctlnd_pft, pctnatpft_o=pctnatpft, pctcft_o=pctcft)
 
     ! Create harvesting data at model resolution
-    call mkharvest_init( ns_o, spval, harvdata, mksrf_fhrvtyp )
+    if (all_veg) then
+       ! In this case, we don't call mkharvest, so we want the harvest variables to be
+       ! initialized reasonably.
+       harvest_initval = 0._r8
+    else
+       harvest_initval = spval
+    end if
+    call mkharvest_init( ns_o, harvest_initval, harvdata, mksrf_fhrvtyp )
     if ( .not. all_veg )then
 
        call mkharvest( ldomain, mapfname=map_fharvest, datfname=mksrf_fhrvtyp, &


### PR DESCRIPTION
### Description of changes

Set harvest-related values to 0 rather than spval when running mksurfdata_map with all_veg = true (for smallville, etc.).

Compared with the baseline, this changes the following fields on the smallville surface dataset, which are all now 0 rather than spval:

```
 RMS CONST_HARVEST_VH1                1.0000E+36            NORMALIZED  2.0000E+00
 RMS CONST_HARVEST_VH2                1.0000E+36            NORMALIZED  2.0000E+00
 RMS CONST_HARVEST_SH1                1.0000E+36            NORMALIZED  2.0000E+00
 RMS CONST_HARVEST_SH2                1.0000E+36            NORMALIZED  2.0000E+00
 RMS CONST_HARVEST_SH3                1.0000E+36            NORMALIZED  2.0000E+00
 RMS CONST_GRAZING                    1.0000E+36            NORMALIZED  2.0000E+00
 RMS CONST_FERTNITRO_CFT              1.0000E+36            NORMALIZED  2.0000E+00
 RMS UNREPRESENTED_PFT_LULCC          1.0000E+36            NORMALIZED  2.0000E+00
 RMS UNREPRESENTED_CFT_LULCC          1.0000E+36            NORMALIZED  2.0000E+00
```

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
- I'm hopeful that this will solve #203 

Are answers expected to change (and if so in what way)? Yes, but just for smallville and similar test cases

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any: none yet
