### PR TITLE
Medlyn-SMS

### DIFF
--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -812,6 +812,7 @@ contains
        if (      trim(stomatalcond_method) == 'Ball-Berry1987' ) then
           this%stomatalcond_mtd = stomatalcond_mtd_bb1987
        else if ( trim(stomatalcond_method) == 'Medlyn2011'     ) then
+          !zqz
           this%stomatalcond_mtd = stomatalcond_mtd_medlyn2011
        else
           call endrun(msg="ERROR bad value for stomtalcond_method in "//nmlname//"namelist"//errmsg(sourcefile, __LINE__))

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -812,7 +812,6 @@ contains
        if (      trim(stomatalcond_method) == 'Ball-Berry1987' ) then
           this%stomatalcond_mtd = stomatalcond_mtd_bb1987
        else if ( trim(stomatalcond_method) == 'Medlyn2011'     ) then
-          !zqz
           this%stomatalcond_mtd = stomatalcond_mtd_medlyn2011
        else
           call endrun(msg="ERROR bad value for stomtalcond_method in "//nmlname//"namelist"//errmsg(sourcefile, __LINE__))


### PR DESCRIPTION
### Description of changes
The Medlyn stomatal conductance functionality was deployed for CLM5. It had not been implemented for use_hydrstress=.false (i.e. SMS). 
Previously if we opted for:
use_hydrstress=.false  and  stomatalcond_method = 'Medlyn2011', the model would actually use the Ball-Berry stomatal conductance model.

In the implementation process, I also noticed that the history fields GSSUN and GSSHA were not being populated when use_hydrstress=.false, which I also updated with this PR.

### Specific notes
CTSM Issues Fixed (include github issue #):
No CTSM 'issue', but this resolves a known bug.

Are answers expected to change (and if so in what way)?
Yes. Many answers will change when use_hydrstress=.false., stomatalcond_method = 'Medlyn2011' including FPSN, QVEGT, etc.
Answers should match for use_hydrstress=.true.
Answers should mostly match for use_hydrstress=.false., stomatalcond_method = 'Ball-Berry1987'
apart from GSSUN and GSSHA, which were previously not being populated, resulting in NaNs.
 
Any User Interface Changes (namelist or namelist defaults changes)?
No.

Testing performed, if any:
Ran a 5-day I2000 SP global simulation to confirm that FPSN differs between:
SMS-Medlyn and SMS-BallBerry, which were previously identical.


