### PR TITLE
Update cime so default end year for GSWP3 forcing is 2013 and change prevyr default for vcmax/jmax

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -26,6 +26,13 @@ repo_url = https://github.com/ESCOMP/MOSART
 tag = mosart1_0_37
 required = True
 
+[cdeps]
+hash = 45b7a85
+protocol = git
+repo_url = https://github.com/ESCOMP/CDEPS.git
+local_path = components/cdeps
+required = True
+
 [cime]
 local_path = cime
 protocol = git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,7 +30,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.8.30
+tag = cime5.8.31
 externals = ../Externals_cime.cfg
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -37,7 +37,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime5.8.31
+tag = branch_tags/cime5.8.31_a01
 externals = ../Externals_cime.cfg
 required = True
 

--- a/Externals_cime.cfg
+++ b/Externals_cime.cfg
@@ -1,22 +1,8 @@
 [cmeps]
-hash = cab9030
+hash = 7654038
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = src/drivers/nuopc/
-required = True
-
-[fox]
-hash = 0ed59c1
-protocol = git
-repo_url = https://github.com/ESMCI/fox.git
-local_path = src/externals/fox
-required = True
-
-[cdeps]
-hash = d7b8a4c8e1b7cbff88da5bdb782ab715de62468a
-protocol = git
-repo_url = https://github.com/ESCOMP/CDEPS.git
-local_path = src/components/cdeps
 required = True
 
 [externals_description]

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1207,7 +1207,8 @@ sub setup_cmdl_run_type {
     if ($opts->{$var} eq "default" ) {
       add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var, 
                   'use_cndv'=>$nl_flags->{'use_cndv'}, 'use_fates'=>$nl_flags->{'use_fates'},
-                  'sim_year'=>$st_year );
+                  'sim_year'=>$st_year, 'sim_year_range'=>$nl_flags->{'sim_year_range'}, 
+                  'bgc_spinup'=>$nl_flags->{'bgc_spinup'} );
     } else {
       my $group = $definition->get_group_name($var);
       $nl->set_variable_value($group, $var, quote_string( $opts->{$var} ) );

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -530,15 +530,19 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTICGRIS.ne30x8">.true.</use_init_interp>
 <!-- 2003 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2003" lnd_tuning_mode="clm5_0_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"             >.true.</use_init_interp>
+                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"                 >.true.</use_init_interp>
 
 <!-- 2013 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2013" lnd_tuning_mode="clm5_0_cam6.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4CONUS.ne30x8"      >.true.</use_init_interp>
-<!-- For an inexact match use either low resolution or high resolution match for SP or BGC mode CLM4.5 and CLM5.0 -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"                                >.true.</use_init_interp>
+<!-- For an inexact match use either low resolution or high resolution match for SP or BGC mode CLM5.0 -->
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  phys="clm5_0"                     >.true.</use_init_interp>
+<!-- For an inexact match use either low resolution or high resolution match for SP or BGC mode CLM4.5 -->
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  lnd_tuning_mode="clm4_5_GSWP3v1"  >.true.</use_init_interp>
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  lnd_tuning_mode="clm4_5_CRUv7"    >.true.</use_init_interp>
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979"  lnd_tuning_mode="clm4_5_cam6.0"   >.true.</use_init_interp>
 <!-- Default to FALSE if couldn't find a match -->
-<use_init_interp                                                                                        >.false.</use_init_interp>
+<use_init_interp                                                                                            >.false.</use_init_interp>
 <!-- NOTE: if use_init_interp is FALSE that indicates that you can't interpolate from an initial conditions file that's similar 
            Either an existing file is too different, too different in the year, or a configuration that can't interpolate
            initial condition files.
@@ -593,8 +597,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
 </init_interp_attributes>
 
-<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm4_5_cam6.0"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm4_5_cam6.0"
+>hgrid=0.9x1.25 maxpft=17 mask=gx1v7 use_cn=.false. use_nitrif_denitrif=.false. use_vertsoilc=.false. use_crop=.false. irrigate=.true. glc_nec=10
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_GSWP3v1"
@@ -806,6 +810,13 @@ p
 </finidat>
 
 <!-- Present day no crop spinup f09/f19 grid with irrigation on -->
+<finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101" use_nitrif_denitrif=".false." use_vertsoilc=".false." sim_year="1979"
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
+         lnd_tuning_mode="clm4_5_cam6.0"
+>lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
+</finidat>
+
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101" use_nitrif_denitrif=".false." use_vertsoilc=".false." sim_year="1979"
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -138,9 +138,9 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 901;
+my $ntests = 949;
 if ( defined($opts{'compare'}) ) {
-   $ntests += 555;
+   $ntests += 591;
 }
 plan( tests=>$ntests );
 
@@ -327,36 +327,38 @@ foreach my $options ( "-configuration nwp",
 print "\n===============================================================================\n";
 print "Test some CAM specific setups for special grids \n";
 print "=================================================================================\n";
-$phys = "clm5_0";
-$mode = "-phys $phys";
-&make_config_cache($phys);
-foreach my $options ( 
-                      "-res ne0np4.ARCTIC.ne30x4 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res ne0np4.ARCTICGRIS.ne30x8 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res 1.9x2.5 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res 0.9x1.25 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res 0.9x1.25 -bgc bgc -crop -use_case 20thC_transient -namelist '&a start_ymd=19500101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res ne0np4CONUS.ne30x8 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20130101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res 1.9x2.5 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20030101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res 1.9x2.5 -bgc sp -use_case 2010_control -namelist '&a start_ymd=20100101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res C192 -bgc sp -use_case 2010_control -namelist '&a start_ymd=20100101/' -lnd_tuning_mode clm5_0_cam6.0",
-                      "-res ne0np4.ARCTIC.ne30x4 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20130101/' -lnd_tuning_mode clm5_0_cam6.0",
+foreach my $phys ( "clm4_5", "clm5_0" ) {
+   $mode = "-phys $phys";
+   &make_config_cache($phys);
+   foreach my $options ( 
+                      "-res ne0np4.ARCTIC.ne30x4 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res ne0np4.ARCTICGRIS.ne30x8 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res 1.9x2.5 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res 0.9x1.25 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res 0.9x1.25 -bgc bgc -crop -use_case 20thC_transient -namelist '&a start_ymd=19500101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res ne0np4CONUS.ne30x8 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20130101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res 1.9x2.5 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20030101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res 1.9x2.5 -bgc sp -use_case 2010_control -namelist '&a start_ymd=20100101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res 1x1_brazil -bgc fates -no-megan -use_case 2000_control -lnd_tuning_mode ${phys}_CRUv7",
+                      "-res C192 -bgc sp -use_case 2010_control -namelist '&a start_ymd=20100101/' -lnd_tuning_mode ${phys}_cam6.0",
+                      "-res ne0np4.ARCTIC.ne30x4 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20130101/' -lnd_tuning_mode ${phys}_cam6.0",
                      ) {
-   &make_env_run();
-   eval{ system( "$bldnml -envxml_dir . $options > $tempfile 2>&1 " ); };
-   is( $@, '', "options: $options" );
-   $cfiles->checkfilesexist( "$options", $mode );
-   $cfiles->shownmldiff( "default", $mode );
-   if ( defined($opts{'compare'}) ) {
-      $cfiles->doNOTdodiffonfile( "$tempfile", "$options", $mode );
-      $cfiles->dodiffonfile(      "lnd_in",    "$options", $mode );
-      $cfiles->dodiffonfile( "$real_par_file", "$options", $mode );
-      $cfiles->comparefiles( "$options", $mode, $opts{'compare'} );
+      &make_env_run();
+      eval{ system( "$bldnml -envxml_dir . $options > $tempfile 2>&1 " ); };
+      is( $@, '', "options: $options" );
+      $cfiles->checkfilesexist( "$options", $mode );
+      $cfiles->shownmldiff( "default", $mode );
+      if ( defined($opts{'compare'}) ) {
+         $cfiles->doNOTdodiffonfile( "$tempfile", "$options", $mode );
+         $cfiles->dodiffonfile(      "lnd_in",    "$options", $mode );
+         $cfiles->dodiffonfile( "$real_par_file", "$options", $mode );
+         $cfiles->comparefiles( "$options", $mode, $opts{'compare'} );
+      }
+      if ( defined($opts{'generate'}) ) {
+         $cfiles->copyfiles( "$options", $mode );
+      }
+      &cleanup();
    }
-   if ( defined($opts{'generate'}) ) {
-      $cfiles->copyfiles( "$options", $mode );
-   }
-   &cleanup();
 }
 
 print "\n==============================================================\n";

--- a/bld/unit_testers/xFail/expectedFail.pm
+++ b/bld/unit_testers/xFail/expectedFail.pm
@@ -428,7 +428,7 @@ sub _readXml
    # Add $cfgdir to the list of paths that Perl searches for modules
    my @dirs = ( $cfgdir, "$cfgdir/perl5lib",
                "$cfgdir/../../cime/utils/perl5lib",
-               "$cfgdir/../../../cime/utils/perl5lib"
+               "$cfgdir/../../../../cime/utils/perl5lib"
        );
    unshift @INC, @dirs;
    my $result = eval "require XML::Lite";

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,116 @@
 ===============================================================
+Tag name:  ctsm1.0.dev111
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date: Fri Aug 28 14:08:25 MDT 2020
+One-line Summary: Compsets don't use 2014 for GSWP3 forcing, LUNA prevyr changed back
+
+Purpose of changes
+------------------
+
+Update cime so that default end year for GSWP3 forcing is 2013 because 2014 data is bad. Also update
+the prevyr default for vcmax/jmax to what it was before ctsm1.0.dev102.
+
+Fix some issues for finding initial condition files for Clm45 compsets. Also bring in updated CDEPS/CMEPS
+as they were required with the cime update.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): 
+  Fixes #1107 -- Change initial values of LUNA back to previous global values
+  Fixes #1067 -- Stop using PIO2 in the LILAC build
+  Fixes #1121 -- FMOZ test fails
+
+CIME Issues fixed (include issue #): 
+   Fixes ESMCI/cime#3683 -- Avoid artificial limit on string lengths in shr_string_listMerge
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+   Last time-step in Dec/2013 for GSWP3 data still has zero humidity
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values): None
+
+Changes to the datasets (e.g., parameter, surface or initial files): None
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance): 
+   cime is pointing to a branch_tag we should update it to a trunk tag as soon as possible
+
+Changes to tests or testing: build-namelist unit testing improved to find problems like #1121 a #1125
+
+Code reviewed by: self
+
+
+CTSM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (all identical to previous tag)
+
+  tools-tests (test/tools):
+
+    cheyenne - PASS
+
+  python testing (see instructions in python/README.md; document testing done):
+
+   cheyenne - PASS
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    izumi ------- PASS
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes 
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: (2010 and SSP compsets) and Clm50 with LUNA on (Bgc or Sp)
+    - what platforms/compilers: All
+    - nature of change: similar climate
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): cime, cmeps, cdeps
+   (fox removed as a separate checkout)
+   cime to branch_tags/cime5.8.31_a01
+
+Pull Requests that document the changes (include PR ids):  #1114
+(https://github.com/ESCOMP/ctsm/pull)
+   #1114 -- Update cime so default end year for GSWP3 forcing is 2013 and change prevyr default for vcmax/jmax
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev110
 Originator(s): jedwards (Jim Edwards)
 Date:  Fri Aug 21 10:49:08 MDT 2020

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm1.0.dev111     erik 08/28/2020 Compsets don't use 2014 for GSWP3 forcing, LUNA prevyr changed back
   ctsm1.0.dev110 jedwards 08/21/2020 Fixes needed for PIO2
   ctsm1.0.dev109   negins 08/20/2020 Allow for resorbtion in transition from live to dead wood N
   ctsm1.0.dev108     erik 08/19/2020  Update default PE layouts for new SE/FV3 grids

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -346,8 +346,8 @@ contains
       ! statements.
       allocate(this%vcmx25_z_patch  (begp:endp,1:nlevcan)) ; this%vcmx25_z_patch    (:,:) = 30._r8
       allocate(this%jmx25_z_patch   (begp:endp,1:nlevcan)) ; this%jmx25_z_patch     (:,:) = 60._r8 
-      allocate(this%vcmx_prevyr     (begp:endp,1:nlevcan)) ; this%vcmx_prevyr       (:,:) = 85._r8
-      allocate(this%jmx_prevyr      (begp:endp,1:nlevcan)) ; this%jmx_prevyr        (:,:) = 50._r8
+      allocate(this%vcmx_prevyr     (begp:endp,1:nlevcan)) ; this%vcmx_prevyr       (:,:) = 30._r8
+      allocate(this%jmx_prevyr      (begp:endp,1:nlevcan)) ; this%jmx_prevyr        (:,:) = 60._r8
       allocate(this%pnlc_z_patch    (begp:endp,1:nlevcan)) ; this%pnlc_z_patch      (:,:) = 0.01_r8
       allocate(this%fpsn24_patch    (begp:endp))           ; this%fpsn24_patch      (:)   = nan
       allocate(this%enzs_z_patch    (begp:endp,1:nlevcan)) ; this%enzs_z_patch      (:,:) = 1._r8


### PR DESCRIPTION
### Description of changes

Update cime so that default end year for GSWP3 forcing is 2013 because 2014 data is bad. Also update
the prevyr default for vcmax/jmax to what it was before ctsm1.0.dev102.

Fix some issues for finding initial condition files for Clm45 compsets. Also bring in updated CDEPS/CMEPS 
as they were required with the cime update.

### Specific notes

Contributors other than yourself, if any: @wwieder 

CTSM Issues Fixed (include github issue #): #1107 
  Fixes #1107 
  Fixes #1067
  Fixes #1121

Are answers expected to change (and if so in what way)? Yes
  2010 and SSP compsets may change because of end year
   Clm50 compsets with cold starts may change answers because of prevyr change (both Sp and Bgc)

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: Ran a few tests, will run whole test suite
  Need to wait on cime tag

