### PR TITLE
clm5_1 physics starting point

### DIFF
--- a/.config_files.xml
+++ b/.config_files.xml
@@ -5,19 +5,20 @@
 <entry_id>
 
   <!-- This is the same as the default entry in
-       cime/config/cesm/config_files.xml except for the value for clm:
-       In a standalone clm checkout, COMP_ROOT_DIR_LND is $SRCROOT
+       cime/config/cesm/config_files.xml except for the value for CTSM:
+       In a standalone CTSM checkout, COMP_ROOT_DIR_LND is $SRCROOT
        rather than $SRCROOT/components/clm.
 
        However, because of the way overrides are handled, we need to
        re-specify the full information here rather than just overriding
-       the value for clm.
+       the value for CTSM.
   -->
   <entry id="COMP_ROOT_DIR_LND">
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="clm"      >$SRCROOT</value>
+      <value component="clm"       >$SRCROOT</value>
+      <value component="ctsm"      >$SRCROOT</value>
       <value component="dlnd"      >$CIMEROOT/src/components/data_comps/dlnd</value>
       <value component="slnd"      >$CIMEROOT/src/components/stub_comps/slnd</value>
       <value component="xlnd"      >$CIMEROOT/src/components/xcpl_comps/xlnd</value>

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ buildnmlc
 /bld/unit_testers/drv_flds_in*
 /bld/unit_testers/temp_file.txt*
 /bld/unit_testers/user_nl_clm_real_parameters*
+/bld/unit_testers/user_nl_ctsm_real_parameters*
 /bld/unit_testers/env_run.xml
 
 # tools testing output
@@ -86,8 +87,8 @@ surfdata_*.namelist
 landuse.timeseries_*.namelist
 landuse.timeseries_*.log
 landuse_timeseries_*.txt
-clm.input_data_list
-clm.input_data_list.previous
+ctsm.input_data_list
+ctsm.input_data_list.previous
 *.stdout.txt.o*
 
 # mksurfdata unit tests

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3395,7 +3395,7 @@ sub setup_logic_megan {
 #-------------------------------------------------------------------------------
 
 sub setup_logic_soilm_streams {
-  # prescribed soil moisture streams require clm4_5/clm5_0/ctsm5_1
+  # prescribed soil moisture streams require clm4_5/clm5_0/clm5_1
   my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
       add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_soil_moisture_streams');

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3391,7 +3391,7 @@ sub setup_logic_megan {
 #-------------------------------------------------------------------------------
 
 sub setup_logic_soilm_streams {
-  # prescribed soil moisture streams require clm4_5/clm5_0
+  # prescribed soil moisture streams require clm4_5/clm5_0/ctsm5_1
   my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
       add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_soil_moisture_streams');

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1486,7 +1486,7 @@ sub process_namelist_inline_logic {
   ##############################
   # namelist group: clm_inparm #
   ##############################
-  setup_logic_site_specific($nl_flags, $definition, $nl);
+  setup_logic_site_specific($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_lnd_frac($opts, $nl_flags, $definition, $defaults, $nl, $envxml_ref);
   setup_logic_co2_type($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_irrigate($opts, $nl_flags, $definition, $defaults, $nl);
@@ -1710,7 +1710,7 @@ sub process_namelist_inline_logic {
 
 sub setup_logic_site_specific {
   # site specific requirements
-  my ($nl_flags, $definition, $nl) = @_;
+  my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
   # res check prevents polluting the namelist with an unnecessary
   # false variable for every run
@@ -1741,6 +1741,9 @@ sub setup_logic_site_specific {
       $log->fatal_error("1x1_numaIA grids must use a compset with CN and CROP turned on.");
     }
   }
+  #  Set compname
+  add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'compname',
+              'phys'=>$nl_flags->{'phys'} );
 }
 
 #-------------------------------------------------------------------------------

--- a/bld/config_files/clm_phys_vers.pm
+++ b/bld/config_files/clm_phys_vers.pm
@@ -28,7 +28,7 @@ use bigint;
 #use warnings;
 #use diagnostics;
 
-my @version_strings = ("clm4_5", "clm5_0");
+my @version_strings = ("clm4_5", "clm5_0", "ctsm5_1");
 
 #-------------------------------------------------------------------------------
 
@@ -83,12 +83,12 @@ if ( ! defined(caller) && $#ARGV == -1 ) {
    require Test::More;
    Test::More->import( );
 
-   plan( tests=>2 );
+   plan( tests=>3 );
 
    sub testit {
       print "unit tester\n";
       my %lastv;
-      my @vers_list = ( "clm4_5", "clm5_0" );
+      my @vers_list = ( "clm4_5", "clm5_0", "ctsm5_1" );
       foreach my $vers ( @vers_list ) {
          my $phys = config_files::clm_phys_vers->new($vers);
          isa_ok($phys, "config_files::clm_phys_vers", "created clm_phys_vers object");

--- a/bld/config_files/clm_phys_vers.pm
+++ b/bld/config_files/clm_phys_vers.pm
@@ -28,7 +28,7 @@ use bigint;
 #use warnings;
 #use diagnostics;
 
-my @version_strings = ("clm4_5", "clm5_0", "ctsm5_1");
+my @version_strings = ("clm4_5", "clm5_0", "clm5_1");
 
 #-------------------------------------------------------------------------------
 
@@ -88,7 +88,7 @@ if ( ! defined(caller) && $#ARGV == -1 ) {
    sub testit {
       print "unit tester\n";
       my %lastv;
-      my @vers_list = ( "clm4_5", "clm5_0", "ctsm5_1" );
+      my @vers_list = ( "clm4_5", "clm5_0", "clm5_1" );
       foreach my $vers ( @vers_list ) {
          my $phys = config_files::clm_phys_vers->new($vers);
          isa_ok($phys, "config_files::clm_phys_vers", "created clm_phys_vers object");

--- a/bld/config_files/config_definition_ctsm.xml
+++ b/bld/config_files/config_definition_ctsm.xml
@@ -5,10 +5,10 @@
 <config_definition>
 
 <entry id="phys" 
-       valid_values="clm4_5,clm5_0,ctsm5_1"
+       valid_values="clm4_5,clm5_0,clm5_1"
        value="clm4_5"
        category="physics">
-Specifies either clm4_5, clm5_0, or ctsm5_1 physics
+Specifies either clm4_5, clm5_0, or clm5_1 physics
 </entry>
 
 <entry id="clm_root" 

--- a/bld/config_files/config_definition_ctsm.xml
+++ b/bld/config_files/config_definition_ctsm.xml
@@ -5,10 +5,10 @@
 <config_definition>
 
 <entry id="phys" 
-       valid_values="clm4_5,clm5_0"
+       valid_values="clm4_5,clm5_0,ctsm5_1"
        value="clm4_5"
        category="physics">
-Specifies either clm4_5 or clm5_0 physics
+Specifies either clm4_5, clm5_0, or ctsm5_1 physics
 </entry>
 
 <entry id="clm_root" 

--- a/bld/listDefaultNamelist.pl
+++ b/bld/listDefaultNamelist.pl
@@ -97,7 +97,7 @@ sub make_config_cache {
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0,ctsm5_1">Specifies clm physics</entry>
+<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0,clm5_1">Specifies clm physics</entry>
 </config_definition>
 EOF
    $fh->close();

--- a/bld/listDefaultNamelist.pl
+++ b/bld/listDefaultNamelist.pl
@@ -97,7 +97,7 @@ sub make_config_cache {
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0">Specifies clm physics</entry>
+<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0,ctsm5_1">Specifies clm physics</entry>
 </config_definition>
 EOF
    $fh->close();

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -39,9 +39,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <lnd_tuning_mode phys="clm5_1" >clm5_1_GSWP3v1</lnd_tuning_mode>
 
 <!-- Component name for output files -->
-<compname phys="clm5_1" >clm5</compname>
-<compname phys="clm5_0" >clm5</compname>
-<compname phys="clm4_5" >clm4</compname>
+<compname phys="clm5_1" >clm2</compname>
+<compname phys="clm5_0" >clm2</compname>
+<compname phys="clm4_5" >clm2</compname>
 
 <!-- Accelerated spinup mode -->
 <clm_accelerated_spinup>off</clm_accelerated_spinup>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -39,9 +39,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <lnd_tuning_mode phys="ctsm5_1">ctsm5_1_GSWP3v1</lnd_tuning_mode>
 
 <!-- Component name for output files -->
-<compname phys="ctsm5_1">ctsm51</compname>
-<compname phys="clm5_0" >clm50</compname>
-<compname phys="clm4_5" >clm45</compname>
+<compname phys="ctsm5_1">ctsm5</compname>
+<compname phys="clm5_0" >clm5</compname>
+<compname phys="clm4_5" >clm4</compname>
 
 <!-- Accelerated spinup mode -->
 <clm_accelerated_spinup>off</clm_accelerated_spinup>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -38,6 +38,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <lnd_tuning_mode phys="clm5_0" >clm5_0_cam6.0</lnd_tuning_mode>
 <lnd_tuning_mode phys="ctsm5_1">ctsm5_1_GSWP3v1</lnd_tuning_mode>
 
+<!-- Component name for output files -->
+<compname phys="ctsm5_1">ctsm51</compname>
+<compname phys="clm5_0" >clm50</compname>
+<compname phys="clm4_5" >clm45</compname>
+
 <!-- Accelerated spinup mode -->
 <clm_accelerated_spinup>off</clm_accelerated_spinup>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -457,9 +457,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="ctsm5_1">lnd/clm2/paramdata/clm5_params.c200624.nc</paramfile>
-<paramfile phys="clm5_0" >lnd/clm2/paramdata/clm5_params.c200624.nc</paramfile>
-<paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c200624.nc</paramfile>
+<paramfile phys="ctsm5_1">lnd/clm2/paramdata/ctsm51_params.c200905.nc</paramfile>
+<paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c200905.nc</paramfile>
+<paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c200905.nc</paramfile>
 
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -34,15 +34,20 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Default Biogeochemistry mode -->
 <bgc_mode >sp</bgc_mode>
 
-<lnd_tuning_mode phys="clm4_5">clm4_5_CRUv7</lnd_tuning_mode>
-<lnd_tuning_mode phys="clm5_0">clm5_0_cam6.0</lnd_tuning_mode>
+<lnd_tuning_mode phys="clm4_5" >clm4_5_CRUv7</lnd_tuning_mode>
+<lnd_tuning_mode phys="clm5_0" >clm5_0_cam6.0</lnd_tuning_mode>
+<lnd_tuning_mode phys="ctsm5_1">ctsm5_1_GSWP3v1</lnd_tuning_mode>
 
 <!-- Accelerated spinup mode -->
 <clm_accelerated_spinup>off</clm_accelerated_spinup>
 
 <!-- Spinup state for BGC -->
+<spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="ctsm5_1">2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="clm5_0" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="clm4_5" >1</spinup_state>
+<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="ctsm5_1">2</spinup_state>
+<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="ctsm5_1">2</spinup_state>
+<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm5_0" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm5_0" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm4_5" >1</spinup_state>
 <spinup_state clm_accelerated_spinup="off"                               >0</spinup_state>
@@ -61,29 +66,32 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <hist_mfilt  clm_accelerated_spinup="on">20</hist_mfilt>
 
 <!-- Root and stem acclimation -->
-<rootstem_acc phys="clm5_0">.false.</rootstem_acc>
-<rootstem_acc phys="clm4_5">.false.</rootstem_acc>
+<rootstem_acc phys="ctsm5_1">.false.</rootstem_acc>
+<rootstem_acc phys="clm5_0" >.false.</rootstem_acc>
+<rootstem_acc phys="clm4_5" >.false.</rootstem_acc>
 
 <!-- Light inhibition of photosynthesis -->
-<light_inhibit phys="clm5_0">.true.</light_inhibit>
-<light_inhibit phys="clm4_5">.false.</light_inhibit>
-
-<!-- Light inhibition of photosynthesis -->
-<light_inhibit phys="clm5_0">.true.</light_inhibit>
+<light_inhibit phys="ctsm5_1">.true.</light_inhibit>
+<light_inhibit phys="clm5_0" >.true.</light_inhibit>
+<light_inhibit phys="clm4_5" >.false.</light_inhibit>
 
 <!-- Method to calculate leaf maintenance respiration for canopy top at 25C -->
-<leafresp_method phys="clm5_0" use_cn=".true." >2</leafresp_method>
-<leafresp_method phys="clm4_5" use_cn=".true." >1</leafresp_method>
-<leafresp_method               use_cn=".false.">0</leafresp_method>
+<leafresp_method phys="ctsm5_1" use_cn=".true." >2</leafresp_method>
+<leafresp_method phys="clm5_0"  use_cn=".true." >2</leafresp_method>
+<leafresp_method phys="clm4_5"  use_cn=".true." >1</leafresp_method>
+<leafresp_method                use_cn=".false.">0</leafresp_method>
 
 <!-- Modfy photosyntheiss and LMR for crop -->
+<modifyphoto_and_lmr_forcrop phys="ctsm5_1">.true.</modifyphoto_and_lmr_forcrop>
 <modifyphoto_and_lmr_forcrop phys="clm5_0" >.true.</modifyphoto_and_lmr_forcrop>
 <modifyphoto_and_lmr_forcrop phys="clm4_5" >.false.</modifyphoto_and_lmr_forcrop>
 
 <!-- Method to use for stomatal conducatance -->
-<stomatalcond_method phys="clm5_0" use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
-<stomatalcond_method phys="clm5_0" use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
-<stomatalcond_method phys="clm4_5"                         >Ball-Berry1987</stomatalcond_method>
+<stomatalcond_method phys="ctsm5_1" use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
+<stomatalcond_method phys="ctsm5_1" use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
+<stomatalcond_method phys="clm5_0"  use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
+<stomatalcond_method phys="clm5_0"  use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
+<stomatalcond_method phys="clm4_5"                          >Ball-Berry1987</stomatalcond_method>
 
 <!-- Carbon isotope concentration files -->
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C13_CMIP6_1850-2015_yearly_v2.0_c190528.nc</atm_c13_filename>
@@ -103,9 +111,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="SSP5-8.5" >lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP5B_3x1_global_1850-2100_yearly_c181209.nc</atm_c14_filename>
 
 <!-- Irrigation default -->
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false." sim_year_range="1850-2100">.true.</irrigate>
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."  sim_year_range="1850-2100">.false.</irrigate>
-<irrigate use_crop=".true." phys="clm4_5"                    sim_year_range="1850-2100">.false.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false." sim_year_range="1850-2100">.true.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true."  sim_year_range="1850-2100">.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false."  sim_year_range="1850-2100">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."   sim_year_range="1850-2100">.false.</irrigate>
+<irrigate use_crop=".true." phys="clm4_5"                     sim_year_range="1850-2100">.false.</irrigate>
 
 <irrigate use_crop=".true." >.false.</irrigate>
 <irrigate use_crop=".false.">.true.</irrigate>
@@ -124,60 +134,76 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <suplnitro use_fates=".true." >NONE</suplnitro>
 
 <!-- Albedo for glaciers -->
-<albice phys="clm5_0">0.50,0.30</albice>
-<albice phys="clm4_5">0.60,0.40</albice>
+<albice phys="ctsm5_1">0.50,0.30</albice>
+<albice phys="clm5_0" >0.50,0.30</albice>
+<albice phys="clm4_5" >0.60,0.40</albice>
 
 <!-- Default urban air conditioning/heating and wasteheat -->
+<urban_hac phys="ctsm5_1">ON_WASTEHEAT</urban_hac>
 <urban_hac phys="clm5_0" >ON_WASTEHEAT</urban_hac>
 <urban_hac phys="clm4_5" >ON</urban_hac>
 
-<building_temp_method phys="clm5_0">1</building_temp_method>
-<building_temp_method phys="clm4_5">0</building_temp_method>
+<building_temp_method phys="ctsm5_1">1</building_temp_method>
+<building_temp_method phys="clm5_0" >1</building_temp_method>
+<building_temp_method phys="clm4_5" >0</building_temp_method>
 
-<calc_human_stress_indices phys="clm5_0">FAST</calc_human_stress_indices>
-<calc_human_stress_indices phys="clm4_5">NONE</calc_human_stress_indices>
+<calc_human_stress_indices phys="ctsm5_1">FAST</calc_human_stress_indices>
+<calc_human_stress_indices phys="clm5_0" >FAST</calc_human_stress_indices>
+<calc_human_stress_indices phys="clm4_5" >NONE</calc_human_stress_indices>
 
 <!-- Default urban traffic flux -->
 <urban_traffic>.false.</urban_traffic>
 
 <!-- Soil state settings -->
+<organic_frac_squared phys="ctsm5_1">.true.</organic_frac_squared>
 <organic_frac_squared phys="clm4_5" >.true.</organic_frac_squared>
 <organic_frac_squared phys="clm5_0" >.false.</organic_frac_squared>
 
 <soil_layerstruct_predefined structure="fast">4SL_2m</soil_layerstruct_predefined>
-<soil_layerstruct_predefined structure="standard" phys="clm5_0">20SL_8.5m</soil_layerstruct_predefined>
-<soil_layerstruct_predefined structure="standard" phys="clm4_5">10SL_3.5m</soil_layerstruct_predefined>
+<soil_layerstruct_predefined structure="standard" phys="ctsm5_1">20SL_8.5m</soil_layerstruct_predefined>
+<soil_layerstruct_predefined structure="standard" phys="clm5_0" >20SL_8.5m</soil_layerstruct_predefined>
+<soil_layerstruct_predefined structure="standard" phys="clm4_5" >10SL_3.5m</soil_layerstruct_predefined>
 
-<use_bedrock phys="clm5_0" use_fates =".true.">.false.</use_bedrock>
-<use_bedrock phys="clm5_0" vichydro ="1"      >.false.</use_bedrock>
-<use_bedrock phys="clm5_0">.true.</use_bedrock>
-<use_bedrock phys="clm4_5">.false.</use_bedrock>
+<use_bedrock phys="ctsm5_1" use_fates =".true.">.false.</use_bedrock>
+<use_bedrock phys="ctsm5_1" vichydro ="1"      >.false.</use_bedrock>
+<use_bedrock phys="ctsm5_1"                    >.true.</use_bedrock>
+<use_bedrock phys="clm5_0"  use_fates =".true.">.false.</use_bedrock>
+<use_bedrock phys="clm5_0"  vichydro ="1"      >.false.</use_bedrock>
+<use_bedrock phys="clm5_0"                     >.true.</use_bedrock>
+<use_bedrock phys="clm4_5"                     >.false.</use_bedrock>
 
 
 <!-- Rooting profile namelist defaults -->
-<rooting_profile_method_water  phys="clm5_0">1</rooting_profile_method_water>
-<rooting_profile_method_water  phys="clm4_5">0</rooting_profile_method_water>
+<rooting_profile_method_water  phys="ctsm5_1">1</rooting_profile_method_water>
+<rooting_profile_method_water  phys="clm5_0" >1</rooting_profile_method_water>
+<rooting_profile_method_water  phys="clm4_5" >0</rooting_profile_method_water>
 
-<rooting_profile_method_carbon phys="clm5_0">1</rooting_profile_method_carbon>
-<rooting_profile_method_carbon phys="clm4_5">1</rooting_profile_method_carbon>
+<rooting_profile_method_carbon phys="ctsm5_1">1</rooting_profile_method_carbon>
+<rooting_profile_method_carbon phys="clm5_0" >1</rooting_profile_method_carbon>
+<rooting_profile_method_carbon phys="clm4_5" >1</rooting_profile_method_carbon>
 
 <!-- Soil evaporative resistance namelist defaults -->
-<soil_resis_method phys="clm5_0">1</soil_resis_method>
-<soil_resis_method phys="clm4_5">0</soil_resis_method>
+<soil_resis_method phys="ctsm5_1">1</soil_resis_method>
+<soil_resis_method phys="clm5_0" >1</soil_resis_method>
+<soil_resis_method phys="clm4_5" >0</soil_resis_method>
 
 <!-- Soil hydrology -->
-<baseflow_scalar phys="clm5_0" lower_boundary_condition="1">1.d-2</baseflow_scalar>
-<baseflow_scalar phys="clm5_0" lower_boundary_condition="2">0.001d00</baseflow_scalar>
-<baseflow_scalar phys="clm4_5" lower_boundary_condition="1">1.d-2</baseflow_scalar>
-<baseflow_scalar phys="clm4_5" lower_boundary_condition="2">1.d-2</baseflow_scalar>
+<baseflow_scalar phys="ctsm5_1" lower_boundary_condition="1">1.d-2</baseflow_scalar>
+<baseflow_scalar phys="ctsm5_1" lower_boundary_condition="2">0.001d00</baseflow_scalar>
+<baseflow_scalar phys="clm5_0"  lower_boundary_condition="1">1.d-2</baseflow_scalar>
+<baseflow_scalar phys="clm5_0"  lower_boundary_condition="2">0.001d00</baseflow_scalar>
+<baseflow_scalar phys="clm4_5"  lower_boundary_condition="1">1.d-2</baseflow_scalar>
+<baseflow_scalar phys="clm4_5"  lower_boundary_condition="2">1.d-2</baseflow_scalar>
 
 <!-- Friction velocity -->
-<zetamaxstable phys="clm4_5">2.0d00</zetamaxstable>
-<zetamaxstable phys="clm5_0">0.5d00</zetamaxstable>
+<zetamaxstable phys="clm4_5" >2.0d00</zetamaxstable>
+<zetamaxstable phys="clm5_0" >0.5d00</zetamaxstable>
+<zetamaxstable phys="ctsm5_1">0.5d00</zetamaxstable>
 
 <!-- atm2lnd defaults -->
-<repartition_rain_snow phys="clm5_0">.true.</repartition_rain_snow>
-<repartition_rain_snow phys="clm4_5">.false.</repartition_rain_snow>
+<repartition_rain_snow phys="ctsm5_1">.true.</repartition_rain_snow>
+<repartition_rain_snow phys="clm5_0" >.true.</repartition_rain_snow>
+<repartition_rain_snow phys="clm4_5" >.false.</repartition_rain_snow>
 
 <glcmec_downscale_longwave>.true.</glcmec_downscale_longwave>
 
@@ -192,24 +218,29 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <precip_repartition_nonglc_all_snow_t>0.</precip_repartition_nonglc_all_snow_t>
 <precip_repartition_nonglc_all_rain_t>2.</precip_repartition_nonglc_all_rain_t>
 <!-- For CLM45, we used the same rain-snow partitioning for glaciers as for other landunits -->
-<precip_repartition_glc_all_snow_t phys="clm4_5">0.</precip_repartition_glc_all_snow_t>
-<precip_repartition_glc_all_rain_t phys="clm4_5">2.</precip_repartition_glc_all_rain_t>
+<precip_repartition_glc_all_snow_t phys="clm4_5" >0.</precip_repartition_glc_all_snow_t>
+<precip_repartition_glc_all_rain_t phys="clm4_5" >2.</precip_repartition_glc_all_rain_t>
 <!-- For CLM5, we assume rain at somewhat cooler temperatures. The main
      motivation is to increase glacier melt, which otherwise is too low in
      CESM2. The physical justification is that the 0 - 2 C ramp used elsewhere
      makes sense for typical atmospheric profiles; but over glaciers, inversions
      are more common, so it is more reasonable to expect rain despite
      below-freezing near-surface temperatures. -->
-<precip_repartition_glc_all_snow_t phys="clm5_0">-2.</precip_repartition_glc_all_snow_t>
-<precip_repartition_glc_all_rain_t phys="clm5_0">0.</precip_repartition_glc_all_rain_t>
+<precip_repartition_glc_all_snow_t phys="clm5_0" >-2.</precip_repartition_glc_all_snow_t>
+<precip_repartition_glc_all_rain_t phys="clm5_0" >0.</precip_repartition_glc_all_rain_t>
+
+<precip_repartition_glc_all_snow_t phys="ctsm5_1">-2.</precip_repartition_glc_all_snow_t>
+<precip_repartition_glc_all_rain_t phys="ctsm5_1">0.</precip_repartition_glc_all_rain_t>
 
 <!-- lnd2atm defaults -->
-<melt_non_icesheet_ice_runoff phys="clm4_5">.false.</melt_non_icesheet_ice_runoff>
-<melt_non_icesheet_ice_runoff phys="clm5_0">.true.</melt_non_icesheet_ice_runoff>
+<melt_non_icesheet_ice_runoff phys="clm4_5" >.false.</melt_non_icesheet_ice_runoff>
+<melt_non_icesheet_ice_runoff phys="clm5_0" >.true.</melt_non_icesheet_ice_runoff>
+<melt_non_icesheet_ice_runoff phys="ctsm5_1">.true.</melt_non_icesheet_ice_runoff>
 
 <!-- CN Fire model method defaults -->
-<fire_method phys="clm5_0">li2016crufrc</fire_method>
-<fire_method phys="clm4_5">li2014qianfrc</fire_method>
+<fire_method phys="ctsm5_1">li2021gswpfrc</fire_method>
+<fire_method phys="clm5_0" >li2016crufrc</fire_method>
+<fire_method phys="clm4_5" >li2014qianfrc</fire_method>
 
 <rh_low                   fire_method="li2014qianfrc" >30.0d00</rh_low>
 <rh_hgh                   fire_method="li2014qianfrc" >80.0d00</rh_hgh>
@@ -249,28 +280,49 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <ufuel                    fire_method="li2016crufrc" >1050.d00</ufuel>
 <cmb_cmplt_fact           fire_method="li2016crufrc" >0.5d00, 0.28d00</cmb_cmplt_fact>
 
+<rh_low                   fire_method="li2021gswpfrc" >30.0d00</rh_low>
+<rh_hgh                   fire_method="li2021gswpfrc" >80.0d00</rh_hgh>
+<bt_min                   fire_method="li2021gswpfrc" >0.85d00</bt_min>
+<bt_max                   fire_method="li2021gswpfrc" >0.98d00</bt_max>
+<cli_scale                fire_method="li2021gswpfrc" >0.025d00</cli_scale>
+<boreal_peatfire_c        fire_method="li2021gswpfrc" >0.09d-4</boreal_peatfire_c>
+<pot_hmn_ign_counts_alpha fire_method="li2021gswpfrc" >0.010d00</pot_hmn_ign_counts_alpha>
+<non_boreal_peatfire_c    fire_method="li2021gswpfrc" >0.17d-3</non_boreal_peatfire_c>
+<cropfire_a1              fire_method="li2021gswpfrc" >1.6d-4</cropfire_a1>
+<occur_hi_gdp_tree        fire_method="li2021gswpfrc" >0.33d00</occur_hi_gdp_tree>
+<lfuel                    fire_method="li2021gswpfrc" >75.d00</lfuel>
+<ufuel                    fire_method="li2021gswpfrc" >1050.d00</ufuel>
+<cmb_cmplt_fact           fire_method="li2021gswpfrc" >0.5d00, 0.28d00</cmb_cmplt_fact>
+
 <!-- Canopy fluxes namelist defaults -->
-<use_undercanopy_stability phys="clm5_0">.false.</use_undercanopy_stability>
-<use_undercanopy_stability phys="clm4_5">.true.</use_undercanopy_stability>
+<use_undercanopy_stability phys="ctsm5_1">.false.</use_undercanopy_stability>
+<use_undercanopy_stability phys="clm5_0" >.false.</use_undercanopy_stability>
+<use_undercanopy_stability phys="clm4_5" >.true.</use_undercanopy_stability>
 
 <itmax_canopy_fluxes structure="standard">40</itmax_canopy_fluxes>
 <itmax_canopy_fluxes structure="fast"    >3</itmax_canopy_fluxes>
 
 <!-- Canopy hydrology namelist defaults -->
-<use_clm5_fpi phys="clm5_0">.true.</use_clm5_fpi>
-<interception_fraction phys="clm5_0">1.0</interception_fraction>
-<maximum_leaf_wetted_fraction phys="clm5_0">0.05</maximum_leaf_wetted_fraction>
+<use_clm5_fpi                 phys="ctsm5_1">.true.</use_clm5_fpi>
+<interception_fraction        phys="ctsm5_1">1.0</interception_fraction>
+<maximum_leaf_wetted_fraction phys="ctsm5_1">0.05</maximum_leaf_wetted_fraction>
 
-<use_clm5_fpi phys="clm4_5">.false.</use_clm5_fpi>
-<interception_fraction phys="clm4_5">0.25</interception_fraction>
-<maximum_leaf_wetted_fraction phys="clm4_5">1.0</maximum_leaf_wetted_fraction>
+<use_clm5_fpi                 phys="clm5_0" >.true.</use_clm5_fpi>
+<interception_fraction        phys="clm5_0" >1.0</interception_fraction>
+<maximum_leaf_wetted_fraction phys="clm5_0" >0.05</maximum_leaf_wetted_fraction>
+
+<use_clm5_fpi                 phys="clm4_5" >.false.</use_clm5_fpi>
+<interception_fraction        phys="clm4_5" >0.25</interception_fraction>
+<maximum_leaf_wetted_fraction phys="clm4_5" >1.0</maximum_leaf_wetted_fraction>
 
 <!-- Soilwater movement namelist defaults -->
-<soilwater_movement_method phys="clm4_5">0</soilwater_movement_method>
-<soilwater_movement_method phys="clm5_0">1</soilwater_movement_method>
+<soilwater_movement_method phys="clm4_5" >0</soilwater_movement_method>
+<soilwater_movement_method phys="clm5_0" >1</soilwater_movement_method>
+<soilwater_movement_method phys="ctsm5_1">1</soilwater_movement_method>
 
 <upper_boundary_condition phys="clm4_5" >1</upper_boundary_condition>
 <upper_boundary_condition phys="clm5_0" >1</upper_boundary_condition>
+<upper_boundary_condition phys="ctsm5_1">1</upper_boundary_condition>
 
 <lower_boundary_condition soilwater_movement_method="0"                       >4</lower_boundary_condition>
 <lower_boundary_condition soilwater_movement_method="1" use_bedrock=".true."  >2</lower_boundary_condition>
@@ -291,13 +343,15 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <irrig_length>14400</irrig_length>
 <irrig_target_smp>-3400.</irrig_target_smp>  <!-- -3400 is a standard value for field capacity -->
 <irrig_depth>0.6</irrig_depth>
-<irrig_threshold_fraction phys="clm5_0">1.0</irrig_threshold_fraction>
-<irrig_threshold_fraction phys="clm4_5">0.5</irrig_threshold_fraction>
+<irrig_threshold_fraction phys="ctsm5_1">1.0</irrig_threshold_fraction>
+<irrig_threshold_fraction phys="clm5_0" >1.0</irrig_threshold_fraction>
+<irrig_threshold_fraction phys="clm4_5" >0.5</irrig_threshold_fraction>
 <irrig_river_volume_threshold>0.1</irrig_river_volume_threshold>
 
 <!--  River storage derived lake evaporation and irrigation limitation  -->
-<limit_irrigation_if_rof_enabled phys="clm5_0">.false.</limit_irrigation_if_rof_enabled>
-<limit_irrigation_if_rof_enabled              >.false.</limit_irrigation_if_rof_enabled>
+<limit_irrigation_if_rof_enabled phys="ctsm5_1">.false.</limit_irrigation_if_rof_enabled>
+<limit_irrigation_if_rof_enabled phys="clm5_0" >.false.</limit_irrigation_if_rof_enabled>
+<limit_irrigation_if_rof_enabled               >.false.</limit_irrigation_if_rof_enabled>
 
 <use_groundwater_irrigation>.false.</use_groundwater_irrigation>
 
@@ -307,15 +361,19 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <snowveg_affects_radiation>.true.</snowveg_affects_radiation>
 
 <!-- Snow pack settings-->
-<nlevsno phys="clm5_0" structure="standard">12</nlevsno>
-<nlevsno phys="clm5_0" structure="fast"    >5</nlevsno>
-<nlevsno phys="clm4_5"                     >5</nlevsno>
+<nlevsno phys="ctsm5_1" structure="standard">12</nlevsno>
+<nlevsno phys="ctsm5_1" structure="fast"    >5</nlevsno>
+<nlevsno phys="clm5_0" structure="standard" >12</nlevsno>
+<nlevsno phys="clm5_0" structure="fast"     >5</nlevsno>
+<nlevsno phys="clm4_5"                      >5</nlevsno>
 <!-- h2osno_max is more 'configuration' than 'structure'. But since it's
      tied to nlevsno, we're controlling it via 'structure', like
      nlevsno, so that defaults for the two remain consistent. -->
-<h2osno_max phys="clm5_0" structure="standard">10000.0</h2osno_max>
-<h2osno_max phys="clm5_0" structure="fast"    >5000.0</h2osno_max>
-<h2osno_max phys="clm4_5"                     >1000.0</h2osno_max>
+<h2osno_max phys="ctsm5_1" structure="standard">10000.0</h2osno_max>
+<h2osno_max phys="ctsm5_1" structure="fast"    >5000.0</h2osno_max>
+<h2osno_max phys="clm5_0"  structure="standard">10000.0</h2osno_max>
+<h2osno_max phys="clm5_0"  structure="fast"    >5000.0</h2osno_max>
+<h2osno_max phys="clm4_5"                      >1000.0</h2osno_max>
 
 <snow_dzmin_1>0.010d00</snow_dzmin_1>
 <snow_dzmin_2>0.015d00</snow_dzmin_2>
@@ -324,27 +382,34 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <snow_dzmax_u_1>0.02d00</snow_dzmax_u_1>
 <snow_dzmax_u_2>0.05d00</snow_dzmax_u_2>
 
-<int_snow_max phys="clm5_0">2000.</int_snow_max>
+<int_snow_max phys="ctsm5_1">2000.</int_snow_max>
+<int_snow_max phys="clm5_0" >2000.</int_snow_max>
 <!-- For clm4_5, make this effectively unlimited -->
-<int_snow_max phys="clm4_5">1.e30</int_snow_max>
+<int_snow_max phys="clm4_5" >1.e30</int_snow_max>
 
-<n_melt_glcmec phys="clm5_0">10.0d00</n_melt_glcmec>
-<n_melt_glcmec phys="clm4_5">10.0</n_melt_glcmec>
+<n_melt_glcmec phys="ctsm5_1">10.0d00</n_melt_glcmec>
+<n_melt_glcmec phys="clm5_0" >10.0d00</n_melt_glcmec>
+<n_melt_glcmec phys="clm4_5" >10.0</n_melt_glcmec>
 
+<wind_dependent_snow_density phys="ctsm5_1">.true.</wind_dependent_snow_density>
 <wind_dependent_snow_density phys="clm5_0" >.true.</wind_dependent_snow_density>
 <wind_dependent_snow_density phys="clm4_5" >.false.</wind_dependent_snow_density>
 
-<snow_overburden_compaction_method phys="clm5_0">'Vionnet2012'</snow_overburden_compaction_method>
-<snow_overburden_compaction_method phys="clm4_5">'Anderson1976'</snow_overburden_compaction_method>
+<snow_overburden_compaction_method phys="ctsm5_1">'Vionnet2012'</snow_overburden_compaction_method>
+<snow_overburden_compaction_method phys="clm5_0" >'Vionnet2012'</snow_overburden_compaction_method>
+<snow_overburden_compaction_method phys="clm4_5" >'Anderson1976'</snow_overburden_compaction_method>
 
-<lotmp_snowdensity_method phys="clm5_0">'Slater2017'</lotmp_snowdensity_method>
-<lotmp_snowdensity_method phys="clm4_5">'TruncatedAnderson1976'</lotmp_snowdensity_method>
+<lotmp_snowdensity_method phys="ctsm5_1">'Slater2017'</lotmp_snowdensity_method>
+<lotmp_snowdensity_method phys="clm5_0" >'Slater2017'</lotmp_snowdensity_method>
+<lotmp_snowdensity_method phys="clm4_5" >'TruncatedAnderson1976'</lotmp_snowdensity_method>
 
-<upplim_destruct_metamorph   phys="clm4_5">100.d00</upplim_destruct_metamorph>
-<upplim_destruct_metamorph   phys="clm5_0">175.d00</upplim_destruct_metamorph>
+<upplim_destruct_metamorph   phys="clm4_5" >100.d00</upplim_destruct_metamorph>
+<upplim_destruct_metamorph   phys="clm5_0" >175.d00</upplim_destruct_metamorph>
+<upplim_destruct_metamorph   phys="ctsm5_1">175.d00</upplim_destruct_metamorph>
 
-<fresh_snw_rds_max phys="clm4_5">54.526d00</fresh_snw_rds_max>
-<fresh_snw_rds_max phys="clm5_0">204.526d00</fresh_snw_rds_max>
+<fresh_snw_rds_max phys="clm4_5" >54.526d00</fresh_snw_rds_max>
+<fresh_snw_rds_max phys="clm5_0" >204.526d00</fresh_snw_rds_max>
+<fresh_snw_rds_max phys="ctsm5_1">204.526d00</fresh_snw_rds_max>
 
 <overburden_compress_tfactor>0.08d00</overburden_compress_tfactor>
 
@@ -384,6 +449,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
      simplicity, we tie the defaults for both of these options to the overall
      CLM phys version, rather than having some intermediate option that controls
      the defaults for both h2osno_max and glc_snow_persistence_max_days. -->
+<glc_snow_persistence_max_days phys="ctsm5_1">0</glc_snow_persistence_max_days>
 <glc_snow_persistence_max_days phys="clm5_0" >0</glc_snow_persistence_max_days>
 <glc_snow_persistence_max_days phys="clm4_5" >7300</glc_snow_persistence_max_days>
 
@@ -391,8 +457,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0">lnd/clm2/paramdata/clm5_params.c200624.nc</paramfile>
-<paramfile phys="clm4_5">lnd/clm2/paramdata/clm45_params.c200624.nc</paramfile>
+<paramfile phys="ctsm5_1">lnd/clm2/paramdata/clm5_params.c200624.nc</paramfile>
+<paramfile phys="clm5_0" >lnd/clm2/paramdata/clm5_params.c200624.nc</paramfile>
+<paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c200624.nc</paramfile>
 
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->
@@ -403,13 +470,17 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->
 <!-- ========================================================================================  -->
-<use_flexibleCN phys="clm5_0" use_cn=".true.">.true.</use_flexibleCN>
-<use_flexibleCN phys="clm5_0"                >.false.</use_flexibleCN>
-<use_flexibleCN phys="clm4_5"                >.false.</use_flexibleCN>
+<use_flexibleCN phys="ctsm5_1" use_cn=".true.">.true.</use_flexibleCN>
+<use_flexibleCN phys="ctsm5_1"                >.false.</use_flexibleCN>
+<use_flexibleCN phys="clm5_0"  use_cn=".true.">.true.</use_flexibleCN>
+<use_flexibleCN phys="clm5_0"                 >.false.</use_flexibleCN>
+<use_flexibleCN phys="clm4_5"                 >.false.</use_flexibleCN>
 
 <!-- LUNA model: Leaf Utilization of Nitrogen for Assimilation -->
+<use_luna phys="ctsm5_1" >.true.</use_luna>
+<use_luna phys="ctsm5_1" use_fates=".true." >.false.</use_luna>
 <use_luna phys="clm5_0"  >.true.</use_luna>
-<use_luna phys="clm5_0" use_fates=".true." >.false.</use_luna>
+<use_luna phys="clm5_0"  use_fates=".true." >.false.</use_luna>
 <use_luna phys="clm4_5"  >.false.</use_luna>
 
 <!-- Flexible CN options -->
@@ -437,58 +508,74 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <lnc_opt use_cn=".false."  >.false.</lnc_opt>
 
 <use_fertilizer>.false.</use_fertilizer>
-<use_fertilizer use_crop=".true." phys="clm4_5">.true.</use_fertilizer>
-<use_fertilizer use_crop=".true." phys="clm5_0">.true.</use_fertilizer>
+<use_fertilizer use_crop=".true." phys="clm4_5" >.true.</use_fertilizer>
+<use_fertilizer use_crop=".true." phys="clm5_0" >.true.</use_fertilizer>
+<use_fertilizer use_crop=".true." phys="ctsm5_1">.true.</use_fertilizer>
 
-<jmaxb1 use_luna=".true." phys="clm5_0">0.17</jmaxb1>
+<jmaxb1 use_luna=".true." phys="ctsm5_1">0.17</jmaxb1>
+<jmaxb1 use_luna=".true." phys="clm5_0" >0.17</jmaxb1>
 
 <use_grainproduct>.false.</use_grainproduct>
-<use_grainproduct use_crop=".true." phys="clm4_5">.false.</use_grainproduct> <!-- 1-year grain product pool default to off for clm45 if crop is turned on -->
-<use_grainproduct use_crop=".true." phys="clm5_0">.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
+<use_grainproduct use_crop=".true." phys="clm4_5" >.false.</use_grainproduct> <!-- 1-year grain product pool default to off for clm45 if crop is turned on -->
+<use_grainproduct use_crop=".true." phys="clm5_0" >.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
+<use_grainproduct use_crop=".true." phys="ctsm5_1">.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
 
 <!-- Crop model options -->
-<baset_mapping           use_crop=".true." phys="clm4_5">constant</baset_mapping>
-<baset_mapping           use_crop=".true." phys="clm5_0">varytropicsbylat</baset_mapping>
-<baset_latvary_intercept use_crop=".true." phys="clm5_0" baset_mapping="varytropicsbylat">12.0d00</baset_latvary_intercept>
-<baset_latvary_slope     use_crop=".true." phys="clm5_0" baset_mapping="varytropicsbylat">0.4d00</baset_latvary_slope>
+<baset_mapping           use_crop=".true." phys="clm4_5" >constant</baset_mapping>
+<baset_mapping           use_crop=".true." phys="clm5_0" >varytropicsbylat</baset_mapping>
+<baset_latvary_intercept use_crop=".true." phys="clm5_0"  baset_mapping="varytropicsbylat">12.0d00</baset_latvary_intercept>
+<baset_latvary_slope     use_crop=".true." phys="clm5_0"  baset_mapping="varytropicsbylat">0.4d00</baset_latvary_slope>
+<baset_mapping           use_crop=".true." phys="ctsm5_1">varytropicsbylat</baset_mapping>
+<baset_latvary_intercept use_crop=".true." phys="ctsm5_1" baset_mapping="varytropicsbylat">12.0d00</baset_latvary_intercept>
+<baset_latvary_slope     use_crop=".true." phys="ctsm5_1" baset_mapping="varytropicsbylat">0.4d00</baset_latvary_slope>
 
-<initial_seed_at_planting use_crop=".true." phys="clm5_0">3.d00</initial_seed_at_planting>
-<initial_seed_at_planting use_crop=".true." phys="clm4_5">1.d00</initial_seed_at_planting>
+<initial_seed_at_planting use_crop=".true." phys="ctsm5_1">3.d00</initial_seed_at_planting>
+<initial_seed_at_planting use_crop=".true." phys="clm5_0" >3.d00</initial_seed_at_planting>
+<initial_seed_at_planting use_crop=".true." phys="clm4_5" >1.d00</initial_seed_at_planting>
 
 
 <!-- turnover time modifications    -->
-<decomp_depth_efolding phys="clm4_5">0.5</decomp_depth_efolding>
-<decomp_depth_efolding phys="clm5_0">10.0</decomp_depth_efolding>
+<decomp_depth_efolding phys="clm4_5" >0.5</decomp_depth_efolding>
+<decomp_depth_efolding phys="clm5_0" >10.0</decomp_depth_efolding>
+<decomp_depth_efolding phys="ctsm5_1">10.0</decomp_depth_efolding>
 
 <!-- use additional stress deciduous onset trigger    -->
-<constrain_stress_deciduous_onset phys="clm4_5">.false.</constrain_stress_deciduous_onset>
-<constrain_stress_deciduous_onset phys="clm5_0">.true.</constrain_stress_deciduous_onset>
+<constrain_stress_deciduous_onset phys="clm4_5" >.false.</constrain_stress_deciduous_onset>
+<constrain_stress_deciduous_onset phys="clm5_0" >.true.</constrain_stress_deciduous_onset>
+<constrain_stress_deciduous_onset phys="ctsm5_1">.true.</constrain_stress_deciduous_onset>
 
 <!-- Whether to use subgrid fluxes for snow -->
 <use_subgrid_fluxes>.true.</use_subgrid_fluxes>
 
 <!-- dynamic roots -->
-<use_dynroot phys="clm4_5">.false.</use_dynroot>
-<use_dynroot phys="clm5_0" bgc_mode="sp">.false.</use_dynroot>
-<use_dynroot phys="clm5_0" bgc_mode="cn">.false.</use_dynroot>
-<use_dynroot phys="clm5_0" bgc_mode="fates">.false.</use_dynroot>
-<use_dynroot phys="clm5_0" bgc_mode="bgc">.false.</use_dynroot>
+<use_dynroot phys="clm4_5"                  >.false.</use_dynroot>
+<use_dynroot phys="clm5_0"  bgc_mode="sp"   >.false.</use_dynroot>
+<use_dynroot phys="clm5_0"  bgc_mode="cn"   >.false.</use_dynroot>
+<use_dynroot phys="clm5_0"  bgc_mode="fates">.false.</use_dynroot>
+<use_dynroot phys="clm5_0"  bgc_mode="bgc"  >.false.</use_dynroot>
+<use_dynroot phys="ctsm5_1"                 >.false.</use_dynroot>
 
 <!-- Guardrail for ensuring leaf-Nitrogen doesn't go too small or negative on updates -->
-<use_nguardrail phys="clm4_5"                 >.false.</use_nguardrail>
-<use_nguardrail phys="clm5_0" use_cn=".false.">.false.</use_nguardrail>
-<use_nguardrail phys="clm5_0" use_cn=".true." >.true.</use_nguardrail>
+<use_nguardrail phys="clm4_5"                  >.false.</use_nguardrail>
+<use_nguardrail phys="clm5_0"  use_cn=".false.">.false.</use_nguardrail>
+<use_nguardrail phys="clm5_0"  use_cn=".true." >.true.</use_nguardrail>
+<use_nguardrail phys="ctsm5_1" use_cn=".false.">.false.</use_nguardrail>
+<use_nguardrail phys="ctsm5_1" use_cn=".true." >.true.</use_nguardrail>
 
-<ncrit    phys="clm5_0" use_cn=".true.">1.d-9</ncrit>
-<ncrit    phys="clm4_5" use_cn=".true.">1.d-8</ncrit>
-<cnegcrit phys="clm5_0" use_cn=".true.">-6.d+1</cnegcrit>
-<nnegcrit phys="clm5_0" use_cn=".true.">-6.d+0</nnegcrit>
-<cnegcrit phys="clm4_5" use_cn=".true.">-6.d+2</cnegcrit>
-<nnegcrit phys="clm4_5" use_cn=".true.">-6.d+1</nnegcrit>
+<ncrit    phys="ctsm5_1" use_cn=".true.">1.d-9</ncrit>
+<ncrit    phys="clm5_0"  use_cn=".true.">1.d-9</ncrit>
+<ncrit    phys="clm4_5"  use_cn=".true.">1.d-8</ncrit>
+<cnegcrit phys="ctsm5_1" use_cn=".true.">-6.d+1</cnegcrit>
+<nnegcrit phys="ctsm5_1" use_cn=".true.">-6.d+0</nnegcrit>
+<cnegcrit phys="clm5_0"  use_cn=".true.">-6.d+1</cnegcrit>
+<nnegcrit phys="clm5_0"  use_cn=".true.">-6.d+0</nnegcrit>
+<cnegcrit phys="clm4_5"  use_cn=".true.">-6.d+2</cnegcrit>
+<nnegcrit phys="clm4_5"  use_cn=".true.">-6.d+1</nnegcrit>
 
 <!-- Plant hydraulic stress -->
-<use_hydrstress                                                      >.false.</use_hydrstress>
-<use_hydrstress phys="clm5_0" use_fates=".false." configuration="clm">.true.</use_hydrstress>
+<use_hydrstress                                                       >.false.</use_hydrstress>
+<use_hydrstress phys="clm5_0"  use_fates=".false." configuration="clm">.true.</use_hydrstress>
+<use_hydrstress phys="ctsm5_1" use_fates=".false." configuration="clm">.true.</use_hydrstress>
 
 <!-- General CN options -->
 <dribble_crophrv_xsmrpool_2atm co2_type="prognostic" use_crop=".true.">.true.</dribble_crophrv_xsmrpool_2atm>
@@ -584,6 +671,16 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.false. glc_nec=10
 </init_interp_attributes>
 
+<!-- 1850 for CTSM5.1 -->
+<!-- These two needs to specify use_cn=F/T since there is a version for both, other files just use the BGC version -->
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="ctsm5_1_GSWP3v1" use_cn=".false."
+>hgrid=0.9x1.25 maxpft=17 mask=gx1v7 use_cn=.false. use_nitrif_denitrif=.false. use_vertsoilc=.false. use_crop=.false. irrigate=.true. glc_nec=10
+</init_interp_attributes>
+
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="ctsm5_1_GSWP3v1" use_cn=".true."
+>hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.false. glc_nec=10
+</init_interp_attributes>
+
 <!-- present day -->
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm4_5_GSWP3v1"
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
@@ -598,6 +695,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_GSWP3v1"
+>hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
+</init_interp_attributes>
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="ctsm5_1_GSWP3v1"
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
 </init_interp_attributes>
 
@@ -660,6 +760,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 			hgrid="C96"
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
 </init_interp_attributes>
+
 
 
 <!-- Anything else should use the high resolution file, but just for CLM5.0 -->
@@ -767,6 +868,19 @@ p
 >lnd/clm2/initdata_map/clmi.I1850Clm50SpCru.1706-01-01.0.9x1.25_gx1v7_simyr1850_c200806.nc
 </finidat>
 
+<!-- CTSM5_1 -->
+<finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="18500101" use_nitrif_denitrif=".false." use_vertsoilc=".false." sim_year="1850"
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
+         lnd_tuning_mode="ctsm5_1_GSWP3v1"
+>lnd/clm2/initdata_map/clmi.I1850Clm50Sp.0181-01-01.0.9x1.25_gx1v7_simyr1850_c200806.nc
+</finidat>
+<finidat hgrid="0.9x1.25"  maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="18500101" use_nitrif_denitrif=".true." use_vertsoilc=".true." sim_year="1850"
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
+         lnd_tuning_mode="ctsm5_1_GSWP3v1"
+>lnd/clm2/initdata_map/clmi.I1850Clm50BgcCrop-ciso.1366-01-01.0.9x1.25_gx1v7_simyr1850_c200428.nc
+</finidat>
 
 <!--
      Present day IC (if use_init_interp is set and .true. then MUST still interpolate even on an exact match)
@@ -796,6 +910,13 @@ p
          lnd_tuning_mode="clm5_0_GSWP3v1"
 >lnd/clm2/initdata_map/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c190312.nc
 </finidat>
+<finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="20110101" use_nitrif_denitrif=".true." use_vertsoilc=".true." sim_year="2000"
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         lnd_tuning_mode="ctsm5_1_GSWP3v1"
+>lnd/clm2/initdata_map/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c190312.nc
+</finidat>
+
 
 <!-- This is the same file as above but, for a different tuning mode -->
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
@@ -1250,30 +1371,38 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
  use_crop=".false."   >lnd/clm2/surfdata_map/release-clm5.0.18/landuse.timeseries_10x15_SSP5-3.4_16pfts_Irrig_CMIP6_simyr1850-2100_c190228.nc</flanduse_timeseries>
 
 <!-- Fixation and Uptake of Nitrogen Model (FUN2.0) -->
-<use_fun phys="clm5_0" use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
-<use_fun                                                           >.false.</use_fun>
+<use_fun phys="ctsm5_1" use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
+<use_fun phys="clm5_0"  use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
+<use_fun                                                            >.false.</use_fun>
 
 <br_root>0.83d-06</br_root>
 
 <!-- Scalar of leaf respiration to vcmax (used for SP mode and with luna)-->
+<leaf_mr_vcm phys="ctsm5_1">0.015d00</leaf_mr_vcm>
 <leaf_mr_vcm phys="clm5_0" >0.015d00</leaf_mr_vcm>
 <leaf_mr_vcm phys="clm4_5" >0.015d00</leaf_mr_vcm>
 
 <!-- Initial Carbon stocks for BGC -->
-<initial_Cstocks phys="clm4_5" use_cn=".true."  use_fates=".false." use_century_decomp=".true." >20.0d00, 20.0d00, 20.0d00</initial_Cstocks>
-<initial_Cstocks phys="clm5_0" use_cn=".true."  use_fates=".false." use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
-<initial_Cstocks phys="clm4_5" use_cn=".false." use_fates=".true."  use_century_decomp=".true." >20.0d00, 20.0d00, 20.0d00</initial_Cstocks>
-<initial_Cstocks phys="clm5_0" use_cn=".false." use_fates=".true."  use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
+<initial_Cstocks phys="clm4_5"  use_cn=".true."  use_fates=".false." use_century_decomp=".true." >20.0d00, 20.0d00, 20.0d00</initial_Cstocks>
+<initial_Cstocks phys="clm5_0"  use_cn=".true."  use_fates=".false." use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
+<initial_Cstocks phys="ctsm5_1" use_cn=".true."  use_fates=".false." use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
+<initial_Cstocks phys="clm4_5"  use_cn=".false." use_fates=".true."  use_century_decomp=".true." >20.0d00, 20.0d00, 20.0d00</initial_Cstocks>
+<initial_Cstocks phys="clm5_0"  use_cn=".false." use_fates=".true."  use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
+<initial_Cstocks phys="ctsm5_1" use_cn=".false." use_fates=".true."  use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
 
-<initial_Cstocks_depth phys="clm5_0" use_cn=".true."   use_fates=".false." use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
-<initial_Cstocks_depth phys="clm4_5" use_cn=".true."   use_fates=".false." use_century_decomp=".true." >0.3</initial_Cstocks_depth>
-<initial_Cstocks_depth phys="clm5_0" use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
-<initial_Cstocks_depth phys="clm4_5" use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >0.3</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="ctsm5_1" use_cn=".true."   use_fates=".false." use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="clm5_0"  use_cn=".true."   use_fates=".false." use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="clm4_5"  use_cn=".true."   use_fates=".false." use_century_decomp=".true." >0.3</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="ctsm5_1" use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="clm5_0"  use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="clm4_5"  use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >0.3</initial_Cstocks_depth>
 
-<initial_vegC phys="clm5_0" use_cn=".true."  mm_nuptake_opt=".true." >100.d00</initial_vegC>
-<initial_vegC phys="clm4_5" use_cn=".true."  mm_nuptake_opt=".true." >20.d00</initial_vegC>
-<initial_vegC phys="clm5_0" use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
-<initial_vegC phys="clm4_5" use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
+<initial_vegC phys="ctsm5_1" use_cn=".true."  mm_nuptake_opt=".true." >100.d00</initial_vegC>
+<initial_vegC phys="clm5_0"  use_cn=".true."  mm_nuptake_opt=".true." >100.d00</initial_vegC>
+<initial_vegC phys="clm4_5"  use_cn=".true."  mm_nuptake_opt=".true." >20.d00</initial_vegC>
+<initial_vegC phys="ctsm5_1" use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
+<initial_vegC phys="clm5_0"  use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
+<initial_vegC phys="clm4_5"  use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
 
 <!-- SNICAR (SNow, ICe, and Aerosol Radiative model) datasets -->
 <!--  ***********  Resolution independent:   ***********  -->
@@ -1281,13 +1410,17 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <fsnowaging  >lnd/clm2/snicardata/snicar_drdt_bst_fit_60_c070416.nc</fsnowaging>
 
 <!-- Nitrogen deposition streams namelist defaults -->
-<stream_year_first_ndep phys="clm4_5" use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
-<model_year_align_ndep  phys="clm4_5" use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
+<stream_year_first_ndep phys="clm4_5"  use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5"  use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
+<model_year_align_ndep  phys="clm4_5"  use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
 
-<stream_year_first_ndep phys="clm5_0" use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
-<model_year_align_ndep  phys="clm5_0" use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
+<stream_year_first_ndep phys="clm5_0"  use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_0"  use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
+<model_year_align_ndep  phys="clm5_0"  use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
+
+<stream_year_first_ndep phys="ctsm5_1" use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
+<model_year_align_ndep  phys="ctsm5_1" use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
 
 <stream_year_first_ndep use_cn=".true."   sim_year="2010" >2010</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="2010" >2010</stream_year_last_ndep>
@@ -1307,35 +1440,49 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_ndep>
 
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
 
 <!-- Only the CMIP6 Tier I Nitogen deposition files are available -->
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
+<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
+<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP1-2.6-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
+<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP2-4.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm5_0" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
+<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP3-7.0-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
 
-<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
+<stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
+<stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP1-2.6-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
->lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="clm4_5" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
+<stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
+>lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP2-4.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP3-7.0-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
 
-<ndep_taxmode            phys="clm5_0" use_cn=".true.">cycle</ndep_taxmode>
-<ndep_varlist            phys="clm5_0" use_cn=".true.">NDEP_month</ndep_varlist>
-<ndep_taxmode            phys="clm5_0" use_cn=".true.">limit</ndep_taxmode>
+<stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
+>lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
+>lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP1-2.6-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
+>lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
+>lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP3-7.0-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
 
-<ndep_taxmode            phys="clm4_5" use_cn=".true.">cycle</ndep_taxmode>
-<ndep_varlist            phys="clm4_5" use_cn=".true.">NDEP_month</ndep_varlist>
-<ndep_taxmode            phys="clm4_5" use_cn=".true.">limit</ndep_taxmode>
+<ndep_taxmode            phys="ctsm5_1" use_cn=".true.">cycle</ndep_taxmode>
+<ndep_varlist            phys="ctsm5_1" use_cn=".true.">NDEP_month</ndep_varlist>
+<ndep_taxmode            phys="ctsm5_1" use_cn=".true.">limit</ndep_taxmode>
+
+<ndep_taxmode            phys="clm5_0"  use_cn=".true.">cycle</ndep_taxmode>
+<ndep_varlist            phys="clm5_0"  use_cn=".true.">NDEP_month</ndep_varlist>
+<ndep_taxmode            phys="clm5_0"  use_cn=".true.">limit</ndep_taxmode>
+
+<ndep_taxmode            phys="clm4_5"  use_cn=".true.">cycle</ndep_taxmode>
+<ndep_varlist            phys="clm4_5"  use_cn=".true.">NDEP_month</ndep_varlist>
+<ndep_taxmode            phys="clm4_5"  use_cn=".true.">limit</ndep_taxmode>
 
 <ndepmapalgo                use_cn=".true." >bilinear</ndepmapalgo>
 
@@ -1401,6 +1548,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <light_res    use_cn=".true." fire_method="nofire" >none</light_res>
 <light_res    use_cn=".true." phys="clm4_5"        >94x192</light_res>
 <light_res    use_cn=".true." phys="clm5_0"        >94x192</light_res>
+<light_res    use_cn=".true." phys="ctsm5_1"       >360x720</light_res>
 
 <stream_year_first_lightng use_cn=".true."   >0001</stream_year_first_lightng>
 <stream_year_last_lightng  use_cn=".true."   >0001</stream_year_last_lightng>
@@ -1419,13 +1567,17 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <lightngmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</lightngmapalgo>
 
 <!-- Population density streams namelist defaults -->
-<stream_year_first_popdens phys="clm4_5" cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_5" cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
-<model_year_align_popdens  phys="clm4_5" cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
+<stream_year_first_popdens phys="clm4_5"  cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5"  cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
+<model_year_align_popdens  phys="clm4_5"  cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
 
-<stream_year_first_popdens phys="clm5_0" cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm5_0" cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
-<model_year_align_popdens  phys="clm5_0" cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
+<stream_year_first_popdens phys="clm5_0"  cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_0"  cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
+<model_year_align_popdens  phys="clm5_0"  cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
+
+<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
+<model_year_align_popdens  phys="ctsm5_1" cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
 
 <stream_year_first_popdens use_cn=".true."   sim_year="2010" >2010</stream_year_first_popdens>
 <stream_year_last_popdens  use_cn=".true."   sim_year="2010" >2010</stream_year_last_popdens>
@@ -1474,13 +1626,17 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <popdensmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</popdensmapalgo>
 
 <!-- Urban time varying streams namelist defaults -->
-<stream_year_first_urbantv phys="clm5_0" sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
-<model_year_align_urbantv  phys="clm5_0" sim_year_range="1850-2100" >2015</model_year_align_urbantv>
+<stream_year_first_urbantv phys="ctsm5_1" sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="ctsm5_1" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="ctsm5_1" sim_year_range="1850-2100" >2015</model_year_align_urbantv>
 
-<stream_year_first_urbantv phys="clm4_5" sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm4_5" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
-<model_year_align_urbantv  phys="clm4_5" sim_year_range="1850-2100" >2015</model_year_align_urbantv>
+<stream_year_first_urbantv phys="clm5_0"  sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_0"  sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm5_0"  sim_year_range="1850-2100" >2015</model_year_align_urbantv>
+
+<stream_year_first_urbantv phys="clm4_5"  sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm4_5"  sim_year_range="1850-2100" >2015</model_year_align_urbantv>
 
 <stream_year_first_urbantv sim_year="2000" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  sim_year="2000" >2000</stream_year_last_urbantv>
@@ -1499,6 +1655,9 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 
 <stream_year_first_urbantv sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
+
+<stream_fldfilename_urbantv phys="ctsm5_1" hgrid="0.9x1.25" 
+>lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_0" hgrid="0.9x1.25" 
 >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
@@ -3366,8 +3525,9 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <!-- Defaults for ch4par_in namelist            -->
 <!-- =========================================  -->
 
-<finundation_method phys="clm5_0">TWS_inversion</finundation_method>
-<finundation_method phys="clm4_5">ZWT_inversion</finundation_method>
+<finundation_method phys="ctsm5_1">TWS_inversion</finundation_method>
+<finundation_method phys="clm5_0" >TWS_inversion</finundation_method>
+<finundation_method phys="clm4_5" >ZWT_inversion</finundation_method>
 <use_aereoxid_prog use_cn=".true."   >.true.</use_aereoxid_prog>
 <use_aereoxid_prog use_fates=".true.">.true.</use_aereoxid_prog>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -36,10 +36,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <lnd_tuning_mode phys="clm4_5" >clm4_5_CRUv7</lnd_tuning_mode>
 <lnd_tuning_mode phys="clm5_0" >clm5_0_cam6.0</lnd_tuning_mode>
-<lnd_tuning_mode phys="ctsm5_1">ctsm5_1_GSWP3v1</lnd_tuning_mode>
+<lnd_tuning_mode phys="clm5_1" >clm5_1_GSWP3v1</lnd_tuning_mode>
 
 <!-- Component name for output files -->
-<compname phys="ctsm5_1">ctsm5</compname>
+<compname phys="clm5_1" >clm5</compname>
 <compname phys="clm5_0" >clm5</compname>
 <compname phys="clm4_5" >clm4</compname>
 
@@ -47,11 +47,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <clm_accelerated_spinup>off</clm_accelerated_spinup>
 
 <!-- Spinup state for BGC -->
-<spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="ctsm5_1">2</spinup_state>
+<spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="clm5_1" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="clm5_0" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_cn=".true." phys="clm4_5" >1</spinup_state>
-<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="ctsm5_1">2</spinup_state>
-<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="ctsm5_1">2</spinup_state>
+<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm5_1" >2</spinup_state>
+<spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm5_1" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm5_0" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm5_0" >2</spinup_state>
 <spinup_state clm_accelerated_spinup="on"  use_fates=".true." phys="clm4_5" >1</spinup_state>
@@ -71,29 +71,29 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <hist_mfilt  clm_accelerated_spinup="on">20</hist_mfilt>
 
 <!-- Root and stem acclimation -->
-<rootstem_acc phys="ctsm5_1">.false.</rootstem_acc>
+<rootstem_acc phys="clm5_1" >.false.</rootstem_acc>
 <rootstem_acc phys="clm5_0" >.false.</rootstem_acc>
 <rootstem_acc phys="clm4_5" >.false.</rootstem_acc>
 
 <!-- Light inhibition of photosynthesis -->
-<light_inhibit phys="ctsm5_1">.true.</light_inhibit>
+<light_inhibit phys="clm5_1" >.true.</light_inhibit>
 <light_inhibit phys="clm5_0" >.true.</light_inhibit>
 <light_inhibit phys="clm4_5" >.false.</light_inhibit>
 
 <!-- Method to calculate leaf maintenance respiration for canopy top at 25C -->
-<leafresp_method phys="ctsm5_1" use_cn=".true." >2</leafresp_method>
+<leafresp_method phys="clm5_1"  use_cn=".true." >2</leafresp_method>
 <leafresp_method phys="clm5_0"  use_cn=".true." >2</leafresp_method>
 <leafresp_method phys="clm4_5"  use_cn=".true." >1</leafresp_method>
 <leafresp_method                use_cn=".false.">0</leafresp_method>
 
 <!-- Modfy photosyntheiss and LMR for crop -->
-<modifyphoto_and_lmr_forcrop phys="ctsm5_1">.true.</modifyphoto_and_lmr_forcrop>
+<modifyphoto_and_lmr_forcrop phys="clm5_1" >.true.</modifyphoto_and_lmr_forcrop>
 <modifyphoto_and_lmr_forcrop phys="clm5_0" >.true.</modifyphoto_and_lmr_forcrop>
 <modifyphoto_and_lmr_forcrop phys="clm4_5" >.false.</modifyphoto_and_lmr_forcrop>
 
 <!-- Method to use for stomatal conducatance -->
-<stomatalcond_method phys="ctsm5_1" use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
-<stomatalcond_method phys="ctsm5_1" use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
+<stomatalcond_method phys="clm5_1"  use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
+<stomatalcond_method phys="clm5_1"  use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
 <stomatalcond_method phys="clm5_0"  use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
 <stomatalcond_method phys="clm5_0"  use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
 <stomatalcond_method phys="clm4_5"                          >Ball-Berry1987</stomatalcond_method>
@@ -116,8 +116,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <atm_c14_filename use_c14=".true." use_c14_bombspike =".true." ssp_rcp="SSP5-8.5" >lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP5B_3x1_global_1850-2100_yearly_c181209.nc</atm_c14_filename>
 
 <!-- Irrigation default -->
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false." sim_year_range="1850-2100">.true.</irrigate>
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true."  sim_year_range="1850-2100">.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".false." sim_year_range="1850-2100">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".true."  sim_year_range="1850-2100">.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" use_cndv=".false."  sim_year_range="1850-2100">.true.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."   sim_year_range="1850-2100">.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5"                     sim_year_range="1850-2100">.false.</irrigate>
@@ -139,20 +139,20 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <suplnitro use_fates=".true." >NONE</suplnitro>
 
 <!-- Albedo for glaciers -->
-<albice phys="ctsm5_1">0.50,0.30</albice>
+<albice phys="clm5_1" >0.50,0.30</albice>
 <albice phys="clm5_0" >0.50,0.30</albice>
 <albice phys="clm4_5" >0.60,0.40</albice>
 
 <!-- Default urban air conditioning/heating and wasteheat -->
-<urban_hac phys="ctsm5_1">ON_WASTEHEAT</urban_hac>
+<urban_hac phys="clm5_1" >ON_WASTEHEAT</urban_hac>
 <urban_hac phys="clm5_0" >ON_WASTEHEAT</urban_hac>
 <urban_hac phys="clm4_5" >ON</urban_hac>
 
-<building_temp_method phys="ctsm5_1">1</building_temp_method>
+<building_temp_method phys="clm5_1" >1</building_temp_method>
 <building_temp_method phys="clm5_0" >1</building_temp_method>
 <building_temp_method phys="clm4_5" >0</building_temp_method>
 
-<calc_human_stress_indices phys="ctsm5_1">FAST</calc_human_stress_indices>
+<calc_human_stress_indices phys="clm5_1" >FAST</calc_human_stress_indices>
 <calc_human_stress_indices phys="clm5_0" >FAST</calc_human_stress_indices>
 <calc_human_stress_indices phys="clm4_5" >NONE</calc_human_stress_indices>
 
@@ -160,18 +160,18 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <urban_traffic>.false.</urban_traffic>
 
 <!-- Soil state settings -->
-<organic_frac_squared phys="ctsm5_1">.true.</organic_frac_squared>
+<organic_frac_squared phys="clm5_1" >.true.</organic_frac_squared>
 <organic_frac_squared phys="clm4_5" >.true.</organic_frac_squared>
 <organic_frac_squared phys="clm5_0" >.false.</organic_frac_squared>
 
 <soil_layerstruct_predefined structure="fast">4SL_2m</soil_layerstruct_predefined>
-<soil_layerstruct_predefined structure="standard" phys="ctsm5_1">20SL_8.5m</soil_layerstruct_predefined>
+<soil_layerstruct_predefined structure="standard" phys="clm5_1" >20SL_8.5m</soil_layerstruct_predefined>
 <soil_layerstruct_predefined structure="standard" phys="clm5_0" >20SL_8.5m</soil_layerstruct_predefined>
 <soil_layerstruct_predefined structure="standard" phys="clm4_5" >10SL_3.5m</soil_layerstruct_predefined>
 
-<use_bedrock phys="ctsm5_1" use_fates =".true.">.false.</use_bedrock>
-<use_bedrock phys="ctsm5_1" vichydro ="1"      >.false.</use_bedrock>
-<use_bedrock phys="ctsm5_1"                    >.true.</use_bedrock>
+<use_bedrock phys="clm5_1"  use_fates =".true.">.false.</use_bedrock>
+<use_bedrock phys="clm5_1"  vichydro ="1"      >.false.</use_bedrock>
+<use_bedrock phys="clm5_1"                     >.true.</use_bedrock>
 <use_bedrock phys="clm5_0"  use_fates =".true.">.false.</use_bedrock>
 <use_bedrock phys="clm5_0"  vichydro ="1"      >.false.</use_bedrock>
 <use_bedrock phys="clm5_0"                     >.true.</use_bedrock>
@@ -179,22 +179,22 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 
 <!-- Rooting profile namelist defaults -->
-<rooting_profile_method_water  phys="ctsm5_1">1</rooting_profile_method_water>
+<rooting_profile_method_water  phys="clm5_1" >1</rooting_profile_method_water>
 <rooting_profile_method_water  phys="clm5_0" >1</rooting_profile_method_water>
 <rooting_profile_method_water  phys="clm4_5" >0</rooting_profile_method_water>
 
-<rooting_profile_method_carbon phys="ctsm5_1">1</rooting_profile_method_carbon>
+<rooting_profile_method_carbon phys="clm5_1" >1</rooting_profile_method_carbon>
 <rooting_profile_method_carbon phys="clm5_0" >1</rooting_profile_method_carbon>
 <rooting_profile_method_carbon phys="clm4_5" >1</rooting_profile_method_carbon>
 
 <!-- Soil evaporative resistance namelist defaults -->
-<soil_resis_method phys="ctsm5_1">1</soil_resis_method>
+<soil_resis_method phys="clm5_1" >1</soil_resis_method>
 <soil_resis_method phys="clm5_0" >1</soil_resis_method>
 <soil_resis_method phys="clm4_5" >0</soil_resis_method>
 
 <!-- Soil hydrology -->
-<baseflow_scalar phys="ctsm5_1" lower_boundary_condition="1">1.d-2</baseflow_scalar>
-<baseflow_scalar phys="ctsm5_1" lower_boundary_condition="2">0.001d00</baseflow_scalar>
+<baseflow_scalar phys="clm5_1"  lower_boundary_condition="1">1.d-2</baseflow_scalar>
+<baseflow_scalar phys="clm5_1"  lower_boundary_condition="2">0.001d00</baseflow_scalar>
 <baseflow_scalar phys="clm5_0"  lower_boundary_condition="1">1.d-2</baseflow_scalar>
 <baseflow_scalar phys="clm5_0"  lower_boundary_condition="2">0.001d00</baseflow_scalar>
 <baseflow_scalar phys="clm4_5"  lower_boundary_condition="1">1.d-2</baseflow_scalar>
@@ -203,10 +203,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Friction velocity -->
 <zetamaxstable phys="clm4_5" >2.0d00</zetamaxstable>
 <zetamaxstable phys="clm5_0" >0.5d00</zetamaxstable>
-<zetamaxstable phys="ctsm5_1">0.5d00</zetamaxstable>
+<zetamaxstable phys="clm5_1" >0.5d00</zetamaxstable>
 
 <!-- atm2lnd defaults -->
-<repartition_rain_snow phys="ctsm5_1">.true.</repartition_rain_snow>
+<repartition_rain_snow phys="clm5_1" >.true.</repartition_rain_snow>
 <repartition_rain_snow phys="clm5_0" >.true.</repartition_rain_snow>
 <repartition_rain_snow phys="clm4_5" >.false.</repartition_rain_snow>
 
@@ -234,16 +234,16 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <precip_repartition_glc_all_snow_t phys="clm5_0" >-2.</precip_repartition_glc_all_snow_t>
 <precip_repartition_glc_all_rain_t phys="clm5_0" >0.</precip_repartition_glc_all_rain_t>
 
-<precip_repartition_glc_all_snow_t phys="ctsm5_1">-2.</precip_repartition_glc_all_snow_t>
-<precip_repartition_glc_all_rain_t phys="ctsm5_1">0.</precip_repartition_glc_all_rain_t>
+<precip_repartition_glc_all_snow_t phys="clm5_1" >-2.</precip_repartition_glc_all_snow_t>
+<precip_repartition_glc_all_rain_t phys="clm5_1" >0.</precip_repartition_glc_all_rain_t>
 
 <!-- lnd2atm defaults -->
 <melt_non_icesheet_ice_runoff phys="clm4_5" >.false.</melt_non_icesheet_ice_runoff>
 <melt_non_icesheet_ice_runoff phys="clm5_0" >.true.</melt_non_icesheet_ice_runoff>
-<melt_non_icesheet_ice_runoff phys="ctsm5_1">.true.</melt_non_icesheet_ice_runoff>
+<melt_non_icesheet_ice_runoff phys="clm5_1" >.true.</melt_non_icesheet_ice_runoff>
 
 <!-- CN Fire model method defaults -->
-<fire_method phys="ctsm5_1">li2021gswpfrc</fire_method>
+<fire_method phys="clm5_1" >li2021gswpfrc</fire_method>
 <fire_method phys="clm5_0" >li2016crufrc</fire_method>
 <fire_method phys="clm4_5" >li2014qianfrc</fire_method>
 
@@ -300,7 +300,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <cmb_cmplt_fact           fire_method="li2021gswpfrc" >0.5d00, 0.28d00</cmb_cmplt_fact>
 
 <!-- Canopy fluxes namelist defaults -->
-<use_undercanopy_stability phys="ctsm5_1">.false.</use_undercanopy_stability>
+<use_undercanopy_stability phys="clm5_1" >.false.</use_undercanopy_stability>
 <use_undercanopy_stability phys="clm5_0" >.false.</use_undercanopy_stability>
 <use_undercanopy_stability phys="clm4_5" >.true.</use_undercanopy_stability>
 
@@ -308,9 +308,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <itmax_canopy_fluxes structure="fast"    >3</itmax_canopy_fluxes>
 
 <!-- Canopy hydrology namelist defaults -->
-<use_clm5_fpi                 phys="ctsm5_1">.true.</use_clm5_fpi>
-<interception_fraction        phys="ctsm5_1">1.0</interception_fraction>
-<maximum_leaf_wetted_fraction phys="ctsm5_1">0.05</maximum_leaf_wetted_fraction>
+<use_clm5_fpi                 phys="clm5_1" >.true.</use_clm5_fpi>
+<interception_fraction        phys="clm5_1" >1.0</interception_fraction>
+<maximum_leaf_wetted_fraction phys="clm5_1" >0.05</maximum_leaf_wetted_fraction>
 
 <use_clm5_fpi                 phys="clm5_0" >.true.</use_clm5_fpi>
 <interception_fraction        phys="clm5_0" >1.0</interception_fraction>
@@ -323,11 +323,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Soilwater movement namelist defaults -->
 <soilwater_movement_method phys="clm4_5" >0</soilwater_movement_method>
 <soilwater_movement_method phys="clm5_0" >1</soilwater_movement_method>
-<soilwater_movement_method phys="ctsm5_1">1</soilwater_movement_method>
+<soilwater_movement_method phys="clm5_1" >1</soilwater_movement_method>
 
 <upper_boundary_condition phys="clm4_5" >1</upper_boundary_condition>
 <upper_boundary_condition phys="clm5_0" >1</upper_boundary_condition>
-<upper_boundary_condition phys="ctsm5_1">1</upper_boundary_condition>
+<upper_boundary_condition phys="clm5_1" >1</upper_boundary_condition>
 
 <lower_boundary_condition soilwater_movement_method="0"                       >4</lower_boundary_condition>
 <lower_boundary_condition soilwater_movement_method="1" use_bedrock=".true."  >2</lower_boundary_condition>
@@ -348,13 +348,13 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <irrig_length>14400</irrig_length>
 <irrig_target_smp>-3400.</irrig_target_smp>  <!-- -3400 is a standard value for field capacity -->
 <irrig_depth>0.6</irrig_depth>
-<irrig_threshold_fraction phys="ctsm5_1">1.0</irrig_threshold_fraction>
+<irrig_threshold_fraction phys="clm5_1" >1.0</irrig_threshold_fraction>
 <irrig_threshold_fraction phys="clm5_0" >1.0</irrig_threshold_fraction>
 <irrig_threshold_fraction phys="clm4_5" >0.5</irrig_threshold_fraction>
 <irrig_river_volume_threshold>0.1</irrig_river_volume_threshold>
 
 <!--  River storage derived lake evaporation and irrigation limitation  -->
-<limit_irrigation_if_rof_enabled phys="ctsm5_1">.false.</limit_irrigation_if_rof_enabled>
+<limit_irrigation_if_rof_enabled phys="clm5_1" >.false.</limit_irrigation_if_rof_enabled>
 <limit_irrigation_if_rof_enabled phys="clm5_0" >.false.</limit_irrigation_if_rof_enabled>
 <limit_irrigation_if_rof_enabled               >.false.</limit_irrigation_if_rof_enabled>
 
@@ -366,16 +366,16 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <snowveg_affects_radiation>.true.</snowveg_affects_radiation>
 
 <!-- Snow pack settings-->
-<nlevsno phys="ctsm5_1" structure="standard">12</nlevsno>
-<nlevsno phys="ctsm5_1" structure="fast"    >5</nlevsno>
+<nlevsno phys="clm5_1"  structure="standard">12</nlevsno>
+<nlevsno phys="clm5_1"  structure="fast"    >5</nlevsno>
 <nlevsno phys="clm5_0" structure="standard" >12</nlevsno>
 <nlevsno phys="clm5_0" structure="fast"     >5</nlevsno>
 <nlevsno phys="clm4_5"                      >5</nlevsno>
 <!-- h2osno_max is more 'configuration' than 'structure'. But since it's
      tied to nlevsno, we're controlling it via 'structure', like
      nlevsno, so that defaults for the two remain consistent. -->
-<h2osno_max phys="ctsm5_1" structure="standard">10000.0</h2osno_max>
-<h2osno_max phys="ctsm5_1" structure="fast"    >5000.0</h2osno_max>
+<h2osno_max phys="clm5_1"  structure="standard">10000.0</h2osno_max>
+<h2osno_max phys="clm5_1"  structure="fast"    >5000.0</h2osno_max>
 <h2osno_max phys="clm5_0"  structure="standard">10000.0</h2osno_max>
 <h2osno_max phys="clm5_0"  structure="fast"    >5000.0</h2osno_max>
 <h2osno_max phys="clm4_5"                      >1000.0</h2osno_max>
@@ -387,34 +387,34 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <snow_dzmax_u_1>0.02d00</snow_dzmax_u_1>
 <snow_dzmax_u_2>0.05d00</snow_dzmax_u_2>
 
-<int_snow_max phys="ctsm5_1">2000.</int_snow_max>
+<int_snow_max phys="clm5_1" >2000.</int_snow_max>
 <int_snow_max phys="clm5_0" >2000.</int_snow_max>
 <!-- For clm4_5, make this effectively unlimited -->
 <int_snow_max phys="clm4_5" >1.e30</int_snow_max>
 
-<n_melt_glcmec phys="ctsm5_1">10.0d00</n_melt_glcmec>
+<n_melt_glcmec phys="clm5_1" >10.0d00</n_melt_glcmec>
 <n_melt_glcmec phys="clm5_0" >10.0d00</n_melt_glcmec>
 <n_melt_glcmec phys="clm4_5" >10.0</n_melt_glcmec>
 
-<wind_dependent_snow_density phys="ctsm5_1">.true.</wind_dependent_snow_density>
+<wind_dependent_snow_density phys="clm5_1" >.true.</wind_dependent_snow_density>
 <wind_dependent_snow_density phys="clm5_0" >.true.</wind_dependent_snow_density>
 <wind_dependent_snow_density phys="clm4_5" >.false.</wind_dependent_snow_density>
 
-<snow_overburden_compaction_method phys="ctsm5_1">'Vionnet2012'</snow_overburden_compaction_method>
+<snow_overburden_compaction_method phys="clm5_1" >'Vionnet2012'</snow_overburden_compaction_method>
 <snow_overburden_compaction_method phys="clm5_0" >'Vionnet2012'</snow_overburden_compaction_method>
 <snow_overburden_compaction_method phys="clm4_5" >'Anderson1976'</snow_overburden_compaction_method>
 
-<lotmp_snowdensity_method phys="ctsm5_1">'Slater2017'</lotmp_snowdensity_method>
+<lotmp_snowdensity_method phys="clm5_1" >'Slater2017'</lotmp_snowdensity_method>
 <lotmp_snowdensity_method phys="clm5_0" >'Slater2017'</lotmp_snowdensity_method>
 <lotmp_snowdensity_method phys="clm4_5" >'TruncatedAnderson1976'</lotmp_snowdensity_method>
 
 <upplim_destruct_metamorph   phys="clm4_5" >100.d00</upplim_destruct_metamorph>
 <upplim_destruct_metamorph   phys="clm5_0" >175.d00</upplim_destruct_metamorph>
-<upplim_destruct_metamorph   phys="ctsm5_1">175.d00</upplim_destruct_metamorph>
+<upplim_destruct_metamorph   phys="clm5_1" >175.d00</upplim_destruct_metamorph>
 
 <fresh_snw_rds_max phys="clm4_5" >54.526d00</fresh_snw_rds_max>
 <fresh_snw_rds_max phys="clm5_0" >204.526d00</fresh_snw_rds_max>
-<fresh_snw_rds_max phys="ctsm5_1">204.526d00</fresh_snw_rds_max>
+<fresh_snw_rds_max phys="clm5_1" >204.526d00</fresh_snw_rds_max>
 
 <overburden_compress_tfactor>0.08d00</overburden_compress_tfactor>
 
@@ -454,7 +454,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
      simplicity, we tie the defaults for both of these options to the overall
      CLM phys version, rather than having some intermediate option that controls
      the defaults for both h2osno_max and glc_snow_persistence_max_days. -->
-<glc_snow_persistence_max_days phys="ctsm5_1">0</glc_snow_persistence_max_days>
+<glc_snow_persistence_max_days phys="clm5_1" >0</glc_snow_persistence_max_days>
 <glc_snow_persistence_max_days phys="clm5_0" >0</glc_snow_persistence_max_days>
 <glc_snow_persistence_max_days phys="clm4_5" >7300</glc_snow_persistence_max_days>
 
@@ -462,7 +462,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="ctsm5_1">lnd/clm2/paramdata/ctsm51_params.c200905.nc</paramfile>
+<paramfile phys="clm5_1" >lnd/clm2/paramdata/ctsm51_params.c200905.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c200905.nc</paramfile>
 <paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c200905.nc</paramfile>
 
@@ -475,15 +475,15 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->
 <!-- ========================================================================================  -->
-<use_flexibleCN phys="ctsm5_1" use_cn=".true.">.true.</use_flexibleCN>
-<use_flexibleCN phys="ctsm5_1"                >.false.</use_flexibleCN>
+<use_flexibleCN phys="clm5_1"  use_cn=".true.">.true.</use_flexibleCN>
+<use_flexibleCN phys="clm5_1"                 >.false.</use_flexibleCN>
 <use_flexibleCN phys="clm5_0"  use_cn=".true.">.true.</use_flexibleCN>
 <use_flexibleCN phys="clm5_0"                 >.false.</use_flexibleCN>
 <use_flexibleCN phys="clm4_5"                 >.false.</use_flexibleCN>
 
 <!-- LUNA model: Leaf Utilization of Nitrogen for Assimilation -->
-<use_luna phys="ctsm5_1" >.true.</use_luna>
-<use_luna phys="ctsm5_1" use_fates=".true." >.false.</use_luna>
+<use_luna phys="clm5_1"  >.true.</use_luna>
+<use_luna phys="clm5_1"  use_fates=".true." >.false.</use_luna>
 <use_luna phys="clm5_0"  >.true.</use_luna>
 <use_luna phys="clm5_0"  use_fates=".true." >.false.</use_luna>
 <use_luna phys="clm4_5"  >.false.</use_luna>
@@ -515,26 +515,26 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_fertilizer>.false.</use_fertilizer>
 <use_fertilizer use_crop=".true." phys="clm4_5" >.true.</use_fertilizer>
 <use_fertilizer use_crop=".true." phys="clm5_0" >.true.</use_fertilizer>
-<use_fertilizer use_crop=".true." phys="ctsm5_1">.true.</use_fertilizer>
+<use_fertilizer use_crop=".true." phys="clm5_1" >.true.</use_fertilizer>
 
-<jmaxb1 use_luna=".true." phys="ctsm5_1">0.17</jmaxb1>
+<jmaxb1 use_luna=".true." phys="clm5_1" >0.17</jmaxb1>
 <jmaxb1 use_luna=".true." phys="clm5_0" >0.17</jmaxb1>
 
 <use_grainproduct>.false.</use_grainproduct>
 <use_grainproduct use_crop=".true." phys="clm4_5" >.false.</use_grainproduct> <!-- 1-year grain product pool default to off for clm45 if crop is turned on -->
 <use_grainproduct use_crop=".true." phys="clm5_0" >.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
-<use_grainproduct use_crop=".true." phys="ctsm5_1">.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
+<use_grainproduct use_crop=".true." phys="clm5_1" >.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
 
 <!-- Crop model options -->
 <baset_mapping           use_crop=".true." phys="clm4_5" >constant</baset_mapping>
 <baset_mapping           use_crop=".true." phys="clm5_0" >varytropicsbylat</baset_mapping>
 <baset_latvary_intercept use_crop=".true." phys="clm5_0"  baset_mapping="varytropicsbylat">12.0d00</baset_latvary_intercept>
 <baset_latvary_slope     use_crop=".true." phys="clm5_0"  baset_mapping="varytropicsbylat">0.4d00</baset_latvary_slope>
-<baset_mapping           use_crop=".true." phys="ctsm5_1">varytropicsbylat</baset_mapping>
-<baset_latvary_intercept use_crop=".true." phys="ctsm5_1" baset_mapping="varytropicsbylat">12.0d00</baset_latvary_intercept>
-<baset_latvary_slope     use_crop=".true." phys="ctsm5_1" baset_mapping="varytropicsbylat">0.4d00</baset_latvary_slope>
+<baset_mapping           use_crop=".true." phys="clm5_1" >varytropicsbylat</baset_mapping>
+<baset_latvary_intercept use_crop=".true." phys="clm5_1"  baset_mapping="varytropicsbylat">12.0d00</baset_latvary_intercept>
+<baset_latvary_slope     use_crop=".true." phys="clm5_1"  baset_mapping="varytropicsbylat">0.4d00</baset_latvary_slope>
 
-<initial_seed_at_planting use_crop=".true." phys="ctsm5_1">3.d00</initial_seed_at_planting>
+<initial_seed_at_planting use_crop=".true." phys="clm5_1" >3.d00</initial_seed_at_planting>
 <initial_seed_at_planting use_crop=".true." phys="clm5_0" >3.d00</initial_seed_at_planting>
 <initial_seed_at_planting use_crop=".true." phys="clm4_5" >1.d00</initial_seed_at_planting>
 
@@ -542,12 +542,12 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- turnover time modifications    -->
 <decomp_depth_efolding phys="clm4_5" >0.5</decomp_depth_efolding>
 <decomp_depth_efolding phys="clm5_0" >10.0</decomp_depth_efolding>
-<decomp_depth_efolding phys="ctsm5_1">10.0</decomp_depth_efolding>
+<decomp_depth_efolding phys="clm5_1" >10.0</decomp_depth_efolding>
 
 <!-- use additional stress deciduous onset trigger    -->
 <constrain_stress_deciduous_onset phys="clm4_5" >.false.</constrain_stress_deciduous_onset>
 <constrain_stress_deciduous_onset phys="clm5_0" >.true.</constrain_stress_deciduous_onset>
-<constrain_stress_deciduous_onset phys="ctsm5_1">.true.</constrain_stress_deciduous_onset>
+<constrain_stress_deciduous_onset phys="clm5_1" >.true.</constrain_stress_deciduous_onset>
 
 <!-- Whether to use subgrid fluxes for snow -->
 <use_subgrid_fluxes>.true.</use_subgrid_fluxes>
@@ -558,20 +558,20 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_dynroot phys="clm5_0"  bgc_mode="cn"   >.false.</use_dynroot>
 <use_dynroot phys="clm5_0"  bgc_mode="fates">.false.</use_dynroot>
 <use_dynroot phys="clm5_0"  bgc_mode="bgc"  >.false.</use_dynroot>
-<use_dynroot phys="ctsm5_1"                 >.false.</use_dynroot>
+<use_dynroot phys="clm5_1"                  >.false.</use_dynroot>
 
 <!-- Guardrail for ensuring leaf-Nitrogen doesn't go too small or negative on updates -->
 <use_nguardrail phys="clm4_5"                  >.false.</use_nguardrail>
 <use_nguardrail phys="clm5_0"  use_cn=".false.">.false.</use_nguardrail>
 <use_nguardrail phys="clm5_0"  use_cn=".true." >.true.</use_nguardrail>
-<use_nguardrail phys="ctsm5_1" use_cn=".false.">.false.</use_nguardrail>
-<use_nguardrail phys="ctsm5_1" use_cn=".true." >.true.</use_nguardrail>
+<use_nguardrail phys="clm5_1"  use_cn=".false.">.false.</use_nguardrail>
+<use_nguardrail phys="clm5_1"  use_cn=".true." >.true.</use_nguardrail>
 
-<ncrit    phys="ctsm5_1" use_cn=".true.">1.d-9</ncrit>
+<ncrit    phys="clm5_1"  use_cn=".true.">1.d-9</ncrit>
 <ncrit    phys="clm5_0"  use_cn=".true.">1.d-9</ncrit>
 <ncrit    phys="clm4_5"  use_cn=".true.">1.d-8</ncrit>
-<cnegcrit phys="ctsm5_1" use_cn=".true.">-6.d+1</cnegcrit>
-<nnegcrit phys="ctsm5_1" use_cn=".true.">-6.d+0</nnegcrit>
+<cnegcrit phys="clm5_1"  use_cn=".true.">-6.d+1</cnegcrit>
+<nnegcrit phys="clm5_1"  use_cn=".true.">-6.d+0</nnegcrit>
 <cnegcrit phys="clm5_0"  use_cn=".true.">-6.d+1</cnegcrit>
 <nnegcrit phys="clm5_0"  use_cn=".true.">-6.d+0</nnegcrit>
 <cnegcrit phys="clm4_5"  use_cn=".true.">-6.d+2</cnegcrit>
@@ -580,7 +580,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Plant hydraulic stress -->
 <use_hydrstress                                                       >.false.</use_hydrstress>
 <use_hydrstress phys="clm5_0"  use_fates=".false." configuration="clm">.true.</use_hydrstress>
-<use_hydrstress phys="ctsm5_1" use_fates=".false." configuration="clm">.true.</use_hydrstress>
+<use_hydrstress phys="clm5_1"  use_fates=".false." configuration="clm">.true.</use_hydrstress>
 
 <!-- General CN options -->
 <dribble_crophrv_xsmrpool_2atm co2_type="prognostic" use_crop=".true.">.true.</dribble_crophrv_xsmrpool_2atm>
@@ -682,11 +682,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- 1850 for CTSM5.1 -->
 <!-- These two needs to specify use_cn=F/T since there is a version for both, other files just use the BGC version -->
-<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="ctsm5_1_GSWP3v1" use_cn=".false."
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_1_GSWP3v1" use_cn=".false."
 >hgrid=0.9x1.25 maxpft=17 mask=gx1v7 use_cn=.false. use_nitrif_denitrif=.false. use_vertsoilc=.false. use_crop=.false. irrigate=.true. glc_nec=10
 </init_interp_attributes>
 
-<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="ctsm5_1_GSWP3v1" use_cn=".true."
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_1_GSWP3v1" use_cn=".true."
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.false. glc_nec=10
 </init_interp_attributes>
 
@@ -706,7 +706,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_GSWP3v1"
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
 </init_interp_attributes>
-<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="ctsm5_1_GSWP3v1"
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_1_GSWP3v1"
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
 </init_interp_attributes>
 
@@ -881,13 +881,13 @@ p
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" use_nitrif_denitrif=".false." use_vertsoilc=".false." sim_year="1850"
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="ctsm5_1_GSWP3v1"
+         lnd_tuning_mode="clm5_1_GSWP3v1"
 >lnd/clm2/initdata_map/clmi.I1850Clm50Sp.0181-01-01.0.9x1.25_gx1v7_simyr1850_c200806.nc
 </finidat>
 <finidat hgrid="0.9x1.25"  maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" use_nitrif_denitrif=".true." use_vertsoilc=".true." sim_year="1850"
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
-         lnd_tuning_mode="ctsm5_1_GSWP3v1"
+         lnd_tuning_mode="clm5_1_GSWP3v1"
 >lnd/clm2/initdata_map/clmi.I1850Clm50BgcCrop-ciso.1366-01-01.0.9x1.25_gx1v7_simyr1850_c200428.nc
 </finidat>
 
@@ -922,7 +922,7 @@ p
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20110101" use_nitrif_denitrif=".true." use_vertsoilc=".true." sim_year="2000"
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         lnd_tuning_mode="ctsm5_1_GSWP3v1"
+         lnd_tuning_mode="clm5_1_GSWP3v1"
 >lnd/clm2/initdata_map/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c190312.nc
 </finidat>
 
@@ -1387,36 +1387,36 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
  use_crop=".false."   >lnd/clm2/surfdata_map/release-clm5.0.18/landuse.timeseries_10x15_SSP5-3.4_16pfts_Irrig_CMIP6_simyr1850-2100_c190228.nc</flanduse_timeseries>
 
 <!-- Fixation and Uptake of Nitrogen Model (FUN2.0) -->
-<use_fun phys="ctsm5_1" use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
+<use_fun phys="clm5_1"  use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
 <use_fun phys="clm5_0"  use_cn=".true." use_nitrif_denitrif=".true.">.true.</use_fun>
 <use_fun                                                            >.false.</use_fun>
 
 <br_root>0.83d-06</br_root>
 
 <!-- Scalar of leaf respiration to vcmax (used for SP mode and with luna)-->
-<leaf_mr_vcm phys="ctsm5_1">0.015d00</leaf_mr_vcm>
+<leaf_mr_vcm phys="clm5_1" >0.015d00</leaf_mr_vcm>
 <leaf_mr_vcm phys="clm5_0" >0.015d00</leaf_mr_vcm>
 <leaf_mr_vcm phys="clm4_5" >0.015d00</leaf_mr_vcm>
 
 <!-- Initial Carbon stocks for BGC -->
 <initial_Cstocks phys="clm4_5"  use_cn=".true."  use_fates=".false." use_century_decomp=".true." >20.0d00, 20.0d00, 20.0d00</initial_Cstocks>
 <initial_Cstocks phys="clm5_0"  use_cn=".true."  use_fates=".false." use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
-<initial_Cstocks phys="ctsm5_1" use_cn=".true."  use_fates=".false." use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
+<initial_Cstocks phys="clm5_1"  use_cn=".true."  use_fates=".false." use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
 <initial_Cstocks phys="clm4_5"  use_cn=".false." use_fates=".true."  use_century_decomp=".true." >20.0d00, 20.0d00, 20.0d00</initial_Cstocks>
 <initial_Cstocks phys="clm5_0"  use_cn=".false." use_fates=".true."  use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
-<initial_Cstocks phys="ctsm5_1" use_cn=".false." use_fates=".true."  use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
+<initial_Cstocks phys="clm5_1"  use_cn=".false." use_fates=".true."  use_century_decomp=".true." >200.0d00, 200.0d00, 200.0d00</initial_Cstocks>
 
-<initial_Cstocks_depth phys="ctsm5_1" use_cn=".true."   use_fates=".false." use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="clm5_1"  use_cn=".true."   use_fates=".false." use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
 <initial_Cstocks_depth phys="clm5_0"  use_cn=".true."   use_fates=".false." use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
 <initial_Cstocks_depth phys="clm4_5"  use_cn=".true."   use_fates=".false." use_century_decomp=".true." >0.3</initial_Cstocks_depth>
-<initial_Cstocks_depth phys="ctsm5_1" use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
+<initial_Cstocks_depth phys="clm5_1"  use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
 <initial_Cstocks_depth phys="clm5_0"  use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >1.50d00</initial_Cstocks_depth>
 <initial_Cstocks_depth phys="clm4_5"  use_cn=".false."  use_fates=".true."  use_century_decomp=".true." >0.3</initial_Cstocks_depth>
 
-<initial_vegC phys="ctsm5_1" use_cn=".true."  mm_nuptake_opt=".true." >100.d00</initial_vegC>
+<initial_vegC phys="clm5_1"  use_cn=".true."  mm_nuptake_opt=".true." >100.d00</initial_vegC>
 <initial_vegC phys="clm5_0"  use_cn=".true."  mm_nuptake_opt=".true." >100.d00</initial_vegC>
 <initial_vegC phys="clm4_5"  use_cn=".true."  mm_nuptake_opt=".true." >20.d00</initial_vegC>
-<initial_vegC phys="ctsm5_1" use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
+<initial_vegC phys="clm5_1"  use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
 <initial_vegC phys="clm5_0"  use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
 <initial_vegC phys="clm4_5"  use_cn=".true."  mm_nuptake_opt=".false.">1.d00</initial_vegC>
 
@@ -1434,9 +1434,9 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_last_ndep  phys="clm5_0"  use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0"  use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
 
-<stream_year_first_ndep phys="ctsm5_1" use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
-<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
-<model_year_align_ndep  phys="ctsm5_1" use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
+<stream_year_first_ndep phys="clm5_1"  use_cn=".true." sim_year_range="1850-2100"  >2015</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_1"  use_cn=".true." sim_year_range="1850-2100"  >2101</stream_year_last_ndep>
+<model_year_align_ndep  phys="clm5_1"  use_cn=".true." sim_year_range="1850-2100"  >2015</model_year_align_ndep>
 
 <stream_year_first_ndep use_cn=".true."   sim_year="2010" >2010</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="2010" >2010</stream_year_last_ndep>
@@ -1456,18 +1456,18 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_first_ndep use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_ndep>
 <stream_year_last_ndep  use_cn=".true."   sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_ndep>
 
-<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
+<stream_fldfilename_ndep phys="clm5_1"  hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
 <stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
 <stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25" use_cn=".true." ssp_rcp="hist" >lnd/clm2/ndepdata/fndep_clm_hist_b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.ensmean_1849-2015_monthly_0.9x1.25_c180926.nc</stream_fldfilename_ndep>
 
 <!-- Only the CMIP6 Tier I Nitogen deposition files are available -->
-<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
+<stream_fldfilename_ndep phys="clm5_1"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP5-8.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
+<stream_fldfilename_ndep phys="clm5_1"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP1-2.6"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP1-2.6-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
+<stream_fldfilename_ndep phys="clm5_1"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP2-4.5"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP2-4.5-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
-<stream_fldfilename_ndep phys="ctsm5_1" hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
+<stream_fldfilename_ndep phys="clm5_1"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP3-7.0-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
 
 <stream_fldfilename_ndep phys="clm5_0"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP5-8.5"
@@ -1488,9 +1488,9 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_fldfilename_ndep phys="clm4_5"  hgrid="0.9x1.25"   use_cn=".true."   ssp_rcp="SSP3-7.0"
 >lnd/clm2/ndepdata/fndep_clm_f09_g17.CMIP6-SSP3-7.0-WACCM_1849-2101_monthly_c191007.nc</stream_fldfilename_ndep>
 
-<ndep_taxmode            phys="ctsm5_1" use_cn=".true.">cycle</ndep_taxmode>
-<ndep_varlist            phys="ctsm5_1" use_cn=".true.">NDEP_month</ndep_varlist>
-<ndep_taxmode            phys="ctsm5_1" use_cn=".true.">limit</ndep_taxmode>
+<ndep_taxmode            phys="clm5_1"  use_cn=".true.">cycle</ndep_taxmode>
+<ndep_varlist            phys="clm5_1"  use_cn=".true.">NDEP_month</ndep_varlist>
+<ndep_taxmode            phys="clm5_1"  use_cn=".true.">limit</ndep_taxmode>
 
 <ndep_taxmode            phys="clm5_0"  use_cn=".true.">cycle</ndep_taxmode>
 <ndep_varlist            phys="clm5_0"  use_cn=".true.">NDEP_month</ndep_varlist>
@@ -1564,7 +1564,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <light_res    use_cn=".true." fire_method="nofire" >none</light_res>
 <light_res    use_cn=".true." phys="clm4_5"        >94x192</light_res>
 <light_res    use_cn=".true." phys="clm5_0"        >94x192</light_res>
-<light_res    use_cn=".true." phys="ctsm5_1"       >360x720</light_res>
+<light_res    use_cn=".true." phys="clm5_1"        >360x720</light_res>
 
 <stream_year_first_lightng use_cn=".true."   >0001</stream_year_first_lightng>
 <stream_year_last_lightng  use_cn=".true."   >0001</stream_year_last_lightng>
@@ -1591,9 +1591,9 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_last_popdens  phys="clm5_0"  cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0"  cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
 
-<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
-<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
-<model_year_align_popdens  phys="ctsm5_1" cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
+<stream_year_first_popdens phys="clm5_1"  cnfireson=".true." sim_year_range="1850-2100"  >2015</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_1"  cnfireson=".true." sim_year_range="1850-2100"  >2100</stream_year_last_popdens>
+<model_year_align_popdens  phys="clm5_1"  cnfireson=".true." sim_year_range="1850-2100"  >2015</model_year_align_popdens>
 
 <stream_year_first_popdens use_cn=".true."   sim_year="2010" >2010</stream_year_first_popdens>
 <stream_year_last_popdens  use_cn=".true."   sim_year="2010" >2010</stream_year_last_popdens>
@@ -1642,9 +1642,9 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <popdensmapalgo use_cn=".true."   hgrid="5x5_amazon"          >nn</popdensmapalgo>
 
 <!-- Urban time varying streams namelist defaults -->
-<stream_year_first_urbantv phys="ctsm5_1" sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="ctsm5_1" sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
-<model_year_align_urbantv  phys="ctsm5_1" sim_year_range="1850-2100" >2015</model_year_align_urbantv>
+<stream_year_first_urbantv phys="clm5_1"  sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_1"  sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm5_1"  sim_year_range="1850-2100" >2015</model_year_align_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0"  sim_year_range="1850-2100" >2015</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  sim_year_range="1850-2100" >2106</stream_year_last_urbantv>
@@ -1672,7 +1672,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_first_urbantv sim_year="constant" sim_year_range="1850-2000" >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
 
-<stream_fldfilename_urbantv phys="ctsm5_1" hgrid="0.9x1.25" 
+<stream_fldfilename_urbantv phys="clm5_1"  hgrid="0.9x1.25" 
 >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_0" hgrid="0.9x1.25" 
@@ -3541,7 +3541,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <!-- Defaults for ch4par_in namelist            -->
 <!-- =========================================  -->
 
-<finundation_method phys="ctsm5_1">TWS_inversion</finundation_method>
+<finundation_method phys="clm5_1" >TWS_inversion</finundation_method>
 <finundation_method phys="clm5_0" >TWS_inversion</finundation_method>
 <finundation_method phys="clm4_5" >ZWT_inversion</finundation_method>
 <use_aereoxid_prog use_cn=".true."   >.true.</use_aereoxid_prog>

--- a/bld/namelist_files/namelist_defaults_drydep.xml
+++ b/bld/namelist_files/namelist_defaults_drydep.xml
@@ -23,6 +23,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <megan_specifier>'ISOP = isoprene', 'C10H16 = pinene_a + carene_3 + thujene_a', 'CH3OH = methanol', 'C2H5OH = ethanol', 'CH2O = formaldehyde', 'CH3CHO = acetaldehyde', 'CH3COOH = acetic_acid', 'CH3COCH3 = acetone'</megan_specifier>
 
+<megan_factors_file phys="ctsm5_1">atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
 <megan_factors_file phys="clm5_0" >atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
 <megan_factors_file phys="clm4_5" >atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
 

--- a/bld/namelist_files/namelist_defaults_drydep.xml
+++ b/bld/namelist_files/namelist_defaults_drydep.xml
@@ -23,7 +23,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <megan_specifier>'ISOP = isoprene', 'C10H16 = pinene_a + carene_3 + thujene_a', 'CH3OH = methanol', 'C2H5OH = ethanol', 'CH2O = formaldehyde', 'CH3CHO = acetaldehyde', 'CH3COOH = acetic_acid', 'CH3COCH3 = acetone'</megan_specifier>
 
-<megan_factors_file phys="ctsm5_1">atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
+<megan_factors_file phys="clm5_1" >atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
 <megan_factors_file phys="clm5_0" >atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
 <megan_factors_file phys="clm4_5" >atm/cam/chem/trop_mozart/emis/megan21_emis_factors_78pft_c20161108.nc</megan_factors_file>
 

--- a/bld/namelist_files/namelist_defaults_overall.xml
+++ b/bld/namelist_files/namelist_defaults_overall.xml
@@ -22,18 +22,23 @@ determine default values for namelists.
 
 -->
 
-<clm_start_type phys="clm5_0" use_cndv=".true." >arb_ic</clm_start_type>
-<clm_start_type phys="clm4_5" use_cndv=".true." >arb_ic</clm_start_type>
-<clm_start_type phys="clm4_5" use_fates=".true.">arb_ic</clm_start_type>
-<clm_start_type phys="clm5_0" use_fates=".true.">arb_ic</clm_start_type>
-<clm_start_type phys="clm4_5" sim_year="1850"   >startup</clm_start_type>
-<clm_start_type phys="clm5_0" sim_year="1850"   >startup</clm_start_type>
-<clm_start_type phys="clm4_5" sim_year="2000"   >startup</clm_start_type>
-<clm_start_type phys="clm5_0" sim_year="2000"   >startup</clm_start_type>
-<clm_start_type phys="clm4_5"                   >arb_ic</clm_start_type>
-<clm_start_type phys="clm5_0"                   >arb_ic</clm_start_type>
-<clm_start_type phys="clm4_5" use_fates=".true.">arb_ic</clm_start_type>
-<clm_start_type bgc_spinup="on"                 >cold</clm_start_type>
+<clm_start_type phys="ctsm5_1" use_cndv=".true." >arb_ic</clm_start_type>
+<clm_start_type phys="clm5_0"  use_cndv=".true." >arb_ic</clm_start_type>
+<clm_start_type phys="clm4_5"  use_cndv=".true." >arb_ic</clm_start_type>
+<clm_start_type phys="clm4_5"  use_fates=".true.">arb_ic</clm_start_type>
+<clm_start_type phys="ctsm5_1" use_fates=".true.">arb_ic</clm_start_type>
+<clm_start_type phys="clm5_0"  use_fates=".true.">arb_ic</clm_start_type>
+<clm_start_type phys="clm4_5"  sim_year="1850"   >startup</clm_start_type>
+<clm_start_type phys="ctsm5_1" sim_year="1850"   >startup</clm_start_type>
+<clm_start_type phys="clm5_0"  sim_year="1850"   >startup</clm_start_type>
+<clm_start_type phys="clm4_5"  sim_year="2000"   >startup</clm_start_type>
+<clm_start_type phys="ctsm5_1" sim_year="2000"   >startup</clm_start_type>
+<clm_start_type phys="clm5_0"  sim_year="2000"   >startup</clm_start_type>
+<clm_start_type phys="clm4_5"                    >arb_ic</clm_start_type>
+<clm_start_type phys="clm5_0"                    >arb_ic</clm_start_type>
+<clm_start_type phys="clm5_0"                    >arb_ic</clm_start_type>
+<clm_start_type phys="clm4_5"  use_fates=".true.">arb_ic</clm_start_type>
+<clm_start_type bgc_spinup="on"                  >cold</clm_start_type>
 
 <clm_start_type sim_year_range="1850-2100">arb_ic</clm_start_type>
 

--- a/bld/namelist_files/namelist_defaults_overall.xml
+++ b/bld/namelist_files/namelist_defaults_overall.xml
@@ -22,17 +22,17 @@ determine default values for namelists.
 
 -->
 
-<clm_start_type phys="ctsm5_1" use_cndv=".true." >arb_ic</clm_start_type>
+<clm_start_type phys="clm5_1"  use_cndv=".true." >arb_ic</clm_start_type>
 <clm_start_type phys="clm5_0"  use_cndv=".true." >arb_ic</clm_start_type>
 <clm_start_type phys="clm4_5"  use_cndv=".true." >arb_ic</clm_start_type>
 <clm_start_type phys="clm4_5"  use_fates=".true.">arb_ic</clm_start_type>
-<clm_start_type phys="ctsm5_1" use_fates=".true.">arb_ic</clm_start_type>
+<clm_start_type phys="clm5_1"  use_fates=".true.">arb_ic</clm_start_type>
 <clm_start_type phys="clm5_0"  use_fates=".true.">arb_ic</clm_start_type>
 <clm_start_type phys="clm4_5"  sim_year="1850"   >startup</clm_start_type>
-<clm_start_type phys="ctsm5_1" sim_year="1850"   >startup</clm_start_type>
+<clm_start_type phys="clm5_1"  sim_year="1850"   >startup</clm_start_type>
 <clm_start_type phys="clm5_0"  sim_year="1850"   >startup</clm_start_type>
 <clm_start_type phys="clm4_5"  sim_year="2000"   >startup</clm_start_type>
-<clm_start_type phys="ctsm5_1" sim_year="2000"   >startup</clm_start_type>
+<clm_start_type phys="clm5_1"  sim_year="2000"   >startup</clm_start_type>
 <clm_start_type phys="clm5_0"  sim_year="2000"   >startup</clm_start_type>
 <clm_start_type phys="clm4_5"                    >arb_ic</clm_start_type>
 <clm_start_type phys="clm5_0"                    >arb_ic</clm_start_type>

--- a/bld/namelist_files/namelist_defaults_overall.xml
+++ b/bld/namelist_files/namelist_defaults_overall.xml
@@ -36,7 +36,7 @@ determine default values for namelists.
 <clm_start_type phys="clm5_0"  sim_year="2000"   >startup</clm_start_type>
 <clm_start_type phys="clm4_5"                    >arb_ic</clm_start_type>
 <clm_start_type phys="clm5_0"                    >arb_ic</clm_start_type>
-<clm_start_type phys="clm5_0"                    >arb_ic</clm_start_type>
+<clm_start_type phys="clm5_1"                    >arb_ic</clm_start_type>
 <clm_start_type phys="clm4_5"  use_fates=".true.">arb_ic</clm_start_type>
 <clm_start_type bgc_spinup="on"                  >cold</clm_start_type>
 

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -54,7 +54,7 @@ Full pathname of master restart file for a branch run. (only used if RUN_TYPE=br
        category="datasets"
        group="clm_inparm" 
        value="clm2"
-       valid_values="clm2,clm45,clm50,ctsm51" >
+       valid_values="clm2,clm4,clm5,ctsm5" >
 Component name to use in history and restart files
 </entry>
 

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -49,6 +49,15 @@ Full pathname of master restart file for a branch run. (only used if RUN_TYPE=br
 (Set with RUN_REFCASE and RUN_REFDATE)
 </entry>
 
+<entry id="compname" 
+       type="char*8" 
+       category="datasets"
+       group="clm_inparm" 
+       value="clm2"
+       valid_values="clm2,clm45,clm50,ctsm51" >
+Component name to use in history and restart files
+</entry>
+
 <entry id="fatmlndfrc" 
        type="char*256" 
        category="datasets"

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -54,7 +54,7 @@ Full pathname of master restart file for a branch run. (only used if RUN_TYPE=br
        category="datasets"
        group="clm_inparm" 
        value="clm2"
-       valid_values="clm2,clm4,clm5,ctsm5" >
+       valid_values="clm2,clm4,clm5" >
 Component name to use in history and restart files
 </entry>
 
@@ -1981,7 +1981,7 @@ Land mask description
 
 <entry id="lnd_tuning_mode" type="char*20" category="default_settings"
        group="default_settings"
-       valid_values="clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,clm5_0_cam6.0,clm5_0_CRUv7,clm5_0_GSWP3v1,ctsm5_1_GSWP3v1">
+       valid_values="clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,clm5_0_cam6.0,clm5_0_CRUv7,clm5_0_GSWP3v1,clm5_1_GSWP3v1">
 General configuration of model version and atmospheric forcing to tune the model to run under.
 This sets the model to run with constants and initial conditions that were set to run well under 
 the configuration of model version and atmospheric forcing. To run well constants would need to be changed

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -198,12 +198,13 @@ formulation (1).
 </entry>
 
 <entry id="fire_method" type="char*80" category="clm_physics"
-       group="cnfire_inparm" valid_values="nofire,li2014qianfrc,li2016crufrc" >
+       group="cnfire_inparm" valid_values="nofire,li2014qianfrc,li2016crufrc,li2021gswpfrc" >
 The method type to use for CNFire
 
 nofire:        Turn fire effects off
 li2014qianfrc: Reference paper Li, et. al.(2014) tuned with QIAN atmospheric forcing
 li2016crufrc:  Reference paper Li, et. al.(2016) tuned with CRU-NCEP atmospheric forcing
+li2021gswpfrc: Reference paper Li, et. al.(2021?) tuned with GSWP3 atmospheric forcing
 </entry>
 
 <entry id="pot_hmn_ign_counts_alpha" type="real" category="clm_physics"
@@ -1971,7 +1972,7 @@ Land mask description
 
 <entry id="lnd_tuning_mode" type="char*20" category="default_settings"
        group="default_settings"
-       valid_values="clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,clm5_0_cam6.0,clm5_0_CRUv7,clm5_0_GSWP3v1">
+       valid_values="clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,clm5_0_cam6.0,clm5_0_CRUv7,clm5_0_GSWP3v1,ctsm5_1_GSWP3v1">
 General configuration of model version and atmospheric forcing to tune the model to run under.
 This sets the model to run with constants and initial conditions that were set to run well under 
 the configuration of model version and atmospheric forcing. To run well constants would need to be changed

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -8,7 +8,7 @@
 
 <sim_year_range>constant</sim_year_range>
 
-<irrigate use_crop=".true." phys="ctsm5_1">.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1">.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5" >.false.</irrigate>
 
@@ -18,8 +18,8 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >1850</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="ctsm5_1" use_cn=".true.">1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true.">1850</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm5_1" use_cn=".true." >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_1" use_cn=".true." >1850</stream_year_last_ndep>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true." >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >1850</stream_year_last_popdens>
@@ -27,8 +27,8 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >1850</stream_year_last_popdens>
 
-<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true.">1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true.">1850</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm5_1" cnfireson=".true." >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_1" cnfireson=".true." >1850</stream_year_last_popdens>
 
 <stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm4_5"  >1850</stream_year_last_urbantv>
@@ -36,10 +36,10 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="ctsm5_1" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="ctsm5_1" >1850</stream_year_last_urbantv>
+<stream_year_first_urbantv phys="clm5_1"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_1"  >1850</stream_year_last_urbantv>
 
-<stream_fldfilename_ndep phys="ctsm5_1" use_cn=".true."
+<stream_fldfilename_ndep phys="clm5_1" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
 
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
@@ -49,6 +49,6 @@
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
  
 <ndep_taxmode            phys="clm5_0"  use_cn=".true." >cycle</ndep_taxmode>
-<ndep_taxmode            phys="ctsm5_1" use_cn=".true." >cycle</ndep_taxmode>
+<ndep_taxmode            phys="clm5_1"  use_cn=".true." >cycle</ndep_taxmode>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_control.xml
+++ b/bld/namelist_files/use_cases/1850_control.xml
@@ -8,6 +8,7 @@
 
 <sim_year_range>constant</sim_year_range>
 
+<irrigate use_crop=".true." phys="ctsm5_1">.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5" >.false.</irrigate>
 
@@ -17,11 +18,17 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >1850</stream_year_last_ndep>
 
+<stream_year_first_ndep phys="ctsm5_1" use_cn=".true.">1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true.">1850</stream_year_last_ndep>
+
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true." >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >1850</stream_year_last_popdens>
 
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >1850</stream_year_last_popdens>
+
+<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true.">1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true.">1850</stream_year_last_popdens>
 
 <stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm4_5"  >1850</stream_year_last_urbantv>
@@ -29,12 +36,19 @@
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>
 
+<stream_year_first_urbantv phys="ctsm5_1" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="ctsm5_1" >1850</stream_year_last_urbantv>
+
+<stream_fldfilename_ndep phys="ctsm5_1" use_cn=".true."
+>lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
+
 <stream_fldfilename_ndep phys="clm5_0" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
  
 <stream_fldfilename_ndep phys="clm4_5" use_cn=".true."
 >lnd/clm2/ndepdata/fndep_clm_WACCM6_CMIP6piControl001_y21-50avg_1850monthly_0.95x1.25_c180802.nc</stream_fldfilename_ndep>
  
-<ndep_taxmode            phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
+<ndep_taxmode            phys="clm5_0"  use_cn=".true." >cycle</ndep_taxmode>
+<ndep_taxmode            phys="ctsm5_1" use_cn=".true." >cycle</ndep_taxmode>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/1850_noanthro_control.xml
+++ b/bld/namelist_files/use_cases/1850_noanthro_control.xml
@@ -10,22 +10,17 @@
 
 <irrigate>.false.</irrigate>
 
-<stream_year_first_ndep phys="clm4_0" bgc="cn"   >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cn"   >1850</stream_year_last_ndep>
-
-<stream_year_first_ndep phys="clm4_0" bgc="cndv" >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cndv" >1850</stream_year_last_ndep>
-
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm4_5" use_cn=".true." >1850</stream_year_last_ndep>
 
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >1850</stream_year_last_ndep>
 
-<ndep_taxmode            phys="clm5_0" use_cn=".true." >cycle</ndep_taxmode>
+<stream_year_first_ndep phys="ctsm5_1" use_cn=".true.">1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true.">1850</stream_year_last_ndep>
 
-<stream_year_first_popdens phys="clm4_0" cnfireson=".true." >1925</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_0" cnfireson=".true." >1925</stream_year_last_popdens>
+<ndep_taxmode            phys="clm5_0"  use_cn=".true." >cycle</ndep_taxmode>
+<ndep_taxmode            phys="ctsm5_1" use_cn=".true." >cycle</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true." >1925</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >1925</stream_year_last_popdens>
@@ -33,10 +28,16 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >1925</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >1925</stream_year_last_popdens>
 
+<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true.">1925</stream_year_first_popdens>
+<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true.">1925</stream_year_last_popdens>
+
 <!-- zero population density file -->
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true."
 >lnd/clm2/firedata/clmforc.no_anthro_zero_hdm_1x1_simyr1925_181113.nc</stream_fldfilename_popdens>
 <popdensmapalgo use_cn=".true.">nn</popdensmapalgo>
+
+<stream_year_first_urbantv phys="ctsm5_1" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="ctsm5_1" >1850</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>

--- a/bld/namelist_files/use_cases/1850_noanthro_control.xml
+++ b/bld/namelist_files/use_cases/1850_noanthro_control.xml
@@ -16,11 +16,11 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >1850</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="ctsm5_1" use_cn=".true.">1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true.">1850</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm5_1"  use_cn=".true.">1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_1"  use_cn=".true.">1850</stream_year_last_ndep>
 
 <ndep_taxmode            phys="clm5_0"  use_cn=".true." >cycle</ndep_taxmode>
-<ndep_taxmode            phys="ctsm5_1" use_cn=".true." >cycle</ndep_taxmode>
+<ndep_taxmode            phys="clm5_1"  use_cn=".true." >cycle</ndep_taxmode>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true." >1925</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >1925</stream_year_last_popdens>
@@ -28,16 +28,16 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >1925</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >1925</stream_year_last_popdens>
 
-<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true.">1925</stream_year_first_popdens>
-<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true.">1925</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm5_1"  cnfireson=".true.">1925</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_1"  cnfireson=".true.">1925</stream_year_last_popdens>
 
 <!-- zero population density file -->
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true."
 >lnd/clm2/firedata/clmforc.no_anthro_zero_hdm_1x1_simyr1925_181113.nc</stream_fldfilename_popdens>
 <popdensmapalgo use_cn=".true.">nn</popdensmapalgo>
 
-<stream_year_first_urbantv phys="ctsm5_1" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="ctsm5_1" >1850</stream_year_last_urbantv>
+<stream_year_first_urbantv phys="clm5_1"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_1"  >1850</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >1850</stream_year_last_urbantv>

--- a/bld/namelist_files/use_cases/2000_control.xml
+++ b/bld/namelist_files/use_cases/2000_control.xml
@@ -8,9 +8,11 @@
 
 <sim_year_range>constant</sim_year_range>
 
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true." >.false.</irrigate>
-<irrigate use_crop=".true." phys="clm4_5"                   >.false.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false." >.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."  >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true." >2000</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2000</stream_year_last_ndep>
@@ -18,11 +20,17 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >2000</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2000</stream_year_last_ndep>
 
+<stream_year_first_ndep phys="ctsm5_1" use_cn=".true.">2000</stream_year_first_ndep>
+<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true.">2000</stream_year_last_ndep>
+
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true." >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >2000</stream_year_last_popdens>
 
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >2000</stream_year_last_popdens>
+
+<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true.">2000</stream_year_first_popdens>
+<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true.">2000</stream_year_last_popdens>
 
 <stream_year_first_urbantv phys="clm4_5" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm4_5" >2000</stream_year_last_urbantv>
@@ -30,7 +38,7 @@
 <stream_year_first_urbantv phys="clm5_0" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" >2000</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="clm4_5" >2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm4_5" >2000</stream_year_last_urbantv>
+<stream_year_first_urbantv phys="ctsm5_1">2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="ctsm5_1">2000</stream_year_last_urbantv>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/2000_control.xml
+++ b/bld/namelist_files/use_cases/2000_control.xml
@@ -8,8 +8,8 @@
 
 <sim_year_range>constant</sim_year_range>
 
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".true." >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" use_cndv=".false." >.true.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."  >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
@@ -20,8 +20,8 @@
 <stream_year_first_ndep phys="clm5_0" use_cn=".true." >2000</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2000</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="ctsm5_1" use_cn=".true.">2000</stream_year_first_ndep>
-<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true.">2000</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm5_1"  use_cn=".true.">2000</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_1"  use_cn=".true.">2000</stream_year_last_ndep>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true." >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >2000</stream_year_last_popdens>
@@ -29,8 +29,8 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true." >2000</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >2000</stream_year_last_popdens>
 
-<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true.">2000</stream_year_first_popdens>
-<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true.">2000</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm5_1"  cnfireson=".true.">2000</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_1"  cnfireson=".true.">2000</stream_year_last_popdens>
 
 <stream_year_first_urbantv phys="clm4_5" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm4_5" >2000</stream_year_last_urbantv>
@@ -38,7 +38,7 @@
 <stream_year_first_urbantv phys="clm5_0" >2000</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0" >2000</stream_year_last_urbantv>
 
-<stream_year_first_urbantv phys="ctsm5_1">2000</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="ctsm5_1">2000</stream_year_last_urbantv>
+<stream_year_first_urbantv phys="clm5_1" >2000</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_1" >2000</stream_year_last_urbantv>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/2010_control.xml
+++ b/bld/namelist_files/use_cases/2010_control.xml
@@ -8,9 +8,9 @@
 
 <sim_year_range>constant</sim_year_range>
 
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".true." >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0"  use_cndv=".false.">.true.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0"  use_cndv=".true." >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
@@ -27,8 +27,8 @@
 <stream_year_first_ndep phys="clm5_0"  use_cn=".true." >2010</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm5_0"  use_cn=".true." >2010</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="ctsm5_1" use_cn=".true." >2010</stream_year_first_ndep>
-<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true." >2010</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm5_1"  use_cn=".true." >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_1"  use_cn=".true." >2010</stream_year_last_ndep>
 
 <stream_year_first_popdens phys="clm4_5"  cnfireson=".true." >2010</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5"  cnfireson=".true." >2010</stream_year_last_popdens>
@@ -36,11 +36,11 @@
 <stream_year_first_popdens phys="clm5_0"  cnfireson=".true." >2010</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0"  cnfireson=".true." >2010</stream_year_last_popdens>
 
-<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true." >2010</stream_year_first_popdens>
-<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true." >2010</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm5_1"  cnfireson=".true." >2010</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_1"  cnfireson=".true." >2010</stream_year_last_popdens>
 
-<stream_year_first_urbantv phys="ctsm5_1" >2010</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="ctsm5_1" >2010</stream_year_last_urbantv>
+<stream_year_first_urbantv phys="clm5_1"  >2010</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_1"  >2010</stream_year_last_urbantv>
 
 <stream_year_first_urbantv phys="clm5_0"  >2010</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm5_0"  >2010</stream_year_last_urbantv>

--- a/bld/namelist_files/use_cases/2010_control.xml
+++ b/bld/namelist_files/use_cases/2010_control.xml
@@ -8,32 +8,44 @@
 
 <sim_year_range>constant</sim_year_range>
 
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true." >.false.</irrigate>
-<irrigate use_crop=".true." phys="clm4_5"                   >.false.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0"  use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
 
-<stream_year_first_ndep phys="clm4_0" bgc="cn"   >2010</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cn"   >2010</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm4_0"  bgc="cn"   >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_0"  bgc="cn"   >2010</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="clm4_0" bgc="cndv" >2010</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_0" bgc="cndv" >2010</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm4_0"  bgc="cndv" >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_0"  bgc="cndv" >2010</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="clm4_5" use_cn=".true." >2010</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm4_5" use_cn=".true." >2010</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm4_5"  use_cn=".true." >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm4_5"  use_cn=".true." >2010</stream_year_last_ndep>
 
-<stream_year_first_ndep phys="clm5_0" use_cn=".true." >2010</stream_year_first_ndep>
-<stream_year_last_ndep  phys="clm5_0" use_cn=".true." >2010</stream_year_last_ndep>
+<stream_year_first_ndep phys="clm5_0"  use_cn=".true." >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_0"  use_cn=".true." >2010</stream_year_last_ndep>
 
-<stream_year_first_popdens phys="clm4_5" cnfireson=".true." >2010</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm4_5" cnfireson=".true." >2010</stream_year_last_popdens>
+<stream_year_first_ndep phys="ctsm5_1" use_cn=".true." >2010</stream_year_first_ndep>
+<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true." >2010</stream_year_last_ndep>
 
-<stream_year_first_popdens phys="clm5_0" cnfireson=".true." >2010</stream_year_first_popdens>
-<stream_year_last_popdens  phys="clm5_0" cnfireson=".true." >2010</stream_year_last_popdens>
+<stream_year_first_popdens phys="clm4_5"  cnfireson=".true." >2010</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm4_5"  cnfireson=".true." >2010</stream_year_last_popdens>
 
-<stream_year_first_urbantv phys="clm5_0" >2010</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm5_0" >2010</stream_year_last_urbantv>
+<stream_year_first_popdens phys="clm5_0"  cnfireson=".true." >2010</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_0"  cnfireson=".true." >2010</stream_year_last_popdens>
 
-<stream_year_first_urbantv phys="clm4_5" >2010</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm4_5" >2010</stream_year_last_urbantv>
+<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true." >2010</stream_year_first_popdens>
+<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true." >2010</stream_year_last_popdens>
+
+<stream_year_first_urbantv phys="ctsm5_1" >2010</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="ctsm5_1" >2010</stream_year_last_urbantv>
+
+<stream_year_first_urbantv phys="clm5_0"  >2010</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_0"  >2010</stream_year_last_urbantv>
+
+<stream_year_first_urbantv phys="clm4_5"  >2010</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm4_5"  >2010</stream_year_last_urbantv>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -14,9 +14,11 @@
 
 <clm_demand >flanduse_timeseries</clm_demand>
 
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true." >.false.</irrigate>
-<irrigate use_crop=".true." phys="clm4_5"                   >.false.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false." >.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."  >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
 
 <stream_year_first_ndep phys="clm4_5" use_cn=".true."   >1850</stream_year_first_ndep>
 <stream_year_last_ndep  phys="clm4_5" use_cn=".true."   >2015</stream_year_last_ndep>
@@ -26,6 +28,10 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
 
+<stream_year_first_ndep phys="ctsm5_1" use_cn=".true."  >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true."  >2015</stream_year_last_ndep>
+<model_year_align_ndep  phys="ctsm5_1" use_cn=".true."  >1850</model_year_align_ndep>
+
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2016</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm4_5" cnfireson=".true."   >1850</model_year_align_popdens>
@@ -33,6 +39,10 @@
 <stream_year_first_popdens phys="clm5_0" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2016</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
+
+<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true."  >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true."  >2016</stream_year_last_popdens>
+<model_year_align_popdens  phys="ctsm5_1" cnfireson=".true."  >1850</model_year_align_popdens>
 
 <stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm4_5"  >2106</stream_year_last_urbantv>
@@ -42,8 +52,8 @@
 <stream_year_last_urbantv  phys="clm5_0"  >2106</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>
 
-<stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="clm4_5"  >2106</stream_year_last_urbantv>
-<model_year_align_urbantv  phys="clm4_5"  >1850</model_year_align_urbantv>
+<stream_year_first_urbantv phys="ctsm5_1" >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="ctsm5_1" >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="ctsm5_1" >1850</model_year_align_urbantv>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/bld/namelist_files/use_cases/20thC_transient.xml
@@ -14,8 +14,8 @@
 
 <clm_demand >flanduse_timeseries</clm_demand>
 
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".true." >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" use_cndv=".false." >.true.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0" use_cndv=".true."  >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
@@ -28,9 +28,9 @@
 <stream_year_last_ndep  phys="clm5_0" use_cn=".true."   >2015</stream_year_last_ndep>
 <model_year_align_ndep  phys="clm5_0" use_cn=".true."   >1850</model_year_align_ndep>
 
-<stream_year_first_ndep phys="ctsm5_1" use_cn=".true."  >1850</stream_year_first_ndep>
-<stream_year_last_ndep  phys="ctsm5_1" use_cn=".true."  >2015</stream_year_last_ndep>
-<model_year_align_ndep  phys="ctsm5_1" use_cn=".true."  >1850</model_year_align_ndep>
+<stream_year_first_ndep phys="clm5_1"  use_cn=".true."  >1850</stream_year_first_ndep>
+<stream_year_last_ndep  phys="clm5_1"  use_cn=".true."  >2015</stream_year_last_ndep>
+<model_year_align_ndep  phys="clm5_1"  use_cn=".true."  >1850</model_year_align_ndep>
 
 <stream_year_first_popdens phys="clm4_5" cnfireson=".true."   >1850</stream_year_first_popdens>
 <stream_year_last_popdens  phys="clm4_5" cnfireson=".true."   >2016</stream_year_last_popdens>
@@ -40,9 +40,9 @@
 <stream_year_last_popdens  phys="clm5_0" cnfireson=".true."   >2016</stream_year_last_popdens>
 <model_year_align_popdens  phys="clm5_0" cnfireson=".true."   >1850</model_year_align_popdens>
 
-<stream_year_first_popdens phys="ctsm5_1" cnfireson=".true."  >1850</stream_year_first_popdens>
-<stream_year_last_popdens  phys="ctsm5_1" cnfireson=".true."  >2016</stream_year_last_popdens>
-<model_year_align_popdens  phys="ctsm5_1" cnfireson=".true."  >1850</model_year_align_popdens>
+<stream_year_first_popdens phys="clm5_1"  cnfireson=".true."  >1850</stream_year_first_popdens>
+<stream_year_last_popdens  phys="clm5_1"  cnfireson=".true."  >2016</stream_year_last_popdens>
+<model_year_align_popdens  phys="clm5_1"  cnfireson=".true."  >1850</model_year_align_popdens>
 
 <stream_year_first_urbantv phys="clm4_5"  >1850</stream_year_first_urbantv>
 <stream_year_last_urbantv  phys="clm4_5"  >2106</stream_year_last_urbantv>
@@ -52,8 +52,8 @@
 <stream_year_last_urbantv  phys="clm5_0"  >2106</stream_year_last_urbantv>
 <model_year_align_urbantv  phys="clm5_0"  >1850</model_year_align_urbantv>
 
-<stream_year_first_urbantv phys="ctsm5_1" >1850</stream_year_first_urbantv>
-<stream_year_last_urbantv  phys="ctsm5_1" >2106</stream_year_last_urbantv>
-<model_year_align_urbantv  phys="ctsm5_1" >1850</model_year_align_urbantv>
+<stream_year_first_urbantv phys="clm5_1"  >1850</stream_year_first_urbantv>
+<stream_year_last_urbantv  phys="clm5_1"  >2106</stream_year_last_urbantv>
+<model_year_align_urbantv  phys="clm5_1"  >1850</model_year_align_urbantv>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/stdurbpt_pd.xml
+++ b/bld/namelist_files/use_cases/stdurbpt_pd.xml
@@ -18,8 +18,10 @@
 
 <urban_hac>'OFF'</urban_hac>
 
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="clm5_0" use_cndv=".true." >.false.</irrigate>
-<irrigate use_crop=".true." phys="clm4_5"                   >.false.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_0"  use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>
 
 </namelist_defaults>

--- a/bld/namelist_files/use_cases/stdurbpt_pd.xml
+++ b/bld/namelist_files/use_cases/stdurbpt_pd.xml
@@ -18,8 +18,8 @@
 
 <urban_hac>'OFF'</urban_hac>
 
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".false.">.true.</irrigate>
-<irrigate use_crop=".true." phys="ctsm5_1" use_cndv=".true." >.false.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".false.">.true.</irrigate>
+<irrigate use_crop=".true." phys="clm5_1"  use_cndv=".true." >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0"  use_cndv=".false.">.true.</irrigate>
 <irrigate use_crop=".true." phys="clm5_0"  use_cndv=".true." >.false.</irrigate>
 <irrigate use_crop=".true." phys="clm4_5"                    >.false.</irrigate>

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -138,7 +138,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 1517;
+my $ntests = 1516;
 if ( defined($opts{'compare'}) ) {
    $ntests += 1017;
 }

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -78,7 +78,7 @@ sub make_config_cache {
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0">Specifies clm physics</entry>
+<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0,ctsm5_1">Specifies clm physics</entry>
 </config_definition>
 EOF
    $fh->close();
@@ -138,9 +138,9 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 893;
+my $ntests = 1461;
 if ( defined($opts{'compare'}) ) {
-   $ntests += 549;
+   $ntests += 975;
 }
 plan( tests=>$ntests );
 
@@ -164,7 +164,7 @@ my $mode = "-phys $phys";
 &make_config_cache($phys);
 
 my $DOMFILE = "$inputdata_rootdir/atm/datm7/domain.lnd.T31_gx3v7.090928.nc";
-my $real_par_file = "user_nl_clm_real_parameters";
+my $real_par_file = "user_nl_ctsm_real_parameters";
 my $bldnml = "../build-namelist -verbose -csmdata $inputdata_rootdir -lnd_frac $DOMFILE -configuration clm -structure standard -glc_nec 10 -no-note -output_reals $real_par_file";
 if ( $opts{'test'} ) {
    $bldnml .= " -test";
@@ -1072,15 +1072,18 @@ foreach my $key ( keys(%warntest) ) {
    system( "cat $tempfile" );
 }
 
+#
+# Loop over all physics versions
+#
+foreach my $phys ( "clm4_5", "clm5_0", "ctsm5_1" ) {
+$mode = "-phys $phys";
+&make_config_cache($phys);
 
 print "\n==================================================\n";
-print "Test ALL resolutions with CLM5.0 and SP \n";
+print "Test ALL resolutions with SP\n";
 print "==================================================\n";
 
 # Check for ALL resolutions with CLM50SP
-$phys = "clm5_0";
-$mode = "-phys $phys";
-&make_config_cache($phys);
 my $reslist = `../queryDefaultNamelist.pl -res list -s`;
 my @resolutions = split( / /, $reslist );
 my @regional;
@@ -1144,16 +1147,13 @@ foreach my $res ( @resolutions ) {
 }
 
 print "\n==================================================\n";
-print " Test important resolutions for CLM4.5 and BGC\n";
+print " Test important resolutions for BGC\n";
 print "==================================================\n";
 
-$phys = "clm4_5";
-$mode = "-phys $phys";
-&make_config_cache($phys);
 my @resolutions = ( "4x5", "10x15", "ne30np4", "ne16np4", "1.9x2.5", "0.9x1.25" );
 my @regional;
 my $nlbgcmode = "bgc";
-my $mode = "clm45-$nlbgcmode";
+my $mode = "$phys-$nlbgcmode";
 foreach my $res ( @resolutions ) {
    chomp($res);
    print "=== Test $res === \n";
@@ -1211,9 +1211,6 @@ print "Test crop resolutions \n";
 print "==================================================\n";
 
 # Check for crop resolutions
-$phys = "clm5_0";
-$mode = "-phys $phys";
-&make_config_cache($phys);
 my @crop_res = ( "1x1_numaIA", "1x1_smallvilleIA", "4x5", "10x15", "0.9x1.25", "1.9x2.5", "ne30np4" );
 foreach my $res ( @crop_res ) {
    $options = "-bgc bgc -crop -res $res -envxml_dir .";
@@ -1247,9 +1244,6 @@ print "==================================================\n";
 # use cases, but I've kept these pointing to the equivalent normal use
 # cases; I'm not sure if it's actually important to test this with all
 # of the different use cases.
-$phys = "clm4_5";
-$mode = "-phys $phys";
-&make_config_cache($phys);
 my @glc_res = ( "0.9x1.25", "1.9x2.5" );
 my @use_cases = ( "1850-2100_SSP1-2.6_transient",
                   "1850-2100_SSP2-4.5_transient",
@@ -1289,9 +1283,6 @@ foreach my $res ( @glc_res ) {
    }
 }
 # Transient 20th Century simulations
-$phys = "clm5_0";
-$mode = "-phys $phys";
-&make_config_cache($phys);
 my @tran_res = ( "0.9x1.25", "1.9x2.5", "ne30np4", "10x15" );
 my $usecase  = "20thC_transient";
 my $GLC_NEC         = 10;
@@ -1313,9 +1304,6 @@ foreach my $res ( @tran_res ) {
    &cleanup();
 }
 # Transient ssp_rcp scenarios that work
-$phys = "clm5_0";
-$mode = "-phys $phys";
-&make_config_cache($phys);
 my @tran_res = ( "0.9x1.25", "1.9x2.5", "10x15" );
 foreach my $usecase ( "1850_control", "1850-2100_SSP5-8.5_transient", "1850-2100_SSP1-2.6_transient", "1850-2100_SSP3-7.0_transient",
                       "1850-2100_SSP2-4.5_transient" ) {
@@ -1343,7 +1331,15 @@ foreach my $usecase ( "1850_control", "1850-2100_SSP5-8.5_transient", "1850-2100
       &cleanup();
    }
 }
+}  # End loop over all physics versions
+#
+# End loop over versions
+#
+
 # The SSP's that fail...
+$phys = "clm5_0";
+$mode = "-phys $phys";
+&make_config_cache($phys);
 my $res = "0.9x1.25";
 foreach my $usecase ( "1850-2100_SSP4-3.4_transient", "1850-2100_SSP5-3.4_transient", "1850-2100_SSP1-1.9_transient",
                       "1850-2100_SSP4-6.0_transient" ) {
@@ -1355,10 +1351,10 @@ foreach my $usecase ( "1850-2100_SSP4-3.4_transient", "1850-2100_SSP5-3.4_transi
 }
 
 print "\n==================================================\n";
-print "Test clm4.5/clm5.0 resolutions \n";
+print "Test clm4.5/clm5.0/ctsm5_1 resolutions \n";
 print "==================================================\n";
 
-foreach my $phys ( "clm4_5", 'clm5_0' ) {
+foreach my $phys ( "clm4_5", 'clm5_0', 'ctsm5_1' ) {
   my $mode = "-phys $phys";
   &make_config_cache($phys);
   my @clmoptions = ( "-bgc bgc -envxml_dir .", "-bgc bgc -envxml_dir . -clm_accelerated_spinup=on", "-bgc bgc -envxml_dir . -light_res 360x720",
@@ -1450,10 +1446,16 @@ foreach my $phys ( "clm4_5", 'clm5_0' ) {
 my $res = "0.9x1.25";
 my $mask = "gx1v6";
 my $simyr = "1850";
-foreach my $phys ( "clm4_5", 'clm5_0' ) {
+foreach my $phys ( "clm4_5", 'clm5_0', 'ctsm5_1' ) {
   my $mode = "-phys $phys";
   &make_config_cache($phys);
-  foreach my $forc ( "CRUv7", "GSWP3v1", "cam6.0" ) {
+  my @forclist = ();
+  if ( $phys == "ctsm5_1" ) {
+    @forclist = ( "GSWP3v1" );
+  } else {
+    @forclist = ( "CRUv7", "GSWP3v1", "cam6.0" );
+  }
+  foreach my $forc ( @forclist ) {
      foreach my $bgc ( "sp", "bgc" ) {
         my $lndtuningmode = "${phys}_${forc}";
         my $clmoptions = "-res $res -mask $mask -sim_year $simyr -envxml_dir . -lnd_tuning_mod $lndtuningmode -bgc $bgc";

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -78,7 +78,7 @@ sub make_config_cache {
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0,ctsm5_1">Specifies clm physics</entry>
+<entry id="phys" value="$phys" list="" valid_values="clm4_5,clm5_0,clm5_1">Specifies clm physics</entry>
 </config_definition>
 EOF
    $fh->close();
@@ -1079,7 +1079,7 @@ foreach my $key ( keys(%warntest) ) {
 #
 # Loop over all physics versions
 #
-foreach my $phys ( "clm4_5", "clm5_0", "ctsm5_1" ) {
+foreach my $phys ( "clm4_5", "clm5_0", "clm5_1" ) {
 $mode = "-phys $phys";
 &make_config_cache($phys);
 
@@ -1355,10 +1355,10 @@ foreach my $usecase ( "1850-2100_SSP4-3.4_transient", "1850-2100_SSP5-3.4_transi
 }
 
 print "\n==================================================\n";
-print "Test clm4.5/clm5.0/ctsm5_1 resolutions \n";
+print "Test clm4.5/clm5.0/clm5_1 resolutions \n";
 print "==================================================\n";
 
-foreach my $phys ( "clm4_5", 'clm5_0', 'ctsm5_1' ) {
+foreach my $phys ( "clm4_5", 'clm5_0', 'clm5_1' ) {
   my $mode = "-phys $phys";
   &make_config_cache($phys);
   my @clmoptions = ( "-bgc bgc -envxml_dir .", "-bgc bgc -envxml_dir . -clm_accelerated_spinup=on", "-bgc bgc -envxml_dir . -light_res 360x720",
@@ -1450,11 +1450,11 @@ foreach my $phys ( "clm4_5", 'clm5_0', 'ctsm5_1' ) {
 my $res = "0.9x1.25";
 my $mask = "gx1v6";
 my $simyr = "1850";
-foreach my $phys ( "clm4_5", 'clm5_0', 'ctsm5_1' ) {
+foreach my $phys ( "clm4_5", 'clm5_0', 'clm5_1' ) {
   my $mode = "-phys $phys";
   &make_config_cache($phys);
   my @forclist = ();
-  if ( $phys == "ctsm5_1" ) {
+  if ( $phys == "clm5_1" ) {
     @forclist = ( "GSWP3v1" );
   } else {
     @forclist = ( "CRUv7", "GSWP3v1", "cam6.0" );

--- a/cime_config/SystemTests/lciso.py
+++ b/cime_config/SystemTests/lciso.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 class LCISO(SystemTestsCompareTwo):
 
     def __init__(self, case):
+        self.comp = case.get_value("COMP_LND")
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
                                        run_two_suffix = 'cisoallon',
@@ -26,11 +27,11 @@ class LCISO(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = self.comp,
                                 contents = "use_c13=F, use_c14=F")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = self.comp,
                                 contents = "use_c13=.true.,use_c14=.true.,use_c13_timeseries=.true.,use_c14_bombspike=.true." )
 

--- a/cime_config/SystemTests/lciso.py
+++ b/cime_config/SystemTests/lciso.py
@@ -26,11 +26,11 @@ class LCISO(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "use_c13=F, use_c14=F")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "use_c13=.true.,use_c14=.true.,use_c13_timeseries=.true.,use_c14_bombspike=.true." )
 

--- a/cime_config/SystemTests/lii.py
+++ b/cime_config/SystemTests/lii.py
@@ -46,11 +46,11 @@ class LII(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "use_init_interp = .true.")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "use_init_interp = .false.")
 

--- a/cime_config/SystemTests/lii.py
+++ b/cime_config/SystemTests/lii.py
@@ -23,9 +23,9 @@ no_interp test fails.
 
 (2) Copy the finidat_interp_dest.nc file from the 'base' case to the inputdata
 space. Rename this to be similar to the name of the file pointed to in this
-test's user_nl_clm file, but with a new creation date.
+test's user_nl_ctsm file, but with a new creation date.
 
-(3) Update this test's user_nl_clm file (in the appropriate testmods directory)
+(3) Update this test's user_nl_ctsm file (in the appropriate testmods directory)
 to point to the new finidat file.
 """
 
@@ -46,11 +46,11 @@ class LII(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "use_init_interp = .true.")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "use_init_interp = .false.")
 

--- a/cime_config/SystemTests/lii2finidatareas.py
+++ b/cime_config/SystemTests/lii2finidatareas.py
@@ -72,5 +72,5 @@ class LII2FINIDATAREAS(LII):
     def _case_one_setup(self):
         super(LII2FINIDATAREAS, self)._case_one_setup()
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "init_interp_method = 'use_finidat_areas'")

--- a/cime_config/SystemTests/lii2finidatareas.py
+++ b/cime_config/SystemTests/lii2finidatareas.py
@@ -41,7 +41,7 @@ currently used by this test, but with a new creation date.
 
 (3) Update namelist defaults to point to the new finidat file. If
 updating the out-of-the-box file is not desired, then you could instead
-point to this new finidat file with a user_nl_clm file in this testmod.
+point to this new finidat file with a user_nl_ctsm file in this testmod.
 """
 
 from CIME.XML.standard_module_setup import *
@@ -72,5 +72,5 @@ class LII2FINIDATAREAS(LII):
     def _case_one_setup(self):
         super(LII2FINIDATAREAS, self)._case_one_setup()
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "init_interp_method = 'use_finidat_areas'")

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -146,8 +146,8 @@ class LILACSMOKE(SystemTestsCommon):
         # The user_nl_ctsm in the case directory is set up based on the standard testmods
         # mechanism. We use that one in place of the standard user_nl_ctsm, since the one
         # in the case directory may contain test-specific modifications.
-        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_ctsm'),
-                        dst=os.path.join(runtime_inputs, 'user_nl_ctsm'))
+        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_clm'),
+                        dst=os.path.join(runtime_inputs, 'user_nl_clm'))
 
         script_to_run = os.path.join(runtime_inputs, 'make_runtime_inputs')
         self._run_build_cmd('{} --rundir {}'.format(script_to_run, runtime_inputs),

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -152,8 +152,8 @@ class LILACSMOKE(SystemTestsCommon):
         # The user_nl_ctsm in the case directory is set up based on the standard testmods
         # mechanism. We use that one in place of the standard user_nl_ctsm, since the one
         # in the case directory may contain test-specific modifications.
-        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_clm'),
-                        dst=os.path.join(runtime_inputs, 'user_nl_clm'))
+        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_ctsm'),
+                        dst=os.path.join(runtime_inputs, 'user_nl_ctsm'))
 
         script_to_run = os.path.join(runtime_inputs, 'make_runtime_inputs')
         self._run_build_cmd('{} --rundir {}'.format(script_to_run, runtime_inputs),

--- a/cime_config/SystemTests/lvg.py
+++ b/cime_config/SystemTests/lvg.py
@@ -27,11 +27,11 @@ class LVG(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "glacier_region_behavior = 'single_at_atm_topo', 'virtual', 'virtual', 'multiple'")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "glacier_region_behavior = 'single_at_atm_topo', 'virtual', 'virtual', 'virtual'")
 

--- a/cime_config/SystemTests/lvg.py
+++ b/cime_config/SystemTests/lvg.py
@@ -27,11 +27,11 @@ class LVG(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "glacier_region_behavior = 'single_at_atm_topo', 'virtual', 'virtual', 'multiple'")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "glacier_region_behavior = 'single_at_atm_topo', 'virtual', 'virtual', 'virtual'")
 

--- a/cime_config/SystemTests/lwiso.py
+++ b/cime_config/SystemTests/lwiso.py
@@ -34,11 +34,11 @@ class LWISO(SystemTestsCompareTwo):
         # eventually, though, we should change this to the latter. (See
         # <https://github.com/ESCOMP/ctsm/issues/495#issuecomment-516619853>.)
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "enable_water_tracer_consistency_checks=.true.")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "enable_water_tracer_consistency_checks=.false.")
 

--- a/cime_config/SystemTests/lwiso.py
+++ b/cime_config/SystemTests/lwiso.py
@@ -34,11 +34,11 @@ class LWISO(SystemTestsCompareTwo):
         # eventually, though, we should change this to the latter. (See
         # <https://github.com/ESCOMP/ctsm/issues/495#issuecomment-516619853>.)
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "enable_water_tracer_consistency_checks=.true.")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "enable_water_tracer_consistency_checks=.false.")
 

--- a/cime_config/SystemTests/soilstructud.py
+++ b/cime_config/SystemTests/soilstructud.py
@@ -2,10 +2,10 @@
 Implementation of the CIME SOILSTRUCTUD test.
 
 This is a CLM specific test:
-Verifies that a simulation that points to user_nl_clm containing
+Verifies that a simulation that points to user_nl_ctsm containing
 soil_layerstruct_userdefined_nlevsoi = 4
 soil_layerstruct_userdefined = 0.1d0,0.3d0,0.6d0,1.0d0,1.0d0
-gives bfb same results as one that points to user_nl_clm containing
+gives bfb same results as one that points to user_nl_ctsm containing
 soil_layerstruct_predefined = '4SL_2m'
 
 """
@@ -27,11 +27,11 @@ class SOILSTRUCTUD(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "soil_layerstruct_userdefined_nlevsoi = 4,soil_layerstruct_userdefined = 0.1d0,0.3d0,0.6d0,1.0d0,1.0d0")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "clm",
+                                component = "ctsm",
                                 contents = "soil_layerstruct_predefined = '4SL_2m'")
 

--- a/cime_config/SystemTests/soilstructud.py
+++ b/cime_config/SystemTests/soilstructud.py
@@ -27,11 +27,11 @@ class SOILSTRUCTUD(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "soil_layerstruct_userdefined_nlevsoi = 4,soil_layerstruct_userdefined = 0.1d0,0.3d0,0.6d0,1.0d0,1.0d0")
 
     def _case_two_setup(self):
         append_to_user_nl_files(caseroot = self._get_caseroot(),
-                                component = "ctsm",
+                                component = "clm",
                                 contents = "soil_layerstruct_predefined = '4SL_2m'")
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-build clm library
+build ctsm library
 """
 import sys, os
 
@@ -64,6 +64,8 @@ def _write_ctsm_mk(gmake, gmake_opts, makefile, exeroot, libroot):
 # ======================================================================
 # The following settings are meant for internal use, and generally
 # should not be included directly in an atmosphere model's build.
+# NOTE: clm library name and subdirectory will eventually need to
+#       be updated to ctsm.
 # ======================================================================
 
 CTSM_BLD_DIR   = {ctsm_bld_dir}
@@ -103,8 +105,10 @@ def _main_func():
         filepath_file = os.path.join(bldroot,"Filepath")
         if not os.path.isfile(filepath_file):
             caseroot = case.get_value("CASEROOT")
+            compname = case.get_value("COMP_LND")
+            expect( ((compname == "clm") or (compname == "ctsm")), "Unexpected COMP_LND name: %s" % (compname))
 
-            paths = [os.path.join(caseroot,"SourceMods","src.clm"),
+            paths = [os.path.join(caseroot,"SourceMods","src."+compname),
                      os.path.join(lnd_root,"src","main"),
                      os.path.join(lnd_root,"src","biogeophys"),
                      os.path.join(lnd_root,"src","biogeochem"),
@@ -135,10 +139,10 @@ def _main_func():
         # create the library in libroot
         #-------------------------------------------------------
 
-        complib = os.path.join(libroot,"libclm.a")
+        complib = os.path.join(libroot,"lib%s.a"%(compname))
 
-        cmd = "{} complib -j {} MODEL=clm COMPLIB={} -f {} {}" \
-              .format(gmake, gmake_j, complib, makefile, gmake_opts)
+        cmd = "{} complib -j {} MODEL={} COMPLIB={} -f {} {}" \
+              .format(gmake, gmake_j, compname, complib, makefile, gmake_opts)
 
         rc, out, err = run_cmd(cmd)
         logger.info("%s: \n\n output:\n %s \n\n err:\n\n%s\n"%(cmd,out,err))

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -69,7 +69,7 @@ def _write_ctsm_mk(gmake, gmake_opts, makefile, exeroot, libroot):
 # ======================================================================
 
 CTSM_BLD_DIR   = {ctsm_bld_dir}
-CTSM_INC       = $(CTSM_BLD_DIR)/clm/obj
+CTSM_INC       = $(CTSM_BLD_DIR)/ctsm/obj
 
 # ======================================================================
 # The following settings should be included in an atmosphere model's build.
@@ -102,10 +102,10 @@ def _main_func():
         #-------------------------------------------------------
         # create Filepath file
         #-------------------------------------------------------
+        compname = case.get_value("COMP_LND")
         filepath_file = os.path.join(bldroot,"Filepath")
         if not os.path.isfile(filepath_file):
             caseroot = case.get_value("CASEROOT")
-            compname = case.get_value("COMP_LND")
             expect( ((compname == "clm") or (compname == "ctsm")), "Unexpected COMP_LND name: %s" % (compname))
 
             paths = [os.path.join(caseroot,"SourceMods","src."+compname),

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -69,7 +69,7 @@ def _write_ctsm_mk(gmake, gmake_opts, makefile, exeroot, libroot):
 # ======================================================================
 
 CTSM_BLD_DIR   = {ctsm_bld_dir}
-CTSM_INC       = $(CTSM_BLD_DIR)/ctsm/obj
+CTSM_INC       = $(CTSM_BLD_DIR)/clm/obj
 
 # ======================================================================
 # The following settings should be included in an atmosphere model's build.

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-CLM namelist creator
+CTSM namelist creator
 """
 import sys, os, shutil
 
@@ -23,17 +23,17 @@ _config_cache_template = """
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="{clm_phys}" list="" valid_values="clm4_5,clm5_0">Specifies clm physics</entry>
+<entry id="phys" value="{clm_phys}" list="" valid_values="clm4_5,clm5_0,ctsm5_1">Specifies CTSM physics</entry>
 </config_definition>
 """
 
 ###############################################################################
 def buildnml(case, caseroot, compname):
 ###############################################################################
-    """Build the clm namelist """
+    """Build the CTSM namelist """
 
     # Build the component namelist 
-    if compname != "clm":
+    if compname != "ctsm" and compname != "clm":
         raise AttributeError
 
     lnd_root = case.get_value("COMP_ROOT_DIR_LND")
@@ -63,12 +63,12 @@ def buildnml(case, caseroot, compname):
     mask = case.get_value("MASK_GRID")
 
     # -----------------------------------------------------
-    # Set clmconf
+    # Set ctsmconf
     # -----------------------------------------------------
 
-    clmconf = os.path.join(caseroot, "Buildconf", "clmconf")
-    if not os.path.isdir(clmconf):
-        os.makedirs(clmconf)
+    ctsmconf = os.path.join(caseroot, "Buildconf", "ctsmconf")
+    if not os.path.isdir(ctsmconf):
+        os.makedirs(ctsmconf)
 
     # -----------------------------------------------------
     # Create config_cache.xml file 
@@ -80,7 +80,7 @@ def buildnml(case, caseroot, compname):
     clm_phys = case.get_value("CLM_PHYSICS_VERSION")
 
     config_cache_text = _config_cache_template.format(clm_phys=clm_phys)
-    config_cache_path = os.path.join(caseroot, "Buildconf", "clmconf", "config_cache.xml")
+    config_cache_path = os.path.join(caseroot, "Buildconf", "ctsmconf", "config_cache.xml")
     with open(config_cache_path, 'w') as config_cache_file:
         config_cache_file.write(config_cache_text)
 
@@ -148,13 +148,13 @@ def buildnml(case, caseroot, compname):
     
     spinup = "-clm_accelerated_spinup %s "%clm_accelerated_spinup
     
-    infile = os.path.join(clmconf, "namelist")
+    infile = os.path.join(ctsmconf, "namelist")
     
-    inputdata_file = os.path.join(caseroot,"Buildconf","clm.input_data_list")
+    inputdata_file = os.path.join(caseroot,"Buildconf","ctsm.input_data_list")
     
     lndfrac_file = os.path.join(lnd_domain_path,lnd_domain_file)
     
-    config_cache_file = os.path.join(caseroot,"Buildconf","clmconf","config_cache.xml")
+    config_cache_file = os.path.join(caseroot,"Buildconf","ctsmconf","config_cache.xml")
 
     # -----------------------------------------------------
     # Clear out old data
@@ -201,7 +201,7 @@ def buildnml(case, caseroot, compname):
         infile_lines.append(clm_icfile)
 
         user_nl_file = os.path.join(caseroot, "user_nl_clm" + inst_string)
-        namelist_infile = os.path.join(clmconf, "namelist")
+        namelist_infile = os.path.join(ctsmconf, "namelist")
 
         create_namelist_infile(case, user_nl_file, namelist_infile, "\n".join(infile_lines))
 
@@ -218,7 +218,7 @@ def buildnml(case, caseroot, compname):
                      lndfrac_file, glc_nec, ccsm_co2_ppmv, clm_co2_type, config_cache_file,
                      clm_bldnml_opts, spinup, tuning, gridmask))
 
-        rc, out, err = run_cmd(command, from_dir=clmconf)
+        rc, out, err = run_cmd(command, from_dir=ctsmconf)
         expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
         if out is not None:
             logger.debug("     %s"%out)
@@ -230,11 +230,11 @@ def buildnml(case, caseroot, compname):
         # -----------------------------------------------------
 
         if os.path.isdir(rundir):
-            file1 = os.path.join(clmconf, "lnd_in")
+            file1 = os.path.join(ctsmconf, "lnd_in")
             file2 = os.path.join(rundir, "lnd_in")
             if ninst > 1:
                 file2 += inst_string
-            logger.debug("CLM namelist copy: file1 %s file2 %s " %(file1, file2))
+            logger.debug("CTSM namelist copy: file1 %s file2 %s " %(file1, file2))
             shutil.copy(file1,file2)
 
 ###############################################################################
@@ -242,7 +242,8 @@ def _main_func():
 
     caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
-        buildnml(case, caseroot, "clm")
+        compname = case.get_value("COMP_LND")
+        buildnml(case, caseroot, compname)
 
 if __name__ == "__main__":
     _main_func()

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -66,7 +66,7 @@ def buildnml(case, caseroot, compname):
     # Set ctsmconf
     # -----------------------------------------------------
 
-    ctsmconf = os.path.join(caseroot, "Buildconf", "ctsmconf")
+    ctsmconf = os.path.join(caseroot, "Buildconf", compname+"conf")
     if not os.path.isdir(ctsmconf):
         os.makedirs(ctsmconf)
 
@@ -80,7 +80,7 @@ def buildnml(case, caseroot, compname):
     clm_phys = case.get_value("CLM_PHYSICS_VERSION")
 
     config_cache_text = _config_cache_template.format(clm_phys=clm_phys)
-    config_cache_path = os.path.join(caseroot, "Buildconf", "ctsmconf", "config_cache.xml")
+    config_cache_path = os.path.join(caseroot, "Buildconf", compname+"conf", "config_cache.xml")
     with open(config_cache_path, 'w') as config_cache_file:
         config_cache_file.write(config_cache_text)
 
@@ -154,7 +154,7 @@ def buildnml(case, caseroot, compname):
     
     lndfrac_file = os.path.join(lnd_domain_path,lnd_domain_file)
     
-    config_cache_file = os.path.join(caseroot,"Buildconf","ctsmconf","config_cache.xml")
+    config_cache_file = os.path.join(caseroot,"Buildconf", compname+"conf","config_cache.xml")
 
     # -----------------------------------------------------
     # Clear out old data

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -188,11 +188,19 @@ def buildnml(case, caseroot, compname):
         # -----------------------------------------------------
 
         if run_type == "hybrid" or run_type == "branch":
-            clm_startfile = "%s.clm2%s.r.%s-%s.nc"%(run_refcase,inst_string,run_refdate,run_reftod)
-            if not os.path.exists(os.path.join(rundir, clm_startfile)):
-                clm_startfile = "%s.clm2.r.%s-%s.nc"%(run_refcase,run_refdate,run_reftod)
-                logger.warning( "WARNING: the start file being used for a multi-instance case is a single instance: "+clm_startfile )
+            compnames = [ "clm4", "clm5", "ctsm5", "clm2" ]
+            for comp in compnames:
+               clm_startfile = "%s.%s%s.r.%s-%s.nc"%(run_refcase,comp,inst_string,run_refdate,run_reftod)
+               if os.path.exists(os.path.join(rundir, clm_startfile)):
+                 break
+               else:
+                 clm_startfile = "%s.%s.r.%s-%s.nc"%(run_refcase,comp,run_refdate,run_reftod)
+                 if os.path.exists(os.path.join(rundir, clm_startfile)):
+                    logger.warning( "WARNING: the start file being used for a multi-instance case is a single instance: "+clm_startfile )
+                    break
 
+            if not os.path.exists(os.path.join(rundir, clm_startfile)):
+               logger.warning( "WARNING: Could NOT find a start file to use using"+clm_startfile )
             clm_icfile = "%s = \'%s\'"%(startfile_type, clm_startfile)
         else:
             clm_icfile = ""

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -23,7 +23,7 @@ _config_cache_template = """
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="{clm_phys}" list="" valid_values="clm4_5,clm5_0,ctsm5_1">Specifies CTSM physics</entry>
+<entry id="phys" value="{clm_phys}" list="" valid_values="clm4_5,clm5_0,clm5_1">Specifies CTSM physics</entry>
 </config_definition>
 """
 
@@ -188,7 +188,7 @@ def buildnml(case, caseroot, compname):
         # -----------------------------------------------------
 
         if run_type == "hybrid" or run_type == "branch":
-            compnames = [ "clm4", "clm5", "ctsm5", "clm2" ]
+            compnames = [ "clm4", "clm5", "clm2" ]
             for comp in compnames:
                clm_startfile = "%s.%s%s.r.%s-%s.nc"%(run_refcase,comp,inst_string,run_refdate,run_reftod)
                if os.path.exists(os.path.join(rundir, clm_startfile)):

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -25,4 +25,25 @@
       <tfile disposition="ignore">anothercasename.clm2.i.1976-01-01-00000.nc</tfile>
     </test_file_names>
   </comp_archive_spec>
+  <comp_archive_spec compname="ctsm" compclass="lnd">
+    <rest_file_extension>r</rest_file_extension>
+    <rest_file_extension>rh\d?</rest_file_extension>
+    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>e</hist_file_extension>
+    <rest_history_varname>locfnh</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
+      <rpointer_content>./$CASE.ctsm$NINST_STRING.r.$DATENAME.nc</rpointer_content>
+    </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">rpointer.lnd</tfile>
+      <tfile disposition="copy">rpointer.lnd_9999</tfile>
+      <tfile disposition="copy">casename.ctsm.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.ctsm.rh4.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.ctsm.h0.1976-01-01-00000.nc</tfile>
+      <tfile disposition="ignore">casename.ctsm.h0.1976-01-01-00000.nc.base</tfile>
+      <tfile disposition="move">casename.ctsm_0002.e.postassim.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.ctsm_0002.e.preassim.1976-01-01-00000.nc</tfile>
+    </test_file_names>
+  </comp_archive_spec>
 </components>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -16,7 +16,7 @@
   <description modifier_mode="1">
     <desc lnd="CLM45[%SP][%SP-VIC][%CN][%CNDV][%CN-CROP][%CNDV-CROP][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP]"                  >clm4.5:</desc>
     <desc lnd="CLM50[%SP][%SP-VIC][%SP-NOANTHRO][%BGC-NOANTHRO][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%BGC-CROP-CMIP6DECK][%BGC-CROP-CMIP6WACCMDECK][%NWP-SP][%NWP-BGC-CROP]">clm5.0:</desc>
-    <desc lnd="CTSM51[%SP][%SP-NOANTHRO][%BGC-NOANTHRO][%BGC][%BGC-CROP][%FATES][%NWP-SP][%NWP-BGC-CROP]">ctsm5.1:</desc>
+    <desc lnd="CLM51[%SP][%SP-NOANTHRO][%BGC-NOANTHRO][%BGC][%BGC-CROP][%FATES][%NWP-SP][%NWP-BGC-CROP]">clm5.1:</desc>
     <desc option="SP"              >Satellite phenology:</desc>
     <desc option="CN"              >CN: Carbon Nitrogen model</desc>
     <desc option="CNDV"            >CNDV: CN with Dynamic Vegetation (deprecated)</desc>
@@ -66,7 +66,7 @@
     <desc>Tuning parameters and initial conditions should be optimized for what CLM model version and what meteorlogical forcing combination?
     </desc>
     <default_value>UNSET</default_value>
-    <valid_values>clm5_0_cam6.0,clm5_0_GSWP3v1,clm5_0_CRUv7,clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,ctsm5_1_GSWP3v1</valid_values>
+    <valid_values>clm5_0_cam6.0,clm5_0_GSWP3v1,clm5_0_CRUv7,clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,clm5_1_GSWP3v1</valid_values>
     <values>
       <value compset=             "CLM45" >clm4_5_CRUv7</value>
       <value compset="DATM%CRUv7.+_CLM45" >clm4_5_CRUv7</value>
@@ -76,13 +76,13 @@
       <value compset="DATM%CRUv7.+_CLM50" >clm5_0_CRUv7</value>
       <value compset="DATM%GSWP3.+_CLM50" >clm5_0_GSWP3v1</value>
       <value compset="CAM.+_CLM50"        >clm5_0_cam6.0</value>
-      <value compset=            "_CTSM51">ctsm5_1_GSWP3v1</value>
+      <value compset=            "_CLM51" >clm5_1_GSWP3v1</value>
     </values>
   </entry>
 
   <entry id="CLM_PHYSICS_VERSION" >
     <type>char</type>
-    <valid_values>clm4_5,clm5_0,ctsm5_1</valid_values>
+    <valid_values>clm4_5,clm5_0,clm5_1</valid_values>
     <!-- By setting the default_value to UNSET (or some other non-empty
          string that doesn't appear in the list of valid_values), the
          scripts will ensure that one of the below values is picked up
@@ -91,7 +91,7 @@
     <values>
       <value compset="_CLM45" >clm4_5</value>
       <value compset="_CLM50" >clm5_0</value>
-      <value compset="_CTSM51">ctsm5_1</value>
+      <value compset="_CLM51" >clm5_1</value>
     </values>
     <group>run_component_ctsm</group>
     <file>env_run.xml</file>
@@ -192,10 +192,10 @@
       <value compset="_CLM50%[^_]*SP-VIC"	 >-bgc sp -vichydro </value>
       <value compset="_CLM50%[^_]*FATES"         >-bgc fates -no-megan</value>
 
-      <value compset="_CTSM51%[^_]*SP"		 >-bgc sp</value>
-      <value compset="_CTSM51%[^_]*BGC"		 >-bgc bgc</value>
-      <value compset="_CTSM51%[^_]*BGC-CROP"	 >-bgc bgc -crop</value>
-      <value compset="_CTSM51%[^_]*FATES"        >-bgc fates -no-megan</value>
+      <value compset="_CLM51%[^_]*SP"		 >-bgc sp</value>
+      <value compset="_CLM51%[^_]*BGC"		 >-bgc bgc</value>
+      <value compset="_CLM51%[^_]*BGC-CROP"	 >-bgc bgc -crop</value>
+      <value compset="_CLM51%[^_]*FATES"         >-bgc fates -no-megan</value>
     </values>
     <group>run_component_ctsm</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -16,6 +16,7 @@
   <description modifier_mode="1">
     <desc lnd="CLM45[%SP][%SP-VIC][%CN][%CNDV][%CN-CROP][%CNDV-CROP][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP]"                  >clm4.5:</desc>
     <desc lnd="CLM50[%SP][%SP-VIC][%SP-NOANTHRO][%BGC-NOANTHRO][%CN][%BGC][%BGC-CROP][%FATES][%BGCDV][%BGCDV-CROP][%BGC-CROP-CMIP6DECK][%BGC-CROP-CMIP6WACCMDECK][%NWP-SP][%NWP-BGC-CROP]">clm5.0:</desc>
+    <desc lnd="CTSM51[%SP][%SP-NOANTHRO][%BGC-NOANTHRO][%BGC][%BGC-CROP][%FATES][%NWP-SP][%NWP-BGC-CROP]">ctsm5.1:</desc>
     <desc option="SP"              >Satellite phenology:</desc>
     <desc option="CN"              >CN: Carbon Nitrogen model</desc>
     <desc option="CNDV"            >CNDV: CN with Dynamic Vegetation (deprecated)</desc>
@@ -36,11 +37,14 @@
     <desc option="NWP-SP"          >NWP configuration with satellite phenology:</desc>
     <desc option="NWP-BGC-CROP"    >NWP configuration with BGC and CROP:</desc>
   </description>
-
   <entry id="COMP_LND">
     <type>char</type>
-    <valid_values>clm</valid_values>
-    <default_value>clm</default_value>
+    <valid_values>clm,ctsm</valid_values>
+    <default_value>UNSET</default_value>
+    <values>
+      <value compset="CLM" >clm</value>
+      <value compset="CTSM">ctsm</value>
+    </values>
     <group>case_comp</group>
     <file>env_case.xml</file>
     <desc>Name of land component</desc>
@@ -50,19 +54,19 @@
     <type>char</type>
     <valid_values>on,off</valid_values>
     <default_value>off</default_value>
-    <group>build_component_clm</group>
+    <group>build_component_ctsm</group>
     <file>env_build.xml</file>
     <desc>Flag to enable building the LILAC cap and coupling code</desc>
   </entry>
 
   <entry id="LND_TUNING_MODE">
     <type>char</type>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Tuning parameters and initial conditions should be optimized for what CLM model version and what meteorlogical forcing combination?
     </desc>
     <default_value>UNSET</default_value>
-    <valid_values>clm5_0_cam6.0,clm5_0_GSWP3v1,clm5_0_CRUv7,clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0</valid_values>
+    <valid_values>clm5_0_cam6.0,clm5_0_GSWP3v1,clm5_0_CRUv7,clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam6.0,ctsm5_1_GSWP3v1</valid_values>
     <values>
       <value compset=             "CLM45" >clm4_5_CRUv7</value>
       <value compset="DATM%CRUv7.+_CLM45" >clm4_5_CRUv7</value>
@@ -72,22 +76,24 @@
       <value compset="DATM%CRUv7.+_CLM50" >clm5_0_CRUv7</value>
       <value compset="DATM%GSWP3.+_CLM50" >clm5_0_GSWP3v1</value>
       <value compset="CAM.+_CLM50"        >clm5_0_cam6.0</value>
+      <value compset=            "_CTSM51">ctsm5_1_GSWP3v1</value>
     </values>
   </entry>
 
   <entry id="CLM_PHYSICS_VERSION" >
     <type>char</type>
-    <valid_values>clm4_5,clm5_0</valid_values>
+    <valid_values>clm4_5,clm5_0,ctsm5_1</valid_values>
     <!-- By setting the default_value to UNSET (or some other non-empty
          string that doesn't appear in the list of valid_values), the
          scripts will ensure that one of the below values is picked up
          by the compset match. -->
     <default_value>UNSET</default_value>
     <values>
-      <value compset="_CLM45">clm4_5</value>
-      <value compset="_CLM50">clm5_0</value>
+      <value compset="_CLM45" >clm4_5</value>
+      <value compset="_CLM50" >clm5_0</value>
+      <value compset="_CTSM51">ctsm5_1</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Overall physics version to use.
     This sets the default values for many different namelist options.
@@ -101,7 +107,7 @@
     <values>
       <value compset="_CLM[^_]*%NWP">nwp</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Sets CLM default namelist options related to model configuration.
     clm: Configuration used for climate applications (CLM)
@@ -116,7 +122,7 @@
     <values>
       <value compset="_CLM[^_]*%NWP">fast</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Sets CLM default namelist options related to model structure.
     standard: Standard model structure, allowing for more subgrid heterogeneity,
@@ -148,7 +154,7 @@
       <value compset="^AMIP_"	                    >20thC_transient</value>
       <value compset="^PIPD_"                       >1850-2100_SSP5-8.5_transient</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>CLM namelist use_case.
       Determines the use-case that will be sent to the CLM build-namelist utility.
@@ -185,8 +191,13 @@
       <value compset="_CLM50%[^_]*BGCDV-CROP"	 >-bgc bgc -dynamic_vegetation -crop</value>
       <value compset="_CLM50%[^_]*SP-VIC"	 >-bgc sp -vichydro </value>
       <value compset="_CLM50%[^_]*FATES"         >-bgc fates -no-megan</value>
+
+      <value compset="_CTSM51%[^_]*SP"		 >-bgc sp</value>
+      <value compset="_CTSM51%[^_]*BGC"		 >-bgc bgc</value>
+      <value compset="_CTSM51%[^_]*BGC-CROP"	 >-bgc bgc -crop</value>
+      <value compset="_CTSM51%[^_]*FATES"        >-bgc fates -no-megan</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>CLM build-namelist options</desc>
   </entry>
@@ -202,7 +213,7 @@
       <value compset="HIST.*_DATM" >diagnostic</value>
       <value compset="SSP.*_DATM"  >diagnostic</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Determines how CLM will determine where CO2 is set.
       If value is constant, it will be set to CCSM_CO2_PPMV,
@@ -217,7 +228,7 @@
   <entry id="CLM_NAMELIST_OPTS">
     <type>char</type>
     <default_value></default_value>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>CLM-specific namelist settings for -namelist option in the CLM
       build-namelist. CLM_NAMELIST_OPTS is normally set as a compset variable
@@ -232,7 +243,7 @@
     <type>char</type>
     <valid_values>on,off</valid_values>
     <default_value>off</default_value>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Turn on any settings for accellerating the model spinup.
     </desc>
@@ -241,7 +252,7 @@
   <entry id="CLM_USRDAT_NAME">
     <type>char</type>
     <default_value>UNSET</default_value>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Dataset name for user-created datasets. This is used as the argument
       in Buildconf/clm.buildnml to build-namelist -clm_usr_name. An example of
@@ -253,13 +264,13 @@
     <type>char</type>
     <valid_values>on,off</valid_values>
     <default_value>off</default_value>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_run.xml</file>
     <desc>Flag to the CLM build-namelist command to force CLM to do a
       cold start (finidat will be set to blanks).
       A value of on forces the model to spin up from a cold-start
       (arbitrary initial conditions). Setting this value in the xml file will take
-      precedence over any settings for finidat in the $CASEROOT/user_clm_clm file.</desc>
+      precedence over any settings for finidat in the $CASEROOT/user_nl_ctsm file.</desc>
   </entry>
 
   <entry id="CLM_USER_MODS">
@@ -272,7 +283,7 @@
       <value                  compset="_CLM50%[^_]*CMIP6WACCMDECK[%_]">$COMP_ROOT_DIR_LND/cime_config/usermods_dirs/cmip6_waccm_deck</value>
       <value grid="l%1.9x2.5" compset="_CLM50%[^_]*CMIP6WACCMDECK[%_]">$COMP_ROOT_DIR_LND/cime_config/usermods_dirs/cmip6_waccm_nociso_deck</value>
     </values>
-    <group>run_component_clm</group>
+    <group>run_component_ctsm</group>
     <file>env_case.xml</file>
     <desc>User mods to apply to specific compset matches. </desc>
   </entry>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -92,6 +92,11 @@
     <lname>2000_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>I2000Clm51BgcGs</alias>
+    <lname>2000_DATM%GSWP3v1_CLM51%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
   <!-- Primarily for testing -->
   <compset>
     <alias>I2000Clm50Cn</alias>
@@ -118,6 +123,12 @@
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
   </compset>
+
+  <compset>
+    <alias>I1850Clm51BgcGs</alias>
+    <lname>1850_DATM%GSWP3v1_CLM51%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
 
   <!-- Primarily for testing the CMIP6DECK compset option -->
   <compset>
@@ -231,8 +242,13 @@
   </compset>
 
   <compset>
-    <alias>IHistClm51BgcCrop</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM51%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <alias>IHistClm51BgcGs</alias>
+    <lname>HIST_DATM%GSWP3v1_CLM51%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>IHistClm51BgcCropGs</alias>
+    <lname>HIST_DATM%GSWP3v1_CLM51%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -93,6 +93,11 @@
   </compset>
 
   <compset>
+    <alias>I2000Clm51BgcCropGs</alias>
+    <lname>2000_DATM%GSWP3v1_CLM51%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>I2000Clm51BgcGs</alias>
     <lname>2000_DATM%GSWP3v1_CLM51%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -14,7 +14,7 @@
     Where for the CAM specific compsets below the following is supported
     TIME = Time period (e.g. 2000, HIST, SSP585...)
     ATM  = [CAM40, CAM50, CAM55]
-    LND  = [CLM45, CLM50, SLND]
+    LND  = [CLM45, CLM50, CTSM51, SLND]
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
     ROF  = [RTM, SROF]
@@ -223,6 +223,11 @@
     <lname>HIST_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
+  </compset>
+
+  <compset>
+    <alias>IHistCtsm51BgcCrop</alias>
+    <lname>HIST_DATM%GSWP3v1_CTSM51%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -14,7 +14,7 @@
     Where for the CAM specific compsets below the following is supported
     TIME = Time period (e.g. 2000, HIST, SSP585...)
     ATM  = [CAM40, CAM50, CAM55]
-    LND  = [CLM45, CLM50, CTSM51, SLND]
+    LND  = [CLM45, CLM50, CLM51, SLND]
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
     ROF  = [RTM, SROF]
@@ -232,7 +232,7 @@
 
   <compset>
     <alias>IHistCtsm51BgcCrop</alias>
-    <lname>HIST_DATM%GSWP3v1_CTSM51%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
+    <lname>HIST_DATM%GSWP3v1_CLM51%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -231,7 +231,7 @@
   </compset>
 
   <compset>
-    <alias>IHistCtsm51BgcCrop</alias>
+    <alias>IHistClm51BgcCrop</alias>
     <lname>HIST_DATM%GSWP3v1_CLM51%BGC-CROP_SICE_SOCN_MOSART_CISM2%NOEVOLVE_SWAV</lname>
   </compset>
 

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -530,13 +530,6 @@
   </compset>
 
   <compset>
-    <alias>IHistClm40SpGswGs</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM40%SP_SICE_SOCN_RTM_SGLC_SWAV</lname>
-    <science_support grid="f09_g17"/>
-    <science_support grid="f19_g17"/>
-  </compset>
-
-  <compset>
     <alias>IHistClm50BgcCropG</alias>
     <lname>HIST_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_MOSART_CISM2%EVOLVE_SWAV</lname>
   </compset>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="ERI_D_Ld9" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="clm/default">
+  <test name="ERI_D_Ld9" grid="f10_f10_musgs" compset="I1850Clm51BgcGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
     </machines>
@@ -189,7 +189,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERI_N2_Ld9" grid="f19_g17" compset="I2000Clm50BgcCrop" testmods="clm/default">
+  <test name="ERI_N2_Ld9" grid="f19_g17" compset="I2000Clm51BgcCropGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -197,7 +197,15 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D" grid="f10_f10_musgs" compset="IHistClm50Bgc" testmods="clm/decStart">
+  <test name="ERP_Ld9" grid="f45_g37" compset="I2000Clm51BgcGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+  <test name="ERP_D" grid="f10_f10_musgs" compset="IHistClm51BgcGs" testmods="clm/decStart">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
@@ -332,7 +340,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D_Ld5_P48x1" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="clm/ciso">
+  <test name="ERP_D_Ld5_P48x1" grid="f10_f10_musgs" compset="I1850Clm51BgcGs" testmods="clm/ciso">
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
     </machines>
@@ -340,7 +348,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D_Ld10_P36x2" grid="f10_f10_musgs" compset="IHistClm50BgcCrop" testmods="clm/ciso_decStart">
+  <test name="ERP_D_Ld10_P36x2" grid="f10_f10_musgs" compset="IHistClm51BgcCropGs" testmods="clm/ciso_decStart">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -384,7 +392,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D_P36x2_Ld3" grid="f10_f10_musgs" compset="I2000Clm50BgcCrop" testmods="clm/coldStart">
+  <test name="ERP_D_P36x2_Ld3" grid="f10_f10_musgs" compset="I2000Clm51BgcCropGs" testmods="clm/coldStart">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -434,7 +442,7 @@
       <option name="comment"  >NOTE(bja, 201509) constrain_stress_deciduous_onset is on by default for clm50, but functionality is not exercised by nine day tests, Sean Swenson verified that it is active during 30 day tests.</option>
     </options>
   </test>
-  <test name="ERP_D_P36x2_Ld5" grid="f10_f10_musgs" compset="I2000Clm50BgcCrop" testmods="clm/irrig_spunup">
+  <test name="ERP_D_P36x2_Ld5" grid="f10_f10_musgs" compset="I2000Clm51BgcCropGs" testmods="clm/irrig_spunup">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -462,7 +470,7 @@
       <option name="comment"  >Do a test with RTM and flooding on as that also impacts CLM code</option>
     </options>
   </test>
-  <test name="ERP_D_P48x1" grid="f10_f10_musgs" compset="IHistClm50Bgc" testmods="clm/decStart">
+  <test name="ERP_D_P48x1" grid="f10_f10_musgs" compset="IHistClm51BgcGs" testmods="clm/decStart">
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
       <machine name="izumi" compiler="nag" category="prealpha"/>
@@ -682,7 +690,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_P36x2_Lm13" grid="f10_f10_musgs" compset="IHistClm50Bgc" testmods="clm/monthly">
+  <test name="ERP_P36x2_Lm13" grid="f10_f10_musgs" compset="IHistClm51BgcGs" testmods="clm/monthly">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
@@ -736,7 +744,7 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_P72x2_Lm25" grid="f10_f10_musgs" compset="I2000Clm50BgcCrop" testmods="clm/monthly">
+  <test name="ERP_P72x2_Lm25" grid="f10_f10_musgs" compset="I2000Clm51BgcCropGs" testmods="clm/monthly">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1031,7 +1039,7 @@
       <option name="wallclock">02:30:00</option>
     </options>
   </test>
-  <test name="ERS_Ly5_P144x1" grid="f10_f10_musgs" compset="IHistClm50BgcCrop" testmods="clm/cropMonthOutput">
+  <test name="ERS_Ly5_P144x1" grid="f10_f10_musgs" compset="IHistClm51BgcCropGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1077,7 +1085,7 @@
       <option name="comment"  >Exercise the init_interp_method='use_finidat_areas' option. See documentation at the top of the python script implementing this test for more details and rationale. This test requires a compatible finidat file (i.e., a file that can be used without interpolation). If no such file is available out-of-the-box, then the test will need to use a testmod that points to a compatible file.</option>
     </options>
   </test>
-  <test name="LVG_Ld5_D" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="clm/no_vector_output">
+  <test name="LVG_Ld5_D" grid="f10_f10_musgs" compset="I1850Clm51BgcGs" testmods="clm/no_vector_output">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1086,7 +1094,7 @@
       <option name="comment"  >Include one LVG debug test (exact configuration is not very important). Note that the LVG test will fail if there is any 1-d output, or output separated by glacier elevation classes (e.g., the various *_FORC fields), so this includes a testmod that turns off any 1-d output.</option>
     </options>
   </test>
-  <test name="LCISO_Lm13" grid="f10_f10_musgs" compset="IHistClm50BgcCrop" testmods="clm/ciso_monthly">
+  <test name="LCISO_Lm13" grid="f10_f10_musgs" compset="IHistClm51BgcCropGs" testmods="clm/ciso_monthly">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
@@ -1114,7 +1122,7 @@
       <option name="wallclock">00:60:00</option>
     </options>
   </test>
-  <test name="PEM_Ld1" grid="f10_f10_musgs" compset="I2000Clm50BgcCropGs" testmods="clm/crop">
+  <test name="PEM_Ld1" grid="f10_f10_musgs" compset="I2000Clm51BgcCropGs" testmods="clm/crop">
     <machines>
       <machine name="izumi" compiler="intel" category="aux_clm"/>
       <machine name="izumi" compiler="intel" category="prebeta"/>
@@ -1223,7 +1231,7 @@ for ERS test as otherwise it won't work for a sub-day test"</option>
       <option name="comment"  >Include at least one production test with Cn</option>
     </options>
   </test>
-  <test name="SMS_D" grid="f10_f10_musgs" compset="I2000Clm50BgcCrop" testmods="clm/crop">
+  <test name="SMS_D" grid="f10_f10_musgs" compset="I2000Clm51BgcCropGs" testmods="clm/crop">
     <machines>
       <machine name="izumi" compiler="intel" category="aux_clm"/>
       <machine name="izumi" compiler="pgi" category="aux_clm"/>
@@ -1495,7 +1503,7 @@ for ERS test as otherwise it won't work for a sub-day test"</option>
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="SMS_Ld5_D_P48x1" grid="f10_f10_musgs" compset="IHistClm50Bgc" testmods="clm/decStart">
+  <test name="SMS_Ld5_D_P48x1" grid="f10_f10_musgs" compset="IHistClm51BgcGs" testmods="clm/decStart">
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
     </machines>
@@ -1548,7 +1556,7 @@ for ERS test as otherwise it won't work for a sub-day test"</option>
       <option name="comment"  >nlevsno less than 5 is not important scientifically, but is useful for making sure no code assumes that there are 5 snow layers (because this should result in an array bounds exception); this test can be removed once CLM5 is released and most new branches are based off of CLM5 (which will have a runtime-set number of snow layers, rather than assuming 5 snow layers)... until then, I want this test to catch any new code that assumes 5 snow layers</option>
     </options>
   </test>
-  <test name="SMS_Lm13" grid="f19_g17" compset="I2000Clm50BgcCrop" testmods="clm/cropMonthOutput">
+  <test name="SMS_Lm13" grid="f19_g17" compset="I2000Clm51BgcCropGs" testmods="clm/cropMonthOutput">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
@@ -1594,7 +1602,7 @@ for ERS test as otherwise it won't work for a sub-day test"</option>
       <option name="comment"  >Include a few debug tests of Cn</option>
     </options>
   </test>
-  <test name="SSP_D_Ld10" grid="f19_g17" compset="I1850Clm50Bgc" testmods="clm/rtmColdSSP">
+  <test name="SSP_D_Ld10" grid="f19_g17" compset="I1850Clm51BgcGs" testmods="clm/rtmColdSSP">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -35,6 +35,26 @@
       <option name="comment"  >Include a debug test of this scientifically-supported compset, at a scientifically-supported resolution</option>
     </options>
   </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="I1850Clm45BgcCruGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm45BgcCruGs at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="I1850Clm45BgcCruGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm45BgcCruGs at f19</option>
+    </options>
+  </test>
   <test name="ERI_D_Ld9" grid="f10_f10_musgs" compset="I2000Clm50BgcCruGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
@@ -78,6 +98,26 @@
       <option name="comment"  >Include a test of this scientifically-supported compset at a scientifically-supported resolution</option>
     </options>
   </test>
+  <test name="SMS_Ld1" grid="f09_g17" compset="I1850Clm50Sp" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50Sp at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld1" grid="f19_g17" compset="I1850Clm50Sp" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50Sp at f19</option>
+    </options>
+  </test>
   <test name="SMS_D_Ld1" grid="f09_g17" compset="I1850Clm50SpCru" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
@@ -85,6 +125,26 @@
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment"  >Include a test of this scientifically-supported compset, at a scientifically-supported resolution</option>
+    </options>
+  </test>
+  <test name="SMS_Ld1" grid="f09_g17" compset="I1850Clm50SpCru" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50SpCru at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld1" grid="f19_g17" compset="I1850Clm50SpCru" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50SpCru at f19</option>
     </options>
   </test>
   <test name="ERP_D_Ld3" grid="f09_g17" compset="I2000Clm50SpGs" testmods="clm/prescribed">
@@ -231,6 +291,26 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="I1850Clm50Bgc" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50Bgc at f19</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="I1850Clm50Bgc" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50Bgc at f09</option>
+    </options>
+  </test>
   <test name="ERP_D_Ld5" grid="ne30_g17" compset="I1850Clm50BgcCrop" testmods="clm/default">
     <machines>
       <machine name="izumi" compiler="nag" category="prealpha"/>
@@ -246,6 +326,26 @@
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment">Use a transient compset so we allocate and run all PFTs (non-transient cases only allocate memory for non-zero-weight PFTs)</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm50BgcCrop" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm50BgcCrop at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="IHistClm50BgcCrop" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm50BgcCrop at f19</option>
     </options>
   </test>
   <test name="ERP_D_Ld5" grid="f10_f10_musgs" compset="IHistClm50BgcCrop" testmods="clm/allActive">
@@ -338,6 +438,26 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm50SpCru" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm50SpCru at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="IHistClm50SpCru" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm50SpCru at f19</option>
     </options>
   </test>
   <test name="ERP_D_Ld5_P48x1" grid="f10_f10_musgs" compset="I1850Clm51BgcGs" testmods="clm/ciso">
@@ -562,6 +682,26 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
+  <test name="SMS_Ld3" grid="f09_g17" compset="I1850Clm50BgcCropCru" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50BgcCropCru at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld3" grid="f19_g17" compset="I1850Clm50BgcCropCru" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm50BgcCropCru at f19</option>
+    </options>
+  </test>
   <test name="ERP_Ld5_P48x1" grid="f10_f10_musgs" compset="I1850Clm50Bgc" testmods="clm/default">
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
@@ -618,6 +758,26 @@
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment"  >include a debug test of I1850Clm45Bgc</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="I1850Clm45BgcGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm45BgcGs at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="I1850Clm45BgcGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for I1850Clm45BgcGs at f19</option>
     </options>
   </test>
   <test name="ERI_D_Ld9" grid="f10_f10_musgs" compset="I1850Clm45Bgc" testmods="clm/default">
@@ -682,12 +842,72 @@
       <option name="comment"  >include a debug test of IHistClm45BgcCruGs</option>
     </options>
   </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm45BgcCruGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm45BgcCruGs at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="IHistClm45BgcCruGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm45BgcCruGs at f19</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm45BgcGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm45BgcGs at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="IHistClm45BgcGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm45BgcGs at f19</option>
+    </options>
+  </test>
   <test name="ERP_D_Ld5" grid="f10_f10_musgs" compset="IHistClm45SpGs" testmods="clm/decStart">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm45SpGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm45SpGs at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="IHistClm45SpGs" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm45SpGs at f19</option>
     </options>
   </test>
   <test name="ERP_P36x2_Lm13" grid="f10_f10_musgs" compset="IHistClm51BgcGs" testmods="clm/monthly">
@@ -1202,6 +1422,26 @@ for ERS test as otherwise it won't work for a sub-day test"</option>
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment"  >Run CONUS for transient case starting in 2013 as for CAM case"</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm50Sp" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm50Sp at f09</option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="IHistClm50Sp" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
+      <machine name="izumi"    compiler="intel" category="ctsm_sci"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Science support for IHistClm50Sp at f19</option>
     </options>
   </test>
   <test name="SMS_Ln9" grid="ne30pg2_ne30pg2_mg17" compset="I1850Clm50Sp" testmods="clm/clm50cam6LndTuningMode">

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -26,15 +26,6 @@
      <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="f09_g17" compset="I1850Clm45BgcCruGs" testmods="clm/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:20:00</option>
-      <option name="comment"  >Include a debug test of this scientifically-supported compset, at a scientifically-supported resolution</option>
-    </options>
-  </test>
   <test name="SMS_Ld5" grid="f09_g17" compset="I1850Clm45BgcCruGs" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="ctsm_sci"/>
@@ -116,15 +107,6 @@
     <options>
       <option name="wallclock">00:20:00</option>
       <option name="comment"  >Science support for I1850Clm50Sp at f19</option>
-    </options>
-  </test>
-  <test name="SMS_D_Ld1" grid="f09_g17" compset="I1850Clm50SpCru" testmods="clm/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
-    </machines>
-    <options>
-      <option name="wallclock">00:20:00</option>
-      <option name="comment"  >Include a test of this scientifically-supported compset, at a scientifically-supported resolution</option>
     </options>
   </test>
   <test name="SMS_Ld1" grid="f09_g17" compset="I1850Clm50SpCru" testmods="clm/default">

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,122 @@
 ===============================================================
+Tag name:  ctsm5.1.dev001
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date: Wed Sep 23 02:16:01 MDT 2020
+One-line Summary: Start the clm5_1 physics series, with some changes to the fire model from Fang Li
+
+Purpose of changes
+------------------
+
+
+Fang's latest Fire version - includes allowing clm5.1 phys version. New physics option is added
+called "clm5_1", with currently the new feature to use the latest fire changes. This has some
+adjustments to the fire model and includes some changes to the parameter file. Other new features
+will be added into clm5_1 in future tags.
+
+Also bring in mksurfdata changes for the raw urban dataset change. This adds some changes to
+mksurfdata for a new urban raw dataset, as well as preparation for new changes for some other
+urban changes that will be a future part of clm5_1. Also use the half degree lightning dataset
+by default for clm5_1.
+
+Start adding a new test list ctsm_sci that tests all the scientifically supported compsets.
+Some of those tests fail due to existing issues, that will be fixed later.
+
+Some more work done to change clm to ctsm, and allow for ctsm as a component.
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): 
+  Fix #1142 -- Add ctsm_sci test list
+  Fix #1145 -- File was corrupted on glade
+  Fix #1144 -- Move btran2 to just inside of fire model
+  Fix #889 --- Some adjustments to the Li Fire model
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): Adds clm5_1 option to CLM_PHYSICS_VERSION
+  clm5_1_GSWP3v1 is the only LND_TUNING_MDOE option for clm5_1
+  New compsets added for CLM51 I2000Clm51BgcCropGs, I2000Clm51BgcGs, I1850Clm51BgcGs, IHistClm51BgcGs, IHistClm51BgcCropGs
+     
+
+Changes made to namelist defaults (e.g., changed parameter values): clm5_1 physics options added in
+    Add the ability to set the component name in filenames (default is still clm2, but can be clm4, olr clm5)
+     By default lightning dataset for clm5_1 is the half degree file
+
+Changes to the datasets (e.g., parameter, surface or initial files): All params files updated with new fields for fire
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+
+Changes to tests or testing: Add ctsm_sci test list and move some clm5_0 to clm5_1 and one one clm5_1 specific test
+
+Code reviewed by: self
+
+
+CTSM testing: regular, tools
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS (853 tests are different)
+
+  tools-tests (test/tools):
+
+    cheyenne - PASS
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    cheyenne -- PASS
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    izumi ------- PASS
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: No (although clm5_1 is a new physics option that is different)
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+  #1151 -- Move btran2 to inside CNFireBase
+  #1150 -- ctsm5.1 starting point
+  #1157 -- Urban mksurfdata_map changes
+
+===============================================================
+===============================================================
 Tag name:  ctsm1.0.dev113
 Originator(s):  negins (Negin Sobhani,UCAR/TSS,303-497-1224)
 Date: Tue Sep  8 15:57:49 MDT 2020

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,14 +1,13 @@
 ===============================================================
 Tag name:  ctsm5.1.dev001
 Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
-Date: Wed Sep 23 02:16:01 MDT 2020
+Date: Wed Sep 23 02:29:08 MDT 2020
 One-line Summary: Start the clm5_1 physics series, with some changes to the fire model from Fang Li
 
 Purpose of changes
 ------------------
 
-
-Fang's latest Fire version - includes allowing clm5.1 phys version. New physics option is added
+Fang Li's latest Fire version - includes allowing clm5.1 phys version. New physics option is added
 called "clm5_1", with currently the new feature to use the latest fire changes. This has some
 adjustments to the fire model and includes some changes to the parameter file. Other new features
 will be added into clm5_1 in future tags.
@@ -114,6 +113,8 @@ Pull Requests that document the changes (include PR ids):
   #1151 -- Move btran2 to inside CNFireBase
   #1150 -- ctsm5.1 starting point
   #1157 -- Urban mksurfdata_map changes
+  #1149 -- LILACSMOKE test change
+  #1146 -- Add --project to LILACS create_newcase
 
 ===============================================================
 ===============================================================

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm5.1.dev001     erik 09/23/2020 Start the clm5_1 physics series, with some changes to the fire model from Fang Li
   ctsm1.0.dev113   negins 09/08/2020 Some bit-for-bit changes needed for the Perturbed Parameter Ensemble work
   ctsm1.0.dev112 sacks/ww 08/28/2020 Small changes to mksurfdata_map, singlept tool and run_sys_tests
   ctsm1.0.dev111     erik 08/28/2020 Compsets don't use 2014 for GSWP3 forcing, LUNA prevyr changed back

--- a/lilac/bld_templates/ctsm_template.cfg
+++ b/lilac/bld_templates/ctsm_template.cfg
@@ -26,7 +26,7 @@ finidat           = UNSET
 # High-level configuration options
 # ------------------------------------------------------------------------
 
-# ctsm_phys: 'clm4_5' or 'clm5_0'
+# ctsm_phys: 'clm4_5', 'clm5_0', or 'clm5_1'
 ctsm_phys         = clm5_0
 
 # configuration: 'nwp' or 'clm'

--- a/python/ctsm/lilac_make_runtime_inputs.py
+++ b/python/ctsm/lilac_make_runtime_inputs.py
@@ -24,7 +24,7 @@ _CONFIG_CACHE_TEMPLATE = """
 <?xml version="1.0"?>
 <config_definition>
 <commandline></commandline>
-<entry id="phys" value="{clm_phys}" list="" valid_values="clm4_5,clm5_0">Specifies clm physics</entry>
+<entry id="phys" value="{clm_phys}" list="" valid_values="clm4_5,clm5_0,clm5_1">Specifies ctsm physics</entry>
 </config_definition>
 """
 
@@ -172,7 +172,7 @@ def buildnml(cime_path, rundir):
     finidat = get_config_value(config, 'buildnml_input', 'finidat', ctsm_cfg_path)
 
     ctsm_phys = get_config_value(config, 'buildnml_input', 'ctsm_phys', ctsm_cfg_path,
-                                 allowed_values=['clm4_5', 'clm5_0'])
+                                 allowed_values=['clm4_5', 'clm5_0', 'clm5_1'])
     configuration = get_config_value(config, 'buildnml_input', 'configuration', ctsm_cfg_path,
                                      allowed_values=['nwp', 'clm'])
     structure = get_config_value(config, 'buildnml_input', 'structure', ctsm_cfg_path,
@@ -217,7 +217,7 @@ def buildnml(cime_path, rundir):
         tempfile.write(env_lilac_text)
 
     # remove any existing clm.input_data_list file
-    inputdatalist_path = os.path.join(rundir, "clm.input_data_list")
+    inputdatalist_path = os.path.join(rundir, "ctsm.input_data_list")
     if os.path.exists(inputdatalist_path):
         os.remove(inputdatalist_path)
 

--- a/src/biogeochem/CNDVDriverMod.F90
+++ b/src/biogeochem/CNDVDriverMod.F90
@@ -419,7 +419,7 @@ contains
     ! Determine initial dataset filenames
     !
     ! !USES:
-    use clm_varctl       , only : caseid, inst_suffix
+    use clm_varctl       , only : caseid, inst_suffix, compname
     use clm_time_manager , only : get_curr_date
     !
     ! !ARGUMENTS:
@@ -435,7 +435,7 @@ contains
 
     call get_curr_date (yr, mon, day, sec)
     write(cdate,'(i4.4,"-",i2.2,"-",i2.2,"-",i5.5)') yr,mon,day,sec
-    set_dgvm_filename = "./"//trim(caseid)//".clm2"//trim(inst_suffix)//&
+    set_dgvm_filename = "./"//trim(caseid)//"."//trim(compname)//trim(inst_suffix)//&
                         ".hv."//trim(cdate)//".nc"
 
   end function set_dgvm_filename

--- a/src/biogeochem/CNFireBaseMod.F90
+++ b/src/biogeochem/CNFireBaseMod.F90
@@ -233,10 +233,6 @@ contains
          h2osoi_vol    => waterstatebulk_inst%h2osoi_vol_col  & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3] (porosity)   (constant)
          )
 
-      SHR_ASSERT_ALL_FL((ubound(watsat)     == (/bounds%endc,nlevgrnd/)), sourcefile, __LINE__)
-      SHR_ASSERT_ALL_FL((ubound(h2osoi_vol) == (/bounds%endc,nlevgrnd/)), sourcefile, __LINE__)
-      SHR_ASSERT_ALL_FL((ubound(rootfr)     == (/bounds%endp,nlevgrnd/)), sourcefile, __LINE__)
-      SHR_ASSERT_ALL_FL((ubound(btran2)     == (/bounds%endp/)),          sourcefile, __LINE__)
       do f = 1, num_exposedvegp
          p = filter_exposedvegp(f)
          btran2(p)   = btran0

--- a/src/biogeochem/CNFireFactoryMod.F90
+++ b/src/biogeochem/CNFireFactoryMod.F90
@@ -94,6 +94,7 @@ contains
     use CNFireNoFireMod  , only : cnfire_nofire_type
     use CNFireLi2014Mod  , only : cnfire_li2014_type
     use CNFireLi2016Mod  , only : cnfire_li2016_type
+    use CNFireLi2021Mod  , only : cnfire_li2021_type
     use decompMod        , only : bounds_type
     !
     ! !ARGUMENTS:
@@ -112,6 +113,8 @@ contains
        allocate(cnfire_li2014_type :: cnfire_method)
     case ("li2016crufrc")
        allocate(cnfire_li2016_type :: cnfire_method)
+    case ("li2021gswpfrc")
+       allocate(cnfire_li2021_type :: cnfire_method)
 
     case default
        write(iulog,*) subname//' ERROR: unknown method: ', fire_method

--- a/src/biogeochem/CNFireLi2021Mod.F90
+++ b/src/biogeochem/CNFireLi2021Mod.F90
@@ -1,0 +1,661 @@
+module CNFireLi2021Mod
+
+#include "shr_assert.h"
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! module for fire dynamics 
+  ! created in Nov, 2012  and revised in Apr, 2013 by F. Li and S. Levis
+  ! based on Li et al. (2012a,b; 2013)
+  ! revised in Apr, 2014 according to Li et al.(2014)
+  ! revised in May, 2015, according to Li et al. (2015, in prep.)
+  ! Fire-related parameters were calibrated or tuned in May, 2015 based on the 
+  ! 20th Century transient simulations at f19_g16 with a CLM4.5 version
+  ! (clm50fire), CRUNCEPv5, and climatological lightning data.
+  !
+  ! !USES:
+  use shr_kind_mod                       , only : r8 => shr_kind_r8, CL => shr_kind_CL
+  use shr_const_mod                      , only : SHR_CONST_PI,SHR_CONST_TKFRZ
+  use shr_infnan_mod                     , only : shr_infnan_isnan
+  use shr_log_mod                        , only : errMsg => shr_log_errMsg
+  use clm_varctl                         , only : iulog
+  use clm_varpar                         , only : nlevdecomp, ndecomp_pools, nlevdecomp_full
+  use clm_varcon                         , only : dzsoi_decomp
+  use pftconMod                          , only : noveg, pftcon
+  use abortutils                         , only : endrun
+  use decompMod                          , only : bounds_type
+  use subgridAveMod                      , only : p2c
+  use atm2lndType                        , only : atm2lnd_type
+  use CNDVType                           , only : dgvs_type
+  use CNVegStateType                     , only : cnveg_state_type
+  use CNVegCarbonStateType               , only : cnveg_carbonstate_type
+  use CNVegCarbonFluxType                , only : cnveg_carbonflux_type
+  use CNVegNitrogenStateType             , only : cnveg_nitrogenstate_type
+  use CNVegNitrogenFluxType              , only : cnveg_nitrogenflux_type
+  use SoilBiogeochemDecompCascadeConType , only : decomp_cascade_con
+  use EnergyFluxType                     , only : energyflux_type
+  use SaturatedExcessRunoffMod           , only : saturated_excess_runoff_type
+  use WaterDiagnosticBulkType            , only : waterdiagnosticbulk_type
+  use Wateratm2lndBulkType               , only : wateratm2lndbulk_type
+  use GridcellType                       , only : grc                
+  use ColumnType                         , only : col                
+  use PatchType                          , only : patch                
+  use SoilBiogeochemStateType            , only : get_spinup_latitude_term
+  use FireMethodType                     , only : fire_method_type
+  use CNFireBaseMod                      , only : cnfire_base_type, cnfire_const, cnfire_params
+  use CNFireBaseMod                      , only : cnfire_base_type, cnfire_const
+  !
+  implicit none
+  private
+  !
+  ! !PUBLIC TYPES:
+  public :: cnfire_li2021_type
+  !
+  type, extends(cnfire_base_type) :: cnfire_li2021_type
+     private
+  contains
+     !
+     ! !PUBLIC MEMBER FUNCTIONS:
+     procedure, public :: need_lightning_and_popdens
+     procedure, public :: CNFireArea    ! Calculate fire area
+  end type cnfire_li2021_type
+
+  !
+  ! !PRIVATE MEMBER DATA:
+  !-----------------------------------------------------------------------
+  character(len=*), parameter, private :: sourcefile = &
+       __FILE__
+
+contains
+
+
+  !-----------------------------------------------------------------------
+  function need_lightning_and_popdens(this)
+    ! !ARGUMENTS:
+    class(cnfire_li2021_type), intent(in) :: this
+    logical :: need_lightning_and_popdens  ! function result
+    !
+    ! !LOCAL VARIABLES:
+
+    character(len=*), parameter :: subname = 'need_lightning_and_popdens'
+    !-----------------------------------------------------------------------
+
+    need_lightning_and_popdens = .true.
+  end function need_lightning_and_popdens
+
+  !-----------------------------------------------------------------------
+  subroutine CNFireArea (this, bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
+       atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, waterdiagnosticbulk_inst, &
+       wateratm2lndbulk_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+    !
+    ! !DESCRIPTION:
+    ! Computes column-level burned area 
+    !
+    ! !USES:
+    use clm_time_manager     , only: get_step_size, get_days_per_year, get_curr_date, get_nstep
+    use clm_varpar           , only: max_patch_per_col
+    use clm_varcon           , only: secspday, secsphr
+    use clm_varctl           , only: spinup_state
+    use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
+    use pftconMod            , only: nbrdlf_evr_trp_tree, nbrdlf_dcd_trp_tree, nbrdlf_evr_shrub
+    use dynSubgridControlMod , only : run_has_transient_landcover
+    !
+    ! !ARGUMENTS:
+    class(cnfire_li2021_type)                             :: this
+    type(bounds_type)                     , intent(in)    :: bounds 
+    integer                               , intent(in)    :: num_soilc       ! number of soil columns in filter
+    integer                               , intent(in)    :: filter_soilc(:) ! filter for soil columns
+    integer                               , intent(in)    :: num_soilp       ! number of soil patches in filter
+    integer                               , intent(in)    :: filter_soilp(:) ! filter for soil patches
+    type(atm2lnd_type)                    , intent(in)    :: atm2lnd_inst
+    type(energyflux_type)                 , intent(in)    :: energyflux_inst
+    type(saturated_excess_runoff_type)    , intent(in)    :: saturated_excess_runoff_inst
+    type(waterdiagnosticbulk_type)        , intent(in)    :: waterdiagnosticbulk_inst
+    type(wateratm2lndbulk_type)           , intent(in)    :: wateratm2lndbulk_inst
+    type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
+    type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
+    real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
+    real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)
+    !
+    ! !LOCAL VARIABLES:
+    !
+    integer  :: g,l,c,p,pi,j,fc,fp,kyr, kmo, kda, mcsec   ! index variables
+    real(r8) :: dt       ! time step variable (s)
+    real(r8) :: dayspyr  ! days per year
+    real(r8) :: cli      ! effect of climate on deforestation fires (0-1)
+    real(r8) :: cri      ! thresholds used for cli, (mm/d), see Eq.(7) in Li et al.(2013)
+    real(r8) :: fb       ! availability of fuel for regs A and C
+    real(r8) :: fhd      ! impact of hd on agricultural fire
+    real(r8) :: fgdp     ! impact of gdp on agricultural fire
+    real(r8) :: fire_m   ! combustability of fuel for fire occurrence
+    real(r8) :: spread_m ! combustability of fuel for fire spread
+    real(r8) :: Lb_lf    ! length-to-breadth ratio added by Lifang 
+    integer  :: i_cwd    ! cwd pool
+    real(r8) :: lh       ! anthro. ignitions (count/km2/hr)
+    real(r8) :: fs       ! hd-dependent fires suppression (0-1)
+    real(r8) :: ig       ! total ignitions (count/km2/hr)
+    real(r8) :: hdmlf    ! human density
+    real(r8) :: arh, arh30 !combustability of fuel related to RH and RH30
+    real(r8) :: afuel    !weight for arh and arh30
+    real(r8) :: btran_col(bounds%begc:bounds%endc)
+    logical  :: transient_landcover  ! whether this run has any prescribed transient landcover
+    real(r8), target  :: prec60_col_target(bounds%begc:bounds%endc)
+    real(r8), target  :: prec10_col_target(bounds%begc:bounds%endc)
+    real(r8), target  :: rh30_col_target(bounds%begc:bounds%endc) 
+    real(r8), pointer :: prec60_col(:)
+    real(r8), pointer :: prec10_col(:)
+    real(r8), pointer :: rh30_col(:)
+    !-----------------------------------------------------------------------
+
+    SHR_ASSERT_ALL((ubound(totlitc_col)           == (/bounds%endc/))                              , errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(decomp_cpools_vr_col)  == (/bounds%endc,nlevdecomp_full,ndecomp_pools/)), errMsg(sourcefile, __LINE__))
+    SHR_ASSERT_ALL((ubound(t_soi17cm_col)         == (/bounds%endc/))                              , errMsg(sourcefile, __LINE__))
+
+    associate(                                                                      & 
+         totlitc            => totlitc_col                                     , & ! Input:  [real(r8) (:)     ]  (gC/m2) total lit C (column-level mean)           
+         decomp_cpools_vr   => decomp_cpools_vr_col                            , & ! Input:  [real(r8) (:,:,:) ]  (gC/m3)  VR decomp. (litter, cwd, soil)
+         tsoi17             => t_soi17cm_col                                   , & ! Input:  [real(r8) (:)     ]  (K) soil T for top 0.17 m                             
+
+         lfuel              => cnfire_const%lfuel                              , & ! Input:  [real(r8)         ]  (gC/m2) Lower threshold of fuel mass
+         ufuel              => cnfire_const%ufuel                              , & ! Input:  [real(r8)         ]  (gC/m2) Upper threshold of fuel mass
+         rh_hgh             => cnfire_const%rh_hgh                             , & ! Input:  [real(r8)         ]  (%) High relative humidity
+         rh_low             => cnfire_const%rh_low                             , & ! Input:  [real(r8)         ]  (%) Low relative humidity
+         cli_scale          => cnfire_const%cli_scale                          , & ! Input:  [real(r8)         ]  (/d) global constant for deforestation fires
+         cropfire_a1        => cnfire_const%cropfire_a1                        , & ! Input:  [real(r8)         ]  (/hr) a1 parameter for cropland fire
+         non_boreal_peatfire_c => cnfire_const%non_boreal_peatfire_c           , & ! Input:  [real(r8)         ]  (/hr) c parameter for non-boreal peatland fire
+         pot_hmn_ign_counts_alpha => cnfire_const%pot_hmn_ign_counts_alpha     , & ! Input:  [real(r8)         ]  (/person/month) Potential human ignition counts
+         boreal_peatfire_c  => cnfire_const%boreal_peatfire_c                  , & ! Input:  [real(r8)         ]  (/hr) c parameter for boreal peatland fire
+         
+         fsr_pft            => pftcon%fsr_pft                                  , & ! Input:
+         fd_pft             => pftcon%fd_pft                                   , & ! Input:
+         rswf_min           => pftcon%rswf_min                                 , & ! Input:
+         rswf_max           => pftcon%rswf_max                                 , & ! Input:
+         btran2             => energyflux_inst%btran2_patch                    , & ! Input:  [real(r8) (:)     ]  root zone soil wetness                            
+         fsat               => saturated_excess_runoff_inst%fsat_col           , & ! Input:  [real(r8) (:)     ]  fractional area with water table at surface       
+         wf2                => waterdiagnosticbulk_inst%wf2_col                , & ! Input:  [real(r8) (:)     ]  soil water as frac. of whc for top 0.17 m         
+         
+         is_cwd             => decomp_cascade_con%is_cwd                       , & ! Input:  [logical  (:)     ]  TRUE => pool is a cwd pool                         
+         spinup_factor      => decomp_cascade_con%spinup_factor                , & ! Input:  [real(r8) (:)     ]  factor for AD spinup associated with each pool           
+
+         forc_rh            => wateratm2lndbulk_inst%forc_rh_grc               , & ! Input:  [real(r8) (:)     ]  relative humidity                                 
+         forc_wind          => atm2lnd_inst%forc_wind_grc                      , & ! Input:  [real(r8) (:)     ]  atmospheric wind speed (m/s)                       
+         forc_t             => atm2lnd_inst%forc_t_downscaled_col              , & ! Input:  [real(r8) (:)     ]  downscaled atmospheric temperature (Kelvin)                  
+         forc_rain          => wateratm2lndbulk_inst%forc_rain_downscaled_col  , & ! Input:  [real(r8) (:)     ]  downscaled rain                                              
+         forc_snow          => wateratm2lndbulk_inst%forc_snow_downscaled_col  , & ! Input:  [real(r8) (:)     ]  downscaled snow                                              
+         prec60             => wateratm2lndbulk_inst%prec60_patch              , & ! Input:  [real(r8) (:)     ]  60-day running mean of tot. precipitation         
+         prec10             => wateratm2lndbulk_inst%prec10_patch              , & ! Input:  [real(r8) (:)     ]  10-day running mean of tot. precipitation         
+         rh30               => wateratm2lndbulk_inst%rh30_patch                , & ! Input:  [real(r8) (:)     ]  10-day running mean of tot. precipitation 
+         dwt_smoothed       => cnveg_state_inst%dwt_smoothed_patch             , & ! Input:  [real(r8) (:)     ]  change in patch weight (-1 to 1) on the gridcell, smoothed over the year
+         cropf_col          => cnveg_state_inst%cropf_col                      , & ! Input:  [real(r8) (:)     ]  cropland fraction in veg column                   
+         gdp_lf             => cnveg_state_inst%gdp_lf_col                     , & ! Input:  [real(r8) (:)     ]  gdp data                                          
+         peatf_lf           => cnveg_state_inst%peatf_lf_col                   , & ! Input:  [real(r8) (:)     ]  peatland fraction data                            
+         abm_lf             => cnveg_state_inst%abm_lf_col                     , & ! Input:  [integer  (:)     ]  prescribed crop fire time                          
+         baf_crop           => cnveg_state_inst%baf_crop_col                   , & ! Output: [real(r8) (:)     ]  burned area fraction for cropland (/sec)  
+         baf_peatf          => cnveg_state_inst%baf_peatf_col                  , & ! Output: [real(r8) (:)     ]  burned area fraction for peatland (/sec)  
+         burndate           => cnveg_state_inst%burndate_patch                 , & ! Output: [integer  (:)     ]  burn date for crop                                 
+         fbac               => cnveg_state_inst%fbac_col                       , & ! Output: [real(r8) (:)     ]  total burned area out of conversion (/sec)
+         fbac1              => cnveg_state_inst%fbac1_col                      , & ! Output: [real(r8) (:)     ]  burned area out of conversion region due to land use fire
+         farea_burned       => cnveg_state_inst%farea_burned_col               , & ! Output: [real(r8) (:)     ]  total fractional area burned (/sec)
+         nfire              => cnveg_state_inst%nfire_col                      , & ! Output: [real(r8) (:)     ]  fire counts (count/km2/sec), valid only in Reg. C
+         fsr_col            => cnveg_state_inst%fsr_col                        , & ! Output: [real(r8) (:)     ]  fire spread rate at column level
+         fd_col             => cnveg_state_inst%fd_col                         , & ! Output: [real(r8) (:)     ]  fire duration rate at column level
+         lgdp_col           => cnveg_state_inst%lgdp_col                       , & ! Output: [real(r8) (:)     ]  gdp limitation factor for nfire                   
+         lgdp1_col          => cnveg_state_inst%lgdp1_col                      , & ! Output: [real(r8) (:)     ]  gdp limitation factor for baf per fire            
+         lpop_col           => cnveg_state_inst%lpop_col                       , & ! Output: [real(r8) (:)     ]  pop limitation factor for baf per fire            
+         lfwt               => cnveg_state_inst%lfwt_col                       , & ! Output: [real(r8) (:)     ]  fractional coverage of non-crop and non-bare-soil Patches
+         trotr1_col         => cnveg_state_inst%trotr1_col                     , & ! Output: [real(r8) (:)     ]  patch weight of BET on the column (0-1)           
+         trotr2_col         => cnveg_state_inst%trotr2_col                     , & ! Output: [real(r8) (:)     ]  patch weight of BDT on the column (0-1)           
+         dtrotr_col         => cnveg_state_inst%dtrotr_col                     , & ! Output: [real(r8) (:)     ]  decreased frac. coverage of BET+BDT on grid for dt
+         lfc                => cnveg_state_inst%lfc_col                        , & ! Output: [real(r8) (:)     ]  conversion area frac. of BET+BDT that haven't burned before
+         wtlf               => cnveg_state_inst%wtlf_col                       , & ! Output: [real(r8) (:)     ]  fractional coverage of non-crop Patches              
+         
+         totvegc            => cnveg_carbonstate_inst%totvegc_col              , & ! Input: [real(r8) (:)     ]  totvegc at column level                           
+         deadcrootc         => cnveg_carbonstate_inst%deadcrootc_patch         , & ! Input:  [real(r8) (:)     ]  (gC/m2) dead coarse root C                        
+         deadcrootc_storage => cnveg_carbonstate_inst%deadcrootc_storage_patch , & ! Input:  [real(r8) (:)     ]  (gC/m2) dead coarse root C storage                
+         deadcrootc_xfer    => cnveg_carbonstate_inst%deadcrootc_xfer_patch    , & ! Input:  [real(r8) (:)     ]  (gC/m2) dead coarse root C transfer               
+         deadstemc          => cnveg_carbonstate_inst%deadstemc_patch          , & ! Input:  [real(r8) (:)     ]  (gC/m2) dead stem root C
+         frootc             => cnveg_carbonstate_inst%frootc_patch             , & ! Input:  [real(r8) (:)     ]  (gC/m2) fine root C                               
+         frootc_storage     => cnveg_carbonstate_inst%frootc_storage_patch     , & ! Input:  [real(r8) (:)     ]  (gC/m2) fine root C storage                       
+         frootc_xfer        => cnveg_carbonstate_inst%frootc_xfer_patch        , & ! Input:  [real(r8) (:)     ]  (gC/m2) fine root C transfer                      
+         livecrootc         => cnveg_carbonstate_inst%livecrootc_patch         , & ! Input:  [real(r8) (:)     ]  (gC/m2) live coarse root C                        
+         livecrootc_storage => cnveg_carbonstate_inst%livecrootc_storage_patch , & ! Input:  [real(r8) (:)     ]  (gC/m2) live coarse root C storage                
+         livecrootc_xfer    => cnveg_carbonstate_inst%livecrootc_xfer_patch    , & ! Input:  [real(r8) (:)     ]  (gC/m2) live coarse root C transfer               
+         leafc              => cnveg_carbonstate_inst%leafc_patch              , & ! Input:  [real(r8) (:)     ]  (gC/m2) leaf C                                    
+         leafc_storage      => cnveg_carbonstate_inst%leafc_storage_patch      , & ! Input:  [real(r8) (:)     ]  (gC/m2) leaf C storage                            
+         leafc_xfer         => cnveg_carbonstate_inst%leafc_xfer_patch         , & ! Input:  [real(r8) (:)     ]  (gC/m2) leaf C transfer                           
+         rootc_col          => cnveg_carbonstate_inst%rootc_col                , & ! Output: [real(r8) (:)     ]  root carbon                                       
+         leafc_col          => cnveg_carbonstate_inst%leafc_col                , & ! Output: [real(r8) (:)     ]  leaf carbon at column level                       
+         deadstemc_col      => cnveg_carbonstate_inst%deadstemc_col            , & ! Output: [real(r8) (:)     ]  deadstem carbon at column level
+         fuelc              => cnveg_carbonstate_inst%fuelc_col                , & ! Output: [real(r8) (:)     ]  fuel load coutside cropland                 
+         fuelc_crop         => cnveg_carbonstate_inst%fuelc_crop_col             & ! Output: [real(r8) (:)     ]  fuel load for cropland                 
+         )
+ 
+      transient_landcover = run_has_transient_landcover()
+
+      !pft to column average 
+      prec10_col =>prec10_col_target
+      call p2c(bounds, num_soilc, filter_soilc, &
+           prec10(bounds%begp:bounds%endp), &
+           prec10_col(bounds%begc:bounds%endc))
+
+      prec60_col =>prec60_col_target
+      call p2c(bounds, num_soilc, filter_soilc, &
+           prec60(bounds%begp:bounds%endp), &
+           prec60_col(bounds%begc:bounds%endc))
+
+      rh30_col =>rh30_col_target
+      call p2c(bounds, num_soilc, filter_soilc, &
+           rh30(bounds%begp:bounds%endp), &
+           rh30_col(bounds%begc:bounds%endc))  
+      
+      call p2c(bounds, num_soilc, filter_soilc, &
+           leafc(bounds%begp:bounds%endp), &
+           leafc_col(bounds%begc:bounds%endc))
+
+      call p2c(bounds, num_soilc, filter_soilc, &
+           deadstemc(bounds%begp:bounds%endp), &
+           deadstemc_col(bounds%begc:bounds%endc))
+
+     call get_curr_date (kyr, kmo, kda, mcsec)
+     dayspyr = get_days_per_year()
+     ! Get model step size
+     dt      = real( get_step_size(), r8 )
+     !
+     ! On first time-step, just set area burned to zero and exit
+     !
+     if ( get_nstep() == 0 )then
+        do fc = 1,num_soilc
+           c = filter_soilc(fc)
+           farea_burned(c) = 0._r8
+           baf_crop(c)     = 0._r8
+           baf_peatf(c)    = 0._r8
+           fbac(c)         = 0._r8
+           fbac1(c)        = 0._r8
+           cropf_col(c)    = 0._r8 
+        end do
+        return
+     end if
+     !
+     ! Calculate fraction of crop (cropf_col) and non-crop and non-bare-soil 
+     ! vegetation (lfwt) in vegetated column
+     !
+     do fc = 1,num_soilc
+        c = filter_soilc(fc)
+        cropf_col(c) = 0._r8 
+        lfwt(c)      = 0._r8   
+     end do
+     do pi = 1,max_patch_per_col
+        do fc = 1,num_soilc
+           c = filter_soilc(fc)
+           if (pi <=  col%npatches(c)) then
+              p = col%patchi(c) + pi - 1
+              ! For crop veg types
+              if( patch%itype(p) > nc4_grass )then
+                 cropf_col(c) = cropf_col(c) + patch%wtcol(p)
+              end if
+              ! For natural vegetation (non-crop and non-bare-soil)
+              if( patch%itype(p) >= ndllf_evr_tmp_tree .and. patch%itype(p) <= nc4_grass )then
+                 lfwt(c) = lfwt(c) + patch%wtcol(p)
+              end if
+           end if
+        end do
+     end do
+     ! 
+     ! Calculate crop fuel   
+     !
+     do fc = 1,num_soilc
+        c = filter_soilc(fc)
+        fuelc_crop(c)=0._r8
+     end do
+     do pi = 1,max_patch_per_col
+        do fc = 1,num_soilc
+           c = filter_soilc(fc)
+           if (pi <=  col%npatches(c)) then
+              p = col%patchi(c) + pi - 1
+              ! For crop PFTs, fuel load includes leaf and litter; only
+              ! column-level litter carbon
+              ! is available, so we use leaf carbon to estimate the
+              ! litter carbon for crop PFTs
+              if( patch%itype(p) > nc4_grass .and. patch%wtcol(p) > 0._r8 .and. leafc_col(c) > 0._r8 )then
+                 fuelc_crop(c)=fuelc_crop(c) + (leafc(p) + leafc_storage(p) + &
+                      leafc_xfer(p))*patch%wtcol(p)/cropf_col(c)     + &
+                      totlitc(c)*leafc(p)/leafc_col(c)*patch%wtcol(p)/cropf_col(c)
+              end if
+           end if
+        end do
+     end do
+     !   
+     ! Calculate noncrop column variables
+     !
+     do fc = 1,num_soilc
+        c = filter_soilc(fc)
+        fsr_col(c)   = 0._r8
+        fd_col(c)    = 0._r8
+        rootc_col(c) = 0._r8
+        lgdp_col(c)  = 0._r8
+        lgdp1_col(c) = 0._r8
+        lpop_col(c)  = 0._r8
+        btran_col(c) = 0._r8
+        wtlf(c)      = 0._r8
+        trotr1_col(c)= 0._r8
+        trotr2_col(c)= 0._r8
+        if (transient_landcover) then
+           dtrotr_col(c)=0._r8
+        end if
+     end do
+     do pi = 1,max_patch_per_col
+        do fc = 1,num_soilc
+           c = filter_soilc(fc)
+           g = col%gridcell(c)
+           if (pi <=  col%npatches(c)) then
+              p = col%patchi(c) + pi - 1
+
+              ! For non-crop -- natural vegetation and bare-soil
+              if( patch%itype(p)  <  nc3crop .and. cropf_col(c)  <  1._r8 )then
+                 if( .not. shr_infnan_isnan(btran2(p))) then
+                    if (btran2(p)  <=  1._r8 ) then
+                       btran_col(c) = btran_col(c)+max(0._r8, min(1._r8, &
+                      (btran2(p)-rswf_min(patch%itype(p)))/(rswf_max(patch%itype(p)) &
+                      -rswf_min(patch%itype(p)))))*patch%wtcol(p)
+                        wtlf(c)      = wtlf(c)+patch%wtcol(p)
+                    end if
+                 end if
+
+                 ! NOTE(wjs, 2016-12-15) These calculations of the fraction of evergreen
+                 ! and deciduous tropical trees (used to determine if a column is
+                 ! tropical closed forest) use the current fractions. However, I think
+                 ! they are used in code that applies to land cover change. Note that
+                 ! land cover change is currently generated on the first time step of the
+                 ! year (even though the fire code sees the annually-smoothed dwt). Thus,
+                 ! I think that, for this to be totally consistent, this code should
+                 ! consider the fractional coverage of each PFT prior to the relevant
+                 ! land cover change event. (These fractions could be computed in the
+                 ! code that handles land cover change, so that the fire code remains
+                 ! agnostic to exactly how and when land cover change happens.)
+                 !
+                 ! For example, if a year started with fractional coverages of
+                 ! nbrdlf_evr_trp_tree = 0.35 and nbrdlf_dcd_trp_tree = 0.35, but then
+                 ! the start-of-year land cover change reduced both of these to 0.2: The
+                 ! current code would consider the column to NOT be tropical closed
+                 ! forest (because nbrdlf_evr_trp_tree+nbrdlf_dcd_trp_tree < 0.6),
+                 ! whereas in fact the land cover change occurred when the column *was*
+                 ! tropical closed forest.
+                 if( patch%itype(p) == nbrdlf_evr_trp_tree .and. patch%wtcol(p)  >  0._r8 )then
+                    trotr1_col(c)=trotr1_col(c)+patch%wtcol(p)*col%wtgcell(c)
+                 end if
+                 if( patch%itype(p) == nbrdlf_dcd_trp_tree .and. patch%wtcol(p)  >  0._r8 )then
+                    trotr2_col(c)=trotr2_col(c)+patch%wtcol(p)*col%wtgcell(c)
+                 end if
+
+                 if (transient_landcover) then
+                    if( patch%itype(p) == nbrdlf_evr_trp_tree .or. patch%itype(p) == nbrdlf_dcd_trp_tree )then
+                       if(dwt_smoothed(p) < 0._r8)then
+                          ! Land cover change in CLM happens all at once on the first time
+                          ! step of the year. However, the fire code needs deforestation
+                          ! rates throughout the year, in order to combine these
+                          ! deforestation rates with the current season's climate. So we
+                          ! use a smoothed version of dwt.
+                          !
+                          ! This isn't ideal, because the carbon stocks that the fire code
+                          ! is operating on will have decreased by the full annual amount
+                          ! before the fire code does anything. But the biggest effect of
+                          ! these deforestation fires is as a trigger for other fires, and
+                          ! the C fluxes are merely diagnostic so don't need to be
+                          ! conservative, so this isn't a big issue.
+                          !
+                          ! (Actually, it would be even better if the fire code had a
+                          ! realistic breakdown of annual deforestation into the
+                          ! different seasons. But having deforestation spread evenly
+                          ! throughout the year is much better than having it all
+                          ! concentrated on January 1.)
+                          dtrotr_col(c)=dtrotr_col(c)-dwt_smoothed(p)*col%wtgcell(c)
+                       end if
+                    end if
+                 end if
+                 if (spinup_state == 2) then         
+                    rootc_col(c) = rootc_col(c) + (frootc(p) + frootc_storage(p) + &
+                         frootc_xfer(p) + deadcrootc(p) * 10._r8 +       &
+                         deadcrootc_storage(p) + deadcrootc_xfer(p) +    &
+                         livecrootc(p)+livecrootc_storage(p) +           &
+                         livecrootc_xfer(p))*patch%wtcol(p)
+                 else
+                    rootc_col(c) = rootc_col(c) + (frootc(p) + frootc_storage(p) + &
+                         frootc_xfer(p) + deadcrootc(p) +                &
+                         deadcrootc_storage(p) + deadcrootc_xfer(p) +    &
+                         livecrootc(p)+livecrootc_storage(p) +           &
+                         livecrootc_xfer(p))*patch%wtcol(p)
+                 endif
+
+                 fsr_col(c) = fsr_col(c) + fsr_pft(patch%itype(p))*patch%wtcol(p)/(1.0_r8-cropf_col(c))
+
+                 hdmlf=this%forc_hdm(g)
+
+                    ! all these constants are in Li et al. BG (2012a,b;2013)
+
+                 if( hdmlf  >  0.1_r8 )then            
+                    ! For NOT bare-soil
+                    if( patch%itype(p)  /=  noveg )then
+                       ! For shrub and grass (crop already excluded above)
+                       if( patch%itype(p)  >=  nbrdlf_evr_shrub )then      !for shurb and grass
+                           lgdp_col(c)  = lgdp_col(c) + (0.1_r8 + 0.9_r8*    &
+                                  exp(-1._r8*SHR_CONST_PI* &
+                                  (gdp_lf(c)/8._r8)**0.5_r8))*patch%wtcol(p) &
+                                  /(1.0_r8 - cropf_col(c))
+                           lgdp1_col(c) = lgdp1_col(c) + (0.2_r8 + 0.8_r8*   &
+                                  exp(-1._r8*SHR_CONST_PI* &
+                                  (gdp_lf(c)/7._r8)))*patch%wtcol(p)/(1._r8 - cropf_col(c))
+                           lpop_col(c)  = lpop_col(c) + (0.2_r8 + 0.8_r8*    &
+                                  exp(-1._r8*SHR_CONST_PI* &
+                                  (hdmlf/450._r8)**0.5_r8))*patch%wtcol(p)/(1._r8 - cropf_col(c))
+                        else   ! for trees
+                           if( gdp_lf(c)  >  20._r8 )then
+                              lgdp_col(c) =lgdp_col(c)+cnfire_const%occur_hi_gdp_tree*patch%wtcol(p)/(1._r8 - cropf_col(c))
+                              lgdp1_col(c) =lgdp1_col(c)+0.62_r8*patch%wtcol(p)/(1._r8 - cropf_col(c)) 
+                           else
+                              if( gdp_lf(c) > 8._r8 )then
+                                 lgdp_col(c)=lgdp_col(c)+0.79_r8*patch%wtcol(p)/(1._r8 - cropf_col(c))
+                                 lgdp1_col(c)=lgdp1_col(c)+0.83_r8*patch%wtcol(p)/(1._r8 - cropf_col(c))
+                              else
+                                 lgdp_col(c) = lgdp_col(c)+patch%wtcol(p)/(1._r8 - cropf_col(c))
+                                 lgdp1_col(c)=lgdp1_col(c)+patch%wtcol(p)/(1._r8 - cropf_col(c))
+                              end if
+                           end if
+                           lpop_col(c) = lpop_col(c) + (0.4_r8 + 0.6_r8*    &
+                                  exp(-1._r8*SHR_CONST_PI* &
+                                  (hdmlf/125._r8)))*patch%wtcol(p)/(1._r8 -cropf_col(c))
+                         end if
+                       end if
+                  else
+                       lgdp_col(c)  = lgdp_col(c)+patch%wtcol(p)/(1.0_r8 - cropf_col(c))
+                       lgdp1_col(c) = lgdp1_col(c)+patch%wtcol(p)/(1.0_r8 -cropf_col(c))
+                       lpop_col(c)  = lpop_col(c)+patch%wtcol(p)/(1.0_r8 -cropf_col(c))
+                  end if
+
+                 fd_col(c) = fd_col(c) + fd_pft(patch%itype(p)) * patch%wtcol(p) * secsphr / (1.0_r8-cropf_col(c))         
+              end if
+           end if
+        end do
+     end do
+
+     ! estimate annual decreased fractional coverage of BET+BDT
+     ! land cover conversion in CLM4.5 is the same for each timestep except for the beginning  
+
+     if (transient_landcover) then
+        do fc = 1,num_soilc
+           c = filter_soilc(fc)
+           if( dtrotr_col(c)  >  0._r8 )then
+              if( kmo == 1 .and. kda == 1 .and. mcsec == 0)then
+                 lfc(c) = 0._r8
+              end if
+              if( kmo == 1 .and. kda == 1 .and. mcsec == dt)then
+                 lfc(c) = dtrotr_col(c)*dayspyr*secspday/dt
+              end if
+           else
+              lfc(c)=0._r8
+           end if
+        end do
+     end if
+     !
+     ! calculate burned area fraction in cropland
+     !
+     do fc = 1,num_soilc
+        c = filter_soilc(fc)
+        baf_crop(c)=0._r8
+     end do
+
+     do fp = 1,num_soilp
+        p = filter_soilp(fp)  
+        if( kmo == 1 .and. kda == 1 .and. mcsec == 0 )then
+           burndate(p) = 10000 ! init. value; actual range [0 365]
+        end if
+     end do
+
+     do pi = 1,max_patch_per_col
+        do fc = 1,num_soilc
+           c = filter_soilc(fc)
+           g= col%gridcell(c)
+           hdmlf=this%forc_hdm(g)
+           if (pi <=  col%npatches(c)) then
+              p = col%patchi(c) + pi - 1
+              ! For crop
+              if( forc_t(c)  >=  SHR_CONST_TKFRZ .and. patch%itype(p)  >  nc4_grass .and.  &
+                   kmo == abm_lf(c) .and. &
+                   burndate(p) >= 999 .and. patch%wtcol(p)  >  0._r8 )then ! catch  crop burn time
+
+                 ! calculate human density impact on ag. fire
+                 fhd = 0.04_r8+0.96_r8*exp(-1._r8*SHR_CONST_PI*(hdmlf/350._r8)**0.5_r8)
+
+                 ! calculate impact of GDP on ag. fire
+                 fgdp = 0.01_r8+0.99_r8*exp(-1._r8*SHR_CONST_PI*(gdp_lf(c)/10._r8))
+
+                 ! calculate burned area
+                 fb   = max(0.0_r8,min(1.0_r8,(fuelc_crop(c)-lfuel)/(ufuel-lfuel)))
+
+                 ! crop fire only for generic crop types at this time
+                 ! managed crops are treated as grasses if crop model is turned on
+                 baf_crop(c) = baf_crop(c) + cropfire_a1/secsphr*fhd*fgdp*patch%wtcol(p)
+                 if( fb*fhd*fgdp*patch%wtcol(p)  >  0._r8)then
+                    burndate(p)=kda
+                 end if
+              end if
+           end if
+        end do
+     end do
+     !
+     ! calculate peatland fire
+     !
+     do fc = 1, num_soilc
+        c = filter_soilc(fc)
+        g= col%gridcell(c)
+        if(grc%latdeg(g) < cnfire_const%borealat )then
+           baf_peatf(c) = non_boreal_peatfire_c/secsphr*max(0._r8, &
+                min(1._r8,(4.0_r8-prec60_col(c)*secspday)/ &
+                4.0_r8))**2*peatf_lf(c)*(1._r8-fsat(c))
+        else
+           baf_peatf(c) = boreal_peatfire_c/secsphr*exp(-SHR_CONST_PI*(max(wf2(c),0._r8)/0.3_r8))* &
+                max(0._r8,min(1._r8,(tsoi17(c)-SHR_CONST_TKFRZ)/10._r8))*peatf_lf(c)* &
+                (1._r8-fsat(c))
+        end if
+     end do
+     !
+     ! calculate other fires
+     !
+
+     ! Set the number of timesteps for e-folding.
+     ! When the simulation has run fewer than this number of steps,
+     ! re-scale the e-folding time to get a stable early estimate.
+
+     ! find which pool is the cwd pool
+     i_cwd = 0
+     do l = 1, ndecomp_pools
+        if ( is_cwd(l) ) then
+           i_cwd = l
+        endif
+     end do
+
+     !
+     ! begin column loop to calculate fractional area affected by fire
+     !
+     do fc = 1, num_soilc
+        c = filter_soilc(fc)
+        g = col%gridcell(c)
+        hdmlf=this%forc_hdm(g)
+        if( cropf_col(c)  <  1._r8 )then
+           fuelc(c) = totlitc(c)+totvegc(c)-rootc_col(c)-fuelc_crop(c)*cropf_col(c)
+           if (spinup_state == 2) then
+              fuelc(c) = fuelc(c) + ((10._r8 - 1._r8)*deadstemc_col(c))
+              do j = 1, nlevdecomp  
+                 fuelc(c) = fuelc(c)+decomp_cpools_vr(c,j,i_cwd) * dzsoi_decomp(j) * spinup_factor(i_cwd) &
+                            * get_spinup_latitude_term(grc%latdeg(col%gridcell(c)))
+              end do
+           else
+              do j = 1, nlevdecomp  
+                 fuelc(c) = fuelc(c)+decomp_cpools_vr(c,j,i_cwd) * dzsoi_decomp(j)
+              end do
+           end if
+           fuelc(c) = fuelc(c)/(1._r8-cropf_col(c))
+           fb       = max(0.0_r8,min(1.0_r8,(fuelc(c)-lfuel)/(ufuel-lfuel)))
+           if (trotr1_col(c)+trotr2_col(c)<=0.6_r8) then  
+              afuel  =min(1._r8,max(0._r8,(fuelc(c)-2500._r8)/(5000._r8-2500._r8)))
+              arh=1._r8-max(0._r8, min(1._r8,(forc_rh(g)-rh_low)/(rh_hgh-rh_low)))
+              arh30=1._r8-max(0.7_r8, min(1._r8,rh30_col(c)/90._r8))
+              if (forc_rh(g) < rh_hgh.and. wtlf(c) > 0._r8 .and. tsoi17(c)> SHR_CONST_TKFRZ)then
+                fire_m   = ((afuel*arh30+(1._r8-afuel)*arh)**1.5_r8) &
+                             *((1._r8-btran_col(c)/wtlf(c))**0.5_r8)
+              else
+                fire_m   = 0._r8
+              end if
+              lh       = pot_hmn_ign_counts_alpha*6.8_r8*hdmlf**(0.43_r8)/30._r8/24._r8
+              fs       = 1._r8-(0.01_r8+0.98_r8*exp(-0.025_r8*hdmlf))
+              ig       = (lh+this%forc_lnfm(g)/(5.16_r8+2.16_r8* &
+                     cos(SHR_CONST_PI/180._r8*3*min(60._r8,abs(grc%latdeg(g)))))*0.22_r8)  &
+                         *(1._r8-fs)*(1._r8-cropf_col(c))
+              nfire(c) = ig/secsphr*fb*fire_m*lgdp_col(c) !fire counts/km2/sec
+              Lb_lf    = 1._r8+10._r8*(1._r8-EXP(-0.06_r8*forc_wind(g)))
+              spread_m = fire_m**0.5_r8
+              farea_burned(c) = min(1._r8,(cnfire_const%g0*spread_m*fsr_col(c)* &
+                   fd_col(c)/1000._r8)**2*lgdp1_col(c)* &
+                   lpop_col(c)*nfire(c)*SHR_CONST_PI*Lb_lf+ &
+                   baf_crop(c)+baf_peatf(c))  ! fraction (0-1) per sec
+           else
+             farea_burned(c)=min(1._r8,baf_crop(c)+baf_peatf(c))
+           end if
+           !
+           ! if landuse change data is used, calculate deforestation fires and 
+           ! add it in the total of burned area fraction
+           !
+           if (transient_landcover) then
+              if( trotr1_col(c)+trotr2_col(c) > 0.6_r8 )then
+                 if(( kmo == 1 .and. kda == 1 .and. mcsec == 0) .or. &
+                      dtrotr_col(c) <=0._r8 )then
+                    fbac1(c)        = 0._r8
+                    farea_burned(c) = baf_crop(c)+baf_peatf(c)
+                 else
+                    cri = (4.0_r8*trotr1_col(c)+1.8_r8*trotr2_col(c))/(trotr1_col(c)+trotr2_col(c))
+                    cli = (max(0._r8,min(1._r8,(cri-prec60_col(c)*secspday)/cri))**0.5)* &
+                         (max(0._r8,min(1._r8,(cri-prec10_col(c)*secspday)/cri))**0.5)* &
+                         (15._r8*min(0.0016_r8,dtrotr_col(c)/dt*dayspyr*secspday)+0.009_r8)* &
+                         max(0._r8,min(1._r8,(0.25_r8-(forc_rain(c)+forc_snow(c))*secsphr)/0.25_r8))
+                    farea_burned(c) = fb*cli*(cli_scale/secspday)+baf_crop(c)+baf_peatf(c)
+                    ! burned area out of conversion region due to land use fire
+                    fbac1(c) = max(0._r8,fb*cli*(cli_scale/secspday) - 2.0_r8*lfc(c)/dt)   
+                 end if
+                 ! total burned area out of conversion 
+                 fbac(c) = fbac1(c)+baf_crop(c)+baf_peatf(c) 
+              else
+                 fbac(c) = farea_burned(c)
+              end if
+           end if
+
+        else
+           farea_burned(c) = min(1._r8,baf_crop(c)+baf_peatf(c))
+        end if
+
+     end do  ! end of column loop
+
+   end associate
+
+ end subroutine CNFireArea
+
+end module CNFireLi2021Mod

--- a/src/biogeophys/SoilMoistStressMod.F90
+++ b/src/biogeophys/SoilMoistStressMod.F90
@@ -369,7 +369,7 @@ contains
          rootr         => soilstate_inst%rootr_patch        , & ! Output: [real(r8) (:,:) ]  effective fraction of roots in each soil layer (SMS method only)
 
          btran         => energyflux_inst%btran_patch       , & ! Output: [real(r8) (:)   ]  transpiration wetness factor (0 to 1) (integrated soil water stress)
-         btran2        => energyflux_inst%btran2_patch      , & ! Output: [real(r8) (:)   ]  integrated soil water stress square
+         btran2        => energyflux_inst%btran2_patch      , & ! Output: [real(r8) (:)   ]  root zone soil wetness (0 to 1)
          rresis        => energyflux_inst%rresis_patch      , & ! Output: [real(r8) (:,:) ]  root soil water stress (resistance) by layer (0-1)  (nlevgrnd)                          
 
          h2osoi_vol    => waterstatebulk_inst%h2osoi_vol_col    , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
@@ -417,11 +417,9 @@ contains
             end if
             s_node = max(h2osoi_vol(c,j)/watsat(c,j), 0.01_r8)
 
-            call soil_water_retention_curve%soil_suction(c, j, s_node, soilstate_inst, smp_node_lf)
+ !           call soil_water_retention_curve%soil_suction(c, j, s_node, soilstate_inst, smp_node_lf)
 
-            smp_node_lf = max(smpsc(patch%itype(p)), smp_node_lf) 
-            btran2(p)   = btran2(p) +rootfr(p,j)*max(0._r8,min((smp_node_lf - smpsc(patch%itype(p))) / &
-                    (smpso(patch%itype(p)) - smpsc(patch%itype(p))), 1._r8))
+            btran2(p)   = btran2(p) +rootfr(p,j)*s_node
          end do
       end do
 

--- a/src/biogeophys/SoilMoistStressMod.F90
+++ b/src/biogeophys/SoilMoistStressMod.F90
@@ -417,9 +417,15 @@ contains
             end if
             s_node = max(h2osoi_vol(c,j)/watsat(c,j), 0.01_r8)
 
- !           call soil_water_retention_curve%soil_suction(c, j, s_node, soilstate_inst, smp_node_lf)
+            if ( .true. )then
+              call soil_water_retention_curve%soil_suction(c, j, s_node, soilstate_inst, smp_node_lf)
 
-            btran2(p)   = btran2(p) +rootfr(p,j)*s_node
+              smp_node_lf = max(smpsc(patch%itype(p)), smp_node_lf) 
+              btran2(p)   = btran2(p) +rootfr(p,j)*max(0._r8,min((smp_node_lf - smpsc(patch%itype(p))) / &
+                      (smpso(patch%itype(p)) - smpsc(patch%itype(p))), 1._r8))
+            else
+              btran2(p)   = btran2(p) +rootfr(p,j)*s_node
+            end if
          end do
       end do
 

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -69,7 +69,7 @@ module clm_varctl
   character(len=256), public :: conventions = "CF-1.0"                   
 
   ! component name for filenames (history or restart files)
-  character(len=4), public :: compname = 'clm2'
+  character(len=8), public :: compname = 'clm2'
 
   !----------------------------------------------------------
   ! Unit Numbers

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -69,7 +69,7 @@ module clm_varctl
   character(len=256), public :: conventions = "CF-1.0"                   
 
   ! component name for filenames (history or restart files)
-  character(len=4), public :: compname = 'ctsm'
+  character(len=4), public :: compname = 'clm2'
 
   !----------------------------------------------------------
   ! Unit Numbers

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -68,6 +68,9 @@ module clm_varctl
   ! dataset conventions
   character(len=256), public :: conventions = "CF-1.0"                   
 
+  ! component name for filenames (history or restart files)
+  character(len=4), public :: compname = 'ctsm'
+
   !----------------------------------------------------------
   ! Unit Numbers
   !----------------------------------------------------------

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -142,7 +142,7 @@ contains
     namelist /clm_inparm / &
          fatmlndfrc, finidat, nrevsn, &
          finidat_interp_dest, &
-         use_init_interp
+         use_init_interp, compname
 
     ! Input datasets
 
@@ -618,6 +618,7 @@ contains
     ! run control variables
     call mpi_bcast (caseid, len(caseid), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (ctitle, len(ctitle), MPI_CHARACTER, 0, mpicom, ier)
+    call mpi_bcast (compname, len(compname), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (version, len(version), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (hostname, len(hostname), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (username, len(username), MPI_CHARACTER, 0, mpicom, ier)

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -12,7 +12,7 @@ module histFileMod
   use shr_sys_mod    , only : shr_sys_flush
   use spmdMod        , only : masterproc
   use abortutils     , only : endrun
-  use clm_varctl     , only : iulog, use_vertsoilc, use_fates
+  use clm_varctl     , only : iulog, use_vertsoilc, use_fates, compname
   use clm_varcon     , only : spval, ispval, dzsoi_decomp 
   use clm_varcon     , only : grlnd, nameg, namel, namec, namep, nameCohort
   use decompMod      , only : get_proc_bounds, get_proc_global, bounds_type
@@ -492,7 +492,7 @@ contains
     !-----------------------------------------------------------------------
 
     if (masterproc) then
-       write(iulog,*)  trim(subname),' Initializing clm2 history files'
+       write(iulog,*)  trim(subname),' Initializing ', trim(compname), ' history files'
        write(iulog,'(72a1)') ("-",i=1,60)
        call shr_sys_flush(iulog)
     endif
@@ -539,7 +539,7 @@ contains
     end do
 
     if (masterproc) then
-       write(iulog,*)  trim(subname),' Successfully initialized clm2 history files'
+       write(iulog,*)  trim(subname),' Successfully initialized ', trim(compname), ' history files'
        write(iulog,'(72a1)') ("-",i=1,60)
        call shr_sys_flush(iulog)
     endif
@@ -3749,7 +3749,7 @@ contains
 
           ! Create the restart history filename and open it
           write(hnum,'(i1.1)') t-1
-          locfnhr(t) = "./" // trim(caseid) //".clm2"// trim(inst_suffix) &
+          locfnhr(t) = "./" // trim(caseid) //"."// trim(compname) // trim(inst_suffix) &
                         // ".rh" // hnum //"."// trim(rdate) //".nc"
 
           call htape_create( t, histrest=.true. )
@@ -4546,7 +4546,7 @@ contains
       write(cdate,'(i4.4,"-",i2.2,"-",i2.2,"-",i5.5)') yr,mon,day,sec
    endif
    write(hist_index,'(i1.1)') hist_file - 1
-   set_hist_filename = "./"//trim(caseid)//".clm2"//trim(inst_suffix)//&
+   set_hist_filename = "./"//trim(caseid)//"."//trim(compname)//trim(inst_suffix)//&
                        ".h"//hist_index//"."//trim(cdate)//".nc"
 
    ! check to see if the concatenated filename exceeded the

--- a/src/main/pftconMod.F90
+++ b/src/main/pftconMod.F90
@@ -221,6 +221,8 @@ module pftconMod
      real(r8), allocatable :: fm_droot      (:)
      real(r8), allocatable :: fsr_pft       (:)
      real(r8), allocatable :: fd_pft        (:)
+     real(r8), allocatable :: rswf_min      (:)
+     real(r8), allocatable :: rswf_max      (:)
 
      ! pft parameters for crop code
      real(r8), allocatable :: manunitro     (:)   ! manure
@@ -432,6 +434,8 @@ contains
     allocate( this%fm_droot      (0:mxpft) )
     allocate( this%fsr_pft       (0:mxpft) )
     allocate( this%fd_pft        (0:mxpft) )
+    allocate( this%rswf_max      (0:mxpft) )
+    allocate( this%rswf_min      (0:mxpft) )
     allocate( this%manunitro     (0:mxpft) )
     allocate( this%fleafcn       (0:mxpft) )  
     allocate( this%ffrootcn      (0:mxpft) ) 
@@ -951,6 +955,11 @@ contains
     call ncd_io('fd_pft', this%  fd_pft, 'read', ncid, readvar=readv)  
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(sourcefile, __LINE__))
 
+    call ncd_io('rswf_min', this% rswf_min, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(sourcefile, __LINE__))
+
+    call ncd_io('rswf_max', this% rswf_max, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(sourcefile, __LINE__)) 
     call ncd_io('planting_temp', this%planttemp, 'read', ncid, readvar=readv)  
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(sourcefile, __LINE__))
 
@@ -1365,6 +1374,8 @@ contains
     deallocate( this%fm_droot)
     deallocate( this%fsr_pft)
     deallocate( this%fd_pft)
+    deallocate( this%rswf_min)
+    deallocate( this%rswf_max)
     deallocate( this%manunitro)
     deallocate( this%fleafcn)
     deallocate( this%ffrootcn)

--- a/src/main/restFileMod.F90
+++ b/src/main/restFileMod.F90
@@ -17,7 +17,7 @@ module restFileMod
   use accumulMod       , only : accumulRest
   use clm_instMod      , only : clm_instRest
   use histFileMod      , only : hist_restart_ncd
-  use clm_varctl       , only : iulog, use_fates, use_hydrstress
+  use clm_varctl       , only : iulog, use_fates, use_hydrstress, compname
   use clm_varctl       , only : create_crop_landunit, irrigate
   use clm_varcon       , only : nameg, namel, namec, namep, nameCohort
   use ncdio_pio        , only : file_desc_t, ncd_pio_createfile, ncd_pio_openfile, ncd_global
@@ -263,8 +263,8 @@ contains
        end if
        call getfil( path, file, 0 )
 
-       ! tcraig, adding xx. and .clm2 makes this more robust
-       ctest = 'xx.'//trim(caseid)//'.clm2'
+       ! tcraig, adding xx. and .compname makes this more robust
+       ctest = 'xx.'//trim(caseid)//'.'//trim(compname)
        ftest = 'xx.'//trim(file)
        status = index(trim(ftest),trim(ctest))
        if (status /= 0 .and. .not.(brnch_retain_casename)) then
@@ -466,7 +466,7 @@ contains
     character(len=*), intent(in) :: rdate   ! input date for restart file name 
     !-----------------------------------------------------------------------
 
-    restFile_filename = "./"//trim(caseid)//".clm2"//trim(inst_suffix)//&
+    restFile_filename = "./"//trim(caseid)//"."//trim(compname)//trim(inst_suffix)//&
          ".r."//trim(rdate)//".nc"
     if (masterproc) then
        write(iulog,*)'writing restart file ',trim(restFile_filename),' for model date = ',rdate

--- a/tools/contrib/SpinupStability.ncl
+++ b/tools/contrib/SpinupStability.ncl
@@ -81,9 +81,9 @@ begin
   end if
 
   if (annual_hist) then
-    fls                       = systemfunc("ls " + data_dir + caseid+".clm2.h0.*-*-*-*"+".nc")
+    fls                       = systemfunc("ls " + data_dir + caseid+".clm?.h0.*-*-*-*"+".nc")
   else
-    fls                       = systemfunc("ls " + data_dir + caseid+".clm2.h0.*-*"+".nc")
+    fls                       = systemfunc("ls " + data_dir + caseid+".clm?.h0.*-*"+".nc")
   end if
   flsdims                   = dimsizes(fls)
 

--- a/tools/contrib/run_clm_historical
+++ b/tools/contrib/run_clm_historical
@@ -125,7 +125,7 @@ while ($DONE_RUNA == 0)
     set DONE_RUNA = 1
     echo '1850-1870 run is complete'
     while ($DONE_ARCHIVE == 0) 
-       set nh0 = `ls -l $WDIR/*clm2.h0.* | egrep -c '^-'`
+       set nh0 = `ls -l $WDIR/*clm?.h0.* | egrep -c '^-'`
        echo $nh0
        if ($nh0 == 1) then
           set DONE_ARCHIVE = 1 
@@ -177,7 +177,7 @@ while ($DONE_RUNA == 0)
     set DONE_RUNA = 1
     echo '1850-1900 run is complete'
     while ($DONE_ARCHIVE == 0) 
-       set nh0 = `ls -l $WDIR/*clm2.h0.* | egrep -c '^-'`
+       set nh0 = `ls -l $WDIR/*clm?.h0.* | egrep -c '^-'`
        echo $nh0
        if ($nh0 == 1) then
           set DONE_ARCHIVE = 1 
@@ -242,7 +242,7 @@ while ($DONE_RUNA == 0)
     set DONE_RUNA = 1
     echo '1901-1989 run is complete'
     while ($DONE_ARCHIVE == 0)
-       set nh0 = `ls -l $WDIR/*clm2.h0.* | egrep -c '^-'`
+       set nh0 = `ls -l $WDIR/*clm?.h0.* | egrep -c '^-'`
        echo $nh0
        if ($nh0 == 1) then
           set DONE_ARCHIVE = 1
@@ -295,7 +295,7 @@ while ($DONE_RUNA == 0)
     set DONE_RUNA = 1
     echo '1989-2004 run is complete'
     while ($DONE_ARCHIVE == 0)
-       set nh0 = `ls -l $WDIR/*clm2.h0.* | egrep -c '^-'`
+       set nh0 = `ls -l $WDIR/*clm?.h0.* | egrep -c '^-'`
        echo $nh0
        if ($nh0 == 1) then
           set DONE_ARCHIVE = 1
@@ -349,7 +349,7 @@ while ($DONE_RUNA == 0)
     set DONE_RUNA = 1
     echo '2005-2014 run is complete'
     while ($DONE_ARCHIVE == 0)
-       set nh0 = `ls -l $WDIR/*clm2.h0.* | egrep -c '^-'`
+       set nh0 = `ls -l $WDIR/*clm?.h0.* | egrep -c '^-'`
        echo $nh0
        if ($nh0 == 1) then
           set DONE_ARCHIVE = 1


### PR DESCRIPTION
### Description of changes

Fang's latest Fire version - includes allowing clm5.1 phys version

Also bring in #591 mksurfdata changes including raw urban change.

And also update mksurfdata to point to new datasets that have shifting cultivation in them

### Specific notes

Contributors other than yourself, if any: Fang Li

CTSM Issues Fixed (include github issue #):
  Fix #1145
  Fix #1144
  Fix #889

Are answers expected to change (and if so in what way)? Yes, but only for the new clm5_1 physics option

Any User Interface Changes (namelist or namelist defaults changes)? Yes
  New params file for ctsm5_1
  New fire_method option for latest LiFire development

Testing performed, if any: Ran regular testing on cheyenne

NOTE: This version was derived by using patch on the lifang0209/fire2019changes branch which was off the release branch

