### PR TITLE
Record run_sys_tests command-line

### DIFF
--- a/python/ctsm/run_sys_tests.py
+++ b/python/ctsm/run_sys_tests.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import argparse
 import logging
 import os
+import sys
 import subprocess
 from datetime import datetime
 
@@ -434,6 +435,7 @@ def _record_git_status(testroot, dry_run):
             now_str = now.strftime("%m%d-%H%M%S")
             git_status_filepath = git_status_filepath + '_' + now_str
         with open(git_status_filepath, 'w') as git_status_file:
+            git_status_file.write(' '.join(sys.argv) + '\n\n')
             git_status_file.write("SRCROOT: {}\n".format(ctsm_root))
             git_status_file.write(output)
 


### PR DESCRIPTION
I sometimes find myself wanting to check what options I provided to run_sys_tests after the fact. This change records this information in the SRCROOT_GIT_STATUS file. I admit that it's not obvious from the file name that this is the place to look for this information, but it seemed silly to create a second file just for this purpose, especially because there are some complexities in creating this file (in case you are rerunning in an existing directory). If people prefer, we could change the name of this file to something else.

@ekluzek @negin513 @slevisconsulting I wanted to point this out to you. Feel free to comment, but don't feel a need to. I'll merge directly to master unless any of you object.