### PR TITLE
Bypass grid-level water mass check when fates hydro is active

### DIFF
--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -2321,7 +2321,7 @@
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
-      <option name="comment">Longer smoke debug test for single site grid with serial mpi with coverage for FATES Hydro.</option>
+      <option name="comment">Longer smoke debug test for single site grid with serial mpi with coverage for FATES Hydro. Bypasses grid level mass checks.</option>
     </options>
   </test>
   <test name="ERS_D_Ld5" grid="1x1_brazil" compset="I2000Clm50FatesCru" testmods="clm/FatesHydro">
@@ -2332,7 +2332,7 @@
     </machines>
     <options>
       <option name="wallclock">00:40:00</option>
-      <option name="comment">Short exact restart debug test for single site grid with coverage for FATES Hydro.</option>
+      <option name="comment">Short exact restart debug test for single site grid with coverage for FATES Hydro. Bypasses grid level mass checks.</option>
     </options>
   </test>
   <test name="ERS_Ld5" grid="f19_g17" compset="I2000Clm45Fates" testmods="clm/FatesColdDef">

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -11,6 +11,7 @@ module BalanceCheckMod
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
   use clm_varctl         , only : iulog
+  use clm_varctl         , only : use_fates_planthydro
   use clm_varcon         , only : namep, namec, nameg
   use clm_varpar         , only : nlevsoi
   use GetGlobalValuesMod , only : GetGlobalIndex
@@ -723,7 +724,7 @@ contains
 
        errh2o_max_val = maxval(abs(errh2o_grc(bounds%begg:bounds%endg)))
 
-       if (errh2o_max_val > h2o_warning_thresh) then
+       if (errh2o_max_val > h2o_warning_thresh .and. .not.use_fates_planthydro) then
 
           indexg = maxloc( abs(errh2o_grc(bounds%begg:bounds%endg)), 1 ) + bounds%begg - 1
           write(iulog,*)'WARNING:  grid cell-level water balance error ',&

--- a/src/biogeophys/BalanceCheckMod.F90
+++ b/src/biogeophys/BalanceCheckMod.F90
@@ -724,6 +724,8 @@ contains
 
        errh2o_max_val = maxval(abs(errh2o_grc(bounds%begg:bounds%endg)))
 
+       ! BUG(rgk, 2021-04-13, ESCOMP/CTSM#1314) Temporarily bypassing gridcell-level check with use_fates_planthydro until issue 1314 is resolved
+       
        if (errh2o_max_val > h2o_warning_thresh .and. .not.use_fates_planthydro) then
 
           indexg = maxloc( abs(errh2o_grc(bounds%begg:bounds%endg)), 1 ) + bounds%begg - 1

--- a/src/biogeophys/WaterDiagnosticType.F90
+++ b/src/biogeophys/WaterDiagnosticType.F90
@@ -296,7 +296,7 @@ contains
     ! !USES:
     use clm_varcon       , only : nameg, namec
     use ncdio_pio        , only : file_desc_t, ncd_double
-    use clm_varctl         , only : use_fates_planthydro
+    use clm_varctl       , only : use_fates_planthydro
     use restUtilMod
     !
     ! !ARGUMENTS:

--- a/src/biogeophys/WaterDiagnosticType.F90
+++ b/src/biogeophys/WaterDiagnosticType.F90
@@ -296,6 +296,7 @@ contains
     ! !USES:
     use clm_varcon       , only : nameg, namec
     use ncdio_pio        , only : file_desc_t, ncd_double
+    use clm_varctl         , only : use_fates_planthydro
     use restUtilMod
     !
     ! !ARGUMENTS:
@@ -329,14 +330,14 @@ contains
          units='kg/kg', &
          interpinic_flag='interp', readvar=readvar, data=this%qaf_lun)
 
-
-    call restartvar(ncid=ncid, flag=flag, &
-         varname=this%info%fname('TOTAL_PLANT_STORED_H2O'), &
-         xtype=ncd_double, dim1name=namec, &
-         long_name=this%info%lname('total plant stored water (for fates hydro)'), &
-         units='kg/m2', &
-         interpinic_flag='interp', readvar=readvar, data=this%total_plant_stored_h2o_col)
-
+    if(use_fates_planthydro) then
+       call restartvar(ncid=ncid, flag=flag, &
+            varname=this%info%fname('TOTAL_PLANT_STORED_H2O'), &
+            xtype=ncd_double, dim1name=namec, &
+            long_name=this%info%lname('total plant stored water (for fates hydro)'), &
+            units='kg/m2', &
+            interpinic_flag='interp', readvar=readvar, data=this%total_plant_stored_h2o_col)
+    end if
 
   end subroutine Restart
 

--- a/src/biogeophys/WaterDiagnosticType.F90
+++ b/src/biogeophys/WaterDiagnosticType.F90
@@ -294,7 +294,7 @@ contains
     ! Read/Write module information to/from restart file.
     !
     ! !USES:
-    use clm_varcon       , only : nameg
+    use clm_varcon       , only : nameg, namec
     use ncdio_pio        , only : file_desc_t, ncd_double
     use restUtilMod
     !
@@ -328,6 +328,15 @@ contains
          long_name=this%info%lname('urban canopy specific humidity'), &
          units='kg/kg', &
          interpinic_flag='interp', readvar=readvar, data=this%qaf_lun)
+
+
+    call restartvar(ncid=ncid, flag=flag, &
+         varname=this%info%fname('TOTAL_PLANT_STORED_H2O'), &
+         xtype=ncd_double, dim1name=namec, &
+         long_name=this%info%lname('total plant stored water (for fates hydro)'), &
+         units='kg/m2', &
+         interpinic_flag='interp', readvar=readvar, data=this%total_plant_stored_h2o_col)
+
 
   end subroutine Restart
 


### PR DESCRIPTION
### Description of changes

With changes forthcoming in FATES PR: https://github.com/NGEET/fates/pull/727 

Note: **This need not be synchronized with FATES 727**.

Column-scale water balance checks with FATES-HYDRO are passing with consistency, including scenarios where plants are allowed to by dynamic (grow, recruit, die and non-mortal turnover).  However, we are still failing a grid-level mass balance check.

Fixes: #510 

See issue: #1314 

This PR is a temporary fix, that bypasses grid-scale water mass checks only for fates-hydro runs.  Since column level checks pass, the expectation is that there is a bug on the upscaling from column to grid that is presently unknown. However, this PR will allow hydro tests to pass which will prevent further regressions.

Note that column level plant stored water was also added to the restart file (CLM side) to enable tests to pass.

### Specific notes


CTSM Issues Fixed (include github issue #):  Does not fix, but addresses #1314 partially.

Are answers expected to change (and if so in what way)?  Answers should go from no-answers, to has-answers for fates-hydro. Should not impact other answers.

Any User Interface Changes (namelist or namelist defaults changes)?  No

Testing performed, if any:

TBD

(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
