### PR TITLE
fix paths to slnd and xlnd in config_files

### DIFF
--- a/.config_files.xml
+++ b/.config_files.xml
@@ -21,8 +21,10 @@
       <value component="ctsm"      >$SRCROOT</value>
       <value component="dlnd" comp_interface="mct">$SRCROOT/components/cpl7/components/data_comps_mct/dlnd</value>
       <value component="dlnd" comp_interface="nuopc">$SRCROOT/components/cdeps/dlnd</value>
-      <value component="slnd"      >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/slnd</value>
-      <value component="xlnd"      >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xlnd</value>
+      <value component="slnd"  comp_interface="mct"     >$SRCROOT/components/cpl7/components/stub_comps_mct/slnd</value>
+      <value component="xlnd" comp_interface="mct"      >$SRCROOT/components/cpl7/components/xcpl_comps_mct/xlnd</value>
+      <value component="slnd"  comp_interface="nuopc"    >$CIMEROOT/src/components/stub_comps_nuopc/slnd</value>
+      <value component="xlnd"  comp_interface="nuopc"    >$CIMEROOT/src/components/xcpl_comps_nuopc/xlnd</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
### Description of changes
Fix paths to xlnd and slnd in .config_files.xml

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #): Fixes #1438

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
