### PR TITLE
Add --project argument to LILAC's create_newcase command

### DIFF
--- a/python/ctsm/lilac_build_ctsm.py
+++ b/python/ctsm/lilac_build_ctsm.py
@@ -606,6 +606,9 @@ def _create_case(cime_path, build_dir, compiler,
                           '--res', _RES,
                           '--compiler', compiler,
                           '--driver', 'nuopc',
+                          # Project isn't used for anything in the LILAC workflow, but it
+                          # still needs to be specified on machines that expect it.
+                          '--project', 'UNSET',
                           '--run-unsupported']
     create_newcase_cmd.extend(machine_args)
     if inputdata_path:


### PR DESCRIPTION
### Description of changes

Add --project argument to LILAC's create_newcase command

### Specific notes

This isn't needed by anything in the LILAC workflow, but cime requires it on machines that expect PROJECT to be set. I guess that, until now, everyone who was testing and using the LILAC workflow had PROJECT set in their environment, or a .cesm_proj file in their home directory. @glemieux ran into this issue, however, and it would likely affect others.

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
- python testing (on my mac)
- LILACSMOKE_Vnuopc_D_Ld2.f10_f10_musgs.I2000Ctsm50NwpSpAsRsGs.cheyenne_intel.clm-lilac

In my view, that is sufficient testing, since those are the only tests that would touch this code.

I ran the system test when I had temporarily unset PROJECT from the environment and removed my .cesm_proj file.