### PR TITLE
Move mksurfdata_map rounding of special landunits to before wetland fill

### DIFF
--- a/tools/mksurfdata_map/README.developers
+++ b/tools/mksurfdata_map/README.developers
@@ -207,7 +207,7 @@ And here are some things to check for when making new landuse.timeseries
 datasets (which often happens at the same time, and most of the above applies
 as well):
 
-- Compare one of the productive resolution datasets to a previous version.
+- Compare one of the production resolution datasets to a previous version.
 
   - If part of it should be identical (for example the historical period) make
     sure it is identical as expected (using cprnc make sure the historical period

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -711,6 +711,18 @@ program mksurfdat
 
     do n = 1,ns_o
 
+       ! Truncate all percentage fields on output grid. This is needed to
+       ! insure that wt is zero (not a very small number such as
+       ! 1e-16) where it really should be zero
+       
+       do k = 1,nlevsoi
+          pctsand(n,k) = float(nint(pctsand(n,k)))
+          pctclay(n,k) = float(nint(pctclay(n,k)))
+       end do
+       pctlak(n) = float(nint(pctlak(n)))
+       pctwet(n) = float(nint(pctwet(n)))
+       pctgla(n) = float(nint(pctgla(n)))
+       
        ! Assume wetland, glacier and/or lake when dataset landmask implies ocean 
        ! (assume medium soil color (15) and loamy texture).
        ! Also set pftdata_mask here
@@ -734,18 +746,6 @@ program mksurfdat
           pftdata_mask(n) = 1
        end if
 
-       ! Truncate all percentage fields on output grid. This is needed to
-       ! insure that wt is zero (not a very small number such as
-       ! 1e-16) where it really should be zero
-       
-       do k = 1,nlevsoi
-          pctsand(n,k) = float(nint(pctsand(n,k)))
-          pctclay(n,k) = float(nint(pctclay(n,k)))
-       end do
-       pctlak(n) = float(nint(pctlak(n)))
-       pctwet(n) = float(nint(pctwet(n)))
-       pctgla(n) = float(nint(pctgla(n)))
-       
        ! Make sure sum of land cover types does not exceed 100. If it does,
        ! subtract excess from most dominant land cover.
        


### PR DESCRIPTION
### Description of changes

I think this may be important to avoid errors and/or wrong behavior in
some edge cases where we have < 0.5% cover of glacier and/or lake, and
other cases.

See https://github.com/ESCOMP/CTSM/issues/1118 for detailed thoughts

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Resolves #1118 

Are answers expected to change (and if so in what way)? Possible answer changes, but this should be rare

Any User Interface Changes (namelist or namelist defaults changes)? N

Testing performed, if any:

I created a subset of our standard surface datasets with `make -f Makefile.data global-present` before and after this change. The three surface datasets created in this way (f09, f19 and f10) were all bit-for-bit. There could be answer changes in rare cases, but this demonstrates that I haven't majorly broken anything with this change.
- Update (2020-08-27): as noted below, I also compared f45.