### PR TITLE
Point to CTSM-specific forums

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: CESM forums
-    url: https://xenforo.cgd.ucar.edu/cesm/
+    url: https://bb.cgd.ucar.edu/cesm/forums/ctsm-clm-mosart-rtm.134/
     about: For support with model use, troubleshooting, etc., please use the CTSM forum

--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ and
 
 https://github.com/ESCOMP/ctsm/wiki/Recommended-git-setup
 
-For support with model use, troubleshooting, etc., please use the CTSM forum (or other
-appropriate forum) here:
-
-https://xenforo.cgd.ucar.edu/cesm/
+For support with model use, troubleshooting, etc., please use the [CTSM
+forum](https://bb.cgd.ucar.edu/cesm/forums/ctsm-clm-mosart-rtm.134/) or other appropriate forum (e.g., for
+infrastructure/porting questions) through the [CESM forums](https://bb.cgd.ucar.edu/cesm/).
 
 To get updates on CTSM tags and important notes on CTSM developments
 join our low traffic email list:

--- a/doc/source/users_guide/overview/getting-help.rst
+++ b/doc/source/users_guide/overview/getting-help.rst
@@ -30,7 +30,9 @@ The CESM Bulletin Board
 
 There is a rich and diverse set of people that use the CESM, and often it is useful to be in contact with others to get help in solving problems or trying something new. To facilitate this we have an online Bulletin Board for questions on the CESM. There are also different sections in the Bulletin Board for the different component models or for different topics.
 
-`CESM Online Bulletin Board <http://bb.cgd.ucar.edu/>`_
+`CTSM Forum <https://bb.cgd.ucar.edu/cesm/forums/ctsm-clm-mosart-rtm.134/>`_
+
+`All CESM Forums (including forums for infrastructure/porting questions, etc.) <http://bb.cgd.ucar.edu/cesm/>`_
 
 -----------------
 The CLM web pages


### PR DESCRIPTION
### Description of changes

@mnlevy1981 pointed out that many of the CESM-General forum posts relate to CTSM. So he wondered if the problem may be that we are pointing to the overall CESM forums from various points in the CTSM repository, and some users may think these forums are all for CTSM. So, at his suggestion, I am adding links directly to the CTSM forums. This has the downside that the URL is more likely to change in the future and we'll have to update these links, but I'm thinking it could be worth that risk.

In the README and github.io documentation, I have kept links to the overall CESM forums in addition to the CTSM forums, because the former could be more appropriate for some questions (e.g., porting) – though if someone doesn't read carefully, they may still end up in the overall forums when they should really go to the CTSM forums, so I'm open to getting rid of the overall forum link if people think that would be better.

In the issue chooser, I made the link just go to the CTSM forums; I didn't feel there was a clean way to provide links to both the CTSM forums and overall CESM forums.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any: none