### PR TITLE
Match file type on read

### DIFF
--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -1612,6 +1612,7 @@ contains
     logical                          :: varpresent ! if true, variable is on tape
     integer                          :: xtype      ! type of var in file
     integer                , pointer :: idata(:)   ! Temporary integer data to send to file
+    real(r4)               , pointer :: fdata(:)   ! Temporary double data to send to file
     real(r8)               , pointer :: ddata(:)   ! Temporary double data to send to file
     type(iodesc_plus_type) , pointer :: iodesc_plus
     type(var_desc_t)                 :: vardesc
@@ -1713,7 +1714,30 @@ contains
              endif
 #else
              call pio_seterrorhandling(ncid, PIO_BCAST_ERROR)
-             call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+#if ({ITYPE}==TYPEINT)
+             if (xtype == PIO_INT .or. xtype == PIO_REAL) then
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+             else if (xtype == PIO_DOUBLE) then
+                allocate(ddata(size(data)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
+                data = int(ddata)
+                deallocate( ddata )
+             endif
+#else if ({ITYPE}==TYPEDOUBLE)
+             if (xtype == PIO_DOUBLE) then
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+             else if (xtype == PIO_INT) then
+                allocate(idata(size(data)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
+                data = real(idata, kind=R8)
+                deallocate(idata)
+             else if (xtype == PIO_REAL) then
+                allocate(fdata(size(data)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, fdata, status)
+                data = real(fdata, kind=R8)
+                deallocate(fdata)
+             endif
+#endif
 #endif
              if ( status /= PIO_NOERR ) then
                 call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
@@ -1818,6 +1842,9 @@ contains
     integer           :: lb1,lb2
     integer           :: ub1,ub2
     integer           :: xtype      ! netcdf type of variable on file
+    integer                , pointer :: idata(:,:)   ! Temporary integer data to read from file
+    real(r4)               , pointer :: fdata(:,:)   ! Temporary double data to read from file
+    real(r8)               , pointer :: ddata(:,:)   ! Temporary double data to read from file
 
     type(iodesc_plus_type) , pointer  :: iodesc_plus
     type(var_desc_t)                  :: vardesc
@@ -1913,18 +1940,40 @@ contains
              if (present(nt)) then
                 call pio_setframe(ncid, vardesc, int(nt,kind=Pio_Offset_Kind))
              end if
-             if (present(switchdim)) then
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, temp, status)
-                do j = lb2,ub2
-                do i = lb1,ub1
-                   data(i,j) = temp(j,i)
-                end do
-                end do
-             else
+#if ({ITYPE}==TYPEINT)
+             if(xtype == PIO_INT .or. xtype == PIO_REAL) then
                 call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+             elseif(xtype == PIO_DOUBLE) then
+                allocate(ddata(size(data,1),size(data,2)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
+                data = int(ddata)
+             endif
+#endif
+#if ({ITYPE}==TYPEDOUBLE)
+             if(xtype == PIO_DOUBLE) then
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+             else if(xtype == PIO_INT) then
+                allocate(idata(size(data,1),size(data,2)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
+                data = real(idata, kind=R8)
+                deallocate(idata)
+             else if(xtype == PIO_REAL) then
+                allocate(fdata(size(data,1),size(data,2)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, fdata, status)
+                data = real(fdata, kind=R8)
+                deallocate(fdata)
+             endif
+#endif
+             if (present(switchdim)) then
+                temp = data
+                do j = lb2,ub2
+                   do i = lb1,ub1
+                      data(i,j) = temp(j,i)
+                   end do
+                end do
              end if
           end if
-#if ({ITYPE}!=TYPEINT)
+#if ({ITYPE}==TYPEDOUBLE)
           if ( present(cnvrtnan2fill) )then
              do j = lb2,ub2
              do i = lb1,ub1
@@ -2054,6 +2103,9 @@ contains
     integer                          :: count(5)   ! netcdf count index
     integer                          :: xtype      ! netcdf type of variable on file
     logical                          :: varpresent ! if true, variable is on tape
+    integer                , pointer :: idata(:,:,:)   ! Temporary integer data to read from file
+    real(r4)               , pointer :: fdata(:,:,:)   ! Temporary double data to read from file
+    real(r8)               , pointer :: ddata(:,:,:)   ! Temporary double data to read from file
     type(iodesc_plus_type) , pointer :: iodesc_plus
     type(var_desc_t)                 :: vardesc
     character(len=*),parameter :: subname='ncd_io_3d_{TYPE}' ! subroutine name
@@ -2116,7 +2168,31 @@ contains
              if (present(nt)) then
                 call pio_setframe(ncid, vardesc, int(nt,kind=Pio_Offset_Kind))
              end if
-             call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+#if ({ITYPE}==TYPEINT)
+             if(xtype == PIO_INT .or. xtype == PIO_REAL) then
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+             elseif (xtype == PIO_DOUBLE) then
+                allocate(ddata(size(data,1),size(data,2),size(data,3)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
+                data = int(ddata)
+                deallocate(ddata)
+             endif
+#endif
+#if ({ITYPE}==TYPEDOUBLE)
+             if(xtype == PIO_INT) then
+                allocate(idata(size(data,1),size(data,2),size(data,3)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
+                data = real(idata, kind=r8)
+                deallocate(idata)
+             else if(xtype == PIO_REAL) then
+                allocate(fdata(size(data,1),size(data,2),size(data,3)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, fdata, status)
+                data = real(fdata, kind=r8)
+                deallocate(fdata)
+             else
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
+             endif
+#endif
           end if
        end if
        if (present(readvar)) readvar = varpresent

--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -1616,6 +1616,7 @@ contains
     real(r8)               , pointer :: ddata(:)   ! Temporary double data to send to file
     type(iodesc_plus_type) , pointer :: iodesc_plus
     type(var_desc_t)                 :: vardesc
+    integer                          :: oldhandle  ! previous value of pio_error_handle
     character(len=*),parameter       :: subname='ncd_io_1d_{TYPE}' ! subroutine name
     !-----------------------------------------------------------------------
 
@@ -1641,7 +1642,6 @@ contains
 
        call ncd_inqvid(ncid, varname, varid, vardesc, readvar=varpresent)
        if (varpresent) then
-          call pio_seterrorhandling(ncid, PIO_BCAST_ERROR)
           if (single_column) then
              start(:) = 1 ; count(:) = 1
              call scam_field_offsets(ncid,clmlevel,vardesc,start,count)
@@ -1660,6 +1660,7 @@ contains
              end if
 #if ({ITYPE}==TYPELOGICAL)
              allocate(idata(size(data)))
+             call pio_seterrorhandling(ncid, PIO_BCAST_ERROR, oldhandle)
              status = pio_get_var(ncid, varid, start(1:n), count(1:n), idata)
              data = (idata == 1)
              if ( any(idata /= 0 .and. idata /= 1) )then
@@ -1673,6 +1674,8 @@ contains
                 call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
                 // errMsg(sourcefile, __LINE__))
              end if
+             call pio_seterrorhandling(ncid, oldhandle)
+
           else
              status = pio_inq_varndims(ncid, vardesc, ndims)
              status = pio_inq_vardimid(ncid, vardesc, dids(1:ndims))
@@ -1694,58 +1697,20 @@ contains
              if (present(nt)) then
                 call pio_setframe(ncid, vardesc, int(nt,kind=Pio_Offset_Kind))
              end if
-#if ({ITYPE}==TYPELOGICAL)
-             if (xtype == PIO_INT .or. xtype == PIO_REAL) then
-                allocate(idata(size(data)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
-                data = (idata == 1)
-                if ( any(idata /= 0 .and. idata /= 1) )then
-                   call shr_sys_abort(' ERROR: read in bad integer value(s) for logical data'//errMsg(sourcefile, __LINE__))
-                end if
-                deallocate( idata )
-             else if (xtype == PIO_DOUBLE) then
-                allocate(ddata(size(data)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
-                data = (ddata == 1.)
-                if ( any(ddata /= 0. .and. ddata /= 1.) )then
-                   call shr_sys_abort(' ERROR: read in bad value(s) for logical data'//errMsg(sourcefile, __LINE__))
-                end if
-                deallocate( ddata )
+             if(xtype == PIO_INT) then
+                call read_darray_{TYPE}_from_int_1(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+             elseif(xtype == PIO_REAL) then
+                call read_darray_{TYPE}_from_real_1(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+             elseif(xtype == PIO_DOUBLE) then
+                call read_darray_{TYPE}_from_double_1(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+             else
+                   call shr_sys_abort(' ERROR: unrecognised type in read'//errMsg(sourcefile, __LINE__))
+
              endif
-#else
-             call pio_seterrorhandling(ncid, PIO_BCAST_ERROR)
-#if ({ITYPE}==TYPEINT)
-             if (xtype == PIO_INT .or. xtype == PIO_REAL) then
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
-             else if (xtype == PIO_DOUBLE) then
-                allocate(ddata(size(data)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
-                data = int(ddata)
-                deallocate( ddata )
-             endif
-#else if ({ITYPE}==TYPEDOUBLE)
-             if (xtype == PIO_DOUBLE) then
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
-             else if (xtype == PIO_INT) then
-                allocate(idata(size(data)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
-                data = real(idata, kind=R8)
-                deallocate(idata)
-             else if (xtype == PIO_REAL) then
-                allocate(fdata(size(data)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, fdata, status)
-                data = real(fdata, kind=R8)
-                deallocate(fdata)
-             endif
-#endif
-#endif
-             if ( status /= PIO_NOERR ) then
-                call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
-                // errMsg(sourcefile, __LINE__))
-             end if
+
           end if
        end if
-       call pio_seterrorhandling(ncid, PIO_INTERNAL_ERROR)
+
        if (present(readvar)) readvar = varpresent
 
     elseif (flag == 'write') then
@@ -1929,48 +1894,41 @@ contains
                 status = pio_inq_dimlen(ncid,dids(n),dims(n))
              enddo
              status = pio_inq_vartype(ncid, vardesc, xtype)
-             if (present(switchdim)) then
-                call ncd_getiodesc(ncid, clmlevel, ndims_iod, dims(1:ndims_iod), dids(1:ndims_iod), &
-                     xtype, iodnum, switchdim=.true.)
-             else
-                call ncd_getiodesc(ncid, clmlevel, ndims_iod, dims(1:ndims_iod), dids(1:ndims_iod), &
-                     xtype, iodnum)
-             end if
-             iodesc_plus => iodesc_list(iodnum)
              if (present(nt)) then
                 call pio_setframe(ncid, vardesc, int(nt,kind=Pio_Offset_Kind))
              end if
-#if ({ITYPE}==TYPEINT)
-             if(xtype == PIO_INT .or. xtype == PIO_REAL) then
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
-             elseif(xtype == PIO_DOUBLE) then
-                allocate(ddata(size(data,1),size(data,2)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
-                data = int(ddata)
-             endif
-#endif
-#if ({ITYPE}==TYPEDOUBLE)
-             if(xtype == PIO_DOUBLE) then
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
-             else if(xtype == PIO_INT) then
-                allocate(idata(size(data,1),size(data,2)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
-                data = real(idata, kind=R8)
-                deallocate(idata)
-             else if(xtype == PIO_REAL) then
-                allocate(fdata(size(data,1),size(data,2)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, fdata, status)
-                data = real(fdata, kind=R8)
-                deallocate(fdata)
-             endif
-#endif
              if (present(switchdim)) then
-                temp = data
+                call ncd_getiodesc(ncid, clmlevel, ndims_iod, dims(1:ndims_iod), dids(1:ndims_iod), &
+                     xtype, iodnum, switchdim=.true.)
+                iodesc_plus => iodesc_list(iodnum)
+                if(xtype == PIO_INT) then
+                   call read_darray_{TYPE}_from_int_2(ncid, vardesc, iodesc_plus%iodesc, varname, temp)
+                elseif(xtype == PIO_REAL) then
+                   call read_darray_{TYPE}_from_real_2(ncid, vardesc, iodesc_plus%iodesc, varname, temp)
+                elseif(xtype == PIO_DOUBLE) then
+                   call read_darray_{TYPE}_from_double_2(ncid, vardesc, iodesc_plus%iodesc, varname, temp)
+                else
+                   call shr_sys_abort(' ERROR: unrecognised type in read'//errMsg(sourcefile, __LINE__))
+                endif
                 do j = lb2,ub2
                    do i = lb1,ub1
                       data(i,j) = temp(j,i)
                    end do
                 end do
+             else
+                call ncd_getiodesc(ncid, clmlevel, ndims_iod, dims(1:ndims_iod), dids(1:ndims_iod), &
+                     xtype, iodnum)
+                iodesc_plus => iodesc_list(iodnum)
+
+                if(xtype == PIO_INT) then
+                   call read_darray_{TYPE}_from_int_2(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+                elseif(xtype == PIO_REAL) then
+                   call read_darray_{TYPE}_from_real_2(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+                elseif(xtype == PIO_DOUBLE) then
+                   call read_darray_{TYPE}_from_double_2(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+                else
+                   call shr_sys_abort(' ERROR: unrecognised type in read'//errMsg(sourcefile, __LINE__))
+                endif
              end if
           end if
 #if ({ITYPE}==TYPEDOUBLE)
@@ -2069,7 +2027,6 @@ contains
     end if
 
   end subroutine ncd_io_2d_{TYPE}
-
   !-----------------------------------------------------------------------
 
   !TYPE int,double
@@ -2168,31 +2125,17 @@ contains
              if (present(nt)) then
                 call pio_setframe(ncid, vardesc, int(nt,kind=Pio_Offset_Kind))
              end if
-#if ({ITYPE}==TYPEINT)
-             if(xtype == PIO_INT .or. xtype == PIO_REAL) then
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
-             elseif (xtype == PIO_DOUBLE) then
-                allocate(ddata(size(data,1),size(data,2),size(data,3)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
-                data = int(ddata)
-                deallocate(ddata)
-             endif
-#endif
-#if ({ITYPE}==TYPEDOUBLE)
-             if(xtype == PIO_INT) then
-                allocate(idata(size(data,1),size(data,2),size(data,3)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
-                data = real(idata, kind=r8)
-                deallocate(idata)
-             else if(xtype == PIO_REAL) then
-                allocate(fdata(size(data,1),size(data,2),size(data,3)))
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, fdata, status)
-                data = real(fdata, kind=r8)
-                deallocate(fdata)
-             else
-                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)
-             endif
-#endif
+
+                if(xtype == PIO_INT) then
+                   call read_darray_{TYPE}_from_int_3(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+                elseif(xtype == PIO_REAL) then
+                   call read_darray_{TYPE}_from_real_3(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+                elseif(xtype == PIO_DOUBLE) then
+                   call read_darray_{TYPE}_from_double_3(ncid, vardesc, iodesc_plus%iodesc, varname, data)
+                else
+                   call shr_sys_abort(' ERROR: unrecognised type in read'//errMsg(sourcefile, __LINE__))
+                endif
+
           end if
        end if
        if (present(readvar)) readvar = varpresent
@@ -2234,6 +2177,154 @@ contains
     endif
 
   end subroutine ncd_io_3d_{TYPE}
+
+
+  !TYPE int,double,logical
+  !DIMS 1,2,3
+  subroutine read_darray_{TYPE}_from_double_{DIMS}(ncid, vardesc, iodesc, varname, data)
+    class(file_desc_t), intent(inout) :: ncid
+    type(var_desc_t), intent(inout) :: vardesc
+    type(io_desc_t), intent(inout) :: iodesc
+    {VTYPE}, pointer :: data{DIMSTR}
+    character(len=*), intent(in) :: varname
+    integer :: status
+
+    real(R8), allocatable :: ddata{DIMSTR}
+    integer :: oldhandle
+
+    call pio_seterrorhandling(ncid, PIO_BCAST_ERROR, oldhandle)
+#if({ITYPE}==TYPEDOUBLE)
+    call pio_read_darray(ncid, vardesc, iodesc, data, status)
+    if ( status /= PIO_NOERR ) then
+       call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
+            // errMsg(sourcefile, __LINE__))
+    end if
+#else
+#if({DIMS}==1)
+    allocate(ddata(size(data)))
+#elif({DIMS}==2)
+    allocate(ddata(size(data,1),size(data,2)))
+#elif({DIMS}==3)
+    allocate(ddata(size(data,1),size(data,2),size(data,3)))
+#endif
+    call pio_read_darray(ncid, vardesc, iodesc, ddata, status)
+    if ( status /= PIO_NOERR ) then
+       call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
+            // errMsg(sourcefile, __LINE__))
+    end if
+#if({ITYPE}==TYPEINT)
+    data = int(ddata)
+#else
+    if ( any(ddata /= 0. .and. ddata /= 1.) )then
+       call shr_sys_abort(' ERROR: read in bad value(s) for logical data'//errMsg(sourcefile, __LINE__))
+    end if
+
+    where( ddata /= 0.)
+      data = .true.
+   elsewhere
+      data = .false.
+    end where
+#endif
+    deallocate(ddata)
+#endif
+    call pio_seterrorhandling(ncid, oldhandle)
+  end subroutine read_darray_{TYPE}_from_double_{DIMS}
+
+  !TYPE int,double,logical
+  !DIMS 1,2,3
+  subroutine read_darray_{TYPE}_from_int_{DIMS}(ncid, vardesc, iodesc, varname, data)
+    class(file_desc_t), intent(inout) :: ncid
+    type(var_desc_t), intent(inout) :: vardesc
+    type(io_desc_t), intent(inout) :: iodesc
+    character(len=*), intent(in) :: varname
+    {VTYPE}, pointer :: data{DIMSTR}
+    integer :: status
+
+    integer, allocatable :: idata{DIMSTR}
+    integer :: oldhandle
+
+    call pio_seterrorhandling(ncid, PIO_BCAST_ERROR, oldhandle)
+#if({ITYPE}==TYPEINT)
+    call pio_read_darray(ncid, vardesc, iodesc, data, status)
+    if ( status /= PIO_NOERR ) then
+       call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
+            // errMsg(sourcefile, __LINE__))
+    end if
+#else
+#if({DIMS}==1)
+    allocate(idata(size(data)))
+#elif({DIMS}==2)
+    allocate(idata(size(data,1),size(data,2)))
+#elif({DIMS}==3)
+    allocate(idata(size(data,1),size(data,2),size(data,3)))
+#endif
+    call pio_read_darray(ncid, vardesc, iodesc, idata, status)
+    if ( status /= PIO_NOERR ) then
+       call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
+            // errMsg(sourcefile, __LINE__))
+    end if
+#if({ITYPE}==TYPEDOUBLE)
+    data = real(idata, kind=R8)
+#else
+    if ( any(idata /= 0 .and. idata /= 1) )then
+       call shr_sys_abort(' ERROR: read in bad integer value(s) for logical data'//errMsg(sourcefile, __LINE__))
+    end if
+    where( idata /= 0)
+      data = .true.
+   elsewhere
+      data = .false.
+    end where
+#endif
+    deallocate(idata)
+#endif
+    call pio_seterrorhandling(ncid, oldhandle)
+  end subroutine read_darray_{TYPE}_from_int_{DIMS}
+
+  !TYPE int,double,logical
+  !DIMS 1,2,3
+  subroutine read_darray_{TYPE}_from_real_{DIMS}(ncid, vardesc, iodesc, varname, data)
+    class(file_desc_t), intent(inout) :: ncid
+    type(var_desc_t), intent(inout) :: vardesc
+    type(io_desc_t), intent(inout) :: iodesc
+    character(len=*), intent(in) :: varname
+    {VTYPE}, pointer :: data{DIMSTR}
+
+    integer :: status
+    real(r4), allocatable :: rdata{DIMSTR}
+    integer :: oldhandle
+
+    call pio_seterrorhandling(ncid, PIO_BCAST_ERROR, oldhandle)
+
+#if({DIMS}==1)
+    allocate(rdata(size(data)))
+#elif({DIMS}==2)
+    allocate(rdata(size(data,1),size(data,2)))
+#elif({DIMS}==3)
+    allocate(rdata(size(data,1),size(data,2),size(data,3)))
+#endif
+    call pio_read_darray(ncid, vardesc, iodesc, rdata, status)
+    if ( status /= PIO_NOERR ) then
+       call shr_sys_abort(' ERROR: reading in variable: '// trim(varname) &
+            // errMsg(sourcefile, __LINE__))
+    end if
+#if({ITYPE}==TYPEDOUBLE)
+    data = real(rdata, kind=R8)
+#elif({ITYPE}==TYPEINT)
+    data = int(rdata)
+#else
+    if ( any(rdata /= 0. .and. rdata /= 1.) )then
+       call shr_sys_abort(' ERROR: read in bad value(s) for logical data'//errMsg(sourcefile, __LINE__))
+    end if
+    where(rdata /= 0.)
+       data = .true.
+    elsewhere
+       data = .false.
+    end where
+#endif
+    deallocate(rdata)
+    call pio_seterrorhandling(ncid, oldhandle)
+
+  end subroutine read_darray_{TYPE}_from_real_{DIMS}
 
   !------------------------------------------------------------------------
 

--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -33,7 +33,7 @@ module ncdio_pio
   use pio            , only : pio_put_att, pio_put_var, pio_read_darray, pio_real, pio_seterrorhandling
   use pio            , only : pio_setframe, pio_unlimited, pio_write, pio_write_darray, var_desc_t
   use pio            , only : pio_iotask_rank, PIO_REARR_SUBSET, PIO_REARR_BOX
-  use pio            , only : pio_inq_vartype
+  use pio            , only : pio_inq_vartype, pio_real
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -1612,6 +1612,7 @@ contains
     logical                          :: varpresent ! if true, variable is on tape
     integer                          :: xtype      ! type of var in file
     integer                , pointer :: idata(:)   ! Temporary integer data to send to file
+    real(r8)               , pointer :: ddata(:)   ! Temporary double data to send to file
     type(iodesc_plus_type) , pointer :: iodesc_plus
     type(var_desc_t)                 :: vardesc
     character(len=*),parameter       :: subname='ncd_io_1d_{TYPE}' ! subroutine name
@@ -1693,13 +1694,23 @@ contains
                 call pio_setframe(ncid, vardesc, int(nt,kind=Pio_Offset_Kind))
              end if
 #if ({ITYPE}==TYPELOGICAL)
-             allocate(idata(size(data)))
-             call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
-             data = (idata == 1)
-             if ( any(idata /= 0 .and. idata /= 1) )then
-                call shr_sys_abort(' ERROR: read in bad integer value(s) for logical data'//errMsg(sourcefile, __LINE__))
-             end if
-             deallocate( idata )
+             if (xtype == PIO_INT .or. xtype == PIO_REAL) then
+                allocate(idata(size(data)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, idata, status)
+                data = (idata == 1)
+                if ( any(idata /= 0 .and. idata /= 1) )then
+                   call shr_sys_abort(' ERROR: read in bad integer value(s) for logical data'//errMsg(sourcefile, __LINE__))
+                end if
+                deallocate( idata )
+             else if (xtype == PIO_DOUBLE) then
+                allocate(ddata(size(data)))
+                call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, ddata, status)
+                data = (ddata == 1.)
+                if ( any(ddata /= 0. .and. ddata /= 1.) )then
+                   call shr_sys_abort(' ERROR: read in bad value(s) for logical data'//errMsg(sourcefile, __LINE__))
+                end if
+                deallocate( ddata )
+             endif
 #else
              call pio_seterrorhandling(ncid, PIO_BCAST_ERROR)
              call pio_read_darray(ncid, vardesc, iodesc_plus%iodesc, data, status)

--- a/src/main/surfrdMod.F90
+++ b/src/main/surfrdMod.F90
@@ -19,7 +19,7 @@ module surfrdMod
   use ncdio_pio       , only : file_desc_t, var_desc_t, ncd_pio_openfile, ncd_pio_closefile
   use ncdio_pio       , only : ncd_io, check_var, ncd_inqfdims, check_dim, ncd_inqdid, ncd_inqdlen
   use pio
-  use spmdMod                         
+  use spmdMod
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -53,7 +53,7 @@ contains
     !
     ! !DESCRIPTION:
     ! Read the surface dataset grid related information:
-    ! This is the first routine called by clm_initialize 
+    ! This is the first routine called by clm_initialize
     ! NO DOMAIN DECOMPOSITION  HAS BEEN SET YET
     !
     ! !USES:
@@ -61,14 +61,14 @@ contains
     !
     ! !ARGUMENTS:
     character(len=*), intent(in)    :: filename  ! grid filename
-    integer         , pointer       :: mask(:)   ! grid mask 
+    integer         , pointer       :: mask(:)   ! grid mask
     integer         , intent(out)   :: ni, nj    ! global grid sizes
     !
     ! !LOCAL VARIABLES:
     logical :: isgrid2d
     integer :: dimid,varid         ! netCDF id's
     integer :: ns                  ! size of grid on file
-    integer :: n,i,j               ! index 
+    integer :: n,i,j               ! index
     integer :: ier                 ! error status
     type(file_desc_t)  :: ncid     ! netcdf id
     type(var_desc_t)   :: vardesc  ! variable descriptor
@@ -106,7 +106,7 @@ contains
 
     if (isgrid2d) then
        allocate(idata2d(ni,nj))
-       idata2d(:,:) = 1	
+       idata2d(:,:) = 1
        call ncd_io(ncid=ncid, varname='LANDMASK', data=idata2d, flag='read', readvar=readvar)
        if (.not. readvar) then
           call ncd_io(ncid=ncid, varname='mask', data=idata2d, flag='read', readvar=readvar)
@@ -114,7 +114,7 @@ contains
        if (readvar) then
           do j = 1,nj
           do i = 1,ni
-             n = (j-1)*ni + i	
+             n = (j-1)*ni + i
              mask(n) = idata2d(i,j)
           enddo
           enddo
@@ -147,7 +147,7 @@ contains
     use fileutils , only : getfil
     !
     ! !ARGUMENTS:
-    integer          ,intent(in)    :: begg, endg 
+    integer          ,intent(in)    :: begg, endg
     type(domain_type),intent(inout) :: ldomain   ! domain to init
     character(len=*) ,intent(in)    :: filename  ! grid filename
     character(len=*) ,optional, intent(in) :: glcfilename ! glc mask filename
@@ -161,7 +161,7 @@ contains
     integer :: dimid,varid                  ! netCDF id's
     integer :: start(1), count(1)           ! 1d lat/lon array sections
     integer :: ier,ret                      ! error status
-    logical :: readvar                      ! true => variable is on input file 
+    logical :: readvar                      ! true => variable is on input file
     logical :: isgrid2d                     ! true => file is 2d lat/lon
     logical :: istype_domain                ! true => input file is of type domain
     real(r8), allocatable :: rdata2d(:,:)   ! temporary
@@ -189,7 +189,7 @@ contains
     call domain_init(ldomain, isgrid2d=isgrid2d, ni=ni, nj=nj, nbeg=begg, nend=endg)
 
     ! Determine type of file - old style grid file or new style domain file
-    call check_var(ncid=ncid, varname='xc', vardesc=vardesc, readvar=readvar) 
+    call check_var(ncid=ncid, varname='xc', vardesc=vardesc, readvar=readvar)
     if (readvar)then
         istype_domain = .true.
     else
@@ -204,11 +204,11 @@ contains
        ! convert from radians**2 to km**2
        ldomain%area = ldomain%area * (re**2)
        if (.not. readvar) call endrun( msg=' ERROR: area NOT on file'//errMsg(sourcefile, __LINE__))
-       
+
        call ncd_io(ncid=ncid, varname= 'xc', flag='read', data=ldomain%lonc, &
             dim1name=grlnd, readvar=readvar)
        if (.not. readvar) call endrun( msg=' ERROR: xc NOT on file'//errMsg(sourcefile, __LINE__))
-       
+
        call ncd_io(ncid=ncid, varname= 'yc', flag='read', data=ldomain%latc, &
             dim1name=grlnd, readvar=readvar)
        if (.not. readvar) call endrun( msg=' ERROR: yc NOT on file'//errMsg(sourcefile, __LINE__))
@@ -298,7 +298,7 @@ contains
 
     !
     ! !ARGUMENTS:
-    integer,          intent(in) :: begg, endg, actual_numcft      
+    integer,          intent(in) :: begg, endg, actual_numcft
     type(domain_type),intent(in) :: ldomain     ! land domain
     character(len=*), intent(in) :: lfsurdat    ! surface dataset filename
     !
@@ -314,7 +314,7 @@ contains
     real(r8)          :: rmaxlon,rmaxlat      ! local min/max vars
     type(file_desc_t) :: ncid                 ! netcdf id
     logical           :: istype_domain        ! true => input file is of type domain
-    logical           :: isgrid2d             ! true => intut grid is 2d 
+    logical           :: isgrid2d             ! true => intut grid is 2d
 
     character(len=32) :: subname = 'surfrd_get_data'    ! subroutine name
     !-----------------------------------------------------------------------
@@ -344,11 +344,11 @@ contains
 
     ! Check if fsurdat grid is "close" to fatmlndfrc grid, exit if lats/lon > 0.001
 
-    call check_var(ncid=ncid, varname='xc', vardesc=vardesc, readvar=readvar) 
+    call check_var(ncid=ncid, varname='xc', vardesc=vardesc, readvar=readvar)
     if (readvar) then
        istype_domain = .true.
     else
-       call check_var(ncid=ncid, varname='LONGXY', vardesc=vardesc, readvar=readvar) 
+       call check_var(ncid=ncid, varname='LONGXY', vardesc=vardesc, readvar=readvar)
        if (readvar) then
           istype_domain = .false.
        else
@@ -440,7 +440,7 @@ contains
     !         mksurfdat.F90 toosmallPFT = 1.e-10
 
     call collapse_individual_lunits(wt_lunit, begg, endg, toosmall_soil, &
-                                    toosmall_crop, toosmall_glacier, & 
+                                    toosmall_crop, toosmall_glacier, &
                                     toosmall_lake, toosmall_wetland, &
                                     toosmall_urban)
 
@@ -448,12 +448,12 @@ contains
        write(iulog,*) 'Successfully read surface boundary data'
        write(iulog,*)
     end if
-    
+
     ! read the lakemask (necessary for initialisation of dynamical lakes)
     if (get_do_transient_lakes()) then
         call surfrd_lakemask(begg, endg)
     end if
-    
+
   end subroutine surfrd_get_data
 
 !-----------------------------------------------------------------------
@@ -521,7 +521,7 @@ contains
     use UrbanParamsType , only : CheckUrban
     !
     ! !ARGUMENTS:
-    integer          , intent(in)    :: begg, endg 
+    integer          , intent(in)    :: begg, endg
     type(file_desc_t), intent(inout) :: ncid   ! netcdf id
     integer          , intent(in)    :: ns     ! domain size
     !
@@ -572,7 +572,7 @@ contains
 
     ! Read urban info
     if (nlevurb == 0) then
-      ! If PCT_URBAN is not multi-density then set pcturb to zero 
+      ! If PCT_URBAN is not multi-density then set pcturb to zero
       pcturb = 0._r8
       urban_valid(begg:endg) = .false.
       write(iulog,*)'PCT_URBAN is not multi-density, pcturb set to 0'
@@ -699,7 +699,7 @@ contains
 
     call ncd_io(ncid=ncid, varname='PCT_CFT', flag='read', data=wt_cft, &
             dim1name=grlnd, readvar=readvar)
-    if (.not. readvar) call endrun( msg=' ERROR: PCT_CFT NOT on surfdata file'//errMsg(sourcefile, __LINE__)) 
+    if (.not. readvar) call endrun( msg=' ERROR: PCT_CFT NOT on surfdata file'//errMsg(sourcefile, __LINE__))
 
     if ( cft_size > 0 )then
        call ncd_io(ncid=ncid, varname='CONST_FERTNITRO_CFT', flag='read', data=fert_cft, &
@@ -732,7 +732,7 @@ contains
     wt_nat_patch(begg:,natpft_lb:natpft_size-1+natpft_lb) = array2D(begg:,:)
     deallocate( array2D )
 
-  end subroutine surfrd_cftformat      
+  end subroutine surfrd_cftformat
 
 !-----------------------------------------------------------------------
   subroutine surfrd_pftformat( begg, endg, ncid )
@@ -881,12 +881,12 @@ contains
        if ( masterproc ) write(iulog,*) "WARNING: The PFT format is an unsupported format that will be removed in the future!"
        ! Check dimension size
        call surfrd_pftformat( begg, endg, ncid )                                 ! Format where crop is part of the natural veg. landunit
-    else 
+    else
        call endrun( msg=' ERROR: Problem figuring out format of input fsurdat file'//errMsg(sourcefile, __LINE__))
     end if
 
     ! Do some checking
-    
+
     if ( (cft_size == 0) .and. any(wt_lunit(begg:endg,istcrop) > 0._r8) ) then
        call endrun( msg=' ERROR: if PCT_CROP > 0 anywhere, then cft_size must be > 0'// &
                ' (if the surface dataset has a separate crop landunit, then the code'// &
@@ -941,7 +941,7 @@ contains
     use clm_instur, only : wt_nat_patch
     !
     ! !ARGUMENTS:
-    integer, intent(in) :: begg, endg  
+    integer, intent(in) :: begg, endg
     !
     ! !LOCAL VARIABLES:
     character(len=*), parameter :: subname = 'surfrd_veg_dgvm'
@@ -970,21 +970,20 @@ contains
      use fileutils            , only : getfil
     !
     ! !ARGUMENTS:
-    integer,           intent(in)    :: begg, endg  
-    ! 
+    integer,           intent(in)    :: begg, endg
+    !
     !
     ! !LOCAL VARIABLES:
     type(file_desc_t)         :: ncid_dynuse          ! netcdf id for landuse timeseries file
     character(len=256)        :: locfn                ! local file name
     character(len=fname_len)  :: fdynuse              ! landuse.timeseries filename
     logical                   :: readvar
-    real(r8),pointer          :: haslake_id(:)
     !
     character(len=*), parameter :: subname = 'surfrd_lakemask'
     !
     !-----------------------------------------------------------------------
 
-    ! get filename of landuse_timeseries file 
+    ! get filename of landuse_timeseries file
     fdynuse = get_flanduse_timeseries()
 
     if (masterproc) then
@@ -993,34 +992,22 @@ contains
           write(iulog,*)'fdynuse must be specified'
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
-    end if   
-    
+    end if
+
     call getfil(fdynuse, locfn, 0 )
 
-   ! open landuse_timeseries file 
-    call ncd_pio_openfile (ncid_dynuse, trim(locfn), 0)    
-    
-    
-    allocate(haslake_id(begg:endg))
-    
+   ! open landuse_timeseries file
+    call ncd_pio_openfile (ncid_dynuse, trim(locfn), 0)
+
     ! read the lakemask
-    call ncd_io(ncid=ncid_dynuse, varname='HASLAKE'  , flag='read', data=haslake_id, &
+    call ncd_io(ncid=ncid_dynuse, varname='HASLAKE'  , flag='read', data=haslake, &
            dim1name=grlnd, readvar=readvar)
     if (.not. readvar) call endrun( msg=' ERROR: HASLAKE is not on landuse.timeseries file'//errMsg(sourcefile, __LINE__))
 
-    where (haslake_id == 1._r8)
-        haslake = .true.
-    elsewhere
-        haslake = .false.
-    end where
-
-    ! close landuse_timeseries file again 
+    ! close landuse_timeseries file again
     call ncd_pio_closefile(ncid_dynuse)
-    
-    deallocate(haslake_id)
 
-    
   end subroutine surfrd_lakemask
-  
-  
+
+
 end module surfrdMod


### PR DESCRIPTION
### Description of changes
Change for read_darray into variables of type logical.  Type in pio_read_darray should match type on file. 

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #): #1091 

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any: SMS_D.f19_g17.IHistClm50Sp.cheyenne_intel with namelist changes noted in #1091 

(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
