### PR TITLE
Updating pointer to new fates tag for fixed biogeography update

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.35.5_api.11.1.0
+tag = sci.1.36.0_api.11.2.0
 required = True
 
 [PTCLM]


### PR DESCRIPTION
### Description of changes
This PR is created in response to the merge of PR #985 (and it's concurrent FATES PR).  The `Externals_CLM.cfg` file has been updated to point to the correct tag `sci.1.36.0_api.11.2.0`.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #): N/A

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None as deemed not necessary

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
