### PR TITLE
Miscellaneous small answer changes

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2232,10 +2232,20 @@ sub setup_logic_surface_dataset {
   if ($flanduse_timeseries ne "null" && &value_is_true($nl_flags->{'use_cndv'}) ) {
      $log->fatal_error( "dynamic PFT's (setting flanduse_timeseries) are incompatible with dynamic vegetation (use_cndv=.true)." );
   }
-  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'fsurdat',
+  # Always get the crop version of the datasets now and let the code turn it into the form desired
+  my $var = "fsurdat";
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
               'hgrid'=>$nl_flags->{'res'}, 'ssp_rcp'=>$nl_flags->{'ssp_rcp'},
-              'sim_year'=>$nl_flags->{'sim_year'}, 'irrigate'=>$nl_flags->{'irrigate'},
-              'use_crop'=>$nl_flags->{'use_crop'}, 'glc_nec'=>$nl_flags->{'glc_nec'});
+              'sim_year'=>$nl_flags->{'sim_year'}, 'irrigate'=>".true.",
+              'use_crop'=>".true.", 'glc_nec'=>$nl_flags->{'glc_nec'}, 'nofail'=>1);
+  # If didn't find the crop version check for the exact match
+  if ( ! defined($nl->get_value($var) ) ) {
+     $log->verbose_message( "Crop version of $var NOT found, searching for an exact match" );
+     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
+                 'hgrid'=>$nl_flags->{'res'}, 'ssp_rcp'=>$nl_flags->{'ssp_rcp'},
+                 'sim_year'=>$nl_flags->{'sim_year'}, 'irrigate'=>$nl_flags->{'irrigate'},
+                 'use_crop'=>$nl_flags->{'use_crop'}, 'glc_nec'=>$nl_flags->{'glc_nec'});
+  }
 }
 
 #-------------------------------------------------------------------------------

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -870,12 +870,13 @@ sub setup_cmdl_bgc {
   my $var = "soil_decomp_method";
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
               'phys'=>$nl_flags->{'phys'}, 'use_cn'=>$nl_flags->{'use_cn'}, 'use_fates'=>$nl_flags->{'use_fates'} );
+  my $soil_decomp_method = remove_leading_and_trailing_quotes( $nl->get_value( $var ) );
 
   if ( &value_is_true($nl_flags->{'use_cn'}) ||  &value_is_true($nl_flags->{'use_fates'}))  {
-     if ( remove_leading_and_trailing_quotes( $nl->get_value($var)) eq "None" ) {
+     if ( $soil_decomp_method eq "None" ) {
         $log->fatal_error("$var must NOT be None if use_cn or use_fates are on");
      }
-  } elsif ( remove_leading_and_trailing_quotes($nl->get_value($var)) ne "None" ) {
+  } elsif ( $soil_decomp_method ne "None" ) {
      $log->fatal_error("$var must be None if use_cn or use_fates are not");
   }
   #
@@ -885,13 +886,13 @@ sub setup_cmdl_bgc {
   my %settings = ( 'bgc_mode'=>$nl_flags->{'bgc_mode'} );
   foreach my $var ( @list ) {
      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,
-                 'phys'=>$nl_flags->{'phys'}, 'use_cn'=>$nl_flags->{'use_cn'}, 'use_fates'=>$nl_flags->{'use_fates'} );
+                 'phys'=>$nl_flags->{'phys'}, 'soil_decomp_method'=>$soil_decomp_method );
      $nl_flags->{$var} = $nl->get_value($var);
   }
-  if ( remove_leading_and_trailing_quotes( $nl->get_value($var)) eq "None" ) {
+  if ( $soil_decomp_method eq "None" ) {
      foreach my $var ( @list ) {
         if ( &value_is_true($nl_flags->{$var}) ) {
-           $log->fatal_error("When soil_decomp_method is NONE $var can NOT be TRUE");
+           $log->fatal_error("When soil_decomp_method is None $var can NOT be TRUE");
         }
      }
   } else {

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2527,15 +2527,14 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <!-- Defaults for different BGC modes           -->
 <!-- =========================================  -->
 
-<use_lch4                              >.false.</use_lch4>
-<use_lch4           use_cn=".true."    >.true.</use_lch4>
-<use_lch4           use_fates=".true." >.false.</use_lch4>
 <soil_decomp_method use_cn=".true."    >CENTURYKoven2013</soil_decomp_method>
 <soil_decomp_method use_fates=".true." >CENTURYKoven2013</soil_decomp_method>
 <soil_decomp_method                    >None</soil_decomp_method>
-<use_nitrif_denitrif                   >.false.</use_nitrif_denitrif>
-<use_nitrif_denitrif use_cn=".true."   >.true.</use_nitrif_denitrif>
-<use_nitrif_denitrif use_fates=".true.">.false.</use_nitrif_denitrif>
+
+<use_lch4            soil_decomp_method="None" >.false.</use_lch4>
+<use_lch4                                      >.true.</use_lch4>
+<use_nitrif_denitrif soil_decomp_method="None" >.false.</use_nitrif_denitrif>
+<use_nitrif_denitrif                           >.true.</use_nitrif_denitrif>
 
 <!-- ===== FATES DEFAULTS =========== -->
 <fates_spitfire_mode           use_fates=".true.">0</fates_spitfire_mode>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -101,11 +101,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <modifyphoto_and_lmr_forcrop phys="clm4_5" >.false.</modifyphoto_and_lmr_forcrop>
 
 <!-- Method to use for stomatal conducatance -->
-<stomatalcond_method phys="clm5_1"  use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
-<stomatalcond_method phys="clm5_1"  use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
-<stomatalcond_method phys="clm5_0"  use_hydrstress=".true." >Medlyn2011</stomatalcond_method>
-<stomatalcond_method phys="clm5_0"  use_hydrstress=".false.">Ball-Berry1987</stomatalcond_method>
-<stomatalcond_method phys="clm4_5"                          >Ball-Berry1987</stomatalcond_method>
+<stomatalcond_method phys="clm5_1"         >Medlyn2011</stomatalcond_method>
+<stomatalcond_method phys="clm5_0"         >Medlyn2011</stomatalcond_method>
+<stomatalcond_method phys="clm4_5"         >Ball-Berry1987</stomatalcond_method>
 
 <!-- Carbon isotope concentration files -->
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C13_CMIP6_1850-2015_yearly_v2.0_c190528.nc</atm_c13_filename>

--- a/bld/namelist_files/use_cases/1850_noanthro_control.xml
+++ b/bld/namelist_files/use_cases/1850_noanthro_control.xml
@@ -54,7 +54,7 @@
 <do_harvest                    >.false.</do_harvest>
 
 <!-- Set contants having to do with fire due to human influences to zero (human ignition counts, and crop fires -->
-<pot_hmn_ign_counts_alpha      >0.0</pot_hmn_ign_counts_alpha>
-<cropfire_a1                   >0.0</cropfire_a1>
+<pot_hmn_ign_counts_alpha use_cn=".true.">0.0</pot_hmn_ign_counts_alpha>
+<cropfire_a1              use_cn=".true.">0.0</cropfire_a1>
 
 </namelist_defaults>

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -163,7 +163,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 1839;
+my $ntests = 1843;
 if ( defined($opts{'compare'}) ) {
    $ntests += 1251;
 }
@@ -462,6 +462,7 @@ foreach my $options (
                       "-bgc sp  -use_case 2000_control -res 0.9x1.25 -namelist '&a use_soil_moisture_streams = T/'",
                       "-bgc bgc -use_case 1850-2100_SSP5-8.5_transient -namelist '&a start_ymd=19101023/'",
                       "-bgc bgc -use_case 2000_control -namelist \"&a fire_method='nofire'/\" -crop",
+                      "-res 0.9x1.25 -bgc sp -use_case 1850_noanthro_control -drydep -fire_emis",
                       "-res 0.9x1.25 -bgc bgc -use_case 1850_noanthro_control -drydep -fire_emis -light_res 360x720",
                      ) {
    my $file = $startfile;

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -165,7 +165,7 @@ my $testType="namelistTest";
 #
 my $ntests = 1843;
 if ( defined($opts{'compare'}) ) {
-   $ntests += 1251;
+   $ntests += 1254;
 }
 plan( tests=>$ntests );
 

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -163,7 +163,7 @@ my $testType="namelistTest";
 #
 # Figure out number of tests that will run
 #
-my $ntests = 1843;
+my $ntests = 1842;
 if ( defined($opts{'compare'}) ) {
    $ntests += 1254;
 }
@@ -638,12 +638,6 @@ my %failtest = (
                                      namelst=>"baset_mapping='constant', baset_latvary_slope=1.0, baset_latvary_intercept=10.0",
                                      GLC_TWO_WAY_COUPLING=>"FALSE",
                                      phys=>"clm5_0",
-                                   },
-     # This one should fail now, because we don't have non irrigated non-crop datasets
-     "-irrigate=F without -crop" =>{ options=>"-bgc bgc -no-crop -envxml_dir .",
-                                    namelst=>"irrigate=.false.",
-                                    GLC_TWO_WAY_COUPLING=>"FALSE",
-                                    phys=>"clm4_5",
                                    },
      "grainproductWOcrop"       =>{ options=>"-bgc bgc -no-crop -envxml_dir .",
                                     namelst=>"use_grainproduct=.true.",

--- a/cime_config/testdefs/testmods_dirs/clm/smallville_dynlakes_monthly/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/smallville_dynlakes_monthly/user_nl_clm
@@ -6,9 +6,3 @@ do_transient_lakes = .true.
 ! PCT_CROP is also changed so that PCT_LAKE + PCT_CROP <= 100. (Here, PCT_CROP increases and decreases at the same time as PCT_LAKE in order to exercise the simultaneous increase or decrease of two landunits, but that isn't a critical part of this test.)
 ! Note that the use of this file means that this testmod can only be used with the 1x1_smallvilleIA grid.
 flanduse_timeseries = '$DIN_LOC_ROOT/lnd/clm2/surfdata_map/landuse.timeseries_1x1_smallvilleIA_hist_78pfts_simyr1850-1855_dynLakes_c200928.nc'
-
-! BUG(wjs, 2020-09-25, ESCOMP/CTSM#43) Dynamic lakes don't work when methane is active,
-! so for now disable methane for this test.
-! This also requires use_nitrif_denitrif to be off as well
-use_lch4 = .false.
-use_nitrif_denitrif = .true.

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -4241,7 +4241,6 @@ contains
     real(r8) :: aquad, bquad, cquad  ! terms for quadratic equations
     real(r8) :: r1, r2               ! roots of quadratic equation
     real(r8) :: term                 ! intermediate in Medlyn stomatal model
-    real(r8), parameter :: max_cs = 10.e-06_r8  ! Max CO2 partial pressure at leaf surface (Pa) for PHS
     !
     !------------------------------------------------------------------------------
     

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -1898,17 +1898,13 @@ contains
                end if
 
                !
-               ! Turn this off right now as it causes an apparant change in
-               ! answers (See ESCOMP/#CTSM/1446) for history variables 
                ! This sets the  variables GSSUN and GSSHA
                !
-               if ( .false. )then
-                   ! Write stomatal conductance to the appropriate phase
-                   if (phase=='sun') then
-                      gs_mol_sun(p,iv) = gs_mol(p,iv)
-                   else if (phase=='sha') then
-                      gs_mol_sha(p,iv) = gs_mol(p,iv)
-                   end if
+               ! Write stomatal conductance to the appropriate phase
+               if (phase=='sun') then
+                  gs_mol_sun(p,iv) = gs_mol(p,iv)
+               else if (phase=='sha') then
+                  gs_mol_sha(p,iv) = gs_mol(p,iv)
                end if
 
                ! Use time period 1 hour before and 1 hour after local noon inclusive (11AM-1PM)

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -732,7 +732,7 @@ contains
                   end if
                else
                   if (col%itype(c) == icol_road_perv .or. col%itype(c) == icol_road_imperv) then
-                     this%t_soisno_col(c,1:nlevgrnd) = 274._r8
+                     this%t_soisno_col(c,1:nlevgrnd) = 272._r8
                   else if (col%itype(c) == icol_sunwall .or. col%itype(c) == icol_shadewall &
                        .or. col%itype(c) == icol_roof) then
                      ! Set sunwall, shadewall, roof to fairly high temperature to avoid initialization


### PR DESCRIPTION
### Description of changes

Change ceta from 450 to 358 for CTSM5.1
Turn Medlyn on for PHS off for clm51 and clm50 (3 dynroot tests will change answers)
Make max CO2 partial pressure consistent
Change surface datasets to only use 78PFT versions (so SP results may change)
Fix GSSUN and GSSHA history variables so now not just missing values
Changes FATES to run with use_nitrif_dentrif=T by defaul;t
Change dynlakes test to methane/use_nitrif_=T
(This will allow use_nitrif and methane flags to be removed)


### Specific notes

Contributors other than yourself, if any: @djk2120 

CTSM Issues Fixed (include github issue #):
  Fixes #1462
  Fixes #1394
  Fixes #1460
  Fixes #1465
  Fixes #1356
  Fixes #1496

Are answers expected to change (and if so in what way)? Yes! 
  Small changes to a few defaults will change answers in most configurations

Any User Interface Changes (namelist or namelist defaults changes)? Changes some defaults

Testing performed, if any: Limited so far, will do regular testing
