### PR TITLE
Add new FATES history output variable dimension for patch age x fuel size class

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.43.0_api.14.1.0
+tag = sci.1.43.2_api.14.2.0
 required = True
 
 [PTCLM]

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -2092,7 +2092,7 @@ contains
        call ncd_defdim(lnfid, 'fates_levelpft', num_elements_fates * numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levelcwd', num_elements_fates * ncwd, dimid)
        call ncd_defdim(lnfid, 'fates_levelage', num_elements_fates * nlevage, dimid)
-       call ncd_defdim(lnfid, 'fates_levagenfsc', nlevage * nfsc, dimid)
+       call ncd_defdim(lnfid, 'fates_levagefuel', nlevage * nfsc, dimid)
     end if
 
     if ( .not. lhistrest )then
@@ -2641,9 +2641,9 @@ contains
                    long_name='FATES pft map into patch age x pft', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_agmap_levagepft', xtype=ncd_int, dim1name='fates_levagepft', &
                    long_name='FATES age-class map into patch age x pft', units='-', ncid=nfid(t))
-             call ncd_defvar(varname='fates_agmap_levagenfsc', xtype=ncd_int, dim1name='fates_levagenfsc', &
+             call ncd_defvar(varname='fates_agmap_levagefuel', xtype=ncd_int, dim1name='fates_levagefuel', &
                    long_name='FATES age-class map into patch age x fuel size', units='-', ncid=nfid(t))
-             call ncd_defvar(varname='fates_fscmap_levagenfsc', xtype=ncd_int, dim1name='fates_levagenfsc', &
+             call ncd_defvar(varname='fates_fscmap_levagefuel', xtype=ncd_int, dim1name='fates_levagefuel', &
                    long_name='FATES fuel size-class map into patch age x fuel size', units='-', ncid=nfid(t))
 
 
@@ -2686,8 +2686,8 @@ contains
              call ncd_io(varname='fates_pftmap_levscagpft',data=fates_hdim_pftmap_levscagpft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_pftmap_levagepft',data=fates_hdim_pftmap_levagepft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_agmap_levagepft',data=fates_hdim_agmap_levagepft, ncid=nfid(t), flag='write')
-             call ncd_io(varname='fates_agmap_levagenfsc',data=fates_hdim_agmap_levagenfsc, ncid=nfid(t), flag='write')
-             call ncd_io(varname='fates_fscmap_levagenfsc',data=fates_hdim_fscmap_levagenfsc, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_agmap_levagefuel',data=fates_hdim_agmap_levagefuel, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_fscmap_levagefuel',data=fates_hdim_fscmap_levagefuel, ncid=nfid(t), flag='write')
           end if
 
        endif
@@ -4955,7 +4955,7 @@ contains
        num2d = num_elements_fates*ncwd
     case ('fates_levelage')
        num2d = num_elements_fates*nlevage
-    case ('fates_levagenfsc')
+    case ('fates_levagefuel')
        num2d = nlevage*nfsc
     case('cft')
        if (cft_size > 0) then

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -2537,6 +2537,8 @@ contains
     use FatesInterfaceTypesMod, only : fates_hdim_cwdmap_levelcwd
     use FatesInterfaceTypesMod, only : fates_hdim_elmap_levelage
     use FatesInterfaceTypesMod, only : fates_hdim_agemap_levelage
+    use FatesInterfaceTypesMod, only : fates_hdim_agmap_levagefuel
+    use FatesInterfaceTypesMod, only : fates_hdim_fscmap_levagefuel
 
 
     !

--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -2092,6 +2092,7 @@ contains
        call ncd_defdim(lnfid, 'fates_levelpft', num_elements_fates * numpft_fates, dimid)
        call ncd_defdim(lnfid, 'fates_levelcwd', num_elements_fates * ncwd, dimid)
        call ncd_defdim(lnfid, 'fates_levelage', num_elements_fates * nlevage, dimid)
+       call ncd_defdim(lnfid, 'fates_levagenfsc', nlevage * nfsc, dimid)
     end if
 
     if ( .not. lhistrest )then
@@ -2640,6 +2641,12 @@ contains
                    long_name='FATES pft map into patch age x pft', units='-', ncid=nfid(t))
              call ncd_defvar(varname='fates_agmap_levagepft', xtype=ncd_int, dim1name='fates_levagepft', &
                    long_name='FATES age-class map into patch age x pft', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_agmap_levagenfsc', xtype=ncd_int, dim1name='fates_levagenfsc', &
+                   long_name='FATES age-class map into patch age x fuel size', units='-', ncid=nfid(t))
+             call ncd_defvar(varname='fates_fscmap_levagenfsc', xtype=ncd_int, dim1name='fates_levagenfsc', &
+                   long_name='FATES fuel size-class map into patch age x fuel size', units='-', ncid=nfid(t))
+
+
 
           end if
 
@@ -2679,6 +2686,8 @@ contains
              call ncd_io(varname='fates_pftmap_levscagpft',data=fates_hdim_pftmap_levscagpft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_pftmap_levagepft',data=fates_hdim_pftmap_levagepft, ncid=nfid(t), flag='write')
              call ncd_io(varname='fates_agmap_levagepft',data=fates_hdim_agmap_levagepft, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_agmap_levagenfsc',data=fates_hdim_agmap_levagenfsc, ncid=nfid(t), flag='write')
+             call ncd_io(varname='fates_fscmap_levagenfsc',data=fates_hdim_fscmap_levagenfsc, ncid=nfid(t), flag='write')
           end if
 
        endif
@@ -4946,6 +4955,8 @@ contains
        num2d = num_elements_fates*ncwd
     case ('fates_levelage')
        num2d = num_elements_fates*nlevage
+    case ('fates_levagenfsc')
+       num2d = nlevage*nfsc
     case('cft')
        if (cft_size > 0) then
           num2d = cft_size

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2363,7 +2363,7 @@ module CLMFatesInterfaceMod
    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
    use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
    use FatesIOVariableKindMod, only : site_height_r8, site_elem_r8, site_elpft_r8
-   use FatesIOVariableKindMod, only : site_elcwd_r8, site_elage_r8
+   use FatesIOVariableKindMod, only : site_elcwd_r8, site_elage_r8, site_agenfsc_r8
    use FatesIODimensionsMod, only : fates_bounds_type
 
 
@@ -2502,7 +2502,7 @@ module CLMFatesInterfaceMod
              site_fuel_r8, site_cwdsc_r8, &
              site_can_r8,site_cnlf_r8, site_cnlfpft_r8, site_scag_r8, & 
              site_scagpft_r8, site_agepft_r8, site_elem_r8, site_elpft_r8, &
-             site_elcwd_r8, site_elage_r8)
+             site_elcwd_r8, site_elage_r8, site_agenfsc_r8)
 
 
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
@@ -2875,6 +2875,10 @@ module CLMFatesInterfaceMod
 
    fates%elage_begin = 1
    fates%elage_end   = num_elements * nlevage
+
+   fates%agenfsc_begin = 1
+   fates%agenfsc_end   = nlevage * nfsc
+
 
    call t_stopf('fates_hlm2fatesbnds')
    

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -2363,7 +2363,7 @@ module CLMFatesInterfaceMod
    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
    use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
    use FatesIOVariableKindMod, only : site_height_r8, site_elem_r8, site_elpft_r8
-   use FatesIOVariableKindMod, only : site_elcwd_r8, site_elage_r8, site_agenfsc_r8
+   use FatesIOVariableKindMod, only : site_elcwd_r8, site_elage_r8, site_agefuel_r8
    use FatesIODimensionsMod, only : fates_bounds_type
 
 
@@ -2502,7 +2502,7 @@ module CLMFatesInterfaceMod
              site_fuel_r8, site_cwdsc_r8, &
              site_can_r8,site_cnlf_r8, site_cnlfpft_r8, site_scag_r8, & 
              site_scagpft_r8, site_agepft_r8, site_elem_r8, site_elpft_r8, &
-             site_elcwd_r8, site_elage_r8, site_agenfsc_r8)
+             site_elcwd_r8, site_elage_r8, site_agefuel_r8)
 
 
            d_index = this%fates_hist%dim_kinds(dk_index)%dim2_index
@@ -2876,8 +2876,8 @@ module CLMFatesInterfaceMod
    fates%elage_begin = 1
    fates%elage_end   = num_elements * nlevage
 
-   fates%agenfsc_begin = 1
-   fates%agenfsc_end   = nlevage * nfsc
+   fates%agefuel_begin = 1
+   fates%agefuel_end   = nlevage * nfsc
 
 
    call t_stopf('fates_hlm2fatesbnds')


### PR DESCRIPTION
### Description of changes
This PR makes the necessary interface changes to enable the creation of a new fates history output variable.  The corresponding fates-side PR is https://github.com/NGEET/fates/pull/712.

### Specific notes

Contributors other than yourself, if any: @rgknox 

CTSM Issues Fixed (include github issue #): N/A

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? None

Testing performed, if any: TBD
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
