### PR TITLE
LILACSMOKE: Call case.load_env() before building the atm driver

### DIFF
--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -111,6 +111,12 @@ class LILACSMOKE(SystemTestsCommon):
             debug=str(self._case.get_value('DEBUG')).upper(),
             ctsm_mkfile=os.path.join(caseroot, 'lilac_build', 'ctsm.mk'))
         makecmd = 'make {makevars} atm_driver'.format(makevars=makevars)
+
+        # Normally the user will source either ctsm_build_environment.sh or
+        # ctsm_build_environment.csh before building the atmosphere model. In the context
+        # of this test case, case.load_env does the equivalent.
+        self._case.load_env()
+
         self._run_build_cmd(makecmd, blddir, 'atm_driver.bldlog')
 
     def _create_link_to_atm_driver(self):


### PR DESCRIPTION
### Description of changes

In LILACSMOKE test: Call case.load_env() before building the atm driver. This is needed for the atm driver build to use the correct module environment.

### Specific notes

Things were working for me, and apparently for @ekluzek and @negin513 , without this change. But this is probably because our default module environment was similar to cime's cheyenne_intel environment. @glemieux was running into trouble because he has intel17 loaded in his default environment (whereas the environment loaded by cime uses intel19). This should fix that issue.

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? Answers *may* change for the LILACSMOKE test, if baselines were generated with a slightly different compiler version than the one loaded by cime. However, I do not expect answer changes.

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
- I first reproduced the error reported in https://github.com/ESCOMP/CTSM/pull/1137#issuecomment-690797478 by changing my environment to match @glemieux 's. Specifically, I replaced my `.profile` with his, and replaced the contents of my `.lmod.d` directory with his. So this used intel17. This led to the same issue with the LILACSMOKE test that he reported.
- I then reran the LILACSMOKE test using @glemieux 's environment but with the fix in this PR; now it passed.
- I also ran the LILACSMOKE test using my environment (which uses intel 19.0.5) with this fix; it also passed.