### PR TITLE
Make most QSat output arguments optional

### DIFF
--- a/src/biogeophys/BareGroundFluxesMod.F90
+++ b/src/biogeophys/BareGroundFluxesMod.F90
@@ -141,9 +141,7 @@ contains
     real(r8) :: z0hg_patch(bounds%begp:bounds%endp)
     real(r8) :: z0qg_patch(bounds%begp:bounds%endp)
     real(r8) :: e_ref2m                          ! 2 m height surface saturated vapor pressure [Pa]
-    real(r8) :: de2mdT                           ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
     real(r8) :: qsat_ref2m                       ! 2 m height surface saturated specific humidity [kg/kg]
-    real(r8) :: dqsat2mdT                        ! derivative of 2 m height surface saturated specific humidity on t_ref2m 
     real(r8) :: www                              ! surface soil wetness [-]
     !------------------------------------------------------------------------------
 
@@ -419,7 +417,8 @@ contains
          q_ref2m(p) = forc_q(c) + temp2(p)*dqh(p)*(1._r8/temp22m(p) - 1._r8/temp2(p))
 
          ! 2 m height relative humidity
-         call QSat(t_ref2m(p), forc_pbot(c), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(c), qsat_ref2m, &
+              es = e_ref2m)
 
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
 

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -321,13 +321,10 @@ contains
     real(r8) :: wtalq(bounds%begp:bounds%endp)       ! normalized latent heat cond. for air and leaf [-]
     real(r8) :: wtgaq                                ! normalized latent heat cond. for air and ground [-]
     real(r8) :: el(bounds%begp:bounds%endp)          ! vapor pressure on leaf surface [pa]
-    real(r8) :: deldT                                ! derivative of "el" on "t_veg" [pa/K]
     real(r8) :: qsatl(bounds%begp:bounds%endp)       ! leaf specific humidity [kg/kg]
     real(r8) :: qsatldT(bounds%begp:bounds%endp)     ! derivative of "qsatl" on "t_veg"
     real(r8) :: e_ref2m                              ! 2 m height surface saturated vapor pressure [Pa]
-    real(r8) :: de2mdT                               ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
     real(r8) :: qsat_ref2m                           ! 2 m height surface saturated specific humidity [kg/kg]
-    real(r8) :: dqsat2mdT                            ! derivative of 2 m height surface saturated specific humidity on t_ref2m
     real(r8) :: air(bounds%begp:bounds%endp)         ! atmos. radiation temporay set
     real(r8) :: bir(bounds%begp:bounds%endp)         ! atmos. radiation temporay set
     real(r8) :: cir(bounds%begp:bounds%endp)         ! atmos. radiation temporay set
@@ -740,7 +737,9 @@ contains
          ! Saturated vapor pressure, specific humidity, and their derivatives
          ! at the leaf surface
 
-         call QSat (t_veg(p), forc_pbot(c), el(p), deldT, qsatl(p), qsatldT(p))
+         call QSat (t_veg(p), forc_pbot(c), qsatl(p), &
+              es = el(p), &
+              qsdT = qsatldT(p))
 
          ! Determine atmospheric co2 and o2
 
@@ -1109,7 +1108,9 @@ contains
             ! Re-calculate saturated vapor pressure, specific humidity, and their
             ! derivatives at the leaf surface
 
-            call QSat(t_veg(p), forc_pbot(c), el(p), deldT, qsatl(p), qsatldT(p))
+            call QSat(t_veg(p), forc_pbot(c), qsatl(p), &
+                 es = el(p), &
+                 qsdT = qsatldT(p))
 
             ! Update vegetation/ground surface temperature, canopy air
             ! temperature, canopy vapor pressure, aerodynamic temperature, and
@@ -1228,7 +1229,8 @@ contains
 
          ! 2 m height relative humidity
 
-         call QSat(t_ref2m(p), forc_pbot(c), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(c), qsat_ref2m, &
+              es = e_ref2m)
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
          rh_ref2m_r(p) = rh_ref2m(p)
 

--- a/src/biogeophys/LakeFluxesMod.F90
+++ b/src/biogeophys/LakeFluxesMod.F90
@@ -130,12 +130,10 @@ contains
     integer  :: jtop(bounds%begc:bounds%endc)      ! top level for each column (no longer all 1)
     real(r8) :: ax                                 ! used in iteration loop for calculating t_grnd (numerator of NR solution)
     real(r8) :: bx                                 ! used in iteration loop for calculating t_grnd (denomin. of NR solution)
-    real(r8) :: degdT                              ! d(eg)/dT
     real(r8) :: dqh(bounds%begp:bounds%endp)       ! diff of humidity between ref. height and surface
     real(r8) :: dth(bounds%begp:bounds%endp)       ! diff of virtual temp. between ref. height and surface
     real(r8) :: dthv                               ! diff of vir. poten. temp. between ref. height and surface
     real(r8) :: dzsur(bounds%begc:bounds%endc)     ! 1/2 the top layer thickness (m)
-    real(r8) :: eg                                 ! water vapor pressure at temperature T [pa]
     real(r8) :: htvp(bounds%begc:bounds%endc)      ! latent heat of vapor of water (or sublimation) [j/kg]
     real(r8) :: obu(bounds%begp:bounds%endp)       ! monin-obukhov length (m)
     real(r8) :: obuold(bounds%begp:bounds%endp)    ! monin-obukhov length of previous iteration
@@ -173,9 +171,7 @@ contains
     real(r8) :: t_grnd_temp                        ! Used in surface flux correction over frozen ground
     real(r8) :: betaprime(bounds%begc:bounds%endc) ! Effective beta: sabg_lyr(p,jtop) for snow layers, beta otherwise
     real(r8) :: e_ref2m                            ! 2 m height surface saturated vapor pressure [Pa]
-    real(r8) :: de2mdT                             ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
     real(r8) :: qsat_ref2m                         ! 2 m height surface saturated specific humidity [kg/kg]
-    real(r8) :: dqsat2mdT                          ! derivative of 2 m height surface saturated specific humidity on t_ref2m
     real(r8) :: sabg_nir                           ! NIR that is absorbed (W/m^2)
 
     ! For calculating roughness lengths
@@ -364,7 +360,8 @@ contains
          ! Saturated vapor pressure, specific humidity and their derivatives
          ! at lake surface
 
-         call QSat(t_grnd(c), forc_pbot(c), eg, degdT, qsatg(c), qsatgdT(c))
+         call QSat(t_grnd(c), forc_pbot(c), qsatg(c), &
+              qsdT = qsatgdT(c))
 
          ! Potential, virtual potential temperature, and wind speed at the
          ! reference height
@@ -491,7 +488,8 @@ contains
             ! Re-calculate saturated vapor pressure, specific humidity and their
             ! derivatives at lake surface
 
-            call QSat(t_grnd(c), forc_pbot(c), eg, degdT, qsatg(c), qsatgdT(c))
+            call QSat(t_grnd(c), forc_pbot(c), qsatg(c), &
+                 qsdT = qsatgdT(c))
 
             dth(p)=thm(p)-t_grnd(c)
             dqh(p)=forc_q(c)-qsatg(c)
@@ -643,7 +641,8 @@ contains
 
          ! 2 m height relative humidity
 
-         call QSat(t_ref2m(p), forc_pbot(c), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(c), qsat_ref2m, &
+              es = e_ref2m)
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
 
          ! Human Heat Stress

--- a/src/biogeophys/QSatMod.F90
+++ b/src/biogeophys/QSatMod.F90
@@ -61,8 +61,9 @@ contains
   subroutine QSat (T, p, qs, es, qsdT, esdT)
     !
     ! !DESCRIPTION:
-    ! Computes saturation mixing ratio and (optionally) the change in saturation
-    ! mixing ratio with respect to temperature.
+    ! Computes saturation mixing ratio and (optionally) the change in saturation mixing
+    ! ratio with respect to temperature. Mixing ratio and specific humidity are
+    ! approximately equal and can be treated as the same.
     ! Reference:  Polynomial approximations from:
     !             Piotr J. Flatau, et al.,1992:  Polynomial fits to saturation
     !             vapor pressure.  Journal of Applied Meteorology, 31, 1507-1513.
@@ -86,9 +87,7 @@ contains
     real(r8) :: td,vp,vp1,vp2
     !-----------------------------------------------------------------------
 
-    td = T - SHR_CONST_TKFRZ
-    if (td > 100.0_r8) td=100.0_r8
-    if (td < -75.0_r8) td=-75.0_r8
+    td = min(100.0_r8, max(-75.0_r8, T - SHR_CONST_TKFRZ))
 
     if (td >= 0.0_r8) then
        es_local = a0 + td*(a1 + td*(a2 + td*(a3 + td*(a4 &

--- a/src/biogeophys/QSatMod.F90
+++ b/src/biogeophys/QSatMod.F90
@@ -14,49 +14,48 @@ module QSatMod
   public :: QSat
   !-----------------------------------------------------------------------
 
-    ! For water vapor (temperature range 0C-100C)
-    real(r8), parameter :: a0 =  6.11213476_r8
-    real(r8), parameter :: a1 =  0.444007856_r8
-    real(r8), parameter :: a2 =  0.143064234e-01_r8
-    real(r8), parameter :: a3 =  0.264461437e-03_r8
-    real(r8), parameter :: a4 =  0.305903558e-05_r8
-    real(r8), parameter :: a5 =  0.196237241e-07_r8
-    real(r8), parameter :: a6 =  0.892344772e-10_r8
-    real(r8), parameter :: a7 = -0.373208410e-12_r8
-    real(r8), parameter :: a8 =  0.209339997e-15_r8
-    ! For derivative:water vapor
-    real(r8), parameter :: b0 =  0.444017302_r8
-    real(r8), parameter :: b1 =  0.286064092e-01_r8
-    real(r8), parameter :: b2 =  0.794683137e-03_r8
-    real(r8), parameter :: b3 =  0.121211669e-04_r8
-    real(r8), parameter :: b4 =  0.103354611e-06_r8
-    real(r8), parameter :: b5 =  0.404125005e-09_r8
-    real(r8), parameter :: b6 = -0.788037859e-12_r8
-    real(r8), parameter :: b7 = -0.114596802e-13_r8
-    real(r8), parameter :: b8 =  0.381294516e-16_r8
-    ! For ice (temperature range -75C-0C)
-    real(r8), parameter :: c0 =  6.11123516_r8
-    real(r8), parameter :: c1 =  0.503109514_r8
-    real(r8), parameter :: c2 =  0.188369801e-01_r8
-    real(r8), parameter :: c3 =  0.420547422e-03_r8
-    real(r8), parameter :: c4 =  0.614396778e-05_r8
-    real(r8), parameter :: c5 =  0.602780717e-07_r8
-    real(r8), parameter :: c6 =  0.387940929e-09_r8
-    real(r8), parameter :: c7 =  0.149436277e-11_r8
-    real(r8), parameter :: c8 =  0.262655803e-14_r8
-    ! For derivative:ice
-    real(r8), parameter :: d0 =  0.503277922_r8
-    real(r8), parameter :: d1 =  0.377289173e-01_r8
-    real(r8), parameter :: d2 =  0.126801703e-02_r8
-    real(r8), parameter :: d3 =  0.249468427e-04_r8
-    real(r8), parameter :: d4 =  0.313703411e-06_r8
-    real(r8), parameter :: d5 =  0.257180651e-08_r8
-    real(r8), parameter :: d6 =  0.133268878e-10_r8
-    real(r8), parameter :: d7 =  0.394116744e-13_r8
-    real(r8), parameter :: d8 =  0.498070196e-16_r8  
+  ! For water vapor (temperature range 0C-100C)
+  real(r8), parameter :: a0 =  6.11213476_r8
+  real(r8), parameter :: a1 =  0.444007856_r8
+  real(r8), parameter :: a2 =  0.143064234e-01_r8
+  real(r8), parameter :: a3 =  0.264461437e-03_r8
+  real(r8), parameter :: a4 =  0.305903558e-05_r8
+  real(r8), parameter :: a5 =  0.196237241e-07_r8
+  real(r8), parameter :: a6 =  0.892344772e-10_r8
+  real(r8), parameter :: a7 = -0.373208410e-12_r8
+  real(r8), parameter :: a8 =  0.209339997e-15_r8
+  ! For derivative:water vapor
+  real(r8), parameter :: b0 =  0.444017302_r8
+  real(r8), parameter :: b1 =  0.286064092e-01_r8
+  real(r8), parameter :: b2 =  0.794683137e-03_r8
+  real(r8), parameter :: b3 =  0.121211669e-04_r8
+  real(r8), parameter :: b4 =  0.103354611e-06_r8
+  real(r8), parameter :: b5 =  0.404125005e-09_r8
+  real(r8), parameter :: b6 = -0.788037859e-12_r8
+  real(r8), parameter :: b7 = -0.114596802e-13_r8
+  real(r8), parameter :: b8 =  0.381294516e-16_r8
+  ! For ice (temperature range -75C-0C)
+  real(r8), parameter :: c0 =  6.11123516_r8
+  real(r8), parameter :: c1 =  0.503109514_r8
+  real(r8), parameter :: c2 =  0.188369801e-01_r8
+  real(r8), parameter :: c3 =  0.420547422e-03_r8
+  real(r8), parameter :: c4 =  0.614396778e-05_r8
+  real(r8), parameter :: c5 =  0.602780717e-07_r8
+  real(r8), parameter :: c6 =  0.387940929e-09_r8
+  real(r8), parameter :: c7 =  0.149436277e-11_r8
+  real(r8), parameter :: c8 =  0.262655803e-14_r8
+  ! For derivative:ice
+  real(r8), parameter :: d0 =  0.503277922_r8
+  real(r8), parameter :: d1 =  0.377289173e-01_r8
+  real(r8), parameter :: d2 =  0.126801703e-02_r8
+  real(r8), parameter :: d3 =  0.249468427e-04_r8
+  real(r8), parameter :: d4 =  0.313703411e-06_r8
+  real(r8), parameter :: d5 =  0.257180651e-08_r8
+  real(r8), parameter :: d6 =  0.133268878e-10_r8
+  real(r8), parameter :: d7 =  0.394116744e-13_r8
+  real(r8), parameter :: d8 =  0.498070196e-16_r8
+
 contains
-
-
 
   !-----------------------------------------------------------------------
   subroutine QSat (T, p, es, esdT, qs, qsdT)
@@ -94,8 +93,8 @@ contains
     if (td >= 0.0_r8) then
        es   = a0 + td*(a1 + td*(a2 + td*(a3 + td*(a4 &
             + td*(a5 + td*(a6 + td*(a7 + td*a8)))))))
-            
-      esdT = b0 + td*(b1 + td*(b2 + td*(b3 + td*(b4 &
+
+       esdT = b0 + td*(b1 + td*(b2 + td*(b3 + td*(b4 &
             + td*(b5 + td*(b6 + td*(b7 + td*b8)))))))
 
     else
@@ -111,7 +110,7 @@ contains
 
     esdT  = esdT  * 100._r8            ! pa/K
 
-    
+
     vp    = 1.0_r8   / (p - 0.378_r8*es)
     vp1   = 0.622_r8 * vp
     vp2   = vp1   * vp

--- a/src/biogeophys/QSatMod.F90
+++ b/src/biogeophys/QSatMod.F90
@@ -12,7 +12,6 @@ module QSatMod
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: QSat
-  public :: rhoSat
   !-----------------------------------------------------------------------
 
     ! For water vapor (temperature range 0C-100C)
@@ -123,45 +122,4 @@ contains
 
   end subroutine QSat
 
-
-  
-!-------------------------------------------------------------------------------
-  subroutine rhoSat(T, rho, rhodT)
-  ! compute the saturated vapor pressure density and its derivative against the temperature
-  ! jyt
-  use clm_varcon,    only: rwat
-  use shr_const_mod, only: SHR_CONST_TKFRZ
-
-  implicit none
-  real(r8), intent(in) :: T
-  real(r8), intent(out) :: rho
-  real(r8), optional, intent(out) :: rhodT
-    
-
-  !------------------
-    
-  real(r8) :: T_limit
-  real(r8) :: td, es, esdT
-  
-  T_limit = T - SHR_CONST_TKFRZ
-  if (T_limit > 100.0_r8) T_limit=100.0_r8
-  if (T_limit < -75.0_r8) T_limit=-75.0_r8
-
-  td       = T_limit
-  if (td >= 0.0_r8) then
-    es   = a0 + td*(a1 + td*(a2 + td*(a3 + td*(a4 &
-            + td*(a5 + td*(a6 + td*(a7 + td*a8)))))))
-    esdT = b0 + td*(b1 + td*(b2 + td*(b3 + td*(b4 &
-            + td*(b5 + td*(b6 + td*(b7 + td*b8)))))))
-  else
-    es   = c0 + td*(c1 + td*(c2 + td*(c3 + td*(c4 &
-            + td*(c5 + td*(c6 + td*(c7 + td*c8)))))))
-    esdT = d0 + td*(d1 + td*(d2 + td*(d3 + td*(d4 &
-            + td*(d5 + td*(d6 + td*(d7 + td*d8)))))))
-  endif
-
-  es    = es    * 100._r8            ! pa
-  rho   = es/(rwat*T)                !kg  m^-3
-  if(present(rhodT))rhodT= esdT/(rwat*T)-rho/T         !kg  m^-3 K^-1
-  end subroutine rhoSat  
 end module QSatMod

--- a/src/biogeophys/SurfaceHumidityMod.F90
+++ b/src/biogeophys/SurfaceHumidityMod.F90
@@ -65,9 +65,7 @@ contains
     integer  :: fp           ! lake filter patch index
     integer  :: fc           ! lake filter column index
     real(r8) :: qred         ! soil surface relative humidity
-    real(r8) :: eg           ! water vapor pressure at temperature T [pa]
     real(r8) :: qsatg        ! saturated humidity [kg/kg]
-    real(r8) :: degdT        ! d(eg)/dT
     real(r8) :: qsatgdT      ! d(qsatg)/dT
     real(r8) :: qsatgdT_snow ! d(qsatg)/dT, for snow
     real(r8) :: qsatgdT_soil ! d(qsatg)/dT, for soil
@@ -184,7 +182,8 @@ contains
          ! compute humidities individually for snow, soil, h2osfc for vegetated landunits
          if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
 
-            call QSat(t_soisno(c,1) , forc_pbot(c), eg, degdT, qsatg, qsatgdT_soil)
+            call QSat(t_soisno(c,1), forc_pbot(c), qsatg, &
+                 qsdT = qsatgdT_soil)
             if (qsatg > forc_q(c) .and. forc_q(c) > hr*qsatg) then
                qsatg = forc_q(c)
                qsatgdT_soil = 0._r8
@@ -192,7 +191,8 @@ contains
             qg_soil(c) = hr*qsatg
 
             if (snl(c) < 0) then
-               call QSat(t_soisno(c,snl(c)+1), forc_pbot(c), eg, degdT, qsatg, qsatgdT_snow)
+               call QSat(t_soisno(c,snl(c)+1), forc_pbot(c), qsatg, &
+                    qsdT = qsatgdT_snow)
                qg_snow(c) = qsatg
                dqgdT(c) = frac_sno_eff(c)*qsatgdT_snow + &
                     (1._r8 - frac_sno_eff(c) - frac_h2osfc(c))*hr*qsatgdT_soil
@@ -204,7 +204,8 @@ contains
             endif
 
             if (frac_h2osfc(c) > 0._r8) then
-               call QSat(t_h2osfc(c), forc_pbot(c), eg, degdT, qsatg, qsatgdT_h2osfc)
+               call QSat(t_h2osfc(c), forc_pbot(c), qsatg, &
+                    qsdT = qsatgdT_h2osfc)
                qg_h2osfc(c) = qsatg
                dqgdT(c) = dqgdT(c) + frac_h2osfc(c) * qsatgdT_h2osfc
             else
@@ -215,7 +216,8 @@ contains
                  + frac_h2osfc(c) * qg_h2osfc(c)
 
          else
-            call QSat(t_grnd(c), forc_pbot(c), eg, degdT, qsatg, qsatgdT)
+            call QSat(t_grnd(c), forc_pbot(c), qsatg, &
+                 qsdT = qsatgdT)
             qg(c) = qred*qsatg
             dqgdT(c) = qred*qsatgdT
 

--- a/src/biogeophys/UrbanFluxesMod.F90
+++ b/src/biogeophys/UrbanFluxesMod.F90
@@ -210,9 +210,7 @@ contains
     integer  :: indexl                                               ! index of first found in search loop
     integer  :: nstep                                                ! time step number
     real(r8) :: e_ref2m                                              ! 2 m height surface saturated vapor pressure [Pa]
-    real(r8) :: de2mdT                                               ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
     real(r8) :: qsat_ref2m                                           ! 2 m height surface saturated specific humidity [kg/kg]
-    real(r8) :: dqsat2mdT                                            ! derivative of 2 m height surface saturated specific humidity on t_ref2m
     !
     real(r8), parameter :: lapse_rate = 0.0098_r8 ! Dry adiabatic lapse rate (K/m)
     integer , parameter  :: niters = 3            ! maximum number of iterations for surface temperature
@@ -887,7 +885,8 @@ contains
 
          ! 2 m height relative humidity
 
-         call QSat(t_ref2m(p), forc_pbot(g), e_ref2m, de2mdT, qsat_ref2m, dqsat2mdT)
+         call QSat(t_ref2m(p), forc_pbot(g), qsat_ref2m, &
+              es = e_ref2m)
          rh_ref2m(p) = min(100._r8, q_ref2m(p) / qsat_ref2m * 100._r8)
          rh_ref2m_u(p) = rh_ref2m(p)
 

--- a/src/biogeophys/test/HumanStress_test/test_humanstress.pf
+++ b/src/biogeophys/test/HumanStress_test/test_humanstress.pf
@@ -51,14 +51,14 @@ contains
     real(r8) :: shum   ! specific humidity
 
     real(r8) :: Teq, epott, sat_vapor
-    real(r8) :: esdT, qsdT
     real(r8) :: es_mb, de_mbdT, dlnes_mbdT, rs, rsdT, foftk, fdT
 
     pres = 100000._r8
 
     temp =  50._r8 + SHR_CONST_TKFRZ
     rh   = 100.0_r8
-    call QSat (temp, pres, sat_vapor, esdT, rs, qsdT)
+    call QSat (temp, pres, rs, &
+         es = sat_vapor)
     call VaporPres( rh, sat_vapor, vapor )
     call VaporPres( rh, rs, shum )
     call Wet_Bulb (temp,vapor,pres,rh,shum,Teq,epott,wbt)
@@ -66,7 +66,8 @@ contains
 
     temp =  59._r8 + SHR_CONST_TKFRZ
     rh   =  65.0_r8
-    call QSat (temp, pres, sat_vapor, esdT, rs, qsdT)
+    call QSat (temp, pres, rs, &
+         es = sat_vapor)
     call VaporPres( rh, sat_vapor, vapor )
     call VaporPres( rh, rs, shum )
     call Wet_Bulb (temp,vapor,pres,rh,shum,Teq,epott,wbt)
@@ -78,7 +79,8 @@ contains
        do while ( pres > 85000._r8 )
           temp =  53._r8 + SHR_CONST_TKFRZ
           do while ( temp > SHR_CONST_TKFRZ-127.0 )
-             call QSat (temp, pres, sat_vapor, esdT, rs, qsdT)
+             call QSat (temp, pres, rs, &
+                  es = sat_vapor)
              call VaporPres( rh, sat_vapor, vapor )
              call VaporPres( rh, rs, shum )
              call Wet_Bulb (temp,vapor,pres,rh,shum,Teq,epott,wbt)
@@ -110,7 +112,6 @@ contains
     real(r8) :: shum   ! specific humidity
 
     real(r8) :: Teq, epott, sat_vapor
-    real(r8) :: esdT, qsdT
     real(r8) :: es_mb, de_mbdT, dlnes_mbdT, rs, rsdT, foftk, fdT
 
     rh = 1.0_r8
@@ -119,7 +120,8 @@ contains
        do while ( pres < 110000._r8 )
           temp =  53._r8 + SHR_CONST_TKFRZ
           do while ( temp <= SHR_CONST_TKFRZ+58.0 )
-             call QSat (temp, pres, sat_vapor, esdT, rs, qsdT)
+             call QSat (temp, pres, rs, &
+                  es = sat_vapor)
              call VaporPres( rh, sat_vapor, vapor )
              call VaporPres( rh, rs, shum )
              write(*,*) 'temp, pres, rh : ', temp-SHR_CONST_TKFRZ, pres, rh

--- a/src/main/atm2lndMod.F90
+++ b/src/main/atm2lndMod.F90
@@ -128,10 +128,9 @@ contains
     ! temporaries for topo downscaling
     real(r8) :: hsurf_g,hsurf_c
     real(r8) :: Hbot, zbot
-    real(r8) :: tbot_g, pbot_g, thbot_g, qbot_g, qs_g, es_g, rhos_g
-    real(r8) :: tbot_c, pbot_c, thbot_c, qbot_c, qs_c, es_c, rhos_c
+    real(r8) :: tbot_g, pbot_g, thbot_g, qbot_g, qs_g, rhos_g
+    real(r8) :: tbot_c, pbot_c, thbot_c, qbot_c, qs_c, rhos_c
     real(r8) :: rhos_c_estimate, rhos_g_estimate
-    real(r8) :: dum1,   dum2
 
     character(len=*), parameter :: subname = 'downscale_forcings'
     !-----------------------------------------------------------------------
@@ -223,8 +222,8 @@ contains
 
          thbot_c= thbot_g + (tbot_c - tbot_g)*exp((zbot/Hbot)*(rair/cpair))  ! pot temp calc
 
-         call Qsat(tbot_g,pbot_g,es_g,dum1,qs_g,dum2)
-         call Qsat(tbot_c,pbot_c,es_c,dum1,qs_c,dum2)
+         call Qsat(tbot_g,pbot_g,qs_g)
+         call Qsat(tbot_c,pbot_c,qs_c)
 
          qbot_c = qbot_g*(qs_c/qs_g)
 


### PR DESCRIPTION
### Description of changes

Make most QSat output arguments optional

This has two benefits:

(1) It prevents callers from needing to create dummy variables to hold
    outputs that they don't actually need.

(2) If neither qsdT nor esdT are needed, then we can avoid doing some
    expensive calculations.

This is partly for the benefit of #1086 

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
- `SMS_D_Ld1_P4x1.f10_f10_musgs.I2000Clm50BgcCropQianRsGs.bishorn_gnu.clm-default` with comparison against master (bfb)
- `PFS_Ld20.f09_g17.I2000Clm50BgcCrop.cheyenne_intel` underway to look at performance changes, if any
