### PR TITLE
updates to current surfdata & landuse files in tools/contrib

### DIFF
--- a/tools/contrib/singlept
+++ b/tools/contrib/singlept
@@ -145,11 +145,12 @@ fdomain  = dir_inputdata+'share/domains/domain.lnd.fv0.9x1.25_gx1v7.151020.nc'
 fdomain2 = dir_output + AddTagToFilename( fdomain, tag )
 
 #--  Specify surface data file  --------------------------------
-fsurf    = dir_inputdata+'lnd/clm2/surfdata_map/surfdata_0.9x1.25_16pfts_CMIP6_simyr1850_c170706.nc'
+fsurf    = dir_inputdata+'lnd/clm2/surfdata_map/release-clm5.0.18/surfdata_0.9x1.25_hist_16pfts_Irrig_CMIP6_simyr2000_c190214.nc'
+
 fsurf2   = dir_output + AddTagToFilename( fsurf, tag )
 
 #--  Specify landuse file  -------------------------------------
-fluse    = dir_inputdata+'lnd/clm2/surfdata_map/landuse.timeseries_0.9x1.25_hist_16pfts_Irrig_CMIP6_simyr1850-2015_c170824.nc'
+fluse    = dir_inputdata+'lnd/clm2/surfdata_map/release-clm5.0.18/landuse.timeseries_0.9x1.25_hist_16pfts_Irrig_CMIP6_simyr1850-2015_c190214.nc'
 fluse2   = dir_output + AddTagToFilename( fluse, tag )
 
 #--  Specify datm domain file  ---------------------------------


### PR DESCRIPTION
### Description of changes
Updates sources of surfacedata and land use time series in tools/contrib
 
### Specific notes
updates source of data used by singlept script in tools/contrib directory.  

Not sure if we should also point to newer:
- datm forcing /glade/p/cgd/tss/CTSM_datm_forcing_data/atm_forcing.datm7.GSWP3.0.5d.v1.1.c181207
-surface data /glade/p/cesmdata/cseg/inputdata/lnd/clm2/surfdata_map/release-clm5.0*
  
Contributors other than yourself, if any:
NA

CTSM Issues Fixed (include github issue #):
Not sure how much these files with code modificatons?

Are answers expected to change (and if so in what way)?
NA

Any User Interface Changes (namelist or namelist defaults changes)?
NA

Testing performed, if any:
created new surface dataset for single point simulation

