### PR TITLE
Building energy fix (issue #803).

### DIFF
--- a/src/biogeophys/UrbBuildTempOleson2015Mod.F90
+++ b/src/biogeophys/UrbBuildTempOleson2015Mod.F90
@@ -229,6 +229,7 @@ contains
     integer, parameter :: neq = 5          ! number of equation/unknowns
     integer  :: fc,fl,c,l                  ! indices
     real(r8) :: dtime                      ! land model time step (s)
+    real(r8) :: building_hwr(bounds%begl:bounds%endl)      ! building height to building width ratio (-)
     real(r8) :: t_roof_inner_bef(bounds%begl:bounds%endl)  ! roof inside surface temperature at previous time step (K)              
     real(r8) :: t_sunw_inner_bef(bounds%begl:bounds%endl)  ! sunwall inside surface temperature at previous time step (K)              
     real(r8) :: t_shdw_inner_bef(bounds%begl:bounds%endl)  ! shadewall inside surface temperature at previous time step (K)              
@@ -341,6 +342,7 @@ contains
     !    See clm_varcon.F90
     ! 3. Set inner surface emissivities (Bueno et al. 2012, GMD).
     ! 4. Set concrete floor properties (Salamanca et al. 2010, TAC).
+    ! 5. Calculate building height to building width ratio
     do fl = 1,num_urbanl
        l = filter_urbanl(fl)
        if (urbpoi(l)) then
@@ -373,13 +375,15 @@ contains
          cv_floori(l) = (dz_floori(l) * cp_floori(l)) / dtime
          ! Density of dry air at standard pressure and t_building (kg m-3)
          rho_dair(l) = pstd / (rair*t_building_bef(l))
+         ! Building height to building width ratio
+         building_hwr(l) = canyon_hwr(l)*(1._r8-wtlunit_roof(l))/wtlunit_roof(l)
        end if
     end do
 
     ! Get terms from soil temperature equations to compute conduction flux
     ! Negative is toward surface - heat added
     ! Note that the conduction flux here is in W m-2 wall area but for purposes of solving the set of
-    ! simultaneous equations this must be converted to W m-2 ground area. This is done below when 
+    ! simultaneous equations this must be converted to W m-2 floor area. This is done below when 
     ! setting up the equation coefficients.
 
     do fc = 1,num_nolakec
@@ -413,14 +417,14 @@ contains
        l = filter_urbanl(fl)
        if (urbpoi(l)) then
 
-         vf_rf(l) = sqrt(1._r8 + canyon_hwr(l)**2._r8) - canyon_hwr(l)
+         vf_rf(l) = sqrt(1._r8 + building_hwr(l)**2._r8) - building_hwr(l)
          vf_fr(l) = vf_rf(l)
 
          ! This view factor implicitly converts from per unit wall area to per unit floor area
          vf_wf(l)  = 0.5_r8*(1._r8 - vf_rf(l))
 
          ! This view factor implicitly converts from per unit floor area to per unit wall area
-         vf_fw(l) = vf_wf(l) / canyon_hwr(l)
+         vf_fw(l) = vf_wf(l) / building_hwr(l)
 
          ! This view factor implicitly converts from per unit roof area to per unit wall area
          vf_rw(l)  = vf_fw(l)
@@ -515,8 +519,8 @@ contains
                   - 4._r8*em_roofi(l)*sb*t_roof_inner_bef(l)**3._r8*vf_rw(l)*(1._r8-em_shdwi(l))*vf_ww(l) &
                   - 4._r8*em_roofi(l)*sb*t_roof_inner_bef(l)**3._r8*vf_rf(l)*(1._r8-em_floori(l))*vf_fw(l)
 
-         a(2,2) =   0.5_r8*hcv_sunwi(l)*canyon_hwr(l) &
-                  + 0.5_r8*tk_sunw_innerl(l)/(zi_sunw_innerl(l) - z_sunw_innerl(l))*canyon_hwr(l) &
+         a(2,2) =   0.5_r8*hcv_sunwi(l)*building_hwr(l) &
+                  + 0.5_r8*tk_sunw_innerl(l)/(zi_sunw_innerl(l) - z_sunw_innerl(l))*building_hwr(l) &
                   + 4._r8*em_sunwi(l)*sb*t_sunw_inner_bef(l)**3._r8 &
                   - 4._r8*em_sunwi(l)*sb*t_sunw_inner_bef(l)**3._r8*vf_wr(l)*(1._r8-em_roofi(l))*vf_rw(l) &
                   - 4._r8*em_sunwi(l)*sb*t_sunw_inner_bef(l)**3._r8*vf_ww(l)*(1._r8-em_shdwi(l))*vf_ww(l) &
@@ -529,11 +533,11 @@ contains
          a(2,4) = - 4._r8*em_sunwi(l)*em_floori(l)*sb*t_floor_bef(l)**3._r8*vf_fw(l) &
                   - 4._r8*em_floori(l)*sb*t_floor_bef(l)**3._r8*vf_fr(l)*(1._r8-em_roofi(l))*vf_rw(l) &
                   - 4._r8*em_floori(l)*sb*t_floor_bef(l)**3._r8*vf_fw(l)*(1._r8-em_shdwi(l))*vf_ww(l)
-         a(2,5) = - 0.5_r8*hcv_sunwi(l)*canyon_hwr(l)
+         a(2,5) = - 0.5_r8*hcv_sunwi(l)*building_hwr(l)
 
-         result(2) =   0.5_r8*tk_sunw_innerl(l)*t_sunw_innerl(l)/(zi_sunw_innerl(l) - z_sunw_innerl(l))*canyon_hwr(l) &
+         result(2) =   0.5_r8*tk_sunw_innerl(l)*t_sunw_innerl(l)/(zi_sunw_innerl(l) - z_sunw_innerl(l))*building_hwr(l) &
                      - 0.5_r8*tk_sunw_innerl(l)*(t_sunw_inner_bef(l)-t_sunw_innerl_bef(l))/(zi_sunw_innerl(l) &
-                     - z_sunw_innerl(l))*canyon_hwr(l) &
+                     - z_sunw_innerl(l))*building_hwr(l) &
                      - 3._r8*em_sunwi(l)*em_roofi(l)*sb*t_roof_inner_bef(l)**4._r8*vf_rw(l) &
                      - 3._r8*em_sunwi(l)*em_shdwi(l)*sb*t_shdw_inner_bef(l)**4._r8*vf_ww(l) &
                      - 3._r8*em_sunwi(l)*em_floori(l)*sb*t_floor_bef(l)**4._r8*vf_fw(l) &
@@ -547,7 +551,7 @@ contains
                      - 3._r8*em_roofi(l)*sb*t_roof_inner_bef(l)**4._r8*vf_rf(l)*(1._r8-em_floori(l))*vf_fw(l) &
                      - 3._r8*em_floori(l)*sb*t_floor_bef(l)**4._r8*vf_fr(l)*(1._r8-em_roofi(l))*vf_rw(l) &
                      - 3._r8*em_floori(l)*sb*t_floor_bef(l)**4._r8*vf_fw(l)*(1._r8-em_shdwi(l))*vf_ww(l) &
-                     - 0.5_r8*hcv_sunwi(l)*(t_sunw_inner_bef(l) - t_building_bef(l))*canyon_hwr(l)
+                     - 0.5_r8*hcv_sunwi(l)*(t_sunw_inner_bef(l) - t_building_bef(l))*building_hwr(l)
 
          ! SHADEWALL
          a(3,1) = - 4._r8*em_shdwi(l)*em_roofi(l)*sb*t_roof_inner_bef(l)**3._r8*vf_rw(l) &
@@ -558,8 +562,8 @@ contains
                   - 4._r8*em_sunwi(l)*sb*t_sunw_inner_bef(l)**3._r8*vf_wf(l)*(1._r8-em_floori(l))*vf_fw(l) &
                   - 4._r8*em_sunwi(l)*sb*t_sunw_inner_bef(l)**3._r8*vf_wr(l)*(1._r8-em_roofi(l))*vf_rw(l)
 
-         a(3,3) =   0.5_r8*hcv_shdwi(l)*canyon_hwr(l) &
-                  + 0.5_r8*tk_shdw_innerl(l)/(zi_shdw_innerl(l) - z_shdw_innerl(l))*canyon_hwr(l) &
+         a(3,3) =   0.5_r8*hcv_shdwi(l)*building_hwr(l) &
+                  + 0.5_r8*tk_shdw_innerl(l)/(zi_shdw_innerl(l) - z_shdw_innerl(l))*building_hwr(l) &
                   + 4._r8*em_shdwi(l)*sb*t_shdw_inner_bef(l)**3._r8 &
                   - 4._r8*em_shdwi(l)*sb*t_shdw_inner_bef(l)**3._r8*vf_wr(l)*(1._r8-em_roofi(l))*vf_rw(l) &
                   - 4._r8*em_shdwi(l)*sb*t_shdw_inner_bef(l)**3._r8*vf_ww(l)*(1._r8-em_sunwi(l))*vf_ww(l) &
@@ -569,11 +573,11 @@ contains
                   - 4._r8*em_floori(l)*sb*t_floor_bef(l)**3._r8*vf_fr(l)*(1._r8-em_roofi(l))*vf_rw(l) &
                   - 4._r8*em_floori(l)*sb*t_floor_bef(l)**3._r8*vf_fw(l)*(1._r8-em_sunwi(l))*vf_ww(l)
 
-         a(3,5) = - 0.5_r8*hcv_shdwi(l)*canyon_hwr(l)
+         a(3,5) = - 0.5_r8*hcv_shdwi(l)*building_hwr(l)
 
-         result(3) =   0.5_r8*tk_shdw_innerl(l)*t_shdw_innerl(l)/(zi_shdw_innerl(l) - z_shdw_innerl(l))*canyon_hwr(l) &
+         result(3) =   0.5_r8*tk_shdw_innerl(l)*t_shdw_innerl(l)/(zi_shdw_innerl(l) - z_shdw_innerl(l))*building_hwr(l) &
                      - 0.5_r8*tk_shdw_innerl(l)*(t_shdw_inner_bef(l)-t_shdw_innerl_bef(l))/(zi_shdw_innerl(l) &
-                     - z_shdw_innerl(l))*canyon_hwr(l) &
+                     - z_shdw_innerl(l))*building_hwr(l) &
                      - 3._r8*em_shdwi(l)*em_roofi(l)*sb*t_roof_inner_bef(l)**4._r8*vf_rw(l) &
                      - 3._r8*em_shdwi(l)*em_sunwi(l)*sb*t_sunw_inner_bef(l)**4._r8*vf_ww(l) &
                      - 3._r8*em_shdwi(l)*em_floori(l)*sb*t_floor_bef(l)**4._r8*vf_fw(l) &
@@ -587,7 +591,7 @@ contains
                      - 3._r8*em_roofi(l)*sb*t_roof_inner_bef(l)**4._r8*vf_rf(l)*(1._r8-em_floori(l))*vf_fw(l) &
                      - 3._r8*em_floori(l)*sb*t_floor_bef(l)**4._r8*vf_fr(l)*(1._r8-em_roofi(l))*vf_rw(l) &
                      - 3._r8*em_floori(l)*sb*t_floor_bef(l)**4._r8*vf_fw(l)*(1._r8-em_sunwi(l))*vf_ww(l) &
-                     - 0.5_r8*hcv_shdwi(l)*(t_shdw_inner_bef(l) - t_building_bef(l))*canyon_hwr(l)
+                     - 0.5_r8*hcv_shdwi(l)*(t_shdw_inner_bef(l) - t_building_bef(l))*building_hwr(l)
 
          ! FLOOR
          a(4,1) = - 4._r8*em_floori(l)*em_roofi(l)*sb*t_roof_inner_bef(l)**3._r8*vf_rf(l) &
@@ -628,24 +632,24 @@ contains
 
          ! Building air temperature
          a(5,1) = - 0.5_r8*hcv_roofi(l)
-         a(5,2) = - 0.5_r8*hcv_sunwi(l)*canyon_hwr(l)
+         a(5,2) = - 0.5_r8*hcv_sunwi(l)*building_hwr(l)
 
-         a(5,3) = - 0.5_r8*hcv_shdwi(l)*canyon_hwr(l)
+         a(5,3) = - 0.5_r8*hcv_shdwi(l)*building_hwr(l)
 
          a(5,4) = - 0.5_r8*hcv_floori(l)
 
          a(5,5) =  ((ht_roof(l)*rho_dair(l)*cpair)/dtime) + &
                    ((ht_roof(l)*vent_ach)/3600._r8)*rho_dair(l)*cpair + &
                    0.5_r8*hcv_roofi(l) + &
-                   0.5_r8*hcv_sunwi(l)*canyon_hwr(l) + &
-                   0.5_r8*hcv_shdwi(l)*canyon_hwr(l) + &
+                   0.5_r8*hcv_sunwi(l)*building_hwr(l) + &
+                   0.5_r8*hcv_shdwi(l)*building_hwr(l) + &
                    0.5_r8*hcv_floori(l)
 
          result(5) = (ht_roof(l)*rho_dair(l)*cpair/dtime)*t_building_bef(l) &
                       + ((ht_roof(l)*vent_ach)/3600._r8)*rho_dair(l)*cpair*taf(l) &
                       + 0.5_r8*hcv_roofi(l)*(t_roof_inner_bef(l) - t_building_bef(l)) &
-                      + 0.5_r8*hcv_sunwi(l)*(t_sunw_inner_bef(l) - t_building_bef(l))*canyon_hwr(l) &
-                      + 0.5_r8*hcv_shdwi(l)*(t_shdw_inner_bef(l) - t_building_bef(l))*canyon_hwr(l) &
+                      + 0.5_r8*hcv_sunwi(l)*(t_sunw_inner_bef(l) - t_building_bef(l))*building_hwr(l) &
+                      + 0.5_r8*hcv_shdwi(l)*(t_shdw_inner_bef(l) - t_building_bef(l))*building_hwr(l) &
                       + 0.5_r8*hcv_floori(l)*(t_floor_bef(l) - t_building_bef(l))
 
          ! Solve equations
@@ -826,7 +830,7 @@ contains
                         + em_floori(l)*sb*t_floor_bef(l)**4._r8 &
                         + 4._r8*em_floori(l)*sb*t_floor_bef(l)**3.*(t_floor(l) - t_floor_bef(l))
 
-         qrd_building(l) = qrd_roof(l) + canyon_hwr(l)*(qrd_sunw(l) + qrd_shdw(l)) + qrd_floor(l)
+         qrd_building(l) = qrd_roof(l) + building_hwr(l)*(qrd_sunw(l) + qrd_shdw(l)) + qrd_floor(l)
 
          if (abs(qrd_building(l)) > .10_r8 ) then
            write (iulog,*) 'urban inside building net longwave radiation balance error ',qrd_building(l)
@@ -851,7 +855,7 @@ contains
          qcd_sunw(l) = 0.5_r8*tk_sunw_innerl(l)*(t_sunw_inner(l) - t_sunw_innerl(l))/(zi_sunw_innerl(l) - z_sunw_innerl(l))  &
                        + 0.5_r8*tk_sunw_innerl(l)*(t_sunw_inner_bef(l) - t_sunw_innerl_bef(l))/(zi_sunw_innerl(l) &
                        - z_sunw_innerl(l))
-         enrgy_bal_sunw(l) = qrd_sunw(l) + qcv_sunw(l)*canyon_hwr(l) + qcd_sunw(l)*canyon_hwr(l)
+         enrgy_bal_sunw(l) = qrd_sunw(l) + qcv_sunw(l)*building_hwr(l) + qcd_sunw(l)*building_hwr(l)
          if (abs(enrgy_bal_sunw(l)) > .10_r8 ) then
            write (iulog,*) 'urban inside sunwall energy balance error ',enrgy_bal_sunw(l)
            write (iulog,*) 'clm model is stopping'
@@ -863,7 +867,7 @@ contains
          qcd_shdw(l) = 0.5_r8*tk_shdw_innerl(l)*(t_shdw_inner(l) - t_shdw_innerl(l))/(zi_shdw_innerl(l) - z_shdw_innerl(l))  &
                        + 0.5_r8*tk_shdw_innerl(l)*(t_shdw_inner_bef(l) - t_shdw_innerl_bef(l))/(zi_shdw_innerl(l) &
                        - z_shdw_innerl(l))
-         enrgy_bal_shdw(l) = qrd_shdw(l) + qcv_shdw(l)*canyon_hwr(l) + qcd_shdw(l)*canyon_hwr(l)
+         enrgy_bal_shdw(l) = qrd_shdw(l) + qcv_shdw(l)*building_hwr(l) + qcd_shdw(l)*building_hwr(l)
          if (abs(enrgy_bal_shdw(l)) > .10_r8 ) then
            write (iulog,*) 'urban inside shadewall energy balance error ',enrgy_bal_shdw(l)
            write (iulog,*) 'clm model is stopping'
@@ -884,10 +888,10 @@ contains
                                  - ht_roof(l)*(vent_ach/3600._r8)*rho_dair(l)*cpair*(taf(l) - t_building(l)) &
                                  - 0.5_r8*hcv_roofi(l)*(t_roof_inner(l) - t_building(l)) &
                                  - 0.5_r8*hcv_roofi(l)*(t_roof_inner_bef(l) - t_building_bef(l)) &
-                                 - 0.5_r8*hcv_sunwi(l)*(t_sunw_inner(l) - t_building(l))*canyon_hwr(l) &
-                                 - 0.5_r8*hcv_sunwi(l)*(t_sunw_inner_bef(l) - t_building_bef(l))*canyon_hwr(l) &
-                                 - 0.5_r8*hcv_shdwi(l)*(t_shdw_inner(l) - t_building(l))*canyon_hwr(l) &
-                                 - 0.5_r8*hcv_shdwi(l)*(t_shdw_inner_bef(l) - t_building_bef(l))*canyon_hwr(l) &
+                                 - 0.5_r8*hcv_sunwi(l)*(t_sunw_inner(l) - t_building(l))*building_hwr(l) &
+                                 - 0.5_r8*hcv_sunwi(l)*(t_sunw_inner_bef(l) - t_building_bef(l))*building_hwr(l) &
+                                 - 0.5_r8*hcv_shdwi(l)*(t_shdw_inner(l) - t_building(l))*building_hwr(l) &
+                                 - 0.5_r8*hcv_shdwi(l)*(t_shdw_inner_bef(l) - t_building_bef(l))*building_hwr(l) &
                                  - 0.5_r8*hcv_floori(l)*(t_floor(l) - t_building(l)) &
                                  - 0.5_r8*hcv_floori(l)*(t_floor_bef(l) - t_building_bef(l))
          if (abs(enrgy_bal_buildair(l)) > .10_r8 ) then


### PR DESCRIPTION


### Description of changes
There is an implicit assumption in the urban building energy model that building width equals street width. However, this assumption has been relaxed and building width is now derived from the morphology dataset.

### Specific notes
There is an implicit assumption in the urban building energy model that building width equals street width. However, this assumption has been relaxed and building width is now derived from the Jackson morphology dataset. Specifically, the equations which use H/Ws (building height over street width) now use H/Wb (building height over building width). Building width is derived from (Ws*froof)/(1-froof), where froof is the roof (building) fraction.
A simulation with the new equations indicate that as expected, for froof=0.5, answers are identical (because H/Ws = H/Wb). Differences in other cases depend on the degree of departure from froof=0.5 and the presence and magnitude of space heating and air conditioning. 

Contributors other than yourself, if any: None

CTSM Issues Fixed (include github issue #): #803

Are answers expected to change (and if so in what way)?  Yes, but only for urban landunits.  The effects on grid cell averages are very small as shown by the diagnostics from this year 2000 case:

http://webext.cgd.ucar.edu/I2000/clm50_ctsm10d098_1deg_GSWP3V1_CON_FIXBUILDENERGY_2000/lnd/clm50_ctsm10d098_1deg_GSWP3V1_CON_FIXBUILDENERGY_2000.1991_2010-clm50_ctsm10d098_1deg_GSWP3V1_CON_2000.1991_2010/setsIndex.html

Any User Interface Changes (namelist or namelist defaults changes)? No.

Testing performed, if any:
The clm_short testlist was run.  All pass except comparison to ctsm1.0.dev098 baseline was not bfb as expected.
