### PR TITLE
Remove support for CISM1

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -18,7 +18,7 @@
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
     ROF  = [RTM, SROF]
-    GLC  = [CISM1, CISM2]
+    GLC  = [CISM2, SGLC]
     WAV  = [SWAV]
     BGC  = optional BGC scenario
 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1190,19 +1190,4 @@
     </mach>
   </grid>
 
-  <overrides>
-    <grid name="any" >
-      <mach name="any" >
-        <pes pesize="any" compset="CISM1">
-          <ntasks>
-            <ntasks_glc>1</ntasks_glc>
-          </ntasks>
-          <nthrds>
-            <nthrds_glc>1</nthrds_glc>
-          </nthrds>
-        </pes>
-      </mach>
-    </grid>
-  </overrides>
-
 </config_pes>


### PR DESCRIPTION
### Description of changes

As of cism2_1_74, CISM1 is no longer supported, so we don't need to have
a PE layout section for it.

**This simple change can be combined with some other changes in some upcoming tag.**

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any: none yet
