### PR TITLE
Sending canopy snow fraction (fcansno) to FATES interface

### DIFF
--- a/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/src/biogeophys/SurfaceAlbedoMod.F90
@@ -997,7 +997,9 @@ contains
           
        call clm_fates%wrap_canopy_radiation(bounds, nc, &
             num_vegsol, filter_vegsol, &
-            coszen_patch(bounds%begp:bounds%endp), surfalb_inst)
+            coszen_patch(bounds%begp:bounds%endp), &
+            waterdiagnosticbulk_inst%fcansno_patch(bounds%begp:bounds%endp), &
+            surfalb_inst)
 
     else
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -834,6 +834,8 @@ module CLMFatesInterfaceMod
             this%fates(nc)%bc_in(s)%wind24_pa(ifp) = &
                   atm2lnd_inst%wind24_patch(p)
 
+            this%fates(nc)bc_in(s)%snocan_pa(ifp) = &
+                     
          end do
          
          if(use_fates_planthydro)then
@@ -1010,7 +1012,6 @@ module CLMFatesInterfaceMod
          snow_depth => waterdiagnosticbulk_inst%snow_depth_col, &
          frac_sno_eff => waterdiagnosticbulk_inst%frac_sno_eff_col, &
          frac_veg_nosno_alb => canopystate_inst%frac_veg_nosno_alb_patch)
-
 
        ! Process input boundary conditions to FATES
        ! --------------------------------------------------------------------------------
@@ -2081,7 +2082,7 @@ module CLMFatesInterfaceMod
  ! ======================================================================================
 
  subroutine wrap_canopy_radiation(this, bounds_clump, nc, &
-         num_vegsol, filter_vegsol, coszen, surfalb_inst)
+         num_vegsol, filter_vegsol, coszen, fcansno, surfalb_inst)
 
 
     ! Arguments
@@ -2093,6 +2094,7 @@ module CLMFatesInterfaceMod
     integer            , intent(in)            :: filter_vegsol(num_vegsol)    
     ! cosine solar zenith angle for next time step
     real(r8)           , intent(in)            :: coszen( bounds_clump%begp: )        
+    real(r8)           , intent(in)            :: fcansno ( bounds_clump%begp: )
     type(surfalb_type) , intent(inout)         :: surfalb_inst 
     
     ! locals
@@ -2124,7 +2126,7 @@ module CLMFatesInterfaceMod
              this%fates(nc)%bc_in(s)%coszen_pa(ifp)  = coszen(p)
              this%fates(nc)%bc_in(s)%albgr_dir_rb(:) = albgrd_col(c,:)
              this%fates(nc)%bc_in(s)%albgr_dif_rb(:) = albgri_col(c,:)
-
+             this%fates(nc)%bc_in(s)%fcansno_pa(ifp) = fcansno(p)
           else
              
              this%fates(nc)%bc_in(s)%filter_vegzen_pa(ifp) = .false.

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -834,8 +834,6 @@ module CLMFatesInterfaceMod
             this%fates(nc)%bc_in(s)%wind24_pa(ifp) = &
                   atm2lnd_inst%wind24_patch(p)
 
-            this%fates(nc)bc_in(s)%snocan_pa(ifp) = &
-                     
          end do
          
          if(use_fates_planthydro)then


### PR DESCRIPTION
### Description of changes
Roughly what it says in the title!  For the purposes of calculating the albedo effect of snow in FATES. 

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
