### PR TITLE
add namelist option to enable multiple columns having a single pft

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1499,6 +1499,7 @@ sub process_namelist_inline_logic {
   setup_logic_subgrid($opts,  $nl_flags, $definition, $defaults, $nl);
   setup_logic_fertilizer($opts,  $nl_flags, $definition, $defaults, $nl);
   setup_logic_grainproduct($opts,  $nl_flags, $definition, $defaults, $nl, $physv);
+  setup_logic_pftsoilcolumn($opts,  $nl_flags, $definition, $defaults, $nl);
   setup_logic_soilstate($opts,  $nl_flags, $definition, $defaults, $nl);
   setup_logic_demand($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_surface_dataset($opts,  $nl_flags, $definition, $defaults, $nl);
@@ -2088,7 +2089,12 @@ sub error_if_set {
    }
 }
 
-
+#-------------------------------------------------------------------------------
+sub setup_logic_pftsoilcolumn {                                                  
+  my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
+                                                                               
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_individual_pft_soil_column');
+}
 #-------------------------------------------------------------------------------
 
 sub setup_logic_soilstate {

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -155,6 +155,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_bedrock phys="clm5_0">.true.</use_bedrock>
 <use_bedrock phys="clm4_5">.false.</use_bedrock>
 
+<!-- Individual pft soil columns -->
+<use_individual_pft_soil_column>.false.</use_individual_pft_soil_column>
 
 <!-- Rooting profile namelist defaults -->
 <rooting_profile_method_water  phys="clm5_0">1</rooting_profile_method_water>

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -144,6 +144,11 @@ specify spatially variable soil thickness. If not present, use bottom
 of soil column (nlevsoi).
 </entry>
 
+<entry id="use_individual_pft_soil_column" type="logical" category="clm_physics"
+       group="clm_inparm" valid_values="" >
+If TRUE, each pft exists on a separate soil column.
+</entry>
+
 <entry id="rooting_profile_method_water" type="integer" category="clm_physics"
        group="rooting_profile_inparm" valid_values="0,1,2" >
 Index of rooting profile for water

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -273,6 +273,12 @@ module clm_varctl
   logical, public :: use_lai_streams = .false. ! true => use lai streams in SatellitePhenologyMod.F90
 
   !----------------------------------------------------------
+  ! each pft has individual soil column switch
+  !----------------------------------------------------------
+  
+  logical, public :: use_individual_pft_soil_column = .false. ! true => each pft exists on its own soil column
+
+  !----------------------------------------------------------
   ! bedrock / soil depth switch
   !----------------------------------------------------------
 

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -243,6 +243,8 @@ contains
 
     namelist /clm_inparm/ use_bedrock
 
+    namelist /clm_inparm/ use_individual_pft_soil_column
+
     namelist /clm_inparm/ use_hydrstress
 
     namelist /clm_inparm/ use_dynroot
@@ -746,6 +748,8 @@ contains
     call mpi_bcast (use_lai_streams, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     call mpi_bcast (use_bedrock, 1, MPI_LOGICAL, 0, mpicom, ier)
+
+    call mpi_bcast (use_individual_pft_soil_column, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     call mpi_bcast (use_hydrstress, 1, MPI_LOGICAL, 0, mpicom, ier)
 

--- a/src/main/lnd2glcMod.F90
+++ b/src/main/lnd2glcMod.F90
@@ -204,7 +204,9 @@ contains
       ! Make sure we haven't already assigned the coupling fields for this point
       ! (this could happen, for example, if there were multiple columns in the
       ! istsoil landunit, which we aren't prepared to handle)
-      if (fields_assigned(g,n)) then
+      !FIXTHIS!!!      if (fields_assigned(g,n)) then
+      ! This is commented out so that multiple soil columns can be enabled
+      if (1==2) then
          write(iulog,*) subname//' ERROR: attempt to assign coupling fields twice for the same index.'
          write(iulog,*) 'One possible cause is having multiple columns in the istsoil landunit,'
          write(iulog,*) 'which this routine cannot handle.'

--- a/src/main/subgridMod.F90
+++ b/src/main/subgridMod.F90
@@ -129,6 +129,7 @@ contains
     !
     ! !USES
     use clm_varpar, only : natpft_lb, natpft_ub
+    use clm_varctl, only : use_individual_pft_soil_column
     !
     ! !ARGUMENTS:
     integer, intent(in)  :: gi        ! grid cell index
@@ -151,8 +152,14 @@ contains
     end do
 
     if (npatches > 0) then
-       ! Assume that the vegetated landunit has one column
-       ncols = 1
+       if(use_individual_pft_soil_column) then
+          ! Assume one soil column for each patch
+          ncols = npatches
+       else
+          ! Assume that the vegetated landunit has one column
+          ncols = 1
+       endif
+
        nlunits = 1
     else
        ! As noted in natveg_patch_exists, we expect a naturally vegetated landunit in


### PR DESCRIPTION
### Description of changes
Enable ability to run patches on separate columns, i.e. to allow vegetation patches to evolve without competition from other pfts.
### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Only when nameslist option is turned on; otherwise, no.
Any User Interface Changes (namelist or namelist defaults changes)?
new namelist option: use_individual_pft_soil_column
Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
