### PR TITLE
Small answer changes in preparation for adding option for bio-mass heat storage

### DIFF
--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -138,7 +138,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 1516;
+my $ntests = 1513;
 if ( defined($opts{'compare'}) ) {
    $ntests += 1017;
 }

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -37,6 +37,11 @@
 <!-- I single point forcing -->
 
   <compset>
+    <alias>I1PtClm51SpRs</alias>
+    <lname>2000_DATM%1PT_CLM51%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>I1PtClm50SpRs</alias>
     <lname>2000_DATM%1PT_CLM50%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
@@ -57,6 +62,17 @@
   <compset>
     <alias>I2000Clm50SpRs</alias>
     <lname>2000_DATM%GSWP3v1_CLM50%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>I2000Clm51Sp</alias>
+    <lname>2000_DATM%GSWP3v1_CLM51%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- Primarily for testing -->
+  <compset>
+    <alias>I2000Clm51SpRs</alias>
+    <lname>2000_DATM%GSWP3v1_CLM51%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing -->
@@ -129,6 +145,11 @@
   </compset>
 
   <compset>
+    <alias>I1850Clm51Sp</alias>
+    <lname>1850_DATM%GSWP3v1_CLM51%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>I1850Clm51Bgc</alias>
     <lname>1850_DATM%GSWP3v1_CLM51%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
@@ -178,6 +199,10 @@
 
   <!---I FATES compsets -->
   <compset>
+    <alias>I2000Clm51Fates</alias>
+    <lname>2000_DATM%GSWP3v1_CLM51%FATES_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+  <compset>
     <alias>I2000Clm50Fates</alias>
     <lname>2000_DATM%GSWP3v1_CLM50%FATES_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
@@ -211,6 +236,16 @@
     <lname>HIST_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
+  </compset>
+
+  <compset>
+     <alias>I1850Clm51SpNoAnthro</alias>
+     <lname>1850_DATM%GSWP3v1_CLM51%SP-NOANTHRO_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+   </compset>
+
+  <compset>
+    <alias>IHistClm51Sp</alias>
+    <lname>HIST_DATM%GSWP3v1_CLM51%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -381,12 +381,13 @@
       <option name="wallclock">00:20:00</option>
     </options>
   </test>
-  <test name="ERP_D_Ld5" grid="f10_f10_musgs" compset="I2000Clm50Sp" testmods="clm/decStart">
+  <test name="ERP_D_Ld5" grid="f10_f10_musgs" compset="I2000Clm51Sp" testmods="clm/decStart">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
+      <option name="comment">2000 Sp test for CLM51</option>
     </options>
   </test>
   <test name="ERP_D_Ld5" grid="f10_f10_musgs" compset="I2000Clm50Sp" testmods="clm/reduceOutput">
@@ -421,6 +422,15 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
+  <test name="ERP_D_Ld5" grid="f10_f10_musgs" compset="IHistClm51Sp" testmods="clm/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment"  >Test Hist compset with Sp for CLM5.1</option>
     </options>
   </test>
   <test name="SMS_Ld5" grid="f09_g17" compset="IHistClm50SpCru" testmods="clm/default">

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,106 @@
 ===============================================================
+Tag name:  ctsm5.1.dev020
+Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date:  Tue Dec 29 17:47:30 MST 2020
+One-line Summary: Potential roundoff changes in preparation for bio-mass heat storage option
+
+Purpose of changes
+------------------
+
+This adds in some changes that may be roundoff different in preparation for bringing in the changes
+that allow turning on the bio-mass heat storage option. There's a few zeroed terms added to some calculations
+in CanopyFluxes. The new terms are identical to what will come in for BHS except the zeroed terms are
+not arrays here but scalars. I showed the new terms are only off by roundoff with a previous commit that added
+explicit tests for the terms and verified it for two tests.
+
+
+Bugs fixed or introduced
+------------------------
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Notes of particular relevance for users
+---------------------------------------
+
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables): Added new Clm51 compsets
+     I1PtClm51SpRs
+     I2000Clm51Sp
+     I2000Clm51SpRs
+     I1850Clm51Sp
+     I2000Clm51Fates
+     I1850Clm51SpNoAnthro
+     IHistClm51Sp
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+NOTE: Be sure to review the steps in README.CHECKLIST.master_tags as well as the coding style in the Developers Guide
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+   Here I set some terms to zero that will be non-zero even when BHS is off
+   Earlier commits show the smaller set of changes that are needed.
+
+Changes to tests or testing: Switched one Clm50Sp test to Clm51Sp and added one HistClm51Sp test
+
+CTSM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    cheyenne - PASS
+
+  python testing (see instructions in python/README.md; document testing done):
+
+    cheyenne - PASS
+
+  regular tests (aux_clm):
+
+    cheyenne ---- OK
+    izumi ------- OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline:
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: all
+    - what platforms/compilers: izumi-PGI
+    - nature of change: roundoff
+
+   If bitwise differences were observed, how did you show they were no worse
+   than roundoff?
+
+    Earlier commit tested the new terms versus the old and showed they were
+    order e-11 for absolute difference and e-14 relative difference.
+
+Detailed list of changes
+------------------------
+
+Pull Requests that document the changes (include PR ids): #1241
+(https://github.com/ESCOMP/ctsm/pull)
+
+  #1241 -- Small answer changes in preparation for adding option for bio-mass heat storage
+
+===============================================================
+===============================================================
 Tag name:  ctsm5.1.dev019
 Originator(s):  sacks (Bill Sacks)
 Date:  Sat Dec 19 06:55:46 MST 2020

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm5.1.dev020
 Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
-Date: Tue Dec 29 23:31:47 MST 2020
+Date: Wed Dec 30 00:42:16 MST 2020
 One-line Summary: Potential roundoff changes in preparation for bio-mass heat storage option
 
 Purpose of changes

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  ctsm5.1.dev020
 Originator(s):  erik (Erik Kluzek,UCAR/TSS,303-497-1326)
-Date:  Tue Dec 29 17:47:30 MST 2020
+Date: Tue Dec 29 23:31:47 MST 2020
 One-line Summary: Potential roundoff changes in preparation for bio-mass heat storage option
 
 Purpose of changes
@@ -90,6 +90,12 @@ Changes answers relative to baseline:
 
     Earlier commit tested the new terms versus the old and showed they were
     order e-11 for absolute difference and e-14 relative difference.
+
+   Tests that change from baseline....
+
+   ERS_Ly5_P144x1.f10_f10_musgs.IHistClm51BgcCrop.cheyenne_intel.clm-cropMonthOutput
+   SMS.f10_f10_musgs.I2000Clm50BgcCrop.izumi_pgi.clm-crop
+   SMS_D.f10_f10_musgs.I2000Clm51BgcCrop.izumi_pgi.clm-crop
 
 Detailed list of changes
 ------------------------

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-  ctsm5.1.dev020     erik 12/29/2020 Potential roundoff changes in preparation for bio-mass heat storage option
+  ctsm5.1.dev020     erik 12/30/2020 Potential roundoff changes in preparation for bio-mass heat storage option
   ctsm5.1.dev019    sacks 12/19/2020 Fix ndep from coupler
   ctsm5.1.dev018   slevis 12/08/2020 Add ACTIVE (T/F) column to master hist fields table and alphabetize
   ctsm5.1.dev017   slevis 11/17/2020 Write history fields master list to separate optional file

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+  ctsm5.1.dev020     erik 12/29/2020 Potential roundoff changes in preparation for bio-mass heat storage option
   ctsm5.1.dev019    sacks 12/19/2020 Fix ndep from coupler
   ctsm5.1.dev018   slevis 12/08/2020 Add ACTIVE (T/F) column to master hist fields table and alphabetize
   ctsm5.1.dev017   slevis 11/17/2020 Write history fields master list to separate optional file

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1074,8 +1074,12 @@ contains
                   / ((1._r8-frac_rad_abs_by_stem)*(- 4._r8*bir(p)*t_veg(p)**3 &
                   + 4._r8*sa_internal*emv(p)*sb*t_veg(p)**3 &
                   +dc1*wtga+dc2*wtgaq*qsatldT(p))+ cp_leaf/dtime)
-            if ( abs(temp - dt_veg(p) ) > 1.e-12 )then
+            if( temp /= 0._r8 )then
+            if ( abs(temp - dt_veg(p) )/abs(temp) > 1.d-14 )then
+               write(iulog,*) 'Difference = ', temp - dt_veg(p)
+               write(iulog,*) 'R Difference = ', (temp - dt_veg(p))/temp
                call endrun( "Difference greater than roundoff" )
+            end if
             end if
             t_veg(p) = tlbef(p) + dt_veg(p)
             dels = dt_veg(p)
@@ -1097,8 +1101,10 @@ contains
                     - (efsh + dc1*wtga*dt_veg(p)) - (efe(p) + &
                     dc2*wtgaq*qsatldT(p)*dt_veg(p)) &
                     - (cp_leaf/dtime)*(t_veg(p) - tl_ini)
-               if ( abs(temp - err(p) ) > 1.e-12 )then
+               if( temp /= 0._r8 )then
+               if ( abs(temp - err(p) )/abs(temp) > 1.d-14 )then
                   call endrun( "Difference greater than roundoff" )
+               end if
                end if
             end if
 
@@ -1231,9 +1237,11 @@ contains
               *(tlbef(p) + 4._r8*dt_veg(p)) + cir(p)*lw_grnd) &
                 - lw_leaf + lw_stem - eflx_sh_veg(p) - hvap*qflx_evap_veg(p) &
                 - ((t_veg(p)-tl_ini)*cp_leaf/dtime)
-         if ( abs(temp - err(p) ) > 1.e-11 )then
+         if( temp /= 0._r8 )then
+         if ( abs(temp - err(p) )/abs(temp) > 1.d-14 )then
             write(iulog,*) 'Difference = ', temp - err(p)
             call endrun( "Difference greater than roundoff" )
+         end if
          end if
 
          ! Fluxes from ground to canopy space
@@ -1326,8 +1334,10 @@ contains
               *(1.0_r8-frac_rad_abs_by_stem) &
               + emv(p)*emg(c)*sb*ts_ini**3*(ts_ini + 4._r8*dt_stem) &
               *frac_rad_abs_by_stem
-         if ( abs(temp - dlrad(p) ) > 1.e-12 )then
+         if( temp /= 0._r8 )then
+         if ( abs(temp - dlrad(p) ) > 1.d-14*temp )then
             call endrun( "Difference greater than roundoff" )
+         end if
          end if
 
          ! Upward longwave radiation above the canopy
@@ -1342,9 +1352,11 @@ contains
               + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb &
               *ts_ini**3*(ts_ini+ 4._r8*dt_stem)*frac_rad_abs_by_stem &
               + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
-         if ( abs(temp - ulrad(p) ) > 1.e-11 )then
+         if( temp /= 0._r8 )then
+         if ( abs(temp - ulrad(p) ) > 1.d-14*temp )then
             write(iulog,*) 'Difference = ', temp - ulrad(p)
             call endrun( "Difference greater than roundoff" )
+         end if
          end if
 
          ! Calculate the skin temperature as a weighted sum of all the ground and vegetated fraction

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -405,6 +405,7 @@ contains
     real(r8) :: frac_rad_abs_by_stem                     !fraction of incoming radiation absorbed by stems
     real(r8) :: lw_stem                                  !internal longwave stem
     real(r8) :: lw_leaf                                  !internal longwave leaf
+    real(r8) :: temp
 
     integer :: dummy_to_make_pgi_happy
     !------------------------------------------------------------------------------
@@ -1052,11 +1053,18 @@ contains
                  +(1._r8-frac_sno(c)-frac_h2osfc(c))*t_soisno(c,1)**4 &
                  +frac_h2osfc(c)*t_h2osfc(c)**4)
 
+            dt_veg(p) = (sabv(p) + air(p) + bir(p)*t_veg(p)**4 + &
+                 cir(p)*lw_grnd - efsh - efe(p)) / &
+                 (- 4._r8*bir(p)*t_veg(p)**3 +dc1*wtga +dc2*wtgaq*qsatldT(p))
+            temp = dt_veg(p)
             dt_veg(p) = ((1._r8-frac_rad_abs_by_stem)*(sabv(p) + air(p) &
                   + bir(p)*t_veg(p)**4 + cir(p)*lw_grnd) &
                   - efsh - efe(p) - lw_leaf + lw_stem ) &
                   / ((1._r8-frac_rad_abs_by_stem)*(- 4._r8*bir(p)*t_veg(p)**3 &
                   +dc1*wtga+dc2*wtgaq*qsatldT(p)))
+            if ( abs(temp - dt_veg(p) ) > 1.e-13 )then
+               call endrun( "Difference greater than roundoff" )
+            end if
             t_veg(p) = tlbef(p) + dt_veg(p)
             dels = dt_veg(p)
             del(p)  = abs(dels)
@@ -1064,12 +1072,20 @@ contains
             if (del(p) > delmax) then
                dt_veg(p) = delmax*dels/del(p)
                t_veg(p) = tlbef(p) + dt_veg(p)
+               err(p) = sabv(p) + air(p) + bir(p)*tlbef(p)**3*(tlbef(p) + &
+                    4._r8*dt_veg(p)) + cir(p)*lw_grnd - &
+                    (efsh + dc1*wtga*dt_veg(p)) - (efe(p) + &
+                    dc2*wtgaq*qsatldT(p)*dt_veg(p))
+               temp = err(p)
                err(p) = (1._r8-frac_rad_abs_by_stem)*(sabv(p) + air(p) &
                     + bir(p)*tlbef(p)**3*(tlbef(p) + &
                     4._r8*dt_veg(p)) + cir(p)*lw_grnd) &
                     + lw_stem &
                     - (efsh + dc1*wtga*dt_veg(p)) - (efe(p) + &
                     dc2*wtgaq*qsatldT(p)*dt_veg(p))
+               if ( abs(temp - err(p) ) > 1.e-13 )then
+                  call endrun( "Difference greater than roundoff" )
+               end if
             end if
 
             ! Fluxes from leaves to canopy space
@@ -1193,9 +1209,17 @@ contains
               +(1._r8-frac_sno(c)-frac_h2osfc(c))*t_soisno(c,1)**4 &
               +frac_h2osfc(c)*t_h2osfc(c)**4)
 
+         err(p) = sabv(p) + air(p) + bir(p)*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p)) &
+                                !+ cir(p)*t_grnd(c)**4 - eflx_sh_veg(p) - hvap*qflx_evap_veg(p)
+              + cir(p)*lw_grnd - eflx_sh_veg(p) - hvap*qflx_evap_veg(p)
+         temp = err(p)
          err(p) = (1.0_r8-frac_rad_abs_by_stem)*(sabv(p) + air(p) + bir(p)*tlbef(p)**3 &
-              *(tlbef(p) + 4._r8*dt_veg(p)) + cir(p)*t_grnd(c)**4) &
+              *(tlbef(p) + 4._r8*dt_veg(p)) + cir(p)*lw_grnd) &
                 - lw_leaf + lw_stem - eflx_sh_veg(p) - hvap*qflx_evap_veg(p)
+         if ( abs(temp - err(p) ) > 1.e-13 )then
+            write(iulog,*) 'Difference = ', temp - err(p)
+            call endrun( "Difference greater than roundoff" )
+         end if
 
          ! Fluxes from ground to canopy space
 
@@ -1279,17 +1303,30 @@ contains
 
          ! Downward longwave radiation below the canopy
 
+         dlrad(p) = (1._r8-emv(p))*emg(c)*forc_lwrad(c) + &
+              emv(p)*emg(c)*sb*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p))
+         temp = dlrad(p)
          dlrad(p) = (1._r8-emv(p))*emg(c)*forc_lwrad(c) &
               + emv(p)*emg(c)*sb*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p)) &
               *(1.0_r8-frac_rad_abs_by_stem)
+         if ( abs(temp - dlrad(p) ) > 1.e-13 )then
+            call endrun( "Difference greater than roundoff" )
+         end if
 
          ! Upward longwave radiation above the canopy
 
          ulrad(p) = ((1._r8-emg(c))*(1._r8-emv(p))*(1._r8-emv(p))*forc_lwrad(c) &
+              + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb*tlbef(p)**3*(tlbef(p) + &
+              4._r8*dt_veg(p)) + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
+         temp = ulrad(p)
+         ulrad(p) = ((1._r8-emg(c))*(1._r8-emv(p))*(1._r8-emv(p))*forc_lwrad(c) &
               + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb &
               *tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p))*(1._r8-frac_rad_abs_by_stem) &
-              + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb &
               + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
+         if ( abs(temp - ulrad(p) ) > 1.e-13 )then
+            write(iulog,*) 'Difference = ', temp - ulrad(p)
+            call endrun( "Difference greater than roundoff" )
+         end if
 
          ! Calculate the skin temperature as a weighted sum of all the ground and vegetated fraction
          ! The weight is the so-called vegetation emissivity, but not that emv is actually an attentuation 

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -410,7 +410,6 @@ contains
     real(r8) :: lw_stem                                  !internal longwave stem
     real(r8) :: lw_leaf                                  !internal longwave leaf
     real(r8) :: sa_internal                              !min(sa_stem,sa_leaf)
-    real(r8) :: temp
 
     integer :: dummy_to_make_pgi_happy
     !------------------------------------------------------------------------------
@@ -1063,10 +1062,6 @@ contains
                  +(1._r8-frac_sno(c)-frac_h2osfc(c))*t_soisno(c,1)**4 &
                  +frac_h2osfc(c)*t_h2osfc(c)**4)
 
-            dt_veg(p) = (sabv(p) + air(p) + bir(p)*t_veg(p)**4 + &
-                 cir(p)*lw_grnd - efsh - efe(p)) / &
-                 (- 4._r8*bir(p)*t_veg(p)**3 +dc1*wtga +dc2*wtgaq*qsatldT(p))
-            temp = dt_veg(p)
             dt_veg(p) = ((1._r8-frac_rad_abs_by_stem)*(sabv(p) + air(p) &
                   + bir(p)*t_veg(p)**4 + cir(p)*lw_grnd) &
                   - efsh - efe(p) - lw_leaf + lw_stem &
@@ -1074,13 +1069,6 @@ contains
                   / ((1._r8-frac_rad_abs_by_stem)*(- 4._r8*bir(p)*t_veg(p)**3 &
                   + 4._r8*sa_internal*emv(p)*sb*t_veg(p)**3 &
                   +dc1*wtga+dc2*wtgaq*qsatldT(p))+ cp_leaf/dtime)
-            if( temp /= 0._r8 )then
-            if ( abs(temp - dt_veg(p) )/abs(temp) > 1.d-14 )then
-               write(iulog,*) 'Difference = ', temp - dt_veg(p)
-               write(iulog,*) 'R Difference = ', (temp - dt_veg(p))/temp
-               call endrun( "Difference greater than roundoff" )
-            end if
-            end if
             t_veg(p) = tlbef(p) + dt_veg(p)
             dels = dt_veg(p)
             del(p)  = abs(dels)
@@ -1088,11 +1076,6 @@ contains
             if (del(p) > delmax) then
                dt_veg(p) = delmax*dels/del(p)
                t_veg(p) = tlbef(p) + dt_veg(p)
-               err(p) = sabv(p) + air(p) + bir(p)*tlbef(p)**3*(tlbef(p) + &
-                    4._r8*dt_veg(p)) + cir(p)*lw_grnd - &
-                    (efsh + dc1*wtga*dt_veg(p)) - (efe(p) + &
-                    dc2*wtgaq*qsatldT(p)*dt_veg(p))
-               temp = err(p)
                err(p) = (1._r8-frac_rad_abs_by_stem)*(sabv(p) + air(p) &
                     + bir(p)*tlbef(p)**3*(tlbef(p) + &
                     4._r8*dt_veg(p)) + cir(p)*lw_grnd) &
@@ -1101,11 +1084,6 @@ contains
                     - (efsh + dc1*wtga*dt_veg(p)) - (efe(p) + &
                     dc2*wtgaq*qsatldT(p)*dt_veg(p)) &
                     - (cp_leaf/dtime)*(t_veg(p) - tl_ini)
-               if( temp /= 0._r8 )then
-               if ( abs(temp - err(p) )/abs(temp) > 1.d-14 )then
-                  call endrun( "Difference greater than roundoff" )
-               end if
-               end if
             end if
 
             ! Fluxes from leaves to canopy space
@@ -1229,20 +1207,10 @@ contains
               +(1._r8-frac_sno(c)-frac_h2osfc(c))*t_soisno(c,1)**4 &
               +frac_h2osfc(c)*t_h2osfc(c)**4)
 
-         err(p) = sabv(p) + air(p) + bir(p)*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p)) &
-                                !+ cir(p)*t_grnd(c)**4 - eflx_sh_veg(p) - hvap*qflx_evap_veg(p)
-              + cir(p)*lw_grnd - eflx_sh_veg(p) - hvap*qflx_evap_veg(p)
-         temp = err(p)
          err(p) = (1.0_r8-frac_rad_abs_by_stem)*(sabv(p) + air(p) + bir(p)*tlbef(p)**3 &
               *(tlbef(p) + 4._r8*dt_veg(p)) + cir(p)*lw_grnd) &
                 - lw_leaf + lw_stem - eflx_sh_veg(p) - hvap*qflx_evap_veg(p) &
                 - ((t_veg(p)-tl_ini)*cp_leaf/dtime)
-         if( temp /= 0._r8 )then
-         if ( abs(temp - err(p) )/abs(temp) > 1.d-14 )then
-            write(iulog,*) 'Difference = ', temp - err(p)
-            call endrun( "Difference greater than roundoff" )
-         end if
-         end if
 
          ! Fluxes from ground to canopy space
 
@@ -1326,38 +1294,20 @@ contains
 
          ! Downward longwave radiation below the canopy
 
-         dlrad(p) = (1._r8-emv(p))*emg(c)*forc_lwrad(c) + &
-              emv(p)*emg(c)*sb*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p))
-         temp = dlrad(p)
          dlrad(p) = (1._r8-emv(p))*emg(c)*forc_lwrad(c) &
               + emv(p)*emg(c)*sb*tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p)) &
               *(1.0_r8-frac_rad_abs_by_stem) &
               + emv(p)*emg(c)*sb*ts_ini**3*(ts_ini + 4._r8*dt_stem) &
               *frac_rad_abs_by_stem
-         if( temp /= 0._r8 )then
-         if ( abs(temp - dlrad(p) ) > 1.d-14*temp )then
-            call endrun( "Difference greater than roundoff" )
-         end if
-         end if
 
          ! Upward longwave radiation above the canopy
 
-         ulrad(p) = ((1._r8-emg(c))*(1._r8-emv(p))*(1._r8-emv(p))*forc_lwrad(c) &
-              + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb*tlbef(p)**3*(tlbef(p) + &
-              4._r8*dt_veg(p)) + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
-         temp = ulrad(p)
          ulrad(p) = ((1._r8-emg(c))*(1._r8-emv(p))*(1._r8-emv(p))*forc_lwrad(c) &
               + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb &
               *tlbef(p)**3*(tlbef(p) + 4._r8*dt_veg(p))*(1._r8-frac_rad_abs_by_stem) &
               + emv(p)*(1._r8+(1._r8-emg(c))*(1._r8-emv(p)))*sb &
               *ts_ini**3*(ts_ini+ 4._r8*dt_stem)*frac_rad_abs_by_stem &
               + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
-         if( temp /= 0._r8 )then
-         if ( abs(temp - ulrad(p) ) > 1.d-14*temp )then
-            write(iulog,*) 'Difference = ', temp - ulrad(p)
-            call endrun( "Difference greater than roundoff" )
-         end if
-         end if
 
          ! Calculate the skin temperature as a weighted sum of all the ground and vegetated fraction
          ! The weight is the so-called vegetation emissivity, but not that emv is actually an attentuation 


### PR DESCRIPTION
### Description of changes

Some small changes that can change answers in preparation of bringing in the option for bio-mass heat storage. This only changes answers for some compilers. This brings in some new terms (currently set to zero) that will be in use for clm5_1 when bio-mass heat storage is turned on. The terms that change are identical to the BHS version with the exception that some variables have a "p" index in the full BHS version as they are array terms rather than the scalars they are in here.

The full BHS version is PR #1016

### Specific notes

Contributors other than yourself, if any: @swensosc 

CTSM Issues Fixed (include github issue #): None

Are answers expected to change (and if so in what way)? Roundoff changes for some compilers

Any User Interface Changes (namelist or namelist defaults changes)?
  Some new compsets for clm5.1
  Change one clm5.0 test to use the new clm5.1 compset, and add another test

Testing performed, if any: Limited testing on izumi

  I also added an explicit testing inside the code in an earlier version to ensure the changes were on the order of e-11/e-12 for the terms that change.