### PR TITLE
Restructure ozone code

### DIFF
--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1548,10 +1548,10 @@ bioms:   do f = 1, fn
          call PhotosynthesisTotal(fn, filterp, &
               atm2lnd_inst, canopystate_inst, photosyns_inst)
          
-         ! Calculate ozone stress. This needs to be done after rssun and rsshade are
-         ! computed by the Photosynthesis routine. However, Photosynthesis also uses the
-         ! ozone stress computed here. Thus, the ozone stress computed in timestep i is
-         ! applied in timestep (i+1).
+         ! Calculate ozone uptake. This needs to be done after rssun and rsshade are
+         ! computed by the Photosynthesis routine. The updated ozone uptake computed here
+         ! will be used in the next time step to calculate ozone stress for the next time
+         ! step's photosynthesis calculations.
          
          ! COMPILER_BUG(wjs, 2014-11-29, pgi 14.7) The following dummy variable assignment is
          ! needed with pgi 14.7 on yellowstone; without it, forc_pbot_downscaled_col gets
@@ -1566,7 +1566,6 @@ bioms:   do f = 1, fn
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
               tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp))
-         call ozone_inst%CalcOzoneStress(bounds, fn, filterp)
 
          !---------------------------------------------------------
          !update Vc,max and Jmax by LUNA model

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1557,7 +1557,7 @@ bioms:   do f = 1, fn
          ! needed with pgi 14.7 on yellowstone; without it, forc_pbot_downscaled_col gets
          ! resized inappropriately in the following subroutine call, due to a compiler bug.
          dummy_to_make_pgi_happy = ubound(atm2lnd_inst%forc_pbot_downscaled_col, 1)
-         call ozone_inst%CalcOzoneStress( &
+         call ozone_inst%CalcOzoneUptake( &
               bounds, fn, filterp, &
               forc_pbot = atm2lnd_inst%forc_pbot_downscaled_col(bounds%begc:bounds%endc), &
               forc_th   = atm2lnd_inst%forc_th_downscaled_col(bounds%begc:bounds%endc), &
@@ -1566,7 +1566,8 @@ bioms:   do f = 1, fn
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
               tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp))
-         
+         call ozone_inst%CalcOzoneStress(bounds, fn, filterp)
+
          !---------------------------------------------------------
          !update Vc,max and Jmax by LUNA model
          if(use_luna)then

--- a/src/biogeophys/OzoneBaseMod.F90
+++ b/src/biogeophys/OzoneBaseMod.F90
@@ -31,6 +31,7 @@ module OzoneBaseMod
      ! The following routines need to be implemented by all type extensions
      procedure(Init_interface)            , public, deferred :: Init
      procedure(Restart_interface)         , public, deferred :: Restart
+     procedure(CalcOzoneUptake_interface) , public, deferred :: CalcOzoneUptake
      procedure(CalcOzoneStress_interface) , public, deferred :: CalcOzoneStress
 
      ! The following routines should only be called by extensions of the ozone_base_type
@@ -59,8 +60,8 @@ module OzoneBaseMod
        type(file_desc_t) , intent(inout) :: ncid ! netcdf id
        character(len=*)  , intent(in)    :: flag ! 'read', 'write' or 'define'
      end subroutine Restart_interface
-       
-     subroutine CalcOzoneStress_interface(this, bounds, num_exposedvegp, filter_exposedvegp, &
+
+     subroutine CalcOzoneUptake_interface(this, bounds, num_exposedvegp, filter_exposedvegp, &
           forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
        use decompMod    , only : bounds_type
        use shr_kind_mod , only : r8 => shr_kind_r8
@@ -77,8 +78,17 @@ module OzoneBaseMod
        real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
        real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
        real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
-     end subroutine CalcOzoneStress_interface
+     end subroutine CalcOzoneUptake_interface
 
+     subroutine CalcOzoneStress_interface(this, bounds, num_exposedvegp, filter_exposedvegp)
+       use decompMod, only : bounds_type
+       import :: ozone_base_type
+
+       class(ozone_base_type) , intent(inout) :: this
+       type(bounds_type)      , intent(in)    :: bounds
+       integer                , intent(in)    :: num_exposedvegp       ! number of points in filter_exposedvegp
+       integer                , intent(in)    :: filter_exposedvegp(:) ! patch filter for non-snow-covered veg
+     end subroutine CalcOzoneStress_interface
   end interface
      
 contains

--- a/src/biogeophys/OzoneFactoryMod.F90
+++ b/src/biogeophys/OzoneFactoryMod.F90
@@ -41,9 +41,9 @@ contains
     !-----------------------------------------------------------------------
 
     if (use_ozone) then
-       allocate(ozone, source = ozone_type())
+       allocate(ozone_type :: ozone)
     else
-       allocate(ozone, source = ozone_off_type())
+       allocate(ozone_off_type :: ozone)
     end if
 
     call ozone%Init(bounds)

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -63,10 +63,6 @@ module OzoneMod
      procedure, private, nopass :: CalcOzoneStressOnePoint
   end type ozone_type
 
-  interface ozone_type
-     module procedure constructor
-  end interface ozone_type
-
   ! !PRIVATE TYPES:
   
   ! TODO(wjs, 2014-09-29) This parameter will eventually become a spatially-varying
@@ -110,31 +106,6 @@ contains
   ! ========================================================================
   ! Infrastructure routines (initialization, restart, etc.)
   ! ========================================================================
-
-  !-----------------------------------------------------------------------
-  function constructor() result(ozone)
-    !
-    ! !DESCRIPTION:
-    ! Return an instance of ozone_type
-    !
-    ! !USES:
-    !
-    ! !ARGUMENTS:
-    type(ozone_type) :: ozone  ! function result
-    !
-    ! !LOCAL VARIABLES:
-    
-    character(len=*), parameter :: subname = 'constructor'
-    !-----------------------------------------------------------------------
-
-    ! DO NOTHING (simply return a variable of the appropriate type)
-
-    ! Eventually this should call the Init routine (or replace the Init routine
-    ! entirely). But I think it would be confusing to do that until we switch everything
-    ! to use a constructor rather than the init routine.
-    
-  end function constructor
-
 
   !-----------------------------------------------------------------------
   subroutine Init(this, bounds)

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -353,53 +353,6 @@ contains
   end subroutine CalcOzoneUptake
 
   !-----------------------------------------------------------------------
-  subroutine CalcOzoneStress(this, bounds, num_exposedvegp, filter_exposedvegp)
-    !
-    ! !DESCRIPTION:
-    ! Calculate ozone stress.
-    !
-    ! !ARGUMENTS:
-    class(ozone_type), intent(inout) :: this
-    type(bounds_type), intent(in) :: bounds
-    integer  , intent(in) :: num_exposedvegp           ! number of points in filter_exposedvegp
-    integer  , intent(in) :: filter_exposedvegp(:)     ! patch filter for non-snow-covered veg
-    !
-    ! !LOCAL VARIABLES:
-    integer  :: fp             ! filter index
-    integer  :: p              ! patch index
-
-    character(len=*), parameter :: subname = 'CalcOzoneStress'
-    !-----------------------------------------------------------------------
-
-    associate( &
-         o3uptakesha => this%o3uptakesha_patch                , & ! Input:  [real(r8) (:)] ozone dose
-         o3uptakesun => this%o3uptakesun_patch                , & ! Input:  [real(r8) (:)] ozone dose
-         o3coefvsha  => this%o3coefvsha_patch                 , & ! Output: [real(r8) (:)] ozone coef
-         o3coefvsun  => this%o3coefvsun_patch                 , & ! Output: [real(r8) (:)] ozone coef
-         o3coefgsha  => this%o3coefgsha_patch                 , & ! Output: [real(r8) (:)] ozone coef
-         o3coefgsun  => this%o3coefgsun_patch                   & ! Output: [real(r8) (:)] ozone coef
-         )
-
-    do fp = 1, num_exposedvegp
-       p = filter_exposedvegp(fp)
-
-       ! Ozone stress for shaded leaves
-       call CalcOzoneStressOnePoint( &
-            pft_type=patch%itype(p), o3uptake=o3uptakesha(p), &
-            o3coefv=o3coefvsha(p), o3coefg=o3coefgsha(p))
-
-       ! Ozone stress for sunlit leaves
-       call CalcOzoneStressOnePoint( &
-            pft_type=patch%itype(p), o3uptake=o3uptakesun(p), &
-            o3coefv=o3coefvsun(p), o3coefg=o3coefgsun(p))
-    end do
-
-
-    end associate
-
-  end subroutine CalcOzoneStress
-
-  !-----------------------------------------------------------------------
   subroutine CalcOzoneUptakeOnePoint( &
        forc_ozone, forc_pbot, forc_th, &
        rs, rb, ram, &
@@ -445,7 +398,7 @@ contains
     ! calculate instantaneous flux
     o3flux = o3concnmolm3/ (ko3*rs+ rb + ram)
 
-    ! apply o3 flux threshold 
+    ! apply o3 flux threshold
     if (o3flux < o3_flux_threshold) then
        o3fluxcrit = 0._r8
     else
@@ -483,6 +436,53 @@ contains
     end if
 
   end subroutine CalcOzoneUptakeOnePoint
+
+  !-----------------------------------------------------------------------
+  subroutine CalcOzoneStress(this, bounds, num_exposedvegp, filter_exposedvegp)
+    !
+    ! !DESCRIPTION:
+    ! Calculate ozone stress.
+    !
+    ! !ARGUMENTS:
+    class(ozone_type), intent(inout) :: this
+    type(bounds_type), intent(in) :: bounds
+    integer  , intent(in) :: num_exposedvegp           ! number of points in filter_exposedvegp
+    integer  , intent(in) :: filter_exposedvegp(:)     ! patch filter for non-snow-covered veg
+    !
+    ! !LOCAL VARIABLES:
+    integer  :: fp             ! filter index
+    integer  :: p              ! patch index
+
+    character(len=*), parameter :: subname = 'CalcOzoneStress'
+    !-----------------------------------------------------------------------
+
+    associate( &
+         o3uptakesha => this%o3uptakesha_patch                , & ! Input:  [real(r8) (:)] ozone dose
+         o3uptakesun => this%o3uptakesun_patch                , & ! Input:  [real(r8) (:)] ozone dose
+         o3coefvsha  => this%o3coefvsha_patch                 , & ! Output: [real(r8) (:)] ozone coef
+         o3coefvsun  => this%o3coefvsun_patch                 , & ! Output: [real(r8) (:)] ozone coef
+         o3coefgsha  => this%o3coefgsha_patch                 , & ! Output: [real(r8) (:)] ozone coef
+         o3coefgsun  => this%o3coefgsun_patch                   & ! Output: [real(r8) (:)] ozone coef
+         )
+
+    do fp = 1, num_exposedvegp
+       p = filter_exposedvegp(fp)
+
+       ! Ozone stress for shaded leaves
+       call CalcOzoneStressOnePoint( &
+            pft_type=patch%itype(p), o3uptake=o3uptakesha(p), &
+            o3coefv=o3coefvsha(p), o3coefg=o3coefgsha(p))
+
+       ! Ozone stress for sunlit leaves
+       call CalcOzoneStressOnePoint( &
+            pft_type=patch%itype(p), o3uptake=o3uptakesun(p), &
+            o3coefv=o3coefvsun(p), o3coefg=o3coefgsun(p))
+    end do
+
+
+    end associate
+
+  end subroutine CalcOzoneStress
 
   !-----------------------------------------------------------------------
   subroutine CalcOzoneStressOnePoint( &

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -267,26 +267,6 @@ contains
          long_name='ozone uptake for sunlit leaves', units='mmol m^-3', &
          readvar=readvar, interpinic_flag='interp', data=this%o3uptakesun_patch)
 
-    call restartvar(ncid=ncid, flag=flag, varname='o3coefvsun', xtype=ncd_double, &
-         dim1name='pft', &
-         long_name='ozone coefficient for photosynthesis for sunlit leaves', units='unitless', &
-         readvar=readvar, interpinic_flag='interp', data=this%o3coefvsun_patch)
-
-    call restartvar(ncid=ncid, flag=flag, varname='o3coefgsun', xtype=ncd_double, &
-         dim1name='pft', &
-         long_name='ozone coefficient for stomatal conductance for sunlit leaves', units='unitless', &
-         readvar=readvar, interpinic_flag='interp', data=this%o3coefgsun_patch)
-
-    call restartvar(ncid=ncid, flag=flag, varname='o3coefvsha', xtype=ncd_double, &
-         dim1name='pft', &
-         long_name='ozone coefficient for photosynthesis for shaded leaves', units='unitless', &
-         readvar=readvar, interpinic_flag='interp', data=this%o3coefvsha_patch)
-
-    call restartvar(ncid=ncid, flag=flag, varname='o3coefgsha', xtype=ncd_double, &
-         dim1name='pft', &
-         long_name='ozone coefficient for stomatal conductance for shaded leaves', units='unitless', &
-         readvar=readvar, interpinic_flag='interp', data=this%o3coefgsha_patch)
-
   end subroutine Restart
 
   ! ========================================================================

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -9,7 +9,9 @@ module OzoneMod
   ! computed here. Thus, the ozone stress computed in timestep i is applied in timestep
   ! (i+1), requiring these stresses to be saved on the restart file.
   !
-  ! Developed by Danica Lombardozzi.
+  ! Developed by Danica Lombardozzi: Lombardozzi, D., S. Levis, G. Bonan, P. G. Hess, and
+  ! J. P. Sparks (2015), The Influence of Chronic Ozone Exposure on Global Carbon and
+  ! Water Cycles, J Climate, 28(1), 292–305, doi:10.1175/JCLI-D-14-00223.1.
   !
   ! !USES:
 #include "shr_assert.h"
@@ -68,15 +70,15 @@ module OzoneMod
      ! Calculate ozone uptake for a single point, for just sunlit or shaded leaves
      procedure, private, nopass :: CalcOzoneUptakeOnePoint
 
-     ! Original ozone stress parameterization, from Danica Lombardozzi
-     procedure, private :: CalcOzoneStressLombardozzi
+     ! Original ozone stress parameterization, from Danica Lombardozzi 2015
+     procedure, private :: CalcOzoneStressLombardozzi2015
 
      ! Calculate ozone stress for a single point, for just sunlit or shaded leaves
-     procedure, private, nopass :: CalcOzoneStressLombardozziOnePoint
+     procedure, private, nopass :: CalcOzoneStressLombardozzi2015OnePoint
   end type ozone_type
 
   ! !PRIVATE TYPES:
-  integer, parameter :: stress_method_lombardozzi = 1
+  integer, parameter :: stress_method_lombardozzi2015 = 1
   
   ! TODO(wjs, 2014-09-29) This parameter will eventually become a spatially-varying
   ! value, obtained from ATM
@@ -132,7 +134,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! TODO(wjs, 2021-02-06) This will be based on a namelist variable
-    this%stress_method = stress_method_lombardozzi
+    this%stress_method = stress_method_lombardozzi2015
 
     call this%InitAllocate(bounds)
     call this%InitHistory(bounds)
@@ -445,8 +447,8 @@ contains
     !-----------------------------------------------------------------------
 
     select case (this%stress_method)
-    case (stress_method_lombardozzi)
-       call this%CalcOzoneStressLombardozzi(bounds, num_exposedvegp, filter_exposedvegp)
+    case (stress_method_lombardozzi2015)
+       call this%CalcOzoneStressLombardozzi2015(bounds, num_exposedvegp, filter_exposedvegp)
     case default
        write(iulog,*) 'ERROR: unknown ozone stress method: ', this%stress_method
        call endrun('Unknown ozone stress method')
@@ -455,12 +457,12 @@ contains
   end subroutine CalcOzoneStress
 
   !-----------------------------------------------------------------------
-  subroutine CalcOzoneStressLombardozzi(this, bounds, num_exposedvegp, filter_exposedvegp)
+  subroutine CalcOzoneStressLombardozzi2015(this, bounds, num_exposedvegp, filter_exposedvegp)
     !
     ! !DESCRIPTION:
     ! Calculate ozone stress.
     !
-    ! This subroutine uses the Lombardozzi formulation for ozone stress
+    ! This subroutine uses the Lombardozzi2015 formulation for ozone stress
     !
     ! !ARGUMENTS:
     class(ozone_type), intent(inout) :: this
@@ -472,7 +474,7 @@ contains
     integer  :: fp             ! filter index
     integer  :: p              ! patch index
 
-    character(len=*), parameter :: subname = 'CalcOzoneStressLombardozzi'
+    character(len=*), parameter :: subname = 'CalcOzoneStressLombardozzi2015'
     !-----------------------------------------------------------------------
 
     associate( &
@@ -488,12 +490,12 @@ contains
        p = filter_exposedvegp(fp)
 
        ! Ozone stress for shaded leaves
-       call CalcOzoneStressLombardozziOnePoint( &
+       call CalcOzoneStressLombardozzi2015OnePoint( &
             pft_type=patch%itype(p), o3uptake=o3uptakesha(p), &
             o3coefv=o3coefvsha(p), o3coefg=o3coefgsha(p))
 
        ! Ozone stress for sunlit leaves
-       call CalcOzoneStressLombardozziOnePoint( &
+       call CalcOzoneStressLombardozzi2015OnePoint( &
             pft_type=patch%itype(p), o3uptake=o3uptakesun(p), &
             o3coefv=o3coefvsun(p), o3coefg=o3coefgsun(p))
     end do
@@ -501,17 +503,17 @@ contains
 
     end associate
 
-  end subroutine CalcOzoneStressLombardozzi
+  end subroutine CalcOzoneStressLombardozzi2015
 
   !-----------------------------------------------------------------------
-  subroutine CalcOzoneStressLombardozziOnePoint( &
+  subroutine CalcOzoneStressLombardozzi2015OnePoint( &
        pft_type, o3uptake, &
        o3coefv, o3coefg)
     !
     ! !DESCRIPTION:
     ! Calculates ozone stress for a single point, for just sunlit or shaded leaves
     !
-    ! This subroutine uses the Lombardozzi formulation for ozone stress
+    ! This subroutine uses the Lombardozzi2015 formulation for ozone stress
     !
     ! !ARGUMENTS:
     integer  , intent(in)    :: pft_type   ! vegetation type, for indexing into pftvarcon arrays
@@ -525,7 +527,7 @@ contains
     real(r8) :: condInt        ! intercept for conductance
     real(r8) :: condSlope      ! slope for conductance
 
-    character(len=*), parameter :: subname = 'CalcOzoneStressLombardozziOnePoint'
+    character(len=*), parameter :: subname = 'CalcOzoneStressLombardozzi2015OnePoint'
     !-----------------------------------------------------------------------
 
     if (o3uptake == 0._r8) then
@@ -561,6 +563,6 @@ contains
 
     end if
 
-  end subroutine CalcOzoneStressLombardozziOnePoint
+  end subroutine CalcOzoneStressLombardozzi2015OnePoint
 
 end module OzoneMod

--- a/src/biogeophys/OzoneOffMod.F90
+++ b/src/biogeophys/OzoneOffMod.F90
@@ -104,13 +104,7 @@ contains
     SHR_ASSERT_ALL_FL((ubound(ram) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(tlai) == (/bounds%endp/)), sourcefile, __LINE__)
 
-    ! Explicitly set outputs to 1. This isn't really needed, because they should still be
-    ! at 1 from cold-start initialization, but do this for clarity here.
-
-    this%o3coefvsha_patch(bounds%begp:bounds%endp) = 1._r8
-    this%o3coefvsun_patch(bounds%begp:bounds%endp) = 1._r8
-    this%o3coefgsha_patch(bounds%begp:bounds%endp) = 1._r8
-    this%o3coefgsun_patch(bounds%begp:bounds%endp) = 1._r8
+    ! Do nothing: Outputs are already fixed at 1 from cold start initialization.
 
   end subroutine CalcOzoneStress
 

--- a/src/biogeophys/OzoneOffMod.F90
+++ b/src/biogeophys/OzoneOffMod.F90
@@ -22,6 +22,7 @@ module OzoneOffMod
    contains
      procedure, public :: Init
      procedure, public :: Restart
+     procedure, public :: CalcOzoneUptake
      procedure, public :: CalcOzoneStress
   end type ozone_off_type
 
@@ -79,8 +80,8 @@ contains
 
   end subroutine Restart
 
-  subroutine CalcOzoneStress(this, bounds, num_exposedvegp, filter_exposedvegp, &
-          forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
+  subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
 
     class(ozone_off_type) , intent(inout) :: this
     type(bounds_type)      , intent(in)    :: bounds
@@ -104,8 +105,17 @@ contains
     SHR_ASSERT_ALL_FL((ubound(ram) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(tlai) == (/bounds%endp/)), sourcefile, __LINE__)
 
-    ! Do nothing: Outputs are already fixed at 1 from cold start initialization.
+    ! Do nothing: In the ozone off case, we don't need to track ozone uptake
 
+  end subroutine CalcOzoneUptake
+
+  subroutine CalcOzoneStress(this, bounds, num_exposedvegp, filter_exposedvegp)
+    class(ozone_off_type), intent(inout) :: this
+    type(bounds_type)    , intent(in) :: bounds
+    integer              , intent(in) :: num_exposedvegp
+    integer              , intent(in) :: filter_exposedvegp(:)
+
+    ! Do nothing: Outputs (stress terms) are already fixed at 1 from cold start initialization
   end subroutine CalcOzoneStress
 
 end module OzoneOffMod

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -74,13 +74,11 @@ module clm_driver
   use DaylengthMod           , only : UpdateDaylength
   use perf_mod
   !
-  use clm_instMod            , only : nutrient_competition_method
   use GridcellType           , only : grc
   use LandunitType           , only : lun
   use ColumnType             , only : col
   use PatchType              , only : patch
   use clm_instMod
-  use clm_instMod            , only : soil_water_retention_curve
   use EDBGCDynMod            , only : EDBGCDyn, EDBGCDynSummary
   use SoilMoistureStreamMod  , only : PrescribedSoilMoistureInterp, PrescribedSoilMoistureAdvance
   !
@@ -609,6 +607,8 @@ contains
             soilstate_inst, temperature_inst, &
             water_inst%wateratm2lndbulk_inst, water_inst%waterdiagnosticbulk_inst, &
             water_inst%waterstatebulk_inst)
+
+       call ozone_inst%CalcOzoneStress(bounds_clump, filter(nc)%num_exposedvegp, filter(nc)%exposedvegp)
 
        ! TODO(wjs, 2019-10-02) I'd like to keep moving this down until it is below
        ! LakeFluxes... I'll probably leave it in place there.


### PR DESCRIPTION
### Description of changes

Restructure ozone code to better accommodate the new ozone parameterization in #1232 . The changes here were heavily inspired by @ziu1986 's changes in #1232. My main goal was to demonstrate how we can bring in a new ozone stress formulation using a select case statement rather than object-oriented polymorphism, because this will keep the code simpler. A significant side benefit of this restructure was to allow me to remove the ozone stress terms from the restart file.

### Specific notes

Contributors other than yourself, if any: Heavily motivated by changes from @ziu1986 as well as conversations with @sunnivin

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:
```
ERP_D_Ld5_P48x1.f10_f10_musgs.I2000Clm50Sp.izumi_nag.clm-o3
ERP_D_P36x2_Ld3.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_intel.clm-default
ERP_P72x2_Ly3.f10_f10_musgs.I2000Clm50BgcCrop.cheyenne_intel.clm-irrig_o3_reduceOutput
```

All pass and are bit-for-bit with baselines.