### PR TITLE
Two answer changes turn dribble_crophrv_xsmrpool_2atm and correct clm5_1 finidat file for 2000 conditions

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -632,6 +632,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4CONUS.ne30x8"      >.true.</use_init_interp>
 <!-- For an inexact match use either low resolution or high resolution match for SP or BGC mode CLM5.0 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  phys="clm5_0"                     >.true.</use_init_interp>
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  phys="clm5_1"                     >.true.</use_init_interp>
 <!-- For an inexact match use either low resolution or high resolution match for SP or BGC mode CLM4.5 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  lnd_tuning_mode="clm4_5_GSWP3v1"  >.true.</use_init_interp>
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2000"  lnd_tuning_mode="clm4_5_CRUv7"    >.true.</use_init_interp>
@@ -717,6 +718,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
 </init_interp_attributes>
 
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_1_GSWP3v1"
+>hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_nitrif_denitrif=.true. use_vertsoilc=.true. use_crop=.true. irrigate=.true. glc_nec=10
+</init_interp_attributes>
 <!-- specific low reoslution grids should use the 1-degree file for just CLM5.0 -->
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_cam6.0"
                         hgrid="0.9x1.25"

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -586,8 +586,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_hydrstress phys="clm5_1"  use_fates=".false." configuration="clm">.true.</use_hydrstress>
 
 <!-- General CN options -->
-<dribble_crophrv_xsmrpool_2atm co2_type="prognostic" use_crop=".true.">.true.</dribble_crophrv_xsmrpool_2atm>
-<dribble_crophrv_xsmrpool_2atm                       use_crop=".true.">.false.</dribble_crophrv_xsmrpool_2atm>
+<!-- Turn this on all of the time, eventually this namelist item should be removed -->
+<dribble_crophrv_xsmrpool_2atm use_crop=".true.">.true.</dribble_crophrv_xsmrpool_2atm>
  
 <!--
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,105 @@
 ===============================================================
+Tag name:  ctsm5.1.dev008
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date:  Wed Oct  7 11:36:54 MDT 2020
+One-line Summary: Two answer changes: Clm45/50/51 with crop, and for 2000Clm51
+
+Purpose of changes
+------------------
+
+Turn dribble_crophrv_xsmrpool_2atm when crop is on for clm4_5, clm5_0, and clm5_1 physics
+Fix the finidat files being selected for 2000_control conditions for clm5_1
+
+Bugs fixed or introduced
+------------------------
+
+Issues fixed (include CTSM Issue #): 
+   Fixes #1158 -- Turn dribble_crophrv_xsmrpool_2atm on when crop is on for all physics versions
+   Another issue in #1166 -- correct finidat file for 2000Clm51
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[x] clm5_1
+
+[x] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[x] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions): None
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): None
+
+Changes made to namelist defaults (e.g., changed parameter values):
+   dribble_crophrv_xsmrpool_2atm now on when crop on for all physics versions
+
+Changes to the datasets (e.g., parameter, surface or initial files): None
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+   The namelist dribble_crophrv_xsmrpool_2atm should now be removed as a namelist item both
+   in the fortran code and in build-namelist scripts. This change should be bit-for-bit.
+
+Changes to tests or testing: None
+
+CTSM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    cheyenne -- PASS
+
+  regular tests (aux_clm):
+
+    cheyenne ---- PASS
+    izumi ------- PASS
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: Clm45/50/51 with crop (except with prognostic CO2) and 2000Clm51
+    - what platforms/compilers: All
+    - nature of change: same climate
+
+Detailed list of changes
+------------------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.): None
+
+Pull Requests that document the changes (include PR ids): #1177
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #1177 -- Two answer changes turn dribble_crophrv_xsmrpool_2atm and correct clm5_1 finidat 
+           file for 2000 conditions
+
+===============================================================
+===============================================================
 Tag name:  ctsm5.1.dev007
 Originator(s):  sacks (Bill Sacks)
 Date:  Tue Oct  6 09:29:27 MDT 2020

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm5.1.dev008
 Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
-Date:  Wed Oct  7 11:36:54 MDT 2020
+Date: Wed Oct  7 11:48:30 MDT 2020
 One-line Summary: Two answer changes: Clm45/50/51 with crop, and for 2000Clm51
 
 Purpose of changes
@@ -63,7 +63,7 @@ CTSM testing: regular
 
   build-namelist tests:
 
-    cheyenne - PASS
+    cheyenne - PASS (120 tests are different than before)
 
   python testing (see instructions in python/README.md; document testing done):
 

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm5.1.dev008     erik 10/07/2020 Two answer changes: Clm45/50/51 with crop, and for 2000Clm51
   ctsm5.1.dev007    sacks 10/06/2020 CNFire: btran2 fixes and general cleanup
   ctsm5.1.dev006    sacks 10/03/2020 Call correct routine to calculate btran2 for CNFireLi2021
   ctsm5.1.dev005    sacks 10/02/2020 Answer changing bug fixes for clm51: fire and organic_frac_squared


### PR DESCRIPTION
### Description of changes

Turn dribble_crophrv_xsmrpool_2atm when crop is on for clm4_5, clm5_0, and clm5_1 physics
Fix the finidat files being selected for 2000_control conditions for clm5_1

### Specific notes

Contributors other than yourself, if any: self

CTSM Issues Fixed (include github issue #):

  Fixes #1158 
 Another issue in #1166

Are answers expected to change (and if so in what way)? Yes (for all crop compsets and 2000Clm51 compsets)

Any User Interface Changes (namelist or namelist defaults changes)? N

Testing performed, if any: ran build-namelist unit tester, now running regular test suite

