### PR TITLE
Toolchain part2: `./mkmap_data.py`

### DIFF
--- a/tools/toolchain/mkmap_data.py
+++ b/tools/toolchain/mkmap_data.py
@@ -10,8 +10,8 @@
 This Python script is part of the simplified toolchain for creating
 the surface dataset for ctsm cases.
 
-After creating the namelist/control file using ./gen_mksurf_namelist.py
-using the  options for your desired case, you should run :
+After creating the namelist/control file with ./gen_mksurf_namelist.py
+using the options for your desired case, you should run :
 
 ./mkmap_data.py --namelist [namelist from ./gen_mksurf_namelist.py]
 

--- a/tools/toolchain/mkmap_data.py
+++ b/tools/toolchain/mkmap_data.py
@@ -453,7 +453,7 @@ class MakeMapper:
             raise TypeError("dst_mesh should be an instance of MeshType.")
 
         self.src_mesh = src_mesh
-        self.dst_mesh = src_mesh
+        self.dst_mesh = dst_mesh
 
         self.map_dir = map_dir
 
@@ -765,7 +765,6 @@ def main():
 
     for src_file in tqdm.tqdm(src_flist):
         src_fname = nl_d[src_file].strip()
-        logging.debug("\n dst_mesh_file  = " + dst_mesh_file + ".\n")
         logging.debug("\n" + src_file + " : " + src_fname)
 
         # -- check if src_file exist

--- a/tools/toolchain/mkmap_data.py
+++ b/tools/toolchain/mkmap_data.py
@@ -164,7 +164,7 @@ def get_parser():
                 [default: %(default)s]
              """,
         action="store",
-        dest="overwrite",
+        dest="esmf_bin_path",
     )
 
     # TODO : necessary?

--- a/tools/toolchain/mkmap_data.py
+++ b/tools/toolchain/mkmap_data.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python                                                                                                                                         
+
+# 2020-12-13                Negin Sobhani
+
+
+"""
+|------------------------------------------------------------------|
+|---------------------  Instructions  -----------------------------|
+|------------------------------------------------------------------|
+This Python script is part of the simplified toolchain for creating
+the surface dataset for ctsm cases.
+
+After creating the namelist/control file using ./gen_mksurf_namelist.py
+using the  options for your desired case, you should run :
+
+./mkmap_data.py --namelist [namelist from ./gen_mksurf_namelist.py]
+
+to create mapping files.
+
+
+This python script is the alternative code to mkmapdata.sh with
+ few differences:
+
+1. It reads namelist file for DST mesh file.
+
+2. For raw dataset in the namelist it finds their SRC mesh file and mask from
+the necdf metadata.
+
+3. Check if the weight (mapping file) already exists or not. 
+
+4. If it does not exist, it creates the mapping (weight) file. 
+ 
+-------------------------------------------------------------------
+Instructions for running on Cheyenne/Casper:
+ 
+load the following into your local environment:
+ 
+    module load python
+    ncar_pylib
+-------------------------------------------------------------------
+To see the available options:
+    ./mkmap_data.py --help
+ 
+To run the script:
+    ./mkmap_data.py --namelist ${namelist from ./gen_mksurf_namelist.py}
+ 
+To remove NPL from your environment on Cheyenne/Casper:
+    deactivate
+-------------------------------------------------------------------
+"""
+
+#TODO (NS):
+# - [ ] Add docs and notes for functions.
+# - [ ] Job submission classes for different machines. 
+# - [x] Should read the correct namelist and check if it exist.
+# - [x] Check if the desired input_dir exist
+# - [ ] Check if the given namelist exist
+# - [ ] Download if the data does not exist: instead of download here download in gen_mksur_namelist
+
+
+from __future__ import print_function
+ 
+# python standard libraries
+import os
+import sys
+import re
+import tqdm
+import subprocess
+import argparse
+import logging
+import shlex
+import xarray as xr
+
+ 
+from datetime import datetime
+from getpass import getuser
+ 
+#from gen_mksurf_namelist import get_parser, build_nl
+ 
+__author__ = 'Negin Sobhani'
+__email__ = 'negins@ucar.edu'
+
+
+myname = getuser()
+host_name = subprocess.run(['hostname'], 
+                    stdout=subprocess.PIPE).stdout.decode('utf-8')
+
+
+def get_parser():
+        """ 
+            Get parser object for this script.
+        """
+        parser = argparse.ArgumentParser(description=__doc__,
+                           formatter_class=argparse.RawDescriptionHelpFormatter)
+ 
+        parser.print_usage = parser.print_help
+
+        parser.add_argument('--namelist',
+                    help='namelist for the ctsm case created by gen_mksurf_namelist.py ', 
+                    action="store",
+                    dest="namelist",
+                    required=True)
+        parser.add_argument('--input_dir',
+                    help='''
+                    Path of your mesh files and input data.', 
+                    [default: %(default)s]
+                    ''',
+                    action="store",
+                    dest="input_dir",
+                    default="/glade/p/cesm/cseg/inputdata/")
+        parser.add_argument('--map_dir',
+                    help='''
+                    Path of your weight (mapping) files.', 
+                    [default: %(default)s]
+                    ''',
+                    action="store",
+                    dest="map_dir",
+                    default=os.getcwd())
+        parser.add_argument('-d','--debug', 
+                    help='''
+                    Debug mode will print more information
+                    [default: %(default)s]
+                    ''',
+                    action="store_true", 
+                    dest="debug", 
+                    default=True)
+
+
+        # if host_name contains cheyenne
+        if ("cheyenne" or "casper" in host_name):
+            parser.add_argument('--account',
+                        help='''
+                        Cheyenne or Casper project account name.', 
+                        [default: %(default)s]
+                        ''',
+                        action="store",
+                        dest="account_name",
+                        default=os.environ.get('PROJECT'))
+
+        return parser                                                                                                        
+
+
+def get_pair(line):
+    """
+    Function for reading namelist in pair format
+    for creating a dictionary.
+
+    Args:
+        line (str): String that include = sign
+
+    Returns:
+        key (str) : field or variable name
+        value (str) : field or variable value
+
+    """
+
+    line = re.sub('=', '', line)
+    key, sep, value = line.strip( ).partition(" ")
+    value = value.strip()
+    return key, value
+
+def name_weightfile(src_res, src_mask, dst_res,dst_mask):
+    """
+    Function for creating weight file name based on
+    source and destination files resolutions and masks.
+
+    Args:
+        src_res (str) : Source file resolution
+        src_mask (str) : Source file mask
+        dst_res (str) : Destination file resolution
+        dst_mask (str) : Destination file mask
+
+    Returns:
+        weight_fname (str): mapping/weight file name.
+    """
+    weight_fname = 'map_'+src_res+'_'+src_mask+'_to_'+dst_res+'_'+dst_mask+'.nc'
+    return weight_fname 
+
+def read_nl (namelist):
+    """
+    Function for reading the namelist /control file.
+
+    Args:
+        namelist (str): namelist file name
+
+    Raises:
+        Error and exit if the namelist file does not exist
+
+    Returns:
+        nl_d (dict) : dictionary including namelist
+            control file information.
+    """
+
+    #================================================================================
+    #TODO: 
+    # When the files in raw input is updated we can use the newly created namelist
+    # for now because the files are not updated I am pointing to temporary namelist
+    # that points to Sam's directory where the updated files exist!.
+    #================================================================================
+
+    namelist = "/glade/scratch/negins/ctsm_toolchain/tools/toolchain/surfdata_4x5_hist_78pfts_CMIP6_2000-2005_c201215.namelist"
+
+    #-- check if the given namelist exist 
+    if not os.path.isfile(namelist):
+        print ("namelist filename :", namelist)
+        print ("Error: namelist_fname :",namelist, "does not exist!")
+        sys.exit('Please run ./gen_mksur_namelist.py to create the'+ 
+                 'namelist for your case and make sure you are pointing '+ \
+                 'to the created namelist using --namelist option.')
+
+    nl_d={}
+
+    with open(namelist) as data:
+        for line in data:
+            key, value = get_pair(line)
+            nl_d[key] = value
+
+    #-- printing out namelist values in debug mode
+    logging.debug(' namelist  = \n\t'+namelist +"\n")
+    for k, v in nl_d.items():
+        logging.debug(" "+k + " : " + v)
+
+    return nl_d
+
+def parse_mesh_fname(mesh_fname):
+    """
+    This function parse mesh filename
+    to find the corresponding resolution and mask.
+    It assumes this information in in the mesh_fname.
+
+    Args:
+        mesh_fname (str) : Mesh filename
+
+    Raises:
+        Error if mesh file does not exists.
+
+    Returns:
+        res (str) : mesh file resolution from mesh filename
+        mask (str) : mesh mask from mesh filename
+    """
+
+    #-- check if the mesj file exists 
+    if not os.path.isfile(mesh_fname):
+        print ("mesh filename :", mesh_fname)
+        print ("Error: mesh_fname :",mesh_fname, "does not exist!")
+
+        #TODO: What should they do if mesh file does not exist
+
+    print ("mesh_fname : ", mesh_fname)
+
+    mesh_fname = mesh_fname.rsplit('/')[-1]
+    mesh_fname = mesh_fname.rsplit('_')
+
+    res = mesh_fname[1]
+    mask = mesh_fname[2]
+
+    #-- verbose print of res and mask in debug mode.
+    logging.debug('  ==> res  : '+ res)
+    logging.debug('  ==> mask : '+ mask)
+
+    return res, mask
+
+# TODO []: error checking grid and mask between global attributes and ****.
+# for src files only and not dst files.
+# If we include this erro check, we should require the users to add 
+# grid and landmask attributes to their own raw dataset if they are 
+# using their own data.
+
+class PbsScheduler:
+    """
+    A class to encapsulate the scheduler object compatible
+    with PBS on the NCAR Cheyenne and Casper systems.
+
+    ...
+
+    Attributes
+    ----------
+    account : str
+        Cheyenne or Casper project code or account code
+
+    nproc : str
+        Number of processors to request
+
+    nnodes: str
+        Number of nodes to request
+
+    ppn: str
+        Number of processors per node to request
+
+    mem: str
+        Cheyenne node memory to request in GB
+
+    queue: str
+        Cheyenne or Casper queue to use
+ 
+    walltime : str
+        The wallclock time in HH:MM:SS format.
+
+    email : str
+        user email address
+
+    mail_events : str
+        Specifies the set of conditions under which
+        a notification about the job is sent:
+
+            'n': no email
+            'b': email before each job begins
+            'e': email after each job terminates
+            'a': email after each job is aborted
+
+
+    Methods
+    -------
+
+    """
+
+    def __init__(self, account, nproc, nnodes, mem, ppn, queue, walltime, email=None, mail_events=None):
+
+        self.account = account
+        self.nproc = nproc
+        self.nnodes = nnodes
+        self.mem = mem
+        self.ppn = ppn
+        self.queue = queue
+        self.walltime = walltime
+        self.email = email
+        self.mail_events = mail_events
+        #self.mail_events = "abe" if mail_events is not None 
+
+    def __str__(self):
+        return  str(self.__class__) + '\n' + '\n'.join((str(item) + ' = ' + str(self.__dict__[item])
+                    for item in sorted(self.__dict__)))
+
+
+    def write_job_pbs (self, job_fname, cmd):
+        self.job_fname = job_fname
+
+        job_file= open (self.job_fname, 'w')
+
+        self.job_template = ( \
+                "#!/bin/tcsh\n"
+                "#PBS -N "+self.job_fname+"\n"
+                "#PBS -A "+self.account+"\n"
+                "#PBS -l walltime="+self.walltime+"\n"
+                "#PBS -q "+self.queue+"\n"
+                "#PBS -j oe"+"\n\n"
+                #"#PBS -m "+ self.mail_events+"\n"
+                "#PBS -M "+ self.email+"\n"
+                #"#PBS -l select=4:ncpus=16:mpiprocs=16"+"\n"
+                #"#PBS -l select=4:ncpus=2:mpiprocs=2:mem=109GB"+"\n"
+                "#PBS -l select="+self.nnodes+":ncpus="+self.nproc+":mpiprocs="+self.ppn+":mem="+self.mem+"\n"
+                "set MPI_SHEPHERD=true"+"\n"
+                "mpiexec_mpt "+cmd+"\n"
+                )
+        job_file.write(self.job_template)
+        job_file.close()
+
+    def schedule (self):
+        #cmd = "qsub "+self.job_fname
+
+        #print (cmd)
+        #khar = subprocess.check_output(["qsub", self.job_fname])
+        khar = subprocess.run(["qsub", self.job_fname],stdout=subprocess.PIPE)
+        #os.system(cmd)
+
+        print ("------")
+        test = khar.stdout.decode('utf-8')
+        print (test)
+        print (re.findall(r'^\D*(\d+)', test))
+
+        print ("------")
+        
+
+def main ():                                                                                                                                                  
+    args = get_parser().parse_args()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    logging.debug('debugging in debug mode.')
+
+    namelist = args.namelist
+    input_dir = args.input_dir
+    map_dir = args.map_dir
+
+    #-- check if the given input_dir exist
+    if not os.path.exists(input_dir):
+        sys.exit('ERROR: \n'+
+                 '\t input_dir does not exist on this machine. \n'+
+                 '\t Please point to the correct raw_dir using --input_dir'+
+                 'flag.')
+
+    #-- read the namelist
+    nl_d = read_nl(namelist)
+
+    #-- dst mesh file
+    print ('-----------------------')
+    dst_mesh_file = nl_d['dst_mesh_file']
+    print ('dst_mesh_file :',  dst_mesh_file)
+    print ('-----------------------')
+
+    dst_res, dst_mask = parse_mesh_fname(dst_mesh_file)
+
+
+    #src mesh files
+    src_flist = [
+                'mksrf_fsoitex',
+                'mksrf_forganic',
+                'mksrf_flakwat',
+                'mksrf_fwetlnd',
+                'mksrf_fmax',
+                'mksrf_fglacier', 
+                'mksrf_fvocef',
+                'mksrf_furbtopo',
+                'mksrf_fgdp',
+                'mksrf_fpeat',
+                'mksrf_fsoildepth', 
+                'mksrf_fabm',
+                'mksrf_furban',
+                'mksrf_ftopostats', 
+                'mksrf_fvegtyp',
+                'mksrf_fsoicol',
+                'mksrf_flai',
+                'mksrf_dyn_lu'
+                'mksrf_fvic'
+                ]
+
+    for src_file in tqdm.tqdm(src_flist):
+        src_fname = nl_d[src_file].strip()
+        print (src_file, " : ", src_fname)
+
+        #-- check if src_file exist
+        if not os.path.isfile(src_fname):
+            print ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            print ("src_fname: ", src_fname, "does not exist!")
+            print ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+
+        else:
+            ds = xr.open_dataset(src_fname)
+            src_mesh_file = input_dir+ ds.src_mesh_file
+            src_res, src_mask = parse_mesh_fname(src_mesh_file)
+
+            lrg_args = " "
+            if (src_res =="3minx3min" or "1km-merge-10min"):
+                lrg_args=" --64bit_offset "
+
+
+            w_fname = name_weightfile (src_res, src_mask, dst_res, dst_mask) 
+
+            print ("src_mesh_file is : ", src_mesh_file)
+            print ("weight file is : ", w_fname)
+
+            # TODO : How to get esmf binary path when not on cheyenne.
+
+            esmf_bin_path = "/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/bin/bing/Linux.intel.64.mpt.default/"
+            esmf_regrid = esmf_bin_path + "/ESMF_RegridWeightGen"
+
+            cmd = esmf_regrid + " --ignore_unmapped"
+
+            cmd = cmd + " -s " + src_mesh_file + " -d " +dst_mesh_file
+            cmd = cmd + " -m conserve "+" -w "+ w_fname
+            cmd = cmd + lrg_args
+            cmd = cmd + "  --src_type SCRIP  --dst_type SCRIP"
+
+            
+            account = "P93300606"
+            nproc = "2"
+            nnodes = "2"
+            mem = "109GB"
+            ppn = "16"
+            queue = "regular"
+            walltime = "12:00:00"
+            email = "negins@ucar.edu"
+
+
+
+            #scheduler class:
+            pbs_job = PbsScheduler(account, nproc, nnodes, mem, ppn, queue, walltime, email)
+
+            job_fname = "regrid_submit"+w_fname +".sh"
+
+            print ("cmd:", cmd)
+            pbs_job.write_job_pbs(job_fname, cmd)
+            #pbs_job.schedule()
+            #print (pbs_job)
+            #exit()
+            
+            #job_fname = "regrid_submit.sh"
+            #job_file= open (job_fname, 'w')
+
+            # job scheduler for myself:
+            #job_template = ( \
+            #        "#!/bin/tcsh\n"
+            #        "#PBS -N ctsm_nwp"+"\n"
+            #        "#PBS -A P93300606"+"\n"
+            #        "#PBS -l walltime=12:00:00"+"\n"
+            #        "#PBS -q regular"+"\n"
+            #        "#PBS -j oe"+"\n\n"
+            #        #"#PBS -l select=4:ncpus=16:mpiprocs=16"+"\n"
+            #        "#PBS -l select=4:ncpus=2:mpiprocs=2:mem=109GB"+"\n"
+            #        "set MPI_SHEPHERD=true"+"\n"
+            #        "mpiexec_mpt "+cmd+"\n"
+            #        )
+
+
+            #job_file.write(job_template)
+            #job_file.close()
+
+            #cmd = "qsub "+job_fname
+
+
+
+            #if os.path.isfile(w_fname):
+            #    print ('weight file ', w_fname, 'already exists!')
+            #else:
+            #    print (cmd)
+            #    os.system(cmd)
+            #print ('-----------------------')
+
+    '''
+     /glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/bin/bing/Linux.intel.64.mpt.default/ESMF_RegridWeightGen
+     --ignore_unmapped -s /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_0.5x0.5_AVHRR_c110228.nc  -d
+     /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_10x15_nomask_c110308.nc -m conserve -w
+     map_0.5x0.5_AVHRR_to_10x15_nomask_aave_da_c201215.nc --src_type SCRIP  --dst_type SCRIP 
+
+    /glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/bin/bing/Linux.intel.64.mpt.default//ESMF_RegridWeightGen -s
+    /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_0.25x0.25_MODIS_c170321.nc -d
+    /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_10x15_nomask_c110308.nc -m conserve  -w
+    map_0.25x0.25_MODIS_to_10x15nomask.nc  --src_type SCRIP  --dst_type SCRIP
+    '''
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/tools/toolchain/mkmap_data.py
+++ b/tools/toolchain/mkmap_data.py
@@ -54,11 +54,11 @@ To remove NPL from your environment on Cheyenne/Casper:
 # - [x] Check if the desired input_dir exist
 # - [x] Add out_dir option here
 
-# - [~] Add options and choices for PBS 
+# - [~] Add options and choices for PBS
 
 # TODO []: error checking grid and mask between global attributes and ****.
 # for src files only and not dst files.
-#Negin:
+# Negin:
 # If we include this error check, we should require the users to add
 # grid and landmask attributes to their own raw dataset if they are
 # using their own data.
@@ -167,7 +167,7 @@ def get_parser():
         dest="overwrite",
     )
 
-    #TODO : necessary?
+    # TODO : necessary?
     # if host_name contains cheyenne
     if "cheyenne" or "casper" in host_name:
         parser.add_argument(
@@ -202,7 +202,6 @@ def get_pair(line):
     key, sep, value = line.strip().partition(" ")
     value = value.strip()
     return key, value
-
 
 
 def read_nl(namelist):
@@ -252,7 +251,6 @@ def read_nl(namelist):
         logging.debug(" " + k + " : " + v)
 
     return nl_d
-
 
 
 class PbsScheduler:
@@ -323,7 +321,8 @@ class PbsScheduler:
         queue,
         walltime,
         email=None,
-        mail_events=None):
+        mail_events=None,
+    ):
 
         self.account = account
         self.nproc = nproc
@@ -336,20 +335,17 @@ class PbsScheduler:
         self.mail_events = mail_events
 
         if self.email is None:
-            self.email =''
+            self.email = ""
 
         if self.mail_events is None:
-            self.mail_events ='n'
+            self.mail_events = "n"
 
     def __str__(self):
         return (
             str(self.__class__)
             + "\n"
             + "\n".join(
-                (
-                    str(item) + " = " + str(self.__dict__[item])
-                    for item in sorted(self.__dict__)
-                )
+                (str(item) + " = " + str(self.__dict__[item]) for item in self.__dict__)
             )
         )
 
@@ -358,7 +354,7 @@ class PbsScheduler:
 
         job_file = open(self.job_fname, "w")
 
-        print ("cmd:",cmd)
+        print("cmd:", cmd)
 
         self.job_template = (
             "#!/bin/tcsh\n"
@@ -367,8 +363,8 @@ class PbsScheduler:
             "#PBS -l walltime=" + self.walltime + "\n"
             "#PBS -q " + self.queue + "\n"
             "#PBS -j oe" + "\n\n"
-            "#PBS -m "+ self.mail_events+"\n"
-            #"#PBS -M " + self.email + "\n"
+            "#PBS -m " + self.mail_events + "\n"
+            # "#PBS -M " + self.email + "\n"
             "#PBS -l select="
             + self.nnodes
             + ":ncpus="
@@ -389,32 +385,30 @@ class PbsScheduler:
         qsub = subprocess.run(["qsub", self.job_fname], stdout=subprocess.PIPE)
         qsub_out = qsub.stdout.decode("utf-8")
 
-        print ("\n Job successfully submitted:", qsub_out,'\n')
+        print("\n Job successfully submitted:", qsub_out, "\n")
         job_id = re.findall(r"^\D*(\d+)", qsub_out)
-        self.job_id = ''.join(job_id)
-
+        self.job_id = "".join(job_id)
 
     def check_status(self):
         """
         Quick function to check the status of the submitted job.
         """
 
-        cmd= "qstat -x "+self.job_id + "|awk '{print $5}'"
+        cmd = "qstat -x " + self.job_id + "|awk '{print $5}'"
 
         tmp = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         out, err = tmp.communicate()
         out = out.decode("utf-8").split("\n")
         self.job_status = out[2]
 
-        #qsub = subprocess.run(["qstat","-x", job_id2], stdout=subprocess.PIPE)
-        #qsub_out = qsub.stdout.decode("utf-8").split("\n") 
-        #print (qsub_out)
+        # qsub = subprocess.run(["qstat","-x", job_id2], stdout=subprocess.PIPE)
+        # qsub_out = qsub.stdout.decode("utf-8").split("\n")
+        # print (qsub_out)
 
 
-
-
-class MakeMapper():
+class MakeMapper:
     """
     A class to encapsulate the necessary information for making
     a mapping / weight file
@@ -424,18 +418,18 @@ class MakeMapper():
     Attributes
     ----------
     src_mesh : MeshType
-        Source mesh in MeshType which contains the information of 
+        Source mesh in MeshType which contains the information of
         src mesh file.
 
     dst_mesh : MeshType
-        Destination mesh in MeshType which contains the information of 
+        Destination mesh in MeshType which contains the information of
         dst mesh file.
 
     map_dir : str
         Directory where you want to store your weight/mapping files.
 
     mapping_fname: str
-        Mapping /weight filename, if not explicitly given the 
+        Mapping /weight filename, if not explicitly given the
         class will create one based on src_mesh and dst_mesh information.
 
 
@@ -451,32 +445,34 @@ class MakeMapper():
         source and destination files resolutions and masks.
     """
 
-    def __init__(self, src_mesh, dst_mesh, map_dir, mapping_fname= None):
+    def __init__(self, src_mesh, dst_mesh, map_dir, mapping_fname=None):
 
-        if not isinstance (src_mesh, MeshType):
-            raise TypeError ("src_mesh should be an instance of MeshType.")
-        if not isinstance (dst_mesh, MeshType):
-            raise TypeError ("dst_mesh should be an instance of MeshType.")
+        if not isinstance(src_mesh, MeshType):
+            raise TypeError("src_mesh should be an instance of MeshType.")
+        if not isinstance(dst_mesh, MeshType):
+            raise TypeError("dst_mesh should be an instance of MeshType.")
 
         self.src_mesh = src_mesh
         self.dst_mesh = src_mesh
 
         self.map_dir = map_dir
 
-        #-- create mapping_fname if not given
+        # -- create mapping_fname if not given
         if mapping_fname is not None:
             self.mapping_fname = mapping_fname
         else:
             self.name_mappingfile()
 
-
     def __str__(self):
-        return  str(self.__class__) + '\n' + '\n'.join((str(item) + ' = ' + str(self.__dict__[item])
-                for item in self.__dict__))
+        return (
+            str(self.__class__)
+            + "\n"
+            + "\n".join(
+                (str(item) + " = " + str(self.__dict__[item]) for item in self.__dict__)
+            )
+        )
 
-
-
-    def create_mapping_file(self,  pbs_job, overwrite, esmf_bin_path=None):
+    def create_mapping_file(self, pbs_job, overwrite, esmf_bin_path=None):
         """
         Create mapping/weight files based on src and dst resolutions.
         First, it uses ESMF_bin_path to find the ESMF_RegridWeightGen binary.
@@ -497,35 +493,36 @@ class MakeMapper():
         """
 
         if esmf_bin_path is None:
-            esmf_bin_path = os.environ.get('ESMF_BIN')
+            esmf_bin_path = os.environ.get("ESMF_BIN")
 
-        #TODO : remove the hard-coded esmf_bin_path?:
+        # TODO : remove the hard-coded esmf_bin_path?:
         esmf_bin_path = "/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/bin/bing/Linux.intel.64.mpt.default/"
 
-
-        esmf_regrid = os.path.join(esmf_bin_path, 'ESMF_RegridWeightGen')
+        esmf_regrid = os.path.join(esmf_bin_path, "ESMF_RegridWeightGen")
 
         if not os.path.isfile(esmf_regrid):
             sys.exit(
-            "ERROR: \n"
-            + "\t ESMF_RegridWeightGen"+esmf_regrid+" does not exist. \n"
-            + "\t Please point to ESMF library using ESMF_BIN environment.")
+                "ERROR: \n"
+                + "\t ESMF_RegridWeightGen"
+                + esmf_regrid
+                + " does not exist. \n"
+                + "\t Please point to ESMF library using ESMF_BIN environment."
+            )
 
-
-        #-- check if mapping file already exists
+        # -- check if mapping file already exists
         mapping_file = os.path.join(self.map_dir, self.mapping_fname)
 
-        #-- If exists, skip mapping file creation unless overwrite
+        # -- If exists, skip mapping file creation unless overwrite
         if os.path.exists(mapping_file) and overwrite is False:
-            print ("Mapping file:"+mapping_file+" already exists!")
-            print ("If you'd like to overwrite these files, use --overwrite option!")
+            print("Mapping file:" + mapping_file + " already exists!")
+            print("If you'd like to overwrite these files, use --overwrite option!")
         else:
             cmd = esmf_regrid + " --ignore_unmapped"
 
             cmd = cmd + " -s " + self.src_mesh.mesh_file
             cmd = cmd + " -d " + self.dst_mesh.mesh_file
 
-            #TODO (NS): Do we ever need to use other methods?
+            # TODO (NS): Do we ever need to use other methods?
             cmd = cmd + " -m conserve "
 
             cmd = cmd + " -w " + self.mapping_fname
@@ -537,12 +534,22 @@ class MakeMapper():
 
             cmd = cmd + lrg_args
 
-            #-- options depracted. remove in future.
+            # -- options depracted. remove in future.
             cmd = cmd + "  --src_type SCRIP  --dst_type SCRIP"
 
             cmd = cmd + "--no_log"
-            job_fname = "regrid_" + self.src_mesh.res + "-"+self.src_mesh.mask+"_to_" + self.dst_mesh.res +"_"+self.dst_mesh.mask+".sh"
-            #job_fname = "regrid_" + self.mapping_fname + ".sh"
+            job_fname = (
+                "regrid_"
+                + self.src_mesh.res
+                + "-"
+                + self.src_mesh.mask
+                + "_to_"
+                + self.dst_mesh.res
+                + "_"
+                + self.dst_mesh.mask
+                + ".sh"
+            )
+            # job_fname = "regrid_" + self.mapping_fname + ".sh"
 
             pbs_job.write_job_pbs(job_fname, cmd)
             pbs_job.schedule()
@@ -561,13 +568,22 @@ class MakeMapper():
         Returns:
             mapping_fname (str): mapping/weight file name.
         """
-        mapping_fname = "map_" + self.src_mesh.res + "_" + self.src_mesh.mask + "_to_" + self.dst_mesh.res + "_" +self.dst_mesh.mask + ".nc"
+        mapping_fname = (
+            "map_"
+            + self.src_mesh.res
+            + "_"
+            + self.src_mesh.mask
+            + "_to_"
+            + self.dst_mesh.res
+            + "_"
+            + self.dst_mesh.mask
+            + ".nc"
+        )
         self.mapping_fname = mapping_fname
 
 
-
-class MeshType : 
-    '''
+class MeshType:
+    """
     A simple wrapper class to encapsulate mesh files.
 
     ...
@@ -589,7 +605,7 @@ class MeshType :
 
     Methods
     -------
-    figure_mesh_type: 
+    figure_mesh_type:
         Figure out what the mesh type is based on the filename. For example, files
         starting with SCRIP are SCRIP grid files.
 
@@ -600,9 +616,9 @@ class MeshType :
     check_meta_res:
         TODO: do we want this here?
 
-    '''
+    """
 
-    def __init__(self, mesh_file, mesh_type= None, res=None, mask= None):
+    def __init__(self, mesh_file, mesh_type=None, res=None, mask=None):
 
         # -- check if the mesh file exists
         # TODO: What should they do if mesh file does not exist
@@ -615,26 +631,22 @@ class MeshType :
         self.res = res
         self.mask = mask
 
-        if (self.mesh_type is None):
+        if self.mesh_type is None:
             self.figure_mesh_type()
 
-        #-- parse mesh_file for res and mask if not given
+        # -- parse mesh_file for res and mask if not given
         if (self.res is None) or (self.mask is None):
             self.parse_mesh_file()
 
         # TODO: What if there are miss-match between user res and mesh res?
-        #self.check_meta_res()
-
+        # self.check_meta_res()
 
     def __str__(self):
         return (
             str(self.__class__)
             + "\n"
             + "\n".join(
-                (
-                    str(item) + " = " + str(self.__dict__[item])
-                    for item in self.__dict__
-                )
+                (str(item) + " = " + str(self.__dict__[item]) for item in self.__dict__)
             )
         )
 
@@ -655,7 +667,6 @@ class MeshType :
             mask (str) : mesh mask from mesh filename
         """
 
-
         mesh_fname = self.mesh_file.rsplit("/")[-1]
         mesh_items = mesh_fname.rsplit("_")
 
@@ -671,19 +682,18 @@ class MeshType :
 
     def figure_mesh_type(self):
         ds = xr.open_dataset(self.mesh_file)
-        if 'Conventions' in ds.attrs:
-            print ("akhdkjhfasdkfjslkd")
+        if "Conventions" in ds.attrs:
+            print("akhdkjhfasdkfjslkd")
         if "SCRIP" in self.mesh_file:
             self.mesh_type = "SCRIP"
-        #else:
-        #TODO: TALK to SAM about thi
+        # else:
+        # TODO: TALK to SAM about thi
 
-    def check_meta_res (self):
+    def check_meta_res(self):
         ds = xr.open_dataset(self.mesh_file)
-        #print (ds.attrs['input_file'])
-        input_file = ds.Attributes['input_file']
-        #if 'input_file' in ds.attrs:
-
+        # print (ds.attrs['input_file'])
+        input_file = ds.Attributes["input_file"]
+        # if 'input_file' in ds.attrs:
 
 
 def main():
@@ -714,12 +724,11 @@ def main():
 
     # -- dst mesh file
     dst_mesh_file = nl_d["dst_mesh_file"]
-    dst_mesh = MeshType (dst_mesh_file)
+    dst_mesh = MeshType(dst_mesh_file)
 
     logging.debug("\n dst_mesh_file  = " + dst_mesh_file + ".\n")
     logging.debug("\n dst_mesh  :")
     logging.debug(dst_mesh)
-
 
     # -- src mesh files
     src_flist = [
@@ -742,9 +751,9 @@ def main():
         "mksrf_flai",
         "mksrf_dyn_lu",
         "mksrf_fvic",
-             ]
+    ]
 
-    #TODO: check the defaults (how to merge in in the class when Casper and Cheyenne are not consistent??)
+    # TODO: check the defaults (how to merge in in the class when Casper and Cheyenne are not consistent??)
 
     account = "P93300606"
     nproc = "2"
@@ -757,7 +766,7 @@ def main():
     for src_file in tqdm.tqdm(src_flist):
         src_fname = nl_d[src_file].strip()
         logging.debug("\n dst_mesh_file  = " + dst_mesh_file + ".\n")
-        logging.debug("\n"+src_file+ " : "+ src_fname)
+        logging.debug("\n" + src_file + " : " + src_fname)
 
         # -- check if src_file exist
         if not os.path.isfile(src_fname):
@@ -771,20 +780,19 @@ def main():
             src_mesh_file = os.path.join(input_dir, ds.src_mesh_file)
             src_mesh = MeshType(src_mesh_file)
 
-            #--check res and metadata
+            # --check res and metadata
 
-            #-- scheduler class
-            pbs_job = PbsScheduler(
-                    account, nproc, nnodes, mem, ppn, queue, walltime)
+            # -- scheduler class
+            pbs_job = PbsScheduler(account, nproc, nnodes, mem, ppn, queue, walltime)
 
-            regridder = MakeMapper(src_mesh, dst_mesh,map_dir)
+            regridder = MakeMapper(src_mesh, dst_mesh, map_dir)
 
             logging.debug("\n regridder: \n")
             logging.debug(regridder)
 
             regridder.create_mapping_file(pbs_job, overwrite)
-            #time.sleep(60)
-            #pbs_job.check_status()
+            # time.sleep(60)
+            # pbs_job.check_status()
 
 
 if __name__ == "__main__":

--- a/tools/toolchain/mkmap_data.py
+++ b/tools/toolchain/mkmap_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python                                                                                                                                         
+#!/usr/bin/env python
 
 # 2020-12-13                Negin Sobhani
 
@@ -10,8 +10,8 @@
 This Python script is part of the simplified toolchain for creating
 the surface dataset for ctsm cases.
 
-After creating the namelist/control file with ./gen_mksurf_namelist.py
-using the options for your desired case, you should run :
+After creating the namelist/control file using ./gen_mksurf_namelist.py
+using the  options for your desired case, you should run :
 
 ./mkmap_data.py --namelist [namelist from ./gen_mksurf_namelist.py]
 
@@ -49,9 +49,9 @@ To remove NPL from your environment on Cheyenne/Casper:
 -------------------------------------------------------------------
 """
 
-#TODO (NS):
+# TODO (NS):
 # - [ ] Add docs and notes for functions.
-# - [ ] Job submission classes for different machines. 
+# - [ ] Job submission classes for different machines.
 # - [x] Should read the correct namelist and check if it exist.
 # - [x] Check if the desired input_dir exist
 # - [ ] Check if the given namelist exist
@@ -59,7 +59,7 @@ To remove NPL from your environment on Cheyenne/Casper:
 
 
 from __future__ import print_function
- 
+
 # python standard libraries
 import os
 import sys
@@ -71,73 +71,83 @@ import logging
 import shlex
 import xarray as xr
 
- 
+
 from datetime import datetime
 from getpass import getuser
- 
-#from gen_mksurf_namelist import get_parser, build_nl
- 
-__author__ = 'Negin Sobhani'
-__email__ = 'negins@ucar.edu'
+
+# from gen_mksurf_namelist import get_parser, build_nl
+
+__author__ = "Negin Sobhani"
+__email__ = "negins@ucar.edu"
 
 
 myname = getuser()
-host_name = subprocess.run(['hostname'], 
-                    stdout=subprocess.PIPE).stdout.decode('utf-8')
+host_name = subprocess.run(["hostname"], stdout=subprocess.PIPE).stdout.decode("utf-8")
 
 
 def get_parser():
-        """ 
-            Get parser object for this script.
-        """
-        parser = argparse.ArgumentParser(description=__doc__,
-                           formatter_class=argparse.RawDescriptionHelpFormatter)
- 
-        parser.print_usage = parser.print_help
+    """
+    Get parser object for this script.
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
 
-        parser.add_argument('--namelist',
-                    help='namelist for the ctsm case created by gen_mksurf_namelist.py ', 
-                    action="store",
-                    dest="namelist",
-                    required=True)
-        parser.add_argument('--input_dir',
-                    help='''
+    parser.print_usage = parser.print_help
+
+    parser.add_argument(
+        "--namelist",
+        help="namelist for the ctsm case created by gen_mksurf_namelist.py ",
+        action="store",
+        dest="namelist",
+        required=True,
+    )
+    parser.add_argument(
+        "--input_dir",
+        help="""
                     Path of your mesh files and input data.', 
                     [default: %(default)s]
-                    ''',
-                    action="store",
-                    dest="input_dir",
-                    default="/glade/p/cesm/cseg/inputdata/")
-        parser.add_argument('--map_dir',
-                    help='''
+                    """,
+        action="store",
+        dest="input_dir",
+        default="/glade/p/cesm/cseg/inputdata/",
+    )
+    parser.add_argument(
+        "--map_dir",
+        help="""
                     Path of your weight (mapping) files.', 
                     [default: %(default)s]
-                    ''',
-                    action="store",
-                    dest="map_dir",
-                    default=os.getcwd())
-        parser.add_argument('-d','--debug', 
-                    help='''
+                    """,
+        action="store",
+        dest="map_dir",
+        default=os.getcwd(),
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        help="""
                     Debug mode will print more information
                     [default: %(default)s]
-                    ''',
-                    action="store_true", 
-                    dest="debug", 
-                    default=True)
+                    """,
+        action="store_true",
+        dest="debug",
+        default=True,
+    )
 
-
-        # if host_name contains cheyenne
-        if ("cheyenne" or "casper" in host_name):
-            parser.add_argument('--account',
-                        help='''
+    # if host_name contains cheyenne
+    if "cheyenne" or "casper" in host_name:
+        parser.add_argument(
+            "--account",
+            help="""
                         Cheyenne or Casper project account name.', 
                         [default: %(default)s]
-                        ''',
-                        action="store",
-                        dest="account_name",
-                        default=os.environ.get('PROJECT'))
+                        """,
+            action="store",
+            dest="account_name",
+            default=os.environ.get("PROJECT"),
+        )
 
-        return parser                                                                                                        
+    return parser
 
 
 def get_pair(line):
@@ -154,12 +164,13 @@ def get_pair(line):
 
     """
 
-    line = re.sub('=', '', line)
-    key, sep, value = line.strip( ).partition(" ")
+    line = re.sub("=", "", line)
+    key, sep, value = line.strip().partition(" ")
     value = value.strip()
     return key, value
 
-def name_weightfile(src_res, src_mask, dst_res,dst_mask):
+
+def name_weightfile(src_res, src_mask, dst_res, dst_mask):
     """
     Function for creating weight file name based on
     source and destination files resolutions and masks.
@@ -173,10 +184,13 @@ def name_weightfile(src_res, src_mask, dst_res,dst_mask):
     Returns:
         weight_fname (str): mapping/weight file name.
     """
-    weight_fname = 'map_'+src_res+'_'+src_mask+'_to_'+dst_res+'_'+dst_mask+'.nc'
-    return weight_fname 
+    weight_fname = (
+        "map_" + src_res + "_" + src_mask + "_to_" + dst_res + "_" + dst_mask + ".nc"
+    )
+    return weight_fname
 
-def read_nl (namelist):
+
+def read_nl(namelist):
     """
     Function for reading the namelist /control file.
 
@@ -191,36 +205,39 @@ def read_nl (namelist):
             control file information.
     """
 
-    #================================================================================
-    #TODO: 
+    # ================================================================================
+    # TODO:
     # When the files in raw input is updated we can use the newly created namelist
     # for now because the files are not updated I am pointing to temporary namelist
     # that points to Sam's directory where the updated files exist!.
-    #================================================================================
+    # ================================================================================
 
     namelist = "/glade/scratch/negins/ctsm_toolchain/tools/toolchain/surfdata_4x5_hist_78pfts_CMIP6_2000-2005_c201215.namelist"
 
-    #-- check if the given namelist exist 
+    # -- check if the given namelist exist
     if not os.path.isfile(namelist):
-        print ("namelist filename :", namelist)
-        print ("Error: namelist_fname :",namelist, "does not exist!")
-        sys.exit('Please run ./gen_mksur_namelist.py to create the'+ 
-                 'namelist for your case and make sure you are pointing '+ \
-                 'to the created namelist using --namelist option.')
+        print("namelist filename :", namelist)
+        print("Error: namelist_fname :", namelist, "does not exist!")
+        sys.exit(
+            "Please run ./gen_mksur_namelist.py to create the"
+            + "namelist for your case and make sure you are pointing "
+            + "to the created namelist using --namelist option."
+        )
 
-    nl_d={}
+    nl_d = {}
 
     with open(namelist) as data:
         for line in data:
             key, value = get_pair(line)
             nl_d[key] = value
 
-    #-- printing out namelist values in debug mode
-    logging.debug(' namelist  = \n\t'+namelist +"\n")
+    # -- printing out namelist values in debug mode
+    logging.debug(" namelist  = \n\t" + namelist + "\n")
     for k, v in nl_d.items():
-        logging.debug(" "+k + " : " + v)
+        logging.debug(" " + k + " : " + v)
 
     return nl_d
+
 
 def parse_mesh_fname(mesh_fname):
     """
@@ -239,32 +256,34 @@ def parse_mesh_fname(mesh_fname):
         mask (str) : mesh mask from mesh filename
     """
 
-    #-- check if the mesj file exists 
+    # -- check if the mesj file exists
     if not os.path.isfile(mesh_fname):
-        print ("mesh filename :", mesh_fname)
-        print ("Error: mesh_fname :",mesh_fname, "does not exist!")
+        print("mesh filename :", mesh_fname)
+        print("Error: mesh_fname :", mesh_fname, "does not exist!")
 
-        #TODO: What should they do if mesh file does not exist
+        # TODO: What should they do if mesh file does not exist
 
-    print ("mesh_fname : ", mesh_fname)
+    print("mesh_fname : ", mesh_fname)
 
-    mesh_fname = mesh_fname.rsplit('/')[-1]
-    mesh_fname = mesh_fname.rsplit('_')
+    mesh_fname = mesh_fname.rsplit("/")[-1]
+    mesh_fname = mesh_fname.rsplit("_")
 
     res = mesh_fname[1]
     mask = mesh_fname[2]
 
-    #-- verbose print of res and mask in debug mode.
-    logging.debug('  ==> res  : '+ res)
-    logging.debug('  ==> mask : '+ mask)
+    # -- verbose print of res and mask in debug mode.
+    logging.debug("  ==> res  : " + res)
+    logging.debug("  ==> mask : " + mask)
 
     return res, mask
 
+
 # TODO []: error checking grid and mask between global attributes and ****.
 # for src files only and not dst files.
-# If we include this erro check, we should require the users to add 
-# grid and landmask attributes to their own raw dataset if they are 
+# If we include this erro check, we should require the users to add
+# grid and landmask attributes to their own raw dataset if they are
 # using their own data.
+
 
 class PbsScheduler:
     """
@@ -292,7 +311,7 @@ class PbsScheduler:
 
     queue: str
         Cheyenne or Casper queue to use
- 
+
     walltime : str
         The wallclock time in HH:MM:SS format.
 
@@ -314,7 +333,18 @@ class PbsScheduler:
 
     """
 
-    def __init__(self, account, nproc, nnodes, mem, ppn, queue, walltime, email=None, mail_events=None):
+    def __init__(
+        self,
+        account,
+        nproc,
+        nnodes,
+        mem,
+        ppn,
+        queue,
+        walltime,
+        email=None,
+        mail_events=None,
+    ):
 
         self.account = account
         self.nproc = nproc
@@ -325,130 +355,144 @@ class PbsScheduler:
         self.walltime = walltime
         self.email = email
         self.mail_events = mail_events
-        #self.mail_events = "abe" if mail_events is not None 
+        # self.mail_events = "abe" if mail_events is not None
 
     def __str__(self):
-        return  str(self.__class__) + '\n' + '\n'.join((str(item) + ' = ' + str(self.__dict__[item])
-                    for item in sorted(self.__dict__)))
+        return (
+            str(self.__class__)
+            + "\n"
+            + "\n".join(
+                (
+                    str(item) + " = " + str(self.__dict__[item])
+                    for item in sorted(self.__dict__)
+                )
+            )
+        )
 
-
-    def write_job_pbs (self, job_fname, cmd):
+    def write_job_pbs(self, job_fname, cmd):
         self.job_fname = job_fname
 
-        job_file= open (self.job_fname, 'w')
+        job_file = open(self.job_fname, "w")
 
-        self.job_template = ( \
-                "#!/bin/tcsh\n"
-                "#PBS -N "+self.job_fname+"\n"
-                "#PBS -A "+self.account+"\n"
-                "#PBS -l walltime="+self.walltime+"\n"
-                "#PBS -q "+self.queue+"\n"
-                "#PBS -j oe"+"\n\n"
-                #"#PBS -m "+ self.mail_events+"\n"
-                "#PBS -M "+ self.email+"\n"
-                #"#PBS -l select=4:ncpus=16:mpiprocs=16"+"\n"
-                #"#PBS -l select=4:ncpus=2:mpiprocs=2:mem=109GB"+"\n"
-                "#PBS -l select="+self.nnodes+":ncpus="+self.nproc+":mpiprocs="+self.ppn+":mem="+self.mem+"\n"
-                "set MPI_SHEPHERD=true"+"\n"
-                "mpiexec_mpt "+cmd+"\n"
-                )
+        self.job_template = (
+            "#!/bin/tcsh\n"
+            "#PBS -N " + self.job_fname + "\n"
+            "#PBS -A " + self.account + "\n"
+            "#PBS -l walltime=" + self.walltime + "\n"
+            "#PBS -q " + self.queue + "\n"
+            "#PBS -j oe" + "\n\n"
+            # "#PBS -m "+ self.mail_events+"\n"
+            "#PBS -M " + self.email + "\n"
+            # "#PBS -l select=4:ncpus=16:mpiprocs=16"+"\n"
+            # "#PBS -l select=4:ncpus=2:mpiprocs=2:mem=109GB"+"\n"
+            "#PBS -l select="
+            + self.nnodes
+            + ":ncpus="
+            + self.nproc
+            + ":mpiprocs="
+            + self.ppn
+            + ":mem="
+            + self.mem
+            + "\n"
+            "set MPI_SHEPHERD=true" + "\n"
+            "mpiexec_mpt " + cmd + "\n"
+        )
         job_file.write(self.job_template)
         job_file.close()
 
-    def schedule (self):
-        #cmd = "qsub "+self.job_fname
+    def schedule(self):
+        # cmd = "qsub "+self.job_fname
 
-        #print (cmd)
-        #khar = subprocess.check_output(["qsub", self.job_fname])
-        khar = subprocess.run(["qsub", self.job_fname],stdout=subprocess.PIPE)
-        #os.system(cmd)
+        # print (cmd)
+        # khar = subprocess.check_output(["qsub", self.job_fname])
+        khar = subprocess.run(["qsub", self.job_fname], stdout=subprocess.PIPE)
+        # os.system(cmd)
 
-        print ("------")
-        test = khar.stdout.decode('utf-8')
-        print (test)
-        print (re.findall(r'^\D*(\d+)', test))
+        print("------")
+        test = khar.stdout.decode("utf-8")
+        print(test)
+        print(re.findall(r"^\D*(\d+)", test))
 
-        print ("------")
-        
+        print("------")
 
-def main ():                                                                                                                                                  
+
+def main():
     args = get_parser().parse_args()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
 
-    logging.debug('debugging in debug mode.')
+    logging.debug("debugging in debug mode.")
 
     namelist = args.namelist
     input_dir = args.input_dir
     map_dir = args.map_dir
 
-    #-- check if the given input_dir exist
+    # -- check if the given input_dir exist
     if not os.path.exists(input_dir):
-        sys.exit('ERROR: \n'+
-                 '\t input_dir does not exist on this machine. \n'+
-                 '\t Please point to the correct raw_dir using --input_dir'+
-                 'flag.')
+        sys.exit(
+            "ERROR: \n"
+            + "\t input_dir does not exist on this machine. \n"
+            + "\t Please point to the correct raw_dir using --input_dir"
+            + "flag."
+        )
 
-    #-- read the namelist
+    # -- read the namelist
     nl_d = read_nl(namelist)
 
-    #-- dst mesh file
-    print ('-----------------------')
-    dst_mesh_file = nl_d['dst_mesh_file']
-    print ('dst_mesh_file :',  dst_mesh_file)
-    print ('-----------------------')
+    # -- dst mesh file
+    print("-----------------------")
+    dst_mesh_file = nl_d["dst_mesh_file"]
+    print("dst_mesh_file :", dst_mesh_file)
+    print("-----------------------")
 
     dst_res, dst_mask = parse_mesh_fname(dst_mesh_file)
 
-
-    #src mesh files
+    # src mesh files
     src_flist = [
-                'mksrf_fsoitex',
-                'mksrf_forganic',
-                'mksrf_flakwat',
-                'mksrf_fwetlnd',
-                'mksrf_fmax',
-                'mksrf_fglacier', 
-                'mksrf_fvocef',
-                'mksrf_furbtopo',
-                'mksrf_fgdp',
-                'mksrf_fpeat',
-                'mksrf_fsoildepth', 
-                'mksrf_fabm',
-                'mksrf_furban',
-                'mksrf_ftopostats', 
-                'mksrf_fvegtyp',
-                'mksrf_fsoicol',
-                'mksrf_flai',
-                'mksrf_dyn_lu'
-                'mksrf_fvic'
-                ]
+        "mksrf_fsoitex",
+        "mksrf_forganic",
+        "mksrf_flakwat",
+        "mksrf_fwetlnd",
+        "mksrf_fmax",
+        "mksrf_fglacier",
+        "mksrf_fvocef",
+        "mksrf_furbtopo",
+        "mksrf_fgdp",
+        "mksrf_fpeat",
+        "mksrf_fsoildepth",
+        "mksrf_fabm",
+        "mksrf_furban",
+        "mksrf_ftopostats",
+        "mksrf_fvegtyp",
+        "mksrf_fsoicol",
+        "mksrf_flai",
+        "mksrf_dyn_lu" "mksrf_fvic",
+    ]
 
     for src_file in tqdm.tqdm(src_flist):
         src_fname = nl_d[src_file].strip()
-        print (src_file, " : ", src_fname)
+        print(src_file, " : ", src_fname)
 
-        #-- check if src_file exist
+        # -- check if src_file exist
         if not os.path.isfile(src_fname):
-            print ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            print ("src_fname: ", src_fname, "does not exist!")
-            print ("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            print("src_fname: ", src_fname, "does not exist!")
+            print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 
         else:
             ds = xr.open_dataset(src_fname)
-            src_mesh_file = input_dir+ ds.src_mesh_file
+            src_mesh_file = input_dir + ds.src_mesh_file
             src_res, src_mask = parse_mesh_fname(src_mesh_file)
 
             lrg_args = " "
-            if (src_res =="3minx3min" or "1km-merge-10min"):
-                lrg_args=" --64bit_offset "
+            if src_res == "3minx3min" or "1km-merge-10min":
+                lrg_args = " --64bit_offset "
 
+            w_fname = name_weightfile(src_res, src_mask, dst_res, dst_mask)
 
-            w_fname = name_weightfile (src_res, src_mask, dst_res, dst_mask) 
-
-            print ("src_mesh_file is : ", src_mesh_file)
-            print ("weight file is : ", w_fname)
+            print("src_mesh_file is : ", src_mesh_file)
+            print("weight file is : ", w_fname)
 
             # TODO : How to get esmf binary path when not on cheyenne.
 
@@ -457,12 +501,11 @@ def main ():
 
             cmd = esmf_regrid + " --ignore_unmapped"
 
-            cmd = cmd + " -s " + src_mesh_file + " -d " +dst_mesh_file
-            cmd = cmd + " -m conserve "+" -w "+ w_fname
+            cmd = cmd + " -s " + src_mesh_file + " -d " + dst_mesh_file
+            cmd = cmd + " -m conserve " + " -w " + w_fname
             cmd = cmd + lrg_args
             cmd = cmd + "  --src_type SCRIP  --dst_type SCRIP"
 
-            
             account = "P93300606"
             nproc = "2"
             nnodes = "2"
@@ -472,24 +515,24 @@ def main ():
             walltime = "12:00:00"
             email = "negins@ucar.edu"
 
+            # scheduler class:
+            pbs_job = PbsScheduler(
+                account, nproc, nnodes, mem, ppn, queue, walltime, email
+            )
 
+            job_fname = "regrid_submit" + w_fname + ".sh"
 
-            #scheduler class:
-            pbs_job = PbsScheduler(account, nproc, nnodes, mem, ppn, queue, walltime, email)
-
-            job_fname = "regrid_submit"+w_fname +".sh"
-
-            print ("cmd:", cmd)
+            print("cmd:", cmd)
             pbs_job.write_job_pbs(job_fname, cmd)
-            #pbs_job.schedule()
-            #print (pbs_job)
-            #exit()
-            
-            #job_fname = "regrid_submit.sh"
-            #job_file= open (job_fname, 'w')
+            # pbs_job.schedule()
+            # print (pbs_job)
+            # exit()
+
+            # job_fname = "regrid_submit.sh"
+            # job_file= open (job_fname, 'w')
 
             # job scheduler for myself:
-            #job_template = ( \
+            # job_template = ( \
             #        "#!/bin/tcsh\n"
             #        "#PBS -N ctsm_nwp"+"\n"
             #        "#PBS -A P93300606"+"\n"
@@ -502,22 +545,19 @@ def main ():
             #        "mpiexec_mpt "+cmd+"\n"
             #        )
 
+            # job_file.write(job_template)
+            # job_file.close()
 
-            #job_file.write(job_template)
-            #job_file.close()
+            # cmd = "qsub "+job_fname
 
-            #cmd = "qsub "+job_fname
-
-
-
-            #if os.path.isfile(w_fname):
+            # if os.path.isfile(w_fname):
             #    print ('weight file ', w_fname, 'already exists!')
-            #else:
+            # else:
             #    print (cmd)
             #    os.system(cmd)
-            #print ('-----------------------')
+            # print ('-----------------------')
 
-    '''
+    """
      /glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/bin/bing/Linux.intel.64.mpt.default/ESMF_RegridWeightGen
      --ignore_unmapped -s /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_0.5x0.5_AVHRR_c110228.nc  -d
      /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_10x15_nomask_c110308.nc -m conserve -w
@@ -527,10 +567,8 @@ def main ():
     /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_0.25x0.25_MODIS_c170321.nc -d
     /glade/p/cesm/cseg/inputdata/lnd/clm2/mappingdata/grids/SCRIPgrid_10x15_nomask_c110308.nc -m conserve  -w
     map_0.25x0.25_MODIS_to_10x15nomask.nc  --src_type SCRIP  --dst_type SCRIP
-    '''
+    """
+
 
 if __name__ == "__main__":
     main()
-
-
-


### PR DESCRIPTION
### Description of changes

This Python script is the second part of the simplified toolchain for creating surface datasets for global ctsm cases (#644 ).

After creating the namelist/control file with `./gen_mksurf_namelist.py` (PR #1419) using the options for your desired case, you should run :
```
./mkmap_data.py --namelist [namelist from ./gen_mksurf_namelist.py]
```
to create mapping/weight files.

This python script is the alternative code to mkmapdata.sh with few differences:

1. It reads namelist file for DST mesh file.
                
2. For raw dataset in the namelist it finds their SRC mesh file and mask from
the necdf metadata.
                
3. Check if the weight (mapping file) already exists or not. 
                
4. If it does not exist, it creates the mapping (weight) file. 

### Specific notes

Contributors other than yourself, if any: @slevisconsulting 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?


`./mkmap_data.py` has the following interface:
```
usage: mkmap_data.py [-h] --namelist NAMELIST [--input_dir INPUT_DIR]
                     [--map_dir MAP_DIR] [-d] [--overwrite]
                     [--esmf_path OVERWRITE] [--account ACCOUNT_NAME]

|------------------------------------------------------------------|
|---------------------  Instructions  -----------------------------|
|------------------------------------------------------------------|
This Python script is part of the simplified toolchain for creating
the surface dataset for ctsm cases.

After creating the namelist/control file with ./gen_mksurf_namelist.py
using the options for your desired case, you should run :

./mkmap_data.py --namelist [namelist from ./gen_mksurf_namelist.py]

to create mapping files.

This python script is the alternative code to mkmapdata.sh with
 few differences:

1. It reads namelist file for DST mesh file.

2. For raw dataset in the namelist it finds their SRC mesh file and mask from
the necdf metadata.

3. Check if the weight (mapping file) already exists or not. 

4. If it does not exist, it creates the mapping (weight) file. 
 
-------------------------------------------------------------------
Instructions for running on Cheyenne/Casper:
 
load the following into your local environment:
 
    module load python
    ncar_pylib
-------------------------------------------------------------------
To see the available options:
    ./mkmap_data.py --help
 
To run the script:
    ./mkmap_data.py --namelist ${namelist from ./gen_mksurf_namelist.py}
 
To remove NPL from your environment on Cheyenne/Casper:
    deactivate
-------------------------------------------------------------------

optional arguments:
  -h, --help            show this help message and exit
  --namelist NAMELIST   namelist for the ctsm case created by
                        gen_mksurf_namelist.py
  --input_dir INPUT_DIR
                        Path of your mesh files and input data.', [default:
                        /glade/p/cesm/cseg/inputdata/]
  --map_dir MAP_DIR     Path of your weight (mapping) files.', [default: /glad
                        e/scratch/negins/ctsm_toolchain_2/tools/toolchain]
  -d, --debug           Debug mode will print more information [default:
                        False]
  --overwrite           Flag to overwrite the existing mapping files.
                        [default: False]
  --esmf_path OVERWRITE
                        Path of the ESMF library. [default: None]
  --account ACCOUNT_NAME
                        Cheyenne or Casper project account name.', [default:
                        P93300606]

```
Testing performed, if any: @slevisconsulting 
