### PR TITLE
Hydraulic redistribution

### DIFF
--- a/src/biogeophys/CanopyStateType.F90
+++ b/src/biogeophys/CanopyStateType.F90
@@ -48,6 +48,8 @@ module CanopyStateType
      real(r8) , pointer :: rscanopy_patch           (:)   ! patch canopy stomatal resistance (s/m) (ED specific)
 
      real(r8) , pointer :: vegwp_patch              (:,:) ! patch vegetation water matric potential (mm)
+     real(r8) , pointer :: vegwp_ln_patch           (:,:) ! patch vegetation water matric potential at local noon (mm)
+     real(r8) , pointer :: vegwp_pd_patch           (:,:) ! patch vegetation water matric potential from 12am-2am (mm)
 
      real(r8)           :: leaf_mr_vcm = spval            ! Scalar constant of leaf respiration with Vcmax
 
@@ -131,7 +133,8 @@ contains
     allocate(this%rscanopy_patch           (begp:endp))           ; this%rscanopy_patch           (:)   = nan
 !    allocate(this%gccanopy_patch           (begp:endp))           ; this%gccanopy_patch           (:)   = 0.0_r8     
     allocate(this%vegwp_patch              (begp:endp,1:nvegwcs)) ; this%vegwp_patch              (:,:) = nan
-
+    allocate(this%vegwp_ln_patch           (begp:endp,1:nvegwcs)) ; this%vegwp_ln_patch           (:,:) = nan
+    allocate(this%vegwp_pd_patch           (begp:endp,1:nvegwcs)) ; this%vegwp_pd_patch           (:,:) = nan
   end subroutine InitAllocate
 
   !-----------------------------------------------------------------------
@@ -243,6 +246,14 @@ contains
        call hist_addfld2d (fname='VEGWP',  units='mm', type2d='nvegwcs', &
             avgflag='A', long_name='vegetation water matric potential for sun/sha canopy,xyl,root segments', &
             ptr_patch=this%vegwp_patch)
+       this%vegwp_ln_patch(begp:endp,:) = spval
+       call hist_addfld2d (fname='VEGWPLN',  units='mm', type2d='nvegwcs', &
+            avgflag='A', long_name='vegetation water matric potential for sun/sha canopy,xyl,root at local noon', &
+            ptr_patch=this%vegwp_ln_patch)
+       this%vegwp_pd_patch(begp:endp,:) = spval
+       call hist_addfld2d (fname='VEGWPPD',  units='mm', type2d='nvegwcs', avgflag='A', &
+            long_name='vegetation water matric potential for sun/sha canopy,xyl,root for predawn (b/w 12 and 2am)', &
+            ptr_patch=this%vegwp_pd_patch)
     end if
 
   end subroutine InitHistory

--- a/src/biogeophys/CanopyStateType.F90
+++ b/src/biogeophys/CanopyStateType.F90
@@ -49,7 +49,7 @@ module CanopyStateType
 
      real(r8) , pointer :: vegwp_patch              (:,:) ! patch vegetation water matric potential (mm)
      real(r8) , pointer :: vegwp_ln_patch           (:,:) ! patch vegetation water matric potential at local noon (mm)
-     real(r8) , pointer :: vegwp_pd_patch           (:,:) ! patch vegetation water matric potential from 12am-2am (mm)
+     real(r8) , pointer :: vegwp_pd_patch           (:,:) ! patch predawn vegetation water matric potential (mm)
 
      real(r8)           :: leaf_mr_vcm = spval            ! Scalar constant of leaf respiration with Vcmax
 
@@ -252,7 +252,7 @@ contains
             ptr_patch=this%vegwp_ln_patch)
        this%vegwp_pd_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='VEGWPPD',  units='mm', type2d='nvegwcs', avgflag='A', &
-            long_name='vegetation water matric potential for sun/sha canopy,xyl,root for predawn (b/w 12 and 2am)', &
+            long_name='predawn vegetation water matric potential for sun/sha canopy,xyl,root', &
             ptr_patch=this%vegwp_pd_patch)
     end if
 

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -2740,6 +2740,7 @@ contains
          bbb        => photosyns_inst%bbb_patch              , & ! Output: [real(r8) (:)   ]  Ball-Berry minimum leaf conductance (umol H2O/m**2/s)
          mbb        => photosyns_inst%mbb_patch              , & ! Output: [real(r8) (:)   ]  Ball-Berry slope of conductance-photosynthesis relationship
          rh_leaf    => photosyns_inst%rh_leaf_patch          , & ! Output: [real(r8) (:)   ]  fractional humidity at leaf surface (dimensionless)
+         vpd_can    => photosyns_inst%vpd_can_patch          , & ! Output: [real(r8) (:)   ]  canopy vapor pressure deficit (kPa)
          lnc        => photosyns_inst%lnca_patch             , & ! Output: [real(r8) (:)   ]  top leaf layer leaf N concentration (gN leaf/m^2)
          light_inhibit=> photosyns_inst%light_inhibit        , & ! Input:  [logical        ]  flag if light should inhibit respiration
          leafresp_method=> photosyns_inst%leafresp_method    , & ! Input:  [integer        ]  method type to use for leaf-maint.-respiration at 25C canopy top
@@ -3288,6 +3289,7 @@ contains
                else if ( stomatalcond_mtd == stomatalcond_mtd_medlyn2011 )then
                   ! Put some constraints on RH in the canopy when Medlyn stomatal conductance is being used
                   rh_can = max((esat_tv(p) - ceair), 50._r8) * 0.001_r8
+                  vpd_can(p) = rh_can
                end if
 
                ! Electron transport rate for C3 plants. Convert par from W/m2 to
@@ -3631,7 +3633,7 @@ contains
     associate(                                                    &
          qflx_tran_veg => waterfluxbulk_inst%qflx_tran_veg_patch    , & ! Input:  [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)
          vegwp         => canopystate_inst%vegwp_patch           ,& ! Input/Output: [real(r8) (:,:) ]  vegetation water matric potential (mm)
-         vegwp_ln      => canopystate_inst%vegwp_ln_patch         & ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) at local noon
+         vegwp_ln      => canopystate_inst%vegwp_ln_patch        ,& ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) at local noon
          vegwp_pd      => canopystate_inst%vegwp_ln_patch         & ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) between midnight and 2am local time
     )
 

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -3563,7 +3563,7 @@ contains
     !
     !
     !!USES:
-    use clm_time_manager  , only : is_near_local_noon, get_local_time
+    use clm_time_manager  , only : is_near_local_noon
     !
     !! ARGUMENTS:
     implicit none
@@ -3633,8 +3633,7 @@ contains
     associate(                                                    &
          qflx_tran_veg => waterfluxbulk_inst%qflx_tran_veg_patch    , & ! Input:  [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)
          vegwp         => canopystate_inst%vegwp_patch           ,& ! Input/Output: [real(r8) (:,:) ]  vegetation water matric potential (mm)
-         vegwp_ln      => canopystate_inst%vegwp_ln_patch        ,& ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) at local noon
-         vegwp_pd      => canopystate_inst%vegwp_ln_patch         & ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) between midnight and 2am local time
+         vegwp_ln      => canopystate_inst%vegwp_ln_patch         & ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) at local noon
     )
 
     
@@ -3790,14 +3789,6 @@ contains
     else
        vegwp_ln(p,:) = spval
     end if
-
-    !write out predawn vwp (averaged over midnight to 2am)
-    if ( get_local_time( grc%londeg(g)) <= 7200._r8 )then
-       vegwp_pd(p,:) = vegwp(p,:)
-    else
-       vegwp_pd(p,:) = spval
-    end if
-
 
     if (soilflux<0._r8) soilflux = 0._r8
     qflx_tran_veg(p) = soilflux
@@ -4273,6 +4264,7 @@ contains
          tgcm          => temperature_inst%thm_patch            , & ! Input:  [real(r8) (:)   ]  air temperature at agcm reference height (kelvin)
          bsw           => soilstate_inst%bsw_col                , & ! Input:  [real(r8) (:,:) ]  Clapp and Hornberger "b"
          qflx_tran_veg => waterfluxbulk_inst%qflx_tran_veg_patch    , & ! Input:  [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)
+         vegwp_pd      => canopystate_inst%vegwp_pd_patch       , & ! Output: [real(r8) (:,:) ]  vegetation water matric potential (mm) at local noon
          sucsat        => soilstate_inst%sucsat_col               & ! Input:  [real(r8) (:,:) ]  minimum soil suction (mm)
          )
 
@@ -4411,6 +4403,9 @@ contains
             atm2lnd_inst, canopystate_inst, waterdiagnosticbulk_inst, soilstate_inst, temperature_inst)
        if (soilflux<0._r8) soilflux = 0._r8
        qflx_tran_veg(p) = soilflux
+       vegwp_pd(p,:) = x
+    else
+       vegwp_pd(p,:) = spval
     endif
     
     

--- a/src/biogeophys/SoilWaterPlantSinkMod.F90
+++ b/src/biogeophys/SoilWaterPlantSinkMod.F90
@@ -274,27 +274,30 @@ contains
         integer  :: pi                                                    ! patch index
         real(r8) :: temp(bounds%begc:bounds%endc)                         ! accumulator for rootr weighting
         real(r8) :: grav2                 ! soil layer gravitational potential relative to surface (mm H2O)
+        real(r8) :: patchflux             ! patch level soil-to-plant water flux (mm/s)
         integer , parameter :: soil=1,root=4  ! index values
         !-----------------------------------------------------------------------   
         
         associate(&
-              k_soil_root         => soilstate_inst%k_soil_root_patch   , & ! Input:  [real(r8) (:,:) ]  
+              k_soil_root            => soilstate_inst%k_soil_root_patch         , & ! Input:  [real(r8) (:,:) ]  
                                                                             ! soil-root interface conductance (mm/s)
-              qflx_phs_neg_col    => waterfluxbulk_inst%qflx_phs_neg_col    , & ! Input:  [real(r8) (:)   ]  n
-                                                                            ! net neg hydraulic redistribution flux(mm H2O/s)
-              qflx_tran_veg_col   => waterfluxbulk_inst%qflx_tran_veg_col   , & ! Input:  [real(r8) (:)   ]  
+              qflx_phs_neg_col       => waterfluxbulk_inst%qflx_phs_neg_col      , & ! Output:  [real(r8) (:)   ] 
+                                                                            ! net neg hydraulic redistribution flux col (mm H2O/s)
+              qflx_hydr_redist_patch => waterfluxbulk_inst%qflx_hydr_redist_patch, & ! Output:  [real(r8) (:)   ] 
+                                                                            ! net neg hydraulic redistribution flux patch (mm H2O/s)
+              qflx_tran_veg_col      => waterfluxbulk_inst%qflx_tran_veg_col     , & ! Input:  [real(r8) (:)   ]  
                                                                             ! vegetation transpiration (mm H2O/s) (+ = to atm)
-              qflx_tran_veg_patch => waterfluxbulk_inst%qflx_tran_veg_patch , & ! Input:  [real(r8) (:)   ]  
+              qflx_tran_veg_patch    => waterfluxbulk_inst%qflx_tran_veg_patch   , & ! Input:  [real(r8) (:)   ]  
                                                                             ! vegetation transpiration (mm H2O/s) (+ = to atm)
-              qflx_rootsoi_col    => waterfluxbulk_inst%qflx_rootsoi_col    , & ! Output: [real(r8) (:)   ]
+              qflx_rootsoi_col       => waterfluxbulk_inst%qflx_rootsoi_col      , & ! Output: [real(r8) (:)   ]
                                                                             ! col root and soil water 
                                                                             ! exchange [mm H2O/s] [+ into root]
-              smp                 => soilstate_inst%smp_l_col           , & ! Input:  [real(r8) (:,:) ]  soil matrix pot. [mm]
-              frac_veg_nosno      => canopystate_inst%frac_veg_nosno_patch , & ! Input:  [integer  (:)  ] 
+              smp                    => soilstate_inst%smp_l_col                 , & ! Input:  [real(r8) (:,:) ]  soil matrix pot. [mm]
+              frac_veg_nosno         => canopystate_inst%frac_veg_nosno_patch    , & ! Input:  [integer  (:)  ] 
                                                                             ! fraction of vegetation not 
                                                                             ! covered by snow (0 OR 1) [-]  
-              z                   => col%z                              , & ! Input: [real(r8) (:,:) ]  layer node depth (m)
-              vegwp               => canopystate_inst%vegwp_patch         & ! Input: [real(r8) (:,:) ]  vegetation water 
+              z                      => col%z                                    , & ! Input: [real(r8) (:,:) ]  layer node depth (m)
+              vegwp                  => canopystate_inst%vegwp_patch               & ! Input: [real(r8) (:,:) ]  vegetation water 
                                                                             ! matric potential (mm)
               )
           
@@ -308,10 +311,16 @@ contains
                 do pi = 1,max_patch_per_col
                    if (pi <= col%npatches(c)) then
                       p = col%patchi(c) + pi - 1
+                      if (j == 1) then
+                         qflx_hydr_redist_patch(p) = 0._r8
+                      end if
                       if (patch%active(p).and.frac_veg_nosno(p)>0) then 
                          if (patch%wtcol(p) > 0._r8) then
-                            temp(c) = temp(c) + k_soil_root(p,j) &
-                                  * (smp(c,j) - vegwp(p,4) - grav2)* patch%wtcol(p)
+                            patchflux = k_soil_root(p,j) * (smp(c,j) - vegwp(p,4) - grav2)
+                            if (patchflux <0) then
+                               qflx_hydr_redist_patch(p) = qflx_hydr_redist_patch(p) + patchflux
+                            end if
+                            temp(c) = temp(c) + patchflux * patch%wtcol(p)
                          endif
                       end if
                    end if

--- a/src/biogeophys/WaterFluxBulkType.F90
+++ b/src/biogeophys/WaterFluxBulkType.F90
@@ -40,6 +40,7 @@ module WaterFluxBulkType
 
      real(r8), pointer :: qflx_adv_col             (:,:) ! col advective flux across different soil layer interfaces [mm H2O/s] [+ downward]
      real(r8), pointer :: qflx_rootsoi_col         (:,:) ! col root and soil water exchange [mm H2O/s] [+ into root]
+     real(r8), pointer :: qflx_hydr_redist_patch   (:)   ! patch hydraulic redistribution [mm H2O/s]
      real(r8), pointer :: qflx_sat_excess_surf_col (:)   ! col surface runoff due to saturated surface (mm H2O /s)
      real(r8), pointer :: qflx_infl_excess_col     (:)   ! col infiltration excess runoff (mm H2O /s)
      real(r8), pointer :: qflx_infl_excess_surf_col(:)   ! col surface runoff due to infiltration excess (mm H2O /s)
@@ -112,8 +113,8 @@ contains
 
     allocate(this%qflx_snowindunload_patch (begp:endp))              ; this%qflx_snowindunload_patch (:)   = nan
     allocate(this%qflx_snotempunload_patch (begp:endp))              ; this%qflx_snotempunload_patch (:)   = nan
-
-    allocate(this%qflx_phs_neg_col         (begc:endc))              ; this%qflx_phs_neg_col       (:)   = nan
+    allocate(this%qflx_hydr_redist_patch   (begp:endp))              ; this%qflx_hydr_redist_patch   (:)   = nan
+    allocate(this%qflx_phs_neg_col         (begc:endc))              ; this%qflx_phs_neg_col         (:)   = nan
 
     allocate( this%qflx_ev_snow_patch      (begp:endp))              ; this%qflx_ev_snow_patch       (:)   = nan
     allocate( this%qflx_ev_snow_col        (begc:endc))              ; this%qflx_ev_snow_col         (:)   = nan
@@ -185,6 +186,14 @@ contains
          avgflag='A', &
          long_name=this%info%lname('water flux from soil to root in each soil-layer'), &
          ptr_col=this%qflx_rootsoi_col, set_spec=spval, l2g_scale_type='veg', default='inactive')
+
+    this%qflx_hydr_redist_patch(begp:endp) = spval
+    call hist_addfld1d ( &
+         fname=this%info%fname('QHR'),  &
+         units='mm/s', &
+         avgflag='A', &
+         long_name=this%info%lname('hydraulic redistribution'), &
+         ptr_patch=this%qflx_hydr_redist_patch, set_spec=spval, l2g_scale_type='veg', default='inactive')
 
     this%qflx_snowindunload_patch(begp:endp) = spval
     call hist_addfld1d ( &


### PR DESCRIPTION
### Description of changes
Adding four new history fields relevant to plant hydraulic processes:
 - QHR (patch-level hydraulic redistribution)
 - VEGWPLN (local noon vegetation water potential)
 - VEGWPPD (predawn vegetation water potential)
 - VPD_CAN: canopy vapor pressure deficit (functional input to Medlyn model)

CTSM Issues Fixed (include github issue #):
1123

Are answers expected to change (and if so in what way)?
No.

Any User Interface Changes (namelist or namelist defaults changes)?
No, except for the availability of new history fields.

Testing performed, if any:
--compset I2000Clm50Sp --res f09_g17_gl4
Ran a five-day global simulation to confirm that the new history fields were writing out as expected. Compared local noon and predawn vegwp to half-hourly vegwp (at one point) and found agreement between the daily average and the corresponding timeslices in the half-hourly output.
