### PR TITLE
Fix non-standard hexadecimal constant

### DIFF
--- a/src/biogeochem/FireEmisFactorsMod.F90
+++ b/src/biogeochem/FireEmisFactorsMod.F90
@@ -227,7 +227,7 @@ contains
     integer :: i
     integer :: strlen
     integer, parameter :: tbl_max_idx = 15  ! 2**N - 1
-    integer, parameter :: gen_hash_key_offset = z'000053db'
+    integer, parameter :: gen_hash_key_offset = int(z'000053db')
     integer, dimension(0:tbl_max_idx) :: tbl_gen_hash_key =  (/61,59,53,47,43,41,37,31,29,23,17,13,11,7,3,1/)
 
     hash = gen_hash_key_offset

--- a/src/biogeochem/MEGANFactorsMod.F90
+++ b/src/biogeochem/MEGANFactorsMod.F90
@@ -274,7 +274,7 @@ contains
     integer :: i
 
     integer, parameter :: tbl_max_idx = 15  ! 2**N - 1
-    integer, parameter :: gen_hash_key_offset = z'000053db'
+    integer, parameter :: gen_hash_key_offset = int(z'000053db')
     integer, dimension(0:tbl_max_idx) :: tbl_gen_hash_key =  (/61,59,53,47,43,41,37,31,29,23,17,13,11,7,3,1/)
 
     hash = gen_hash_key_offset


### PR DESCRIPTION
### Description of changes

See #1270 for details

This should be folded into an upcoming tag.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #):
- Resolves ESCOMP/CTSM#1270

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
Tested on my mac with test `SMS_D_Ld1_P4x1.f10_f10_musgs.I2000Clm50BgcCropQianRs.bishorn_gnu.clm-o3`. With gfortran10, this passes and is bit-for-bit with a test without these changes but instead with FFLAG `-fallow-invalid-boz` added.
