### PR TITLE
Adjust FV3/SE PE layouts

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ required = True
 local_path = components/cism
 protocol = git
 repo_url = https://github.com/ESCOMP/CISM-wrapper
-tag = cism2_1_68
+tag = cism2_1_69
 externals = Externals_CISM.cfg
 required = True
 
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.8.28
+tag = cime5.8.30
 externals = ../Externals_cime.cfg
 required = True
 

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -5,6 +5,13 @@ repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = src/drivers/nuopc/
 required = True
 
+[fox]
+hash = 0ed59c1
+protocol = git
+repo_url = https://github.com/ESMCI/fox.git
+local_path = src/externals/fox
+required = True
+
 [cdeps]
 hash = cfc5345
 protocol = git

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -13,7 +13,7 @@ local_path = src/externals/fox
 required = True
 
 [cdeps]
-hash = cfc5345
+hash = d7b8a4c8e1b7cbff88da5bdb782ab715de62468a
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = src/components/cdeps

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -1,19 +1,12 @@
 [cmeps]
-hash = 9376b87
+hash = cab9030
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = src/drivers/nuopc/
 required = True
 
-[fox]
-hash = 0ed59c1
-protocol = git
-repo_url = https://github.com/ESMCI/fox.git
-local_path = src/externals/fox
-required = True
-
 [cdeps]
-hash = 8e77759
+hash = cfc5345
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = src/components/cdeps

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -138,9 +138,9 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 893;
+my $ntests = 901;
 if ( defined($opts{'compare'}) ) {
-   $ntests += 549;
+   $ntests += 555;
 }
 plan( tests=>$ntests );
 
@@ -333,6 +333,8 @@ $mode = "-phys $phys";
 foreach my $options ( 
                       "-res ne0np4.ARCTIC.ne30x4 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
                       "-res ne0np4.ARCTICGRIS.ne30x8 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
+                      "-res 1.9x2.5 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
+                      "-res 0.9x1.25 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
                       "-res 0.9x1.25 -bgc bgc -crop -use_case 20thC_transient -namelist '&a start_ymd=19500101/' -lnd_tuning_mode clm5_0_cam6.0",
                       "-res ne0np4CONUS.ne30x8 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20130101/' -lnd_tuning_mode clm5_0_cam6.0",
                       "-res 1.9x2.5 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20030101/' -lnd_tuning_mode clm5_0_cam6.0",

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -154,8 +154,8 @@
        particularly relevant for single-point cases (where datm dominates the
        runtime) -->
   <compset>
-    <alias>I2000Clm50BgcCropQianGs</alias>
-    <lname>2000_DATM%QIA_CLM50%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <alias>I2000Clm50BgcCropQianRsGs</alias>
+    <lname>2000_DATM%QIA_CLM50%BGC-CROP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing - when we want builds and runs to be as
@@ -176,6 +176,11 @@
     <lname>2000_DATM%CRUv7_CLM50%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>I2000Clm50BgcCruRsGs</alias>
+    <lname>2000_DATM%CRUv7_CLM50%BGC_SICE_SOCN_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- Primarily for testing -->
   <compset>
     <alias>I2000Clm50SpRtmFl</alias>
@@ -194,8 +199,8 @@
 
   <!-- Stub glacier needed for regional / single-point -->
   <compset>
-    <alias>I2000Clm50FatesGs</alias>
-    <lname>2000_DATM%GSWP3v1_CLM50%FATES_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <alias>I2000Clm50FatesRsGs</alias>
+    <lname>2000_DATM%GSWP3v1_CLM50%FATES_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -259,6 +264,11 @@
     <lname>HIST_DATM%QIA_CLM50%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>IHistClm50BgcQianRsGs</alias>
+    <lname>HIST_DATM%QIA_CLM50%BGC_SICE_SOCN_SROF_SGLC_SWAV</lname>
+  </compset>
+
   <!-- Future scenario compsets -->
   <compset>
     <alias>ISSP585Clm50BgcCrop</alias>
@@ -306,14 +316,14 @@
        particularly relevant for single-point cases (where datm dominates the
        runtime) -->
   <compset>
-    <alias>IHistClm50BgcCropQianGs</alias>
-    <lname>HIST_DATM%QIA_CLM50%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <alias>IHistClm50BgcCropQianRsGs</alias>
+    <lname>HIST_DATM%QIA_CLM50%BGC-CROP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing (stub glc needed for single-point tests) -->
   <compset>
-    <alias>IHistClm50BgcCropGs</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <alias>IHistClm50BgcCropRsGs</alias>
+    <lname>HIST_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing, not entirely sure this configure works -->
@@ -326,8 +336,8 @@
        faster datm throughput, which is particularly relevant for single-point
        cases (where datm dominates the runtime) -->
   <compset>
-    <alias>I2000Clm50BgcDvCropQianGs</alias>
-    <lname>2000_DATM%QIA_CLM50%BGCDV-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <alias>I2000Clm50BgcDvCropQianRsGs</alias>
+    <lname>2000_DATM%QIA_CLM50%BGCDV-CROP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
 <!-- I cpl history MOAR forcing spinup compsets -->
@@ -388,8 +398,8 @@
        faster datm throughput, which is particularly relevant for single-point
        cases (where datm dominates the runtime) -->
   <compset>
-    <alias>IHistClm45BgcCropQianGs</alias>
-    <lname>HIST_DATM%QIA_CLM45%BGC-CROP_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <alias>IHistClm45BgcCropQianRsGs</alias>
+    <lname>HIST_DATM%QIA_CLM45%BGC-CROP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -414,8 +424,8 @@
   </compset>
 
   <compset>
-    <alias>I2000Clm45FatesGs</alias>
-    <lname>2000_DATM%GSWP3v1_CLM45%FATES_SICE_SOCN_RTM_SGLC_SWAV</lname>
+    <alias>I2000Clm45FatesRsGs</alias>
+    <lname>2000_DATM%GSWP3v1_CLM45%FATES_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -483,7 +483,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="l%ne0np4.ARCTICGRIS.ne30x8" >
+  <grid name="l%ne0np4.ARCTICGRIS.ne30" >
     <mach name="any">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -520,7 +520,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="l%ne0np4.ARCTICGRIS.ne30x8" >
+  <grid name="l%ne0np4.ARCTICGRIS.ne30" >
     <mach name="cheyenne">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -557,7 +557,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="l%ne0np4.ARCTIC.ne30x4" >
+  <grid name="l%ne0np4.ARCTIC.ne30" >
     <mach name="any">
       <pes pesize="any" compset="any">
         <comment>none</comment>
@@ -594,7 +594,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="l%ne0np4.ARCTIC.ne30x4" >
+  <grid name="l%ne0np4.ARCTIC.ne30" >
     <mach name="cheyenne">
       <pes pesize="any" compset="any">
         <comment>none</comment>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -452,13 +452,13 @@
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-150</ntasks_lnd>
-          <ntasks_rof>-150</ntasks_rof>
-          <ntasks_ice>-150</ntasks_ice>
-          <ntasks_ocn>-150</ntasks_ocn>
-          <ntasks_glc>-150</ntasks_glc>
-          <ntasks_wav>-150</ntasks_wav>
-          <ntasks_cpl>-150</ntasks_cpl>
+          <ntasks_lnd>-70</ntasks_lnd>
+          <ntasks_rof>-70</ntasks_rof>
+          <ntasks_ice>-70</ntasks_ice>
+          <ntasks_ocn>-70</ntasks_ocn>
+          <ntasks_glc>-70</ntasks_glc>
+          <ntasks_wav>-70</ntasks_wav>
+          <ntasks_cpl>-70</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -526,13 +526,13 @@
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-150</ntasks_lnd>
-          <ntasks_rof>-150</ntasks_rof>
-          <ntasks_ice>-150</ntasks_ice>
-          <ntasks_ocn>-150</ntasks_ocn>
-          <ntasks_glc>-150</ntasks_glc>
-          <ntasks_wav>-150</ntasks_wav>
-          <ntasks_cpl>-150</ntasks_cpl>
+          <ntasks_lnd>-70</ntasks_lnd>
+          <ntasks_rof>-70</ntasks_rof>
+          <ntasks_ice>-70</ntasks_ice>
+          <ntasks_ocn>-70</ntasks_ocn>
+          <ntasks_glc>-70</ntasks_glc>
+          <ntasks_wav>-70</ntasks_wav>
+          <ntasks_cpl>-70</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -600,13 +600,13 @@
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>-1</ntasks_atm>
-          <ntasks_lnd>-150</ntasks_lnd>
-          <ntasks_rof>-150</ntasks_rof>
-          <ntasks_ice>-150</ntasks_ice>
-          <ntasks_ocn>-150</ntasks_ocn>
-          <ntasks_glc>-150</ntasks_glc>
-          <ntasks_wav>-150</ntasks_wav>
-          <ntasks_cpl>-150</ntasks_cpl>
+          <ntasks_lnd>-70</ntasks_lnd>
+          <ntasks_rof>-70</ntasks_rof>
+          <ntasks_ice>-70</ntasks_ice>
+          <ntasks_ocn>-70</ntasks_ocn>
+          <ntasks_glc>-70</ntasks_glc>
+          <ntasks_wav>-70</ntasks_wav>
+          <ntasks_cpl>-70</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -414,14 +414,88 @@
       <pes pesize="any" compset="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>-8</ntasks_atm>
-          <ntasks_lnd>-8</ntasks_lnd>
-          <ntasks_rof>-8</ntasks_rof>
-          <ntasks_ice>-8</ntasks_ice>
-          <ntasks_ocn>-8</ntasks_ocn>
-          <ntasks_glc>-8</ntasks_glc>
-          <ntasks_wav>-8</ntasks_wav>
-          <ntasks_cpl>-8</ntasks_cpl>
+          <ntasks_atm>-12</ntasks_atm>
+          <ntasks_lnd>-12</ntasks_lnd>
+          <ntasks_rof>-12</ntasks_rof>
+          <ntasks_ice>-12</ntasks_ice>
+          <ntasks_ocn>-12</ntasks_ocn>
+          <ntasks_glc>-12</ntasks_glc>
+          <ntasks_wav>-12</ntasks_wav>
+          <ntasks_cpl>-12</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%ne0np4CONUS" >
+    <mach name="cheyenne">
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-150</ntasks_lnd>
+          <ntasks_rof>-150</ntasks_rof>
+          <ntasks_ice>-150</ntasks_ice>
+          <ntasks_ocn>-150</ntasks_ocn>
+          <ntasks_glc>-150</ntasks_glc>
+          <ntasks_wav>-150</ntasks_wav>
+          <ntasks_cpl>-150</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>-1</rootpe_lnd>
+          <rootpe_rof>-1</rootpe_rof>
+          <rootpe_ice>-1</rootpe_ice>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_glc>-1</rootpe_glc>
+          <rootpe_wav>-1</rootpe_wav>
+          <rootpe_cpl>-1</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%ne0np4.ARCTICGRIS.ne30x8" >
+    <mach name="any">
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>-12</ntasks_atm>
+          <ntasks_lnd>-12</ntasks_lnd>
+          <ntasks_rof>-12</ntasks_rof>
+          <ntasks_ice>-12</ntasks_ice>
+          <ntasks_ocn>-12</ntasks_ocn>
+          <ntasks_glc>-12</ntasks_glc>
+          <ntasks_wav>-12</ntasks_wav>
+          <ntasks_cpl>-12</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -447,18 +521,55 @@
     </mach>
   </grid>
   <grid name="l%ne0np4.ARCTICGRIS.ne30x8" >
+    <mach name="cheyenne">
+      <pes pesize="any" compset="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-150</ntasks_lnd>
+          <ntasks_rof>-150</ntasks_rof>
+          <ntasks_ice>-150</ntasks_ice>
+          <ntasks_ocn>-150</ntasks_ocn>
+          <ntasks_glc>-150</ntasks_glc>
+          <ntasks_wav>-150</ntasks_wav>
+          <ntasks_cpl>-150</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>-1</rootpe_lnd>
+          <rootpe_rof>-1</rootpe_rof>
+          <rootpe_ice>-1</rootpe_ice>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_glc>-1</rootpe_glc>
+          <rootpe_wav>-1</rootpe_wav>
+          <rootpe_cpl>-1</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%ne0np4.ARCTIC.ne30x4" >
     <mach name="any">
       <pes pesize="any" compset="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>-8</ntasks_atm>
-          <ntasks_lnd>-8</ntasks_lnd>
-          <ntasks_rof>-8</ntasks_rof>
-          <ntasks_ice>-8</ntasks_ice>
-          <ntasks_ocn>-8</ntasks_ocn>
-          <ntasks_glc>-8</ntasks_glc>
-          <ntasks_wav>-8</ntasks_wav>
-          <ntasks_cpl>-8</ntasks_cpl>
+          <ntasks_atm>-12</ntasks_atm>
+          <ntasks_lnd>-12</ntasks_lnd>
+          <ntasks_rof>-12</ntasks_rof>
+          <ntasks_ice>-12</ntasks_ice>
+          <ntasks_ocn>-12</ntasks_ocn>
+          <ntasks_glc>-12</ntasks_glc>
+          <ntasks_wav>-12</ntasks_wav>
+          <ntasks_cpl>-12</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -484,18 +595,18 @@
     </mach>
   </grid>
   <grid name="l%ne0np4.ARCTIC.ne30x4" >
-    <mach name="any">
+    <mach name="cheyenne">
       <pes pesize="any" compset="any">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>-8</ntasks_atm>
-          <ntasks_lnd>-8</ntasks_lnd>
-          <ntasks_rof>-8</ntasks_rof>
-          <ntasks_ice>-8</ntasks_ice>
-          <ntasks_ocn>-8</ntasks_ocn>
-          <ntasks_glc>-8</ntasks_glc>
-          <ntasks_wav>-8</ntasks_wav>
-          <ntasks_cpl>-8</ntasks_cpl>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_lnd>-150</ntasks_lnd>
+          <ntasks_rof>-150</ntasks_rof>
+          <ntasks_ice>-150</ntasks_ice>
+          <ntasks_ocn>-150</ntasks_ocn>
+          <ntasks_glc>-150</ntasks_glc>
+          <ntasks_wav>-150</ntasks_wav>
+          <ntasks_cpl>-150</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -509,13 +620,13 @@
         </nthrds>
         <rootpe>
           <rootpe_atm>0</rootpe_atm>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>0</rootpe_ocn>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_lnd>-1</rootpe_lnd>
+          <rootpe_rof>-1</rootpe_rof>
+          <rootpe_ice>-1</rootpe_ice>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_glc>-1</rootpe_glc>
+          <rootpe_wav>-1</rootpe_wav>
+          <rootpe_cpl>-1</rootpe_cpl>
         </rootpe>
       </pes>
     </mach>
@@ -599,6 +710,43 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
+	  <ntasks_atm>-12</ntasks_atm>
+	  <ntasks_lnd>-12</ntasks_lnd>
+	  <ntasks_rof>-12</ntasks_rof>
+	  <ntasks_ice>-12</ntasks_ice>
+	  <ntasks_ocn>-12</ntasks_ocn>
+	  <ntasks_glc>-12</ntasks_glc>
+	  <ntasks_wav>-12</ntasks_wav>
+	  <ntasks_cpl>-12</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%C96" >
+    <mach name="cheyenne">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
 	  <ntasks_atm>1152</ntasks_atm>
 	  <ntasks_lnd>864</ntasks_lnd>
 	  <ntasks_rof>864</ntasks_rof>
@@ -626,6 +774,43 @@
 	  <rootpe_ocn>1152</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>1408</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%C192" >
+    <mach name="any">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-24</ntasks_atm>
+	  <ntasks_lnd>-24</ntasks_lnd>
+	  <ntasks_rof>-24</ntasks_rof>
+	  <ntasks_ice>-24</ntasks_ice>
+	  <ntasks_ocn>-24</ntasks_ocn>
+	  <ntasks_glc>-24</ntasks_glc>
+	  <ntasks_wav>-24</ntasks_wav>
+	  <ntasks_cpl>-24</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
@@ -668,8 +853,45 @@
       </pes>
     </mach>
   </grid>
-  <grid name="l%C384">
+  <grid name="l%C384" >
     <mach name="any">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-48</ntasks_atm>
+	  <ntasks_lnd>-48</ntasks_lnd>
+	  <ntasks_rof>-48</ntasks_rof>
+	  <ntasks_ice>-48</ntasks_ice>
+	  <ntasks_ocn>-48</ntasks_ocn>
+	  <ntasks_glc>-48</ntasks_glc>
+	  <ntasks_wav>-48</ntasks_wav>
+	  <ntasks_cpl>-48</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="l%C384">
+    <mach name="cheyenne">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -747,34 +747,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1152</ntasks_atm>
-	  <ntasks_lnd>864</ntasks_lnd>
-	  <ntasks_rof>864</ntasks_rof>
-	  <ntasks_ice>288</ntasks_ice>
-	  <ntasks_ocn>256</ntasks_ocn>
-	  <ntasks_glc>1152</ntasks_glc>
-	  <ntasks_wav>32</ntasks_wav>
-	  <ntasks_cpl>1152</ntasks_cpl>
+	  <ntasks_atm>-1</ntasks_atm>
+	  <ntasks_lnd>-48</ntasks_lnd>
+	  <ntasks_rof>-48</ntasks_rof>
+	  <ntasks_ice>-48</ntasks_ice>
+	  <ntasks_ocn>-48</ntasks_ocn>
+	  <ntasks_glc>-48</ntasks_glc>
+	  <ntasks_wav>-48</ntasks_wav>
+	  <ntasks_cpl>-48</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>864</rootpe_ice>
-	  <rootpe_ocn>1152</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>1408</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
+	  <rootpe_lnd>-1</rootpe_lnd>
+	  <rootpe_rof>-1</rootpe_rof>
+	  <rootpe_ice>-1</rootpe_ice>
+	  <rootpe_ocn>-1</rootpe_ocn>
+	  <rootpe_glc>-1</rootpe_glc>
+	  <rootpe_wav>-1</rootpe_wav>
+	  <rootpe_cpl>-1</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -817,38 +817,38 @@
     </mach>
   </grid>
   <grid name="l%C192" >
-    <mach name="any">
+    <mach name="cheyenne">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1152</ntasks_atm>
-	  <ntasks_lnd>864</ntasks_lnd>
-	  <ntasks_rof>864</ntasks_rof>
-	  <ntasks_ice>288</ntasks_ice>
-	  <ntasks_ocn>256</ntasks_ocn>
-	  <ntasks_glc>1152</ntasks_glc>
-	  <ntasks_wav>32</ntasks_wav>
-	  <ntasks_cpl>1152</ntasks_cpl>
+	  <ntasks_atm>-1</ntasks_atm>
+	  <ntasks_lnd>-48</ntasks_lnd>
+	  <ntasks_rof>-48</ntasks_rof>
+	  <ntasks_ice>-48</ntasks_ice>
+	  <ntasks_ocn>-48</ntasks_ocn>
+	  <ntasks_glc>-48</ntasks_glc>
+	  <ntasks_wav>-48</ntasks_wav>
+	  <ntasks_cpl>-48</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>3</nthrds_atm>
-	  <nthrds_lnd>3</nthrds_lnd>
-	  <nthrds_rof>3</nthrds_rof>
-	  <nthrds_ice>3</nthrds_ice>
-	  <nthrds_ocn>3</nthrds_ocn>
-	  <nthrds_glc>3</nthrds_glc>
-	  <nthrds_wav>3</nthrds_wav>
-	  <nthrds_cpl>3</nthrds_cpl>
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>864</rootpe_ice>
-	  <rootpe_ocn>1152</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>1408</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
+	  <rootpe_lnd>-1</rootpe_lnd>
+	  <rootpe_rof>-1</rootpe_rof>
+	  <rootpe_ice>-1</rootpe_ice>
+	  <rootpe_ocn>-1</rootpe_ocn>
+	  <rootpe_glc>-1</rootpe_glc>
+	  <rootpe_wav>-1</rootpe_wav>
+	  <rootpe_cpl>-1</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -895,14 +895,14 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>3456</ntasks_atm>
-	  <ntasks_lnd>3456</ntasks_lnd>
-	  <ntasks_rof>3456</ntasks_rof>
-	  <ntasks_ice>3456</ntasks_ice>
-	  <ntasks_ocn>3456</ntasks_ocn>
-	  <ntasks_glc>3456</ntasks_glc>
-	  <ntasks_wav>3456</ntasks_wav>
-	  <ntasks_cpl>3456</ntasks_cpl>
+	  <ntasks_atm>-1</ntasks_atm>
+	  <ntasks_lnd>-96</ntasks_lnd>
+	  <ntasks_rof>-96</ntasks_rof>
+	  <ntasks_ice>-96</ntasks_ice>
+	  <ntasks_ocn>-96</ntasks_ocn>
+	  <ntasks_glc>-96</ntasks_glc>
+	  <ntasks_wav>-96</ntasks_wav>
+	  <ntasks_cpl>-96</ntasks_cpl>
 	</ntasks>
 	<nthrds>
 	  <nthrds_atm>1</nthrds_atm>
@@ -916,13 +916,13 @@
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
+	  <rootpe_lnd>-1</rootpe_lnd>
+	  <rootpe_rof>-1</rootpe_rof>
+	  <rootpe_ice>-1</rootpe_ice>
+	  <rootpe_ocn>-1</rootpe_ocn>
+	  <rootpe_glc>-1</rootpe_glc>
+	  <rootpe_wav>-1</rootpe_wav>
+	  <rootpe_cpl>-1</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1159,13 +1159,14 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_Ln9" grid="ne0ARCTICne30x4_ne0ARCTICne30x4_mt12" compset="IHistClm50Sp" testmods="clm/clm50cam6LndTuningMode_1979Start">
+  <test name="ERS_Ln9" grid="ne0ARCTICne30x4_ne0ARCTICne30x4_mt12" compset="IHistClm50SpGs" testmods="clm/clm50cam6LndTuningMode_1979Start">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment"  >Run ARCTIC for transient case starting in 1979 as for AMIP CAM cases"</option>
+      <option name="comment"  >Run ARCTIC for transient case starting in 1979 as for AMIP CAM cases, be sure to run with stub GLC
+for ERS test as otherwise it won't work for a sub-day test"</option>
     </options>
   </test>
   <test name="SMS_Ln9" grid="ne0ARCTICGRISne30x8_ne0ARCTICGRISne30x8_mt12" compset="IHistClm50Sp" testmods="clm/clm50cam6LndTuningMode_1979Start">

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -17,7 +17,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERI_D_Ld9" grid="1x1_camdenNJ" compset="I2000Clm50BgcCruGs" testmods="clm/default">
+  <test name="ERI_D_Ld9" grid="1x1_camdenNJ" compset="I2000Clm50BgcCruRsGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
@@ -916,7 +916,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Ld7_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropGs" testmods="clm/decStart1851_noinitial">
+  <test name="ERS_D_Ld7_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropRsGs" testmods="clm/decStart1851_noinitial">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -950,7 +950,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_Lm20_Mmpi-serial" grid="1x1_smallvilleIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/monthly_noinitial">
+  <test name="ERS_Lm20_Mmpi-serial" grid="1x1_smallvilleIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/monthly_noinitial">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
@@ -959,7 +959,7 @@
       <option name="comment"  >tests mid-year restart, with the restart file being written in the middle of the first year after cold start initialization</option>
     </options>
   </test>
-  <test name="ERS_Ly5_Mmpi-serial" grid="1x1_smallvilleIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/ciso_monthly">
+  <test name="ERS_Ly5_Mmpi-serial" grid="1x1_smallvilleIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/ciso_monthly">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
@@ -968,7 +968,7 @@
       <option name="comment"  >multi-year test with crops and isotopes that includes all crop types; added (2020-05-21) in order to test the new switchgrass and miscanthus crops (which otherwise aren't currently tested)</option>
     </options>
   </test>
-  <test name="ERS_Lm40_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/monthly">
+  <test name="ERS_Lm40_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/monthly">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
@@ -977,7 +977,7 @@
       <option name="comment"  >tests mid-year restart, with the restart file being written in the middle of the second year</option>
     </options>
   </test>
-  <test name="ERS_Lm54_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="ERS_Lm54_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -986,7 +986,7 @@
       <option name="comment"  >tests mid-year restart, with the restart file being written after more than 2 years, which Sam Levis says is important for testing crop restarts</option>
     </options>
   </test>
-  <test name="ERS_Ly20_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="ERS_Ly20_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1005,7 +1005,7 @@
       <option name="comment"  >Include a long ERS test of the cmip6 configuration, though at coarse resolution. This gives a year+ test covering the output_crop usermod, which is something we want: if this is removed, we should add a test of at least a year duration covering the output_crop usermod. This test needs to use init_interp to work, because of adding virtual Antarctica columns (currently the default out-of-the-box setting uses init_interp for this).</option>
     </options>
   </test>
-  <test name="ERS_Ly3_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="ERS_Ly3_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropQianRsGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
@@ -1023,7 +1023,7 @@
       <option name="comment"  >Multi-year global test of transient crops together with transient glaciers. Use glacier evolution with ERS test</option>
     </options>
   </test>
-  <test name="ERS_Ly5_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/monthly">
+  <test name="ERS_Ly5_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/monthly">
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
     </machines>
@@ -1049,7 +1049,7 @@
       <option name="comment"  >include a long Clm45 test, and include a production intel test of Clm45</option>
     </options>
   </test>
-  <test name="ERS_Ly6_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="ERS_Ly6_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropQianRsGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1382,7 +1382,7 @@
       <option name="comment"  >Want a test of the c13 and c14 timeseries that crosses the year boundary. Ideally this test would include crops (in order to cover as much code as possible combined with the c13/c14 timeseries, even though there are no direct interactions between these timeseries and crops), but crop DecStart tests currently fail because of https://github.com/ESCOMP/ctsm/issues/404 and I didn't want to add another long test just to test these options, so for now using a compset without crops. Using a compset with SGLC to avoid problems with CISM in DecStart tests; the only IHistClm50Bgc compset we have with SGLC is this Qian compset, so I'm using this one.</option>
     </options>
   </test>
-  <test name="SMS_D_Ly6_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm45BgcCropQianGs" testmods="clm/cropMonthOutput">
+  <test name="SMS_D_Ly6_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm45BgcCropQianRsGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1566,7 +1566,7 @@
       <option name="comment"  >Long enough test for SMB to be generated in bare land areas; add a month beyond the 3rd year to allow time for CLM to respond to CISM forcing from the 3rd year. (Note: if we had spun-up initial conditions for an IG compset, we could test this with much shorter test, if it also used the glc override options - much of the need for this long test is to allow the snow pack to spin up.)</option>
     </options>
   </test>
-  <test name="SMS_Ly3_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianGs" testmods="clm/clm50dynroots">
+  <test name="SMS_Ly3_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcCropQianRsGs" testmods="clm/clm50dynroots">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
@@ -1575,7 +1575,7 @@
       <option name="wallclock">01:40:00</option>
     </options>
   </test>
-  <test name="SMS_Ly3_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcDvCropQianGs" testmods="clm/ignor_warn_cropMonthOutputColdStart">
+  <test name="SMS_Ly3_Mmpi-serial" grid="1x1_numaIA" compset="I2000Clm50BgcDvCropQianRsGs" testmods="clm/ignor_warn_cropMonthOutputColdStart">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
@@ -1664,7 +1664,7 @@
       <option name="wallclock">00:40:00</option>
     </options>
   </test>
-  <test name="ERS_D_Mmpi-serial_Ld5" grid="1x1_brazil" compset="I2000Clm45FatesGs" testmods="clm/FatesColdDef">
+  <test name="ERS_D_Mmpi-serial_Ld5" grid="1x1_brazil" compset="I2000Clm45FatesRsGs" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
@@ -1681,7 +1681,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Mmpi-serial_Ld5" grid="1x1_brazil" compset="I2000Clm50FatesGs" testmods="clm/FatesColdDef">
+  <test name="ERS_D_Mmpi-serial_Ld5" grid="1x1_brazil" compset="I2000Clm50FatesRsGs" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
@@ -1931,7 +1931,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Mmpi-serial_Ld5" grid="1x1_brazil" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
+  <test name="ERS_D_Mmpi-serial_Ld5" grid="1x1_brazil" compset="I2000Clm50FatesCruRsGs" testmods="clm/Fates">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
       <machine name="izumi" compiler="nag" category="fates"/>
@@ -1998,7 +1998,7 @@
       <option name="comment"  >Run a short non-Fates test (without land-ice model) in the fates test list, to make sure fates changes do not mess up the standard model</option>
     </options>
   </test>
-  <test name="SMS_Ly2" grid="1x1_brazil" compset="I2000Clm45FatesGs" testmods="clm/Fates">
+  <test name="SMS_Ly2" grid="1x1_brazil" compset="I2000Clm45FatesRsGs" testmods="clm/Fates">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -2038,7 +2038,7 @@
       </machine>
     </machines>
   </test>
-  <test name="SMS_Ly1_Mmpi-serial" grid="1x1_brazil" compset="IHistClm50BgcQianGs" testmods="clm/output_bgc_highfreq">
+  <test name="SMS_Ly1_Mmpi-serial" grid="1x1_brazil" compset="IHistClm50BgcQianRsGs" testmods="clm/output_bgc_highfreq">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm">
         <options>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1618,7 +1618,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="SMS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm45FatesGs" testmods="clm/FatesColdDef">
+  <test name="SMS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm45FatesRsGs" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
@@ -1627,7 +1627,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="SMS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm50FatesGs" testmods="clm/FatesColdDef">
+  <test name="SMS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm50FatesRsGs" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
@@ -1673,7 +1673,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm45FatesGs" testmods="clm/FatesColdDef">
+  <test name="ERS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm45FatesRsGs" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1691,7 +1691,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm50FatesGs" testmods="clm/FatesColdDef">
+  <test name="ERS_D_Mmpi-serial_Ld5" grid="5x5_amazon" compset="I2000Clm50FatesRsGs" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -53,7 +53,7 @@
       <option name="comment">Ran a basic test for fv3 C96 standard resolution</option>
     </options>
   </test>
-  <test name="ERI_D_Ld9" grid="ne30_g16" compset="I2000Clm50BgcCruGs" testmods="clm/vrtlay">
+  <test name="ERI_D_Ld9" grid="ne30_g17" compset="I2000Clm50BgcCruGs" testmods="clm/vrtlay">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -223,7 +223,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D_Ld5" grid="ne30_g16" compset="I1850Clm50BgcCrop" testmods="clm/default">
+  <test name="ERP_D_Ld5" grid="ne30_g17" compset="I1850Clm50BgcCrop" testmods="clm/default">
     <machines>
       <machine name="izumi" compiler="nag" category="prealpha"/>
     </machines>
@@ -1105,7 +1105,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="PEM_D_Ld5" grid="ne30_g16" compset="I2000Clm50BgcCruGs" testmods="clm/default">
+  <test name="PEM_D_Ld5" grid="ne30_g17" compset="I2000Clm50BgcCruGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
@@ -1327,7 +1327,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="SMS_N2_D_Lh12" grid="f09_g16" compset="I2000Clm50SpGs" testmods="clm/pauseResume">
+  <test name="SMS_N2_D_Lh12" grid="f09_g17" compset="I2000Clm50SpGs" testmods="clm/pauseResume">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1874,7 +1874,7 @@
 
     </machines>
   </test>
-  <test name="ERP_D_Ld3" grid="f19_g16" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
+  <test name="ERP_D_Ld3" grid="f19_g17" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -1882,7 +1882,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D_P15x2_Ld3" grid="f19_g16" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
+  <test name="ERP_D_P15x2_Ld3" grid="f19_g17" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -1890,7 +1890,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_Ld3" grid="f09_g16" compset="I2000Clm45Fates" testmods="clm/FatesColdDef">
+  <test name="ERP_Ld3" grid="f09_g17" compset="I2000Clm45Fates" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -1907,7 +1907,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Ld3" grid="f19_g16" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
+  <test name="ERS_D_Ld3" grid="f19_g17" compset="I2000Clm50FatesCruGs" testmods="clm/Fates">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -1915,7 +1915,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Ld5" grid="f19_g16" compset="I2000Clm45Fates" testmods="clm/default">
+  <test name="ERS_D_Ld5" grid="f19_g17" compset="I2000Clm45Fates" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -1923,7 +1923,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_D_Ld5" grid="f19_g16" compset="I2000Clm50FatesCruGs" testmods="clm/default">
+  <test name="ERS_D_Ld5" grid="f19_g17" compset="I2000Clm50FatesCruGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>
@@ -1940,7 +1940,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="f19_g16" compset="I2000Clm45Fates" testmods="clm/FatesColdDef">
+  <test name="ERS_Ld5" grid="f19_g17" compset="I2000Clm45Fates" testmods="clm/FatesColdDef">
     <machines>
       <machine name="cheyenne" compiler="intel" category="fates"/>
     </machines>

--- a/cime_config/testdefs/testmods_dirs/clm/waccmx_offline/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/waccmx_offline/shell_commands
@@ -1,3 +1,4 @@
 ./xmlchange USE_ESMF_LIB=TRUE,ATM_NCPL=288,CALENDAR=GREGORIAN,ROF_NCPL='$ATM_NCPL',LND_TUNING_MODE="clm5_0_cam6.0"
 ./xmlchange CLM_BLDNML_OPTS="-megan -drydep" --append
+./xmlchange RUN_STARTDATE=1979-01-01
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,118 @@
 ===============================================================
+Tag name:  ctsm1.0.dev108
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date: Wed Aug 19 17:23:47 MDT 2020
+One-line Summary:  Update default PE layouts for new SE/FV3 grids
+
+Purpose of changes
+------------------
+
+Change PE layouts for new high resolution SE/FV3 grids. Have a version for cheyenne and a default one
+as well.
+
+Update externals: cime, cism, CMEPS, CDEPS
+Change single point tests to use stub ROF
+Change tests to use gx1v7 rather than gx1v6
+Update waccmx_offline to use START=1979
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): 
+  Fixes #1108 Change single point tests to use stub ROF
+  Fixes #1098 ARCTICGRIS PE layout is very slow
+  Fixes #1105 Default new FV3/SE grid PE layouts are problematic
+  Fixes #1103 Some changes to prevent missing file for WACCMX testing
+  Fixes #1113 ARCTIC test is failing
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations? No
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values): None
+
+Changes to the datasets (e.g., parameter, surface or initial files): None
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+   Some tests were chagned to use stub ROF and one to stub GLC. @billsacks suggest we should also change
+   other tests in this same way.
+
+Changes to tests or testing: Yes
+
+Code reviewed by: self
+
+
+CTSM testing: regular, tools
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS
+
+  tools-tests (test/tools):
+
+    cheyenne - PASS
+
+  PTCLM testing (tools/shared/PTCLM/test):
+
+    cheyenne - OK
+
+  python testing (see instructions in python/README.md; document testing done):
+
+   cheyenne -- PASS
+
+  regular tests (aux_clm):
+
+    cheyenne ---- PASS
+    izumi ------- PASS
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: No (except for waccmx_offline test)
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): cime, cism, CDEPS, CMEPS
+   cism to cism2_1_69
+   cime to cime5.8.30
+   Update hash for CDEPS and CMEPS (so that nuopc test will run)
+
+Pull Requests that document the changes (include PR ids): #1111
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #1111 -- Adjust FV3/SE PE layouts
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev107
 Originator(s):  erik (Erik Kluzek)
 Date: Mon Aug 10 02:21:12 MDT 2020

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev108     erik 08/19/2020  Update default PE layouts for new SE/FV3 grids
   ctsm1.0.dev107     erik 08/10/2020 Answer changes needed for CESM2.2.0
   ctsm1.0.dev106     erik 08/06/2020 Bit-for-bit updates for the CESM2.2.0 release
 release-clm5.0.34    erik 04/20/2020 Update doc for release-clm5.0 (SKIPPED), and fix issues with no-anthro surface dataset creation


### PR DESCRIPTION
### Description of changes

Get reasonable PE layouts for the new FV3/SE grids.
Update cism external
Update cime external
Change single point tests to use stub ROF
Change tests to use gx1v7 rather than gx1v6
Update waccmx_offline to use START=1979

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):

Fixes #1108
Fixes #1098
Fixes #1105
Fixes #1103
Fixes #1113

Are answers expected to change (and if so in what way)? No (other than waccmx_offline test)

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: regular