### PR TITLE
Evaporation limit

### DIFF
--- a/src/biogeophys/BareGroundFluxesMod.F90
+++ b/src/biogeophys/BareGroundFluxesMod.F90
@@ -89,6 +89,8 @@ contains
                                       Wet_Bulb, Wet_BulbS, HeatIndex, AppTemp, &
                                       swbgt, hmdex, dis_coi, dis_coiS, THIndex, &
                                       SwampCoolEff, KtoC, VaporPres
+    use clm_time_manager , only : get_step_size_real
+
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds  
@@ -143,6 +145,10 @@ contains
     real(r8) :: e_ref2m                          ! 2 m height surface saturated vapor pressure [Pa]
     real(r8) :: qsat_ref2m                       ! 2 m height surface saturated specific humidity [kg/kg]
     real(r8) :: www                              ! surface soil wetness [-]
+
+    real(r8) :: snow_evaporation_limit
+    real(r8) :: ev_snow_unconstrained
+    real(r8) :: dtime                                              ! land model time step (sec)
     !------------------------------------------------------------------------------
 
     associate(                                                                    & 
@@ -202,7 +208,7 @@ contains
          t_h2osfc               => temperature_inst%t_h2osfc_col                , & ! Input:  [real(r8) (:)   ]  surface water temperature                                             
          beta                   => temperature_inst%beta_col                    , & ! Input:  [real(r8) (:)   ]  coefficient of conective velocity [-]                                 
 
-         frac_sno               => waterdiagnosticbulk_inst%frac_sno_col                 , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)                           
+         frac_sno_eff            => waterdiagnosticbulk_inst%frac_sno_eff_col        , & ! Input:  [real(r8) (:)   ]  eff. fraction of ground covered by snow (0 to 1)
          qg_snow                => waterdiagnosticbulk_inst%qg_snow_col                  , & ! Input:  [real(r8) (:)   ]  specific humidity at snow surface [kg/kg]                             
          qg_soil                => waterdiagnosticbulk_inst%qg_soil_col                  , & ! Input:  [real(r8) (:)   ]  specific humidity at soil surface [kg/kg]                             
          qg_h2osfc              => waterdiagnosticbulk_inst%qg_h2osfc_col                , & ! Input:  [real(r8) (:)   ]  specific humidity at h2osfc surface [kg/kg]                           
@@ -258,6 +264,10 @@ contains
          begp                   => bounds%begp                                  , &
          endp                   => bounds%endp                                    &
          )
+
+      ! Get step size
+
+      dtime = get_step_size_real()
 
       ! First do some simple settings of values over points where frac vegetation covered
       ! by snow is zero
@@ -416,6 +426,20 @@ contains
          qflx_ev_snow(p)   = -raiw*(forc_q(c) - qg_snow(c))
          qflx_ev_soil(p)   = -raiw*(forc_q(c) - qg_soil(c))
          qflx_ev_h2osfc(p) = -raiw*(forc_q(c) - qg_h2osfc(c))
+
+         ! adjust snow surface layer evaporation
+         j = col%snl(c)+1
+         if ((h2osoi_ice(c,j)+h2osoi_liq(c,j)) > 0._r8 .and. j < 1) then
+            ! assumes for j < 1 that frac_sno_eff > 0
+            snow_evaporation_limit = (h2osoi_ice(c,j)+h2osoi_liq(c,j))*patch%wtcol(p)/frac_sno_eff(c)
+            if (qflx_ev_snow(p)*dtime > snow_evaporation_limit) then
+               ev_snow_unconstrained = qflx_ev_snow(p)
+               qflx_ev_snow(p) = snow_evaporation_limit/dtime
+
+               qflx_evap_soi(p)  = qflx_evap_soi(p) - frac_sno_eff(c)*(ev_snow_unconstrained - qflx_ev_snow(p))
+               qflx_evap_tot(p)  = qflx_evap_soi(p)
+            endif
+         endif
 
          ! 2 m height air temperature
          t_ref2m(p) = thm(p) + temp1(p)*dth(p)*(1._r8/temp12m(p) - 1._r8/temp1(p))

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -432,9 +432,6 @@ contains
 
     integer :: dummy_to_make_pgi_happy
 
-    real(r8) :: snow_evaporation_limit
-    real(r8) :: ev_snow_unconstrained
-
     !------------------------------------------------------------------------------
 
     SHR_ASSERT_ALL_FL((ubound(downreg_patch) == (/bounds%endp/)), sourcefile, __LINE__)
@@ -1439,19 +1436,6 @@ bioms:   do f = 1, fn
          delq_h2osfc = wtalq(p)*qg_h2osfc(c)-wtlq0(p)*qsatl(p)-wtaq0(p)*forc_q(c)
          qflx_ev_h2osfc(p) = forc_rho(c)*wtgq(p)*delq_h2osfc
 
-         ! adjust snow surface layer evaporation
-         j = col%snl(c)+1
-         if ((h2osoi_ice(c,j)+h2osoi_liq(c,j)) > 0._r8 .and. j < 1) then
-            ! assumes for j < 1 that frac_sno_eff > 0
-            snow_evaporation_limit = (h2osoi_ice(c,j)+h2osoi_liq(c,j))*patch%wtcol(p)/frac_sno(c)
-            if (qflx_ev_snow(p)*dtime > snow_evaporation_limit) then
-               ev_snow_unconstrained = qflx_ev_snow(p)
-               qflx_ev_snow(p) = snow_evaporation_limit/dtime
-
-               qflx_evap_soi(p)  = qflx_evap_soi(p) - frac_sno(c)*(ev_snow_unconstrained - qflx_ev_snow(p))
-            endif
-         endif
-         
          ! 2 m height air temperature
 
          t_ref2m(p) = thm(p) + temp1(p)*dth(p)*(1._r8/temp12m(p) - 1._r8/temp1(p))

--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -357,9 +357,9 @@ contains
       end if
 
       if (use_aquifer_layer()) then
-         call WaterTable(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
+         call WaterTable(bounds, num_hydrologyc, filter_hydrologyc, &
               soilhydrology_inst, soilstate_inst, temperature_inst, b_waterstate_inst, &
-              b_waterdiagnostic_inst, b_waterflux_inst)
+              b_waterflux_inst)
       else
 
          call PerchedWaterTable(bounds, num_hydrologyc, filter_hydrologyc, &
@@ -370,12 +370,12 @@ contains
               num_urbanc, filter_urbanc, soilhydrology_inst, soilstate_inst, &
               b_waterstate_inst, b_waterflux_inst) 
 
-         call RenewCondensation(bounds, num_hydrologyc, filter_hydrologyc, &
-              num_urbanc, filter_urbanc,&
-              soilhydrology_inst, soilstate_inst, &
-              b_waterstate_inst, b_waterdiagnostic_inst, b_waterflux_inst)
-         
-      endif
+      end if
+
+      call RenewCondensation(bounds, num_hydrologyc, filter_hydrologyc, &
+           num_urbanc, filter_urbanc,&
+           soilhydrology_inst, soilstate_inst, &
+           b_waterstate_inst, b_waterdiagnostic_inst, b_waterflux_inst)
 
       ! BUG(wjs, 2019-09-16, ESCOMP/ctsm#762) This is needed so that we can test the
       ! tracerization of the following snow stuff without having tracerized everything

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -209,9 +209,12 @@ contains
          p = filter_nolakep(fp)
          c = patch%column(p)
          j = col%snl(c)+1
-         ! snow layers
+         ! snow layers; assumes for j < 1 that frac_sno_eff > 0
          if (j < 1) then
-            ! assumes for j < 1 that frac_sno_eff > 0
+            ! Defining the limitation uniformly for all patches is more 
+            ! strict than absolutely necessary.  This definition assumes 
+            ! each patch is spatially distinct and may remove all the snow
+            ! on its patch, but may not remove snow from adjacent patches. 
             evaporation_limit = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/(frac_sno_eff(c)*dtime)
             if (qflx_ev_snow(p) > evaporation_limit) then
                evaporation_demand = qflx_ev_snow(p)
@@ -222,7 +225,9 @@ contains
             endif
          endif
          
-         ! top soil layer for urban columns (excluding pervious road)
+         ! top soil layer for urban columns (excluding pervious road, which 
+         ! shouldn't be limited here b/c it uses the uses the soilwater
+         ! equations, while the other urban columns do not)
          if (lun%urbpoi(patch%landunit(p)) .and. (col%itype(c)/=icol_road_perv) .and. (j == 1)) then
             evaporation_limit = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/dtime
             if (qflx_evap_soi(p) > evaporation_limit) then

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -290,13 +290,6 @@ contains
          if (.not. lun%urbpoi(l)) eflx_sh_tot(p) = eflx_sh_tot(p) + eflx_sh_stem(p)
          qflx_evap_tot(p) = qflx_evap_veg(p) + qflx_evap_soi(p)
 
-                              if (c==82328) then
-            write(*,*) ' '
-            write(*,*) 'evaptot1: ',c,j,qflx_evap_tot(p),qflx_evap_tot(p)*dtime
-            write(*,*) 'evaptot2: ',c,j,qflx_evap_soi(p),qflx_evap_veg(p)
-            write(*,*) ' '
-         endif
-
          eflx_lh_tot(p)= hvap*qflx_evap_veg(p) + htvp(c)*qflx_evap_soi(p)
          if (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop) then
             eflx_lh_tot_r(p)= eflx_lh_tot(p)
@@ -331,15 +324,6 @@ contains
                if ((h2osoi_liq(c,j)+h2osoi_ice(c,j)) > 0._r8) then
                   qflx_liqevap_from_top_layer(p) = max(qflx_ev_snow(p)*(h2osoi_liq(c,j)/ &
                        (h2osoi_liq(c,j)+h2osoi_ice(c,j))), 0._r8)
-                  !scs
-                  if(c==-8212) then
-                      write(iulog,*) 'evtupdate: ',c,tinc(c)*cgrndl(p)
-                     write(iulog,*) 'evsnow2: ',c,j,qflx_ev_snow(p),qflx_liqevap_from_top_layer(p),qflx_liqevap_from_top_layer(p)*dtime
-                  write(*,*) 'h2oamt2: ',c,j,h2osoi_liq(c,j),h2osoi_ice(c,j),(h2osoi_ice(c,j)+h2osoi_liq(c,j))
-                  write(*,*) 'h2ofrac2: ',c,j,(h2osoi_liq(c,j))/(h2osoi_ice(c,j)+h2osoi_liq(c,j))
-                  write(*,*) ' '
-               endif
-                  
                else
                   qflx_liqevap_from_top_layer(p) = 0._r8
                end if

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -5,7 +5,7 @@ module SoilFluxesMod
   ! Updates surface fluxes based on the new ground temperature.
   !
   ! !USES:
-  use shr_kind_mod	, only : r8 => shr_kind_r8, r4 => shr_kind_r4
+  use shr_kind_mod	, only : r8 => shr_kind_r8
   use shr_log_mod	, only : errMsg => shr_log_errMsg
   use decompMod		, only : bounds_type
   use abortutils	, only : endrun
@@ -78,8 +78,8 @@ contains
     real(r8) :: eflx_lwrad_del(bounds%begp:bounds%endp)            ! update due to eflx_lwrad
     real(r8) :: t_grnd0(bounds%begc:bounds%endc)                   ! t_grnd of previous time step
     real(r8) :: lw_grnd
-    real(r8) :: evaporation_limit
-    real(r8) :: ev_unconstrained
+    real(r8) :: evaporation_limit                                  ! top layer moisture available for evaporation
+    real(r8) :: ev_unconstrained                                   ! evaporative demand 
     !-----------------------------------------------------------------------
 
     associate(                                                                & 
@@ -361,8 +361,7 @@ contains
          ! limit only solid evaporation (sublimation) from top soil layer
          ! (liquid evaporation from soil should not be limited)
          if (j==1 .and. frac_h2osfc(c) < 1._r8) then
-
-            if (real((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(p) * dtime,r4) > real(h2osoi_ice(c,j),r4)) then
+            if (((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(p)*dtime) >= h2osoi_ice(c,j)) then
 
                qflx_liqevap_from_top_layer(p)  &
                     = qflx_liqevap_from_top_layer(p)  &

--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -224,9 +224,8 @@ contains
             endif
          endif
          
-         ! top soil layer for urban columns; adjust qflx_evap_soi directly
-         if (lun%urbpoi(patch%landunit(p))) then
-            j = 1
+         ! top soil layer for urban columns (excluding pervious road); adjust qflx_evap_soi directly
+         if (lun%urbpoi(patch%landunit(p)) .and. (col%itype(c)/=icol_road_perv) .and. (j == 1)) then
             evaporation_limit = (h2osoi_ice(c,j)+h2osoi_liq(c,j))
             if (qflx_evap_soi(p)*dtime > evaporation_limit) then
                ev_unconstrained = qflx_evap_soi(p)

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -571,8 +571,8 @@ contains
    end subroutine UpdateUrbanPonding
 
    !-----------------------------------------------------------------------
-   subroutine WaterTable(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
-        soilhydrology_inst, soilstate_inst, temperature_inst, waterstatebulk_inst, waterdiagnosticbulk_inst, waterfluxbulk_inst) 
+   subroutine WaterTable(bounds, num_hydrologyc, filter_hydrologyc, &
+        soilhydrology_inst, soilstate_inst, temperature_inst, waterstatebulk_inst, waterfluxbulk_inst)
      !
      ! !DESCRIPTION:
      ! Calculate watertable, considering aquifer recharge but no drainage.
@@ -584,14 +584,11 @@ contains
      ! !ARGUMENTS:
      type(bounds_type)        , intent(in)    :: bounds  
      integer                  , intent(in)    :: num_hydrologyc       ! number of column soil points in column filter
-     integer                  , intent(in)    :: num_urbanc           ! number of column urban points in column filter
-     integer                  , intent(in)    :: filter_urbanc(:)     ! column filter for urban points
      integer                  , intent(in)    :: filter_hydrologyc(:) ! column filter for soil points
      type(soilhydrology_type) , intent(inout) :: soilhydrology_inst
      type(soilstate_type)     , intent(in)    :: soilstate_inst
      type(temperature_type)   , intent(in)    :: temperature_inst
      type(waterstatebulk_type)    , intent(inout) :: waterstatebulk_inst
-     type(waterdiagnosticbulk_type)    , intent(inout) :: waterdiagnosticbulk_inst
      type(waterfluxbulk_type)     , intent(inout) :: waterfluxbulk_inst
      !
      ! !LOCAL VARIABLES:
@@ -829,18 +826,6 @@ contains
              endif !k_frz > k_perch 
           endif
        end do
-
-       call RenewCondensation(&
-            bounds                   = bounds, &
-            num_hydrologyc           = num_hydrologyc, &
-            filter_hydrologyc        = filter_hydrologyc, &
-            num_urbanc               = num_urbanc, &
-            filter_urbanc            = filter_urbanc, &
-            soilhydrology_inst       = soilhydrology_inst, &
-            soilstate_inst           = soilstate_inst, &
-            waterstatebulk_inst      = waterstatebulk_inst, &
-            waterdiagnosticbulk_inst = waterdiagnosticbulk_inst, &
-            waterfluxbulk_inst       = waterfluxbulk_inst)
 
      end associate
 

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -2308,19 +2308,8 @@ contains
              ! make consistent with how evap_grnd removed in infiltration
              h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
              h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             if ((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
-                qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
-                qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
-                qflx_ev_snow(c) = qflx_ev_snow(c) &
-                     - (qflx_solidevap_from_top_layer_save &
-                     - qflx_solidevap_from_top_layer(c))
-                ! qflx_solidevap_from_top_layer should be constrained
-                ! in SoilFluxesMod to be <= h2osoi_ice, but check here 
-                if((abs((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1))) > tolerance) then
-                   call endrun(msg="qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
-                endif
-
-                h2osoi_ice(c,1) = 0._r8
+             if (((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1)) >  tolerance) then
+                call endrun(msg="qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
              else
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
              end if

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -65,7 +65,7 @@ module SoilHydrologyMod
   type(params_type), private ::  params_inst
   
   !-----------------------------------------------------------------------
-  real(r8), private :: baseflow_scalar = 1.e-2_r8
+  real(r8), private   :: baseflow_scalar = 1.e-2_r8
   real(r8), parameter :: tolerance = 1.e-12_r8                   ! tolerance for checking whether sublimation is greater than ice in top soil layer
 
   character(len=*), parameter, private :: sourcefile = &
@@ -845,16 +845,8 @@ contains
              ! make consistent with how evap_grnd removed in infiltration
              h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
              h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             if ((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
-                qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
-                qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
-                qflx_ev_snow(c) = qflx_ev_snow(c) - (qflx_solidevap_from_top_layer_save &
-                                       - qflx_solidevap_from_top_layer(c))
-
-                if((abs((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1))) > tolerance) then
-                   call endrun(msg="qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
-                endif
-                h2osoi_ice(c,1) = 0._r8
+             if (((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1) > tolerance)) then
+                call endrun(msg="qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
              else
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
              end if
@@ -870,12 +862,8 @@ contains
              if (snl(c)+1 >= 1) then
                 h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_liqdew_to_top_layer(c) * dtime
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_soliddew_to_top_layer(c) * dtime)
-                if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
-                   qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
-                   qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
-                   qflx_ev_snow(c) = qflx_ev_snow(c) - (qflx_solidevap_from_top_layer_save &
-                                          - qflx_solidevap_from_top_layer(c))
-                   h2osoi_ice(c,1) = 0._r8
+                if ((qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1)) > tolerance) then
+                   call endrun(msg="urban qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
                 else
                    h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_solidevap_from_top_layer(c) * dtime)
                 end if
@@ -2349,12 +2337,8 @@ contains
              if (snl(c)+1 >= 1) then
                 h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_liqdew_to_top_layer(c) * dtime
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_soliddew_to_top_layer(c) * dtime)
-                if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
-                   qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
-                   qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
-                   qflx_ev_snow(c) = qflx_ev_snow(c) - (qflx_solidevap_from_top_layer_save &
-                                          - qflx_solidevap_from_top_layer(c))
-                   h2osoi_ice(c,1) = 0._r8
+                if ((qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1)) > tolerance) then
+                   call endrun(msg="urban qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
                 else
                    h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_solidevap_from_top_layer(c) * dtime)
                 end if

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -844,11 +844,15 @@ contains
              ! make consistent with how evap_grnd removed in infiltration
              h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
              h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
+             if ((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
                 qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
                 qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
                 qflx_ev_snow(c) = qflx_ev_snow(c) - (qflx_solidevap_from_top_layer_save &
                                        - qflx_solidevap_from_top_layer(c))
+
+                if((abs((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1))) > 1.e-8) then
+                   call endrun(msg="solid evap too large! "//errmsg(sourcefile, __LINE__))
+                endif
                 h2osoi_ice(c,1) = 0._r8
              else
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
@@ -2315,11 +2319,15 @@ contains
              ! make consistent with how evap_grnd removed in infiltration
              h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
              h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             if (qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
+             if ((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime > h2osoi_ice(c,1)) then
                 qflx_solidevap_from_top_layer_save = qflx_solidevap_from_top_layer(c)
                 qflx_solidevap_from_top_layer(c) = h2osoi_ice(c,1)/dtime
                 qflx_ev_snow(c) = qflx_ev_snow(c) - (qflx_solidevap_from_top_layer_save &
-                                       - qflx_solidevap_from_top_layer(c))
+                     - qflx_solidevap_from_top_layer(c))
+                if((abs((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1))) > 1.e-8) then
+                   call endrun(msg="solid evap too large! "//errmsg(sourcefile, __LINE__))
+                endif
+
                 h2osoi_ice(c,1) = 0._r8
              else
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -17,6 +17,7 @@ module SoilHydrologyMod
   use column_varcon     , only : icol_road_imperv
   use landunit_varcon   , only : istsoil, istcrop
   use clm_time_manager  , only : get_step_size_real
+  use NumericsMod       , only : truncate_small_values
   use EnergyFluxType    , only : energyflux_type
   use InfiltrationExcessRunoffMod, only : infiltration_excess_runoff_type
   use SoilHydrologyType , only : soilhydrology_type  
@@ -2233,9 +2234,12 @@ contains
      type(waterfluxbulk_type)     , intent(inout) :: waterfluxbulk_inst
      !
      ! !LOCAL VARIABLES:
-     integer  :: c,j,fc,i                                ! indices
-     real(r8) :: dtime                                   ! land model time step (sec)
-     real(r8) :: qflx_solidevap_from_top_layer_save      ! temporary
+     integer  :: c ,j,fc,i                                       ! indices
+     real(r8) :: dtime                                           ! land model time step (sec)
+     real(r8) :: qflx_solidevap_from_top_layer_save              ! temporary
+     integer  :: num_modifiedc                                   ! number of columns in filter_modifiedc
+     integer  :: filter_modifiedc(bounds%endc-bounds%begc+1)     ! column filter of points modified in this subroutine
+     real(r8) :: h2osoi_ice_before_evap(bounds%begc:bounds%endc) ! h2osoi_ice in layer 1 before applying solidevap
      !-----------------------------------------------------------------------
 
      associate(                                                            & 
@@ -2252,6 +2256,7 @@ contains
        ! Get time step
 
        dtime = get_step_size_real()
+       num_modifiedc = 0
 
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
@@ -2259,15 +2264,14 @@ contains
           ! Renew the ice and liquid mass due to condensation
 
           if (snl(c)+1 >= 1) then
+             num_modifiedc = num_modifiedc + 1
+             filter_modifiedc(num_modifiedc) = c
 
              ! make consistent with how evap_grnd removed in infiltration
              h2osoi_liq(c,1) = h2osoi_liq(c,1) + (1._r8 - frac_h2osfc(c))*qflx_liqdew_to_top_layer(c) * dtime
              h2osoi_ice(c,1) = h2osoi_ice(c,1) + (1._r8 - frac_h2osfc(c))*qflx_soliddew_to_top_layer(c) * dtime
-             if (((1._r8 - frac_h2osfc(c))*qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1)) >  tolerance) then
-                call endrun(msg="qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
-             else
-                h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
-             end if
+             h2osoi_ice_before_evap(c) = h2osoi_ice(c,1)
+             h2osoi_ice(c,1) = h2osoi_ice(c,1) - (1._r8 - frac_h2osfc(c)) * qflx_solidevap_from_top_layer(c) * dtime
           end if
 
        end do
@@ -2279,19 +2283,41 @@ contains
 
           if (col%itype(c) == icol_roof .or. col%itype(c) == icol_road_imperv) then
              if (snl(c)+1 >= 1) then
+                num_modifiedc = num_modifiedc + 1
+                filter_modifiedc(num_modifiedc) = c
+
                 h2osoi_liq(c,1) = h2osoi_liq(c,1) + qflx_liqdew_to_top_layer(c) * dtime
                 h2osoi_ice(c,1) = h2osoi_ice(c,1) + (qflx_soliddew_to_top_layer(c) * dtime)
-                if ((qflx_solidevap_from_top_layer(c)*dtime - h2osoi_ice(c,1)) > tolerance) then
-                   call endrun(msg="urban qflx_solidevap_from_top_layer too large! "//errmsg(sourcefile, __LINE__))
-                else
-                   h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_solidevap_from_top_layer(c) * dtime)
-                end if
+                h2osoi_ice_before_evap(c) = h2osoi_ice(c,1)
+                h2osoi_ice(c,1) = h2osoi_ice(c,1) - (qflx_solidevap_from_top_layer(c) * dtime)
              end if
           end if
 
        end do
 
-     end associate
+       call truncate_small_values( &
+            num_f              = num_modifiedc, &
+            filter_f           = filter_modifiedc, &
+            lb                 = bounds%begc, &
+            ub                 = bounds%endc, &
+            data_baseline      = h2osoi_ice_before_evap(bounds%begc:bounds%endc), &
+            data               = h2osoi_ice(bounds%begc:bounds%endc, 1), &
+            custom_rel_epsilon = tolerance)
+
+       do fc = 1, num_modifiedc
+          c = filter_modifiedc(fc)
+
+          if (h2osoi_ice(c,1) < 0._r8) then
+             write(iulog,*) "ERROR: In RenewCondensation, h2osoi_ice has gone significantly negative"
+             write(iulog,*) "c = ", c
+             write(iulog,*) "h2osoi_ice_before_evap = ", h2osoi_ice_before_evap(c)
+             write(iulog,*) "h2osoi_ice(c,1)        = ", h2osoi_ice(c,1)
+             write(iulog,*) "qflx_solidevap_from_top_layer*dtime = ", qflx_solidevap_from_top_layer(c)*dtime
+             call endrun("In RenewCondensation, h2osoi_ice has gone significantly negative")
+          end if
+       end do
+
+       end associate
 
    end subroutine RenewCondensation
 !#8


### PR DESCRIPTION
### Description of changes
Change limitation of top layer evaporation/sublimation.
### Specific notes
Sublimation from top soil layer and evaporation/sublimation from top snow layer needs to be limited to ensure moisture states do not become negative. The original formulation did not always work, so we added a new limitation to SoilFluxesMod.
Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Resolves ESCOMP/CTSM#1253

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
