### PR TITLE
Updated the function call for broadcasting bytes in the file CTSM/src…

### DIFF
--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -801,7 +801,7 @@ contains
     call mpi_bcast (hist_nhtfrq, size(hist_nhtfrq), MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (hist_mfilt, size(hist_mfilt), MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (hist_ndens, size(hist_ndens), MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (hist_avgflag_pertape, size(hist_avgflag_pertape), MPI_CHARACTER, 0, mpicom, ier)
+    call mpi_bcast (hist_avgflag_pertape, len(hist_avgflag_pertape)*size(hist_avgflag_pertape), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (hist_type1d_pertape, max_namlen*size(hist_type1d_pertape), MPI_CHARACTER, 0, mpicom, ier)
     if (use_lch4) then
        call mpi_bcast (hist_wrtch4diag, 1, MPI_LOGICAL, 0, mpicom, ier)


### PR DESCRIPTION
…/main/controlMod.F90 l804 (pointed out by @olyson and @billsacks) ESCMP/CTSM#1191:

call mpi_bcast (hist_avgflag_pertape, size(hist_avgflag_pertape), MPI_CHARACTER, 0, mpicom, ier)
-->
call mpi_bcast (hist_avgflag_pertape, len(hist_avgflag_pertape)*size(hist_avgflag_pertape), MPI_CHARACTER, 0, mpicom, ier)

mpi_bcast should be replaced with shr_mpi_bcast in the whole suproutine in the future.

### Description of changes

### Specific notes

Contributors other than yourself, if any: @olyson, @billsacks, @ekluzek 
, 

CTSM Issues Fixed (include github issue #): 1191 for the master-branch 

Are answers expected to change (and if so in what way)?
The hist_avgflag_pertape should produce the desired averaging type

Any User Interface Changes (namelist or namelist defaults changes)? No 

Testing performed, if any: Should be tested! 
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
