### PR TITLE
Feature: Export land types and LAI

### DIFF
--- a/src/cpl/mct/clm_cpl_indices.F90
+++ b/src/cpl/mct/clm_cpl_indices.F90
@@ -39,6 +39,9 @@ module clm_cpl_indices
   integer, public ::index_l2x_Sl_snowh        ! snow height
   integer, public ::index_l2x_Sl_u10          ! 10m wind
   integer, public ::index_l2x_Sl_ddvel        ! dry deposition velocities (optional)
+  integer, public ::index_l2x_Sl_lwtgcell     ! landunit areas
+  integer, public ::index_l2x_Sl_pwtgcell     ! patch areas
+  integer, public ::index_l2x_Sl_lai          ! leaf area indices
   integer, public ::index_l2x_Sl_fv           ! friction velocity  
   integer, public ::index_l2x_Sl_ram1         ! aerodynamical resistance
   integer, public ::index_l2x_Sl_soilw        ! volumetric soil water
@@ -137,6 +140,8 @@ contains
     use mct_mod        , only: mct_aVect, mct_aVect_init, mct_avect_indexra
     use mct_mod        , only: mct_aVect_clean, mct_avect_nRattr
     use seq_drydep_mod , only: drydep_fields_token, lnd_drydep
+    use seq_drydep_mod , only: luse_fields_token, patch_fields_token
+    use seq_drydep_mod , only: lai_fields_token
     use shr_megan_mod  , only: shr_megan_fields_token, shr_megan_mechcomps_n
     use shr_fire_emis_mod,only: shr_fire_emis_fields_token, shr_fire_emis_ztop_token, shr_fire_emis_mechcomps_n
     use clm_varctl     , only:  ndep_from_cpl
@@ -191,9 +196,15 @@ contains
     index_l2x_Sl_soilw      = mct_avect_indexra(l2x,'Sl_soilw',perrwith='quiet')
 
     if ( lnd_drydep )then
-       index_l2x_Sl_ddvel = mct_avect_indexra(l2x, trim(drydep_fields_token))
+       index_l2x_Sl_ddvel    = mct_avect_indexra(l2x, trim(drydep_fields_token))
+       index_l2x_Sl_lwtgcell = mct_avect_indexra(l2x, trim(luse_fields_token))
+       index_l2x_Sl_pwtgcell = mct_avect_indexra(l2x, trim(patch_fields_token))
+       index_l2x_Sl_lai      = mct_avect_indexra(l2x, trim(lai_fields_token))
     else
-       index_l2x_Sl_ddvel = 0
+       index_l2x_Sl_ddvel    = 0
+       index_l2x_Sl_lwtgcell = 0
+       index_l2x_Sl_pwtgcell = 0
+       index_l2x_Sl_lai      = 0
     end if
 
     index_l2x_Fall_taux     = mct_avect_indexra(l2x,'Fall_taux')

--- a/src/cpl/mct/lnd_import_export.F90
+++ b/src/cpl/mct/lnd_import_export.F90
@@ -224,6 +224,7 @@ contains
     use seq_flds_mod       , only : seq_flds_l2x_fields
     use clm_varctl         , only : iulog
     use seq_drydep_mod     , only : n_drydep
+    use seq_drydep_mod     , only : NLUse, NPatch
     use shr_megan_mod      , only : shr_megan_mechcomps_n
     use shr_fire_emis_mod  , only : shr_fire_emis_mechcomps_n
     use lnd_import_export_utils, only : check_for_nans
@@ -293,12 +294,29 @@ contains
                lnd2atm_inst%ddvel_grc(g,:n_drydep)
        end if
 
+       ! for landunit weights
+       if (index_l2x_Sl_lwtgcell  /= 0 )  then
+           l2x(index_l2x_Sl_lwtgcell:index_l2x_Sl_lwtgcell+NLUse-1,i) = &
+               lnd2atm_inst%lwtgcell_grc(g,:NLUse)
+       end if
+
+       ! for patch weights
+       if (index_l2x_Sl_pwtgcell  /= 0 )  then
+           l2x(index_l2x_Sl_pwtgcell:index_l2x_Sl_pwtgcell+NPatch-1,i) = &
+               lnd2atm_inst%pwtgcell_grc(g,:NPatch)
+       end if
+
+       ! for leaf area indices
+       if (index_l2x_Sl_lai  /= 0 )  then
+           l2x(index_l2x_Sl_lai:index_l2x_Sl_lai+NPatch-1,i) = &
+               lnd2atm_inst%lai_grc(g,:NPatch)
+       end if
+
        ! for MEGAN VOC emis fluxes
        if (index_l2x_Fall_flxvoc  /= 0 ) then
           l2x(index_l2x_Fall_flxvoc:index_l2x_Fall_flxvoc+shr_megan_mechcomps_n-1,i) = &
                -lnd2atm_inst%flxvoc_grc(g,:shr_megan_mechcomps_n)
        end if
-
 
        ! for fire emis fluxes
        if (index_l2x_Fall_flxfire  /= 0 ) then

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1255,7 +1255,8 @@ contains
     call lnd2atm(bounds_proc,                                            &
          atm2lnd_inst, surfalb_inst, temperature_inst, frictionvel_inst, &
          water_inst, &
-         energyflux_inst, solarabs_inst, drydepvel_inst,       &
+         energyflux_inst, solarabs_inst, drydepvel_inst,                 &
+         canopystate_inst, &
          vocemis_inst, fireemis_inst, dust_inst, ch4_inst, glc_behavior, &
          lnd2atm_inst, &
          net_carbon_exchange_grc = net_carbon_exchange_grc(bounds_proc%begg:bounds_proc%endg))

--- a/src/main/lnd2atmMod.F90
+++ b/src/main/lnd2atmMod.F90
@@ -11,7 +11,7 @@ module lnd2atmMod
   use shr_megan_mod        , only : shr_megan_mechcomps_n
   use shr_fire_emis_mod    , only : shr_fire_emis_mechcomps_n
   use clm_varpar           , only : numrad, ndst, nlevgrnd, nlevmaxurbgrnd !ndst = number of dust bins.
-  use clm_varcon           , only : rair, grav, cpair, hfus, tfrz, spval
+  use clm_varcon           , only : rair, grav, cpair, hfus, tfrz, spval, ispval
   use clm_varctl           , only : iulog, use_lch4
   use seq_drydep_mod       , only : n_drydep, drydep_method, DD_XLND
   use decompMod            , only : bounds_type
@@ -19,6 +19,7 @@ module lnd2atmMod
   use filterColMod         , only : filter_col_type, col_filter_from_logical_array
   use lnd2atmType          , only : lnd2atm_type
   use atm2lndType          , only : atm2lnd_type
+  use CanopyStateType      , only : canopystate_type
   use ch4Mod               , only : ch4_type
   use DUSTMod              , only : dust_type
   use DryDepVelocity       , only : drydepvel_type
@@ -33,6 +34,7 @@ module lnd2atmMod
   use WaterType            , only : water_type
   use glcBehaviorMod       , only : glc_behavior_type
   use glc2lndMod           , only : glc2lnd_type
+  use PatchType            , only : patch
   use ColumnType           , only : col
   use LandunitType         , only : lun
   use GridcellType         , only : grc                
@@ -150,6 +152,7 @@ contains
        atm2lnd_inst, surfalb_inst, temperature_inst, frictionvel_inst, &
        water_inst, &
        energyflux_inst, solarabs_inst, drydepvel_inst,  &
+       canopystate_inst, &
        vocemis_inst, fireemis_inst, dust_inst, ch4_inst, glc_behavior, &
        lnd2atm_inst, &
        net_carbon_exchange_grc) 
@@ -170,6 +173,7 @@ contains
     type(energyflux_type)       , intent(in)    :: energyflux_inst
     type(solarabs_type)         , intent(in)    :: solarabs_inst
     type(drydepvel_type)        , intent(in)    :: drydepvel_inst
+    type(canopystate_type)      , intent(in)    :: canopystate_inst
     type(vocemis_type)          , intent(in)    :: vocemis_inst
     type(fireemis_type)         , intent(in)    :: fireemis_inst
     type(dust_type)             , intent(in)    :: dust_inst
@@ -179,7 +183,7 @@ contains
     real(r8)                    , intent(in)    :: net_carbon_exchange_grc( bounds%begg: )  ! net carbon exchange between land and atmosphere, positive for source (gC/m2/s)
     !
     ! !LOCAL VARIABLES:
-    integer  :: c, g  ! indices
+    integer  :: c, g, l, p  ! indices
     real(r8) :: eflx_sh_ice_to_liq_grc(bounds%begg:bounds%endg) ! sensible heat flux generated from the ice to liquid conversion, averaged to gridcell
     real(r8), parameter :: amC   = 12.0_r8 ! Atomic mass number for Carbon
     real(r8), parameter :: amO   = 16.0_r8 ! Atomic mass number for Oxygen
@@ -305,6 +309,36 @@ contains
             lnd2atm_inst%ddvel_grc        (bounds%begg:bounds%endg, :), &
             p2c_scale_type='unity', c2l_scale_type= 'unity', l2g_scale_type='unity')
     endif
+
+    ! Landunit/patch areas
+    if ( drydep_method == DD_XLND ) then
+        lnd2atm_inst%pwtgcell_grc(:,:) = 0.0e+00_r8
+        do p = bounds%begp,bounds%endp
+            if (patch%itype(p) /= ispval) then
+                g = patch%gridcell(p)
+                lnd2atm_inst%pwtgcell_grc(g,patch%itype(p)+1) = patch%wtgcell(p)
+            end if
+        end do
+
+        lnd2atm_inst%lwtgcell_grc(:,:) = 0.0e+00_r8
+        do l = bounds%begl,bounds%endl
+            if (lun%itype(l) /= ispval) then
+                g = lun%gridcell(l)
+                lnd2atm_inst%lwtgcell_grc(g,lun%itype(l)) = lun%wtgcell(l)
+            end if
+        end do
+    end if
+
+    ! Leaf area indices
+    if ( drydep_method == DD_XLND ) then
+        ! Aggregate sunlit and shaded leaf area index
+        lnd2atm_inst%lai_grc(:,:) = 0.0e+00_r8
+        do p = bounds%begp,bounds%endp
+            g = patch%gridcell(p)
+            lnd2atm_inst%lai_grc(g,patch%itype(p)+1) = &
+                canopystate_inst%elai_patch(p)
+        end do
+    end if
 
     ! voc emission flux
     if (shr_megan_mechcomps_n>0) then

--- a/src/main/lnd2atmType.F90
+++ b/src/main/lnd2atmType.F90
@@ -16,6 +16,7 @@ module lnd2atmType
   use shr_megan_mod , only : shr_megan_mechcomps_n
   use shr_fire_emis_mod,only : shr_fire_emis_mechcomps_n
   use seq_drydep_mod, only : n_drydep, drydep_method, DD_XLND
+  use seq_drydep_mod, only : NLUse, NPatch
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -54,6 +55,9 @@ module lnd2atmType
      real(r8), pointer :: fv_grc             (:)   => null() ! friction velocity (m/s) (for dust model)
      real(r8), pointer :: flxdst_grc         (:,:) => null() ! dust flux (size bins)
      real(r8), pointer :: ddvel_grc          (:,:) => null() ! dry deposition velocities
+     real(r8), pointer :: lwtgcell_grc       (:,:) => null() ! landunit areas
+     real(r8), pointer :: pwtgcell_grc       (:,:) => null() ! patch areas
+     real(r8), pointer :: lai_grc            (:,:) => null() ! leaf area indices
      real(r8), pointer :: flxvoc_grc         (:,:) => null() ! VOC flux (size bins)
      real(r8), pointer :: fireflx_grc        (:,:) => null() ! Wild Fire Emissions
      real(r8), pointer :: fireztop_grc       (:)   => null() ! Wild Fire Emissions vertical distribution top
@@ -165,6 +169,11 @@ contains
     endif
     if ( n_drydep > 0 .and. drydep_method == DD_XLND )then
        allocate(this%ddvel_grc(begg:endg,1:n_drydep)); this%ddvel_grc(:,:)=ival
+    end if
+    if ( drydep_method == DD_XLND ) then
+       allocate(this%lwtgcell_grc(begg:endg,1:NLUse));  this%lwtgcell_grc(:,:)=spval
+       allocate(this%pwtgcell_grc(begg:endg,1:NPatch)); this%pwtgcell_grc(:,:)=spval
+       allocate(this%lai_grc(begg:endg,1:NPatch));      this%lai_grc(:,:)     =spval
     end if
 
   end subroutine InitAllocate


### PR DESCRIPTION
This PR allows CLM to export land types and LAI to CAM so that GEOS-Chem may compute dry deposition velocities. This update was originally developed by Thibaud Fritz (MIT) and submitted as https://github.com/ESCOMP/CTSM/pull/1377 on a CESM 2.1 base. This PR supercedes #1377.

Please note that the first commit of this PR does not yet make changes to the NUOPC layer. This commit will come later and merge should not happen before then. I will do full testing once the updates to NUOPC are in place.

Original message from @fritzt:

> Hello!
> 
> I have been working on implementing the GEOS-Chem (version 13.0.0) chemistry module in CESM2.1.1. This new option is designated as CESM2-GC. The implementation of GEOS-Chem chemistry inside CESM2 aims to provide an additional chemistry option alongside CAM-Chem.
> 
> This is the second PR out of three (CAM, CLM, cime). The main PR can be found at ESCOMP/CAM#378
> 
> Description of changes
> This PR focuses on passing land types and leaf area indices (LAI) from CLM to CAM through the coupler. I followed the same workflow as what is done for albedo. The land types and LAI are required in CAM to let GEOS-Chem compute its own dry deposition velocities.
> 
> Specific notes
> Contributors other than yourself, if any: None
> 
> CTSM Issues Fixed (include github issue #): None
> 
> Are answers expected to change (and if so in what way)?
> No, this PR introduces changes that only aim to pass information from CLM to CAM.
> 
> Any User Interface Changes (namelist or namelist defaults changes)?
> No.
> 
> Testing performed, if any:
> I was able to output land types and LAI as archived by CAM.
> 
> Let me know if I am targetting the wrong branch. The CLM tag I used for my work is release-clm5.0.25. Attached is the top-level Externals.cfg that I used for my project.
> 
> Regards,
> Thibaud Fritz
> Laboratory for Aviation and the Environment
> 