### PR TITLE
Change renormalization of landunit areas in mksurfdata_map to be consistent with raw datasets

### DIFF
--- a/tools/mksurfdata_map/src/mkpftUtilsMod.F90
+++ b/tools/mksurfdata_map/src/mkpftUtilsMod.F90
@@ -24,7 +24,6 @@ module mkpftUtilsMod
   ! !PUBLIC MEMBER FUNCTIONS:
   !
   public :: convert_from_p2g         ! Convert a p2g array into pct_pft_type objects
-  public :: adjust_total_natveg_area ! Adjust the total natural vegetated area to a new specified total
 
   !
   ! !PRIVATE MEMBER FUNCTIONS:
@@ -212,40 +211,6 @@ contains
     default_cft(c3cropindex) = 100._r8
 
   end function get_default_cft
-
-  !-----------------------------------------------------------------------
-  subroutine adjust_total_natveg_area(new_total_pct, pctnatpft)
-    !
-    ! !DESCRIPTION:
-    ! Adjust the total natural vegetated area on the grid cell to a new
-    ! specified total.
-    !
-    ! If the old areas are 0%, then all the new area goes into pctnatpft.
-    !
-    ! !USES:
-    use mkpctPftTypeMod, only : pct_pft_type
-    !
-    ! !ARGUMENTS:
-    real(r8), intent(in) :: new_total_pct ! new total % of natural veg landunit
-    class(pct_pft_type), intent(inout) :: pctnatpft ! natural veg cover information
-    !
-    ! !LOCAL VARIABLES:
-    real(r8) :: natpft_l2g ! grid cell % cover of natural veg
-    real(r8) :: old_total  ! old total % cover of natural veg
-    
-    character(len=*), parameter :: subname = 'adjust_total_natveg_area'
-    !-----------------------------------------------------------------------
-    
-    natpft_l2g = pctnatpft%get_pct_l2g()
-    old_total = natpft_l2g
-    if (old_total > 0._r8) then
-       call pctnatpft%set_pct_l2g(natpft_l2g * new_total_pct / old_total)
-    else
-       call pctnatpft%set_pct_l2g(new_total_pct)
-    end if
-
-  end subroutine adjust_total_natveg_area
-
 
 end module mkpftUtilsMod
 

--- a/tools/mksurfdata_map/src/mkpftUtilsMod.F90
+++ b/tools/mksurfdata_map/src/mkpftUtilsMod.F90
@@ -24,7 +24,6 @@ module mkpftUtilsMod
   ! !PUBLIC MEMBER FUNCTIONS:
   !
   public :: convert_from_p2g         ! Convert a p2g array into pct_pft_type objects
-  public :: adjust_total_veg_area    ! Adjust the total vegetated area (natural veg & crop) to a new specified total
   public :: adjust_total_natveg_area ! Adjust the total natural vegetated area to a new specified total
 
   !
@@ -213,44 +212,6 @@ contains
     default_cft(c3cropindex) = 100._r8
 
   end function get_default_cft
-
-
-  !-----------------------------------------------------------------------
-  subroutine adjust_total_veg_area(new_total_pct, pctnatpft, pctcft)
-    !
-    ! !DESCRIPTION:
-    ! Adjust the total vegetated area on the grid cell (natural veg & crop) to a new
-    ! specified total.
-    !
-    ! If the old areas are 0%, then all the new area goes into pctnatpft.
-    !
-    ! !USES:
-    use mkpctPftTypeMod, only : pct_pft_type
-    !
-    ! !ARGUMENTS:
-    real(r8), intent(in) :: new_total_pct ! new total % of natural veg + crop landunits
-    class(pct_pft_type), intent(inout) :: pctnatpft ! natural veg cover information
-    class(pct_pft_type), intent(inout) :: pctcft    ! crop cover information
-    !
-    ! !LOCAL VARIABLES:
-    real(r8) :: natpft_l2g ! grid cell % cover of nat. veg.
-    real(r8) :: cft_l2g    ! grid cell % cover of crop
-    real(r8) :: old_total  ! old total % cover of natural veg + crop landunits
-    
-    character(len=*), parameter :: subname = 'adjust_total_veg_area'
-    !-----------------------------------------------------------------------
-    
-    natpft_l2g = pctnatpft%get_pct_l2g()
-    cft_l2g = pctcft%get_pct_l2g()
-    old_total = natpft_l2g + cft_l2g
-    if (old_total > 0._r8) then
-       call pctnatpft%set_pct_l2g(natpft_l2g * new_total_pct / old_total)
-       call pctcft%set_pct_l2g(cft_l2g * new_total_pct / old_total)
-    else
-       call pctnatpft%set_pct_l2g(new_total_pct)
-    end if
-
-  end subroutine adjust_total_veg_area
 
   !-----------------------------------------------------------------------
   subroutine adjust_total_natveg_area(new_total_pct, pctnatpft)

--- a/tools/mksurfdata_map/src/mkpftUtilsMod.F90
+++ b/tools/mksurfdata_map/src/mkpftUtilsMod.F90
@@ -23,8 +23,9 @@ module mkpftUtilsMod
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   !
-  public :: convert_from_p2g      ! Convert a p2g array into pct_pft_type objects
-  public :: adjust_total_veg_area ! Adjust the total vegetated area (natural veg & crop) to a new specified total
+  public :: convert_from_p2g         ! Convert a p2g array into pct_pft_type objects
+  public :: adjust_total_veg_area    ! Adjust the total vegetated area (natural veg & crop) to a new specified total
+  public :: adjust_total_natveg_area ! Adjust the total natural vegetated area to a new specified total
 
   !
   ! !PRIVATE MEMBER FUNCTIONS:
@@ -250,6 +251,39 @@ contains
     end if
 
   end subroutine adjust_total_veg_area
+
+  !-----------------------------------------------------------------------
+  subroutine adjust_total_natveg_area(new_total_pct, pctnatpft)
+    !
+    ! !DESCRIPTION:
+    ! Adjust the total natural vegetated area on the grid cell to a new
+    ! specified total.
+    !
+    ! If the old areas are 0%, then all the new area goes into pctnatpft.
+    !
+    ! !USES:
+    use mkpctPftTypeMod, only : pct_pft_type
+    !
+    ! !ARGUMENTS:
+    real(r8), intent(in) :: new_total_pct ! new total % of natural veg landunit
+    class(pct_pft_type), intent(inout) :: pctnatpft ! natural veg cover information
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: natpft_l2g ! grid cell % cover of natural veg
+    real(r8) :: old_total  ! old total % cover of natural veg
+    
+    character(len=*), parameter :: subname = 'adjust_total_natveg_area'
+    !-----------------------------------------------------------------------
+    
+    natpft_l2g = pctnatpft%get_pct_l2g()
+    old_total = natpft_l2g
+    if (old_total > 0._r8) then
+       call pctnatpft%set_pct_l2g(natpft_l2g * new_total_pct / old_total)
+    else
+       call pctnatpft%set_pct_l2g(new_total_pct)
+    end if
+
+  end subroutine adjust_total_natveg_area
 
 
 end module mkpftUtilsMod

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1367,8 +1367,6 @@ subroutine normalizencheck_landuse(ldomain)
     integer  :: nsmall_tot                  ! total number of small PFT values in all grid cells
     real(r8) :: suma                        ! sum for error check
     real(r8) :: new_total_natveg_pct        ! new % veg (% of grid cell, natural veg)
-    real(r8) :: sum8, sum8a                 ! sum for error check
-    real(r4) :: sum4a                       ! sum for error check
     real(r8), parameter :: tol_loose = 1.e-4_r8               ! tolerance for some 'loose' error checks
     real(r8), parameter :: toosmallPFT = 1.e-10_r8            ! tolerance for PFT's to ignore
     character(len=32) :: subname = 'normalizencheck_landuse'  ! subroutine name

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1519,46 +1519,6 @@ subroutine normalizencheck_landuse(ldomain)
        
     end do
 
-    ! Check that when pctnatveg+pctcrop identically zero, sum of special landunits is identically 100%
-    ! KO - Not sure if this needs to be changed or is necessary
-
-    if ( .not. outnc_double )then
-       do n = 1,ns_o
-          sum8  =         real(pctlak(n),r4)
-          sum8  = sum8  + real(pctwet(n),r4)
-          sum8  = sum8  + real(pcturb(n),r4)
-          sum8  = sum8  + real(pctgla(n),r4)
-          sum4a =         real(pctnatpft(n)%get_pct_l2g(),r4)
-          sum4a = sum4a + real(pctcft(n)%get_pct_l2g(),r4)
-          if ( sum4a==0.0_r4 .and. sum8 < 100._r4-2._r4*epsilon(sum4a) )then
-             write (6,*) subname, ' error: sum of pctlak, pctwet,', &
-                  'pcturb, pctgla is < 100% when pctnatveg+pctcrop==0 sum = ', sum8
-             write (6,*)'n,pctlak,pctwet,pcturb,pctgla,pctnatveg,pctcrop= ', &
-                  n,pctlak(n),pctwet(n),pcturb(n),pctgla(n), &
-                  pctnatpft(n)%get_pct_l2g(),pctcft(n)%get_pct_l2g()
-             call abort()
-          end if
-       end do
-    else
-       do n = 1,ns_o
-          sum8  =         pctlak(n)
-          sum8  = sum8  + pctwet(n)
-          sum8  = sum8  + pcturb(n)
-          sum8  = sum8  + pctgla(n)
-          sum8a =         pctnatpft(n)%get_pct_l2g()
-          sum8a = sum8a + pctcft(n)%get_pct_l2g()
-          if ( sum8a==0._r8 .and. sum8 < (100._r8-4._r8*epsilon(sum8)) )then
-             write (6,*) subname, ' error: sum of pctlak, pctwet,', &
-                  'pcturb, pctgla is < 100% when pctnatveg+pctcrop==0 sum = ', sum8
-             write (6,*) 'Total error, error/epsilon = ',100._r8-sum8, ((100._r8-sum8)/epsilon(sum8))
-             write (6,*)'n,pctlak,pctwet,pcturb,pctgla,pctnatveg,pctcrop,epsilon= ', &
-                  n,pctlak(n),pctwet(n),pcturb(n),pctgla(n),&
-                  pctnatpft(n)%get_pct_l2g(),pctcft(n)%get_pct_l2g(), epsilon(sum8)
-             call abort()
-          end if
-       end do
-    end if
-
     ! Make sure that there is no vegetation outside the pft mask
     do n = 1,ns_o
        if (pftdata_mask(n) == 0 .and. (pctnatpft(n)%get_pct_l2g() > 0 .or. pctcft(n)%get_pct_l2g() > 0)) then

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1465,7 +1465,11 @@ subroutine normalizencheck_landuse(ldomain)
           call pctcft(n)%set_pct_l2g(pctcft(n)%get_pct_l2g() * 100._r8/suma)
        end if
        
-       ! Roundoff error fix
+       ! This roundoff error fix is needed to handle the situation where new_total_natveg_pct
+       ! ends up near 0 but not exactly 0 due to roundoff issues. In this situation, we set the
+       ! natveg landunit area to exactly 0 and put the remainder into some other landunit. Since
+       ! the remainder is very small, it doesn't really matter which other landunit we add it to,
+       ! so we just pick some landunit that already has at least 1% cover.
        suma = pctlak(n) + pctwet(n) + pcturb(n) + pctgla(n) + pctcft(n)%get_pct_l2g()
        if ( (suma < 100._r8 .and. suma > (100._r8 - 1.e-6_r8)) .or. &
             (pctnatpft(n)%get_pct_l2g() > 0.0_r8 .and. pctnatpft(n)%get_pct_l2g() <  1.e-6_r8) ) then

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1364,7 +1364,6 @@ subroutine normalizencheck_landuse(ldomain)
 ! Precondition: pctlak + pctwet + pcturb + pctgla + pctcrop <= 100 (within roundoff)
 !
 ! !USES:
-    use mkpftUtilsMod     , only : adjust_total_veg_area
     use mkpftUtilsMod     , only : adjust_total_natveg_area
     implicit none
 ! !ARGUMENTS:

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1500,14 +1500,8 @@ subroutine normalizencheck_landuse(ldomain)
           call abort()
        end if
        
-       suma = pctlak(n) + pctwet(n) + pcturb(n) + pctgla(n)
-       if (suma < 100._r8-epsilon(suma) .and. suma > (100._r8 - 4._r8*epsilon(suma))) then
-          write (6,*) subname, 'n,pctlak,pctwet,pcturb,pctgla,pctnatveg,pctcrop= ', &
-               n,pctlak(n),pctwet(n),pcturb(n),pctgla(n),&
-               pctnatpft(n)%get_pct_l2g(), pctcft(n)%get_pct_l2g()
-          call abort()
-       end if
-       suma = suma + pctnatpft(n)%get_pct_l2g() + pctcft(n)%get_pct_l2g()
+       suma = pctlak(n) + pctwet(n) + pcturb(n) + pctgla(n) + pctcft(n)%get_pct_l2g()
+       suma = suma + pctnatpft(n)%get_pct_l2g()
        if ( abs(suma-100._r8) > 1.e-10_r8) then
           write (6,*) subname, ' error: sum of pctlak, pctwet,', &
                'pcturb, pctgla, pctnatveg and pctcrop is NOT equal to 100'

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1364,7 +1364,6 @@ subroutine normalizencheck_landuse(ldomain)
 ! Precondition: pctlak + pctwet + pcturb + pctgla + pctcrop <= 100 (within roundoff)
 !
 ! !USES:
-    use mkpftUtilsMod     , only : adjust_total_natveg_area
     implicit none
 ! !ARGUMENTS:
     type(domain_type)   :: ldomain
@@ -1438,7 +1437,7 @@ subroutine normalizencheck_landuse(ldomain)
        ! correct for rounding error:
        new_total_natveg_pct = max(new_total_natveg_pct, 0._r8)
 
-       call adjust_total_natveg_area(new_total_natveg_pct, pctnatpft=pctnatpft(n))
+       call pctnatpft(n)%set_pct_l2g(new_total_natveg_pct)       
 
        ! Confirm that we have done the rescaling correctly: now the sum of all landunits
        ! should be 100%

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -1432,7 +1432,6 @@ subroutine normalizencheck_landuse(ldomain)
 
        ! Natural vegetated cover is 100% minus the sum of all other landunits
        
-       suma = pctlak(n)+pctwet(n)+pctgla(n)+pcturb(n)+pctcft(n)%get_pct_l2g()
        new_total_natveg_pct = 100._r8 - suma
        ! correct for rounding error:
        new_total_natveg_pct = max(new_total_natveg_pct, 0._r8)

--- a/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/tools/mksurfdata_map/src/mksurfdat.F90
@@ -750,13 +750,7 @@ program mksurfdat
        ! types proportionally.
 
        suma = pctlak(n) + pctwet(n) + pcturb(n) + pctgla(n) + pctcft(n)%get_pct_l2g()
-       if (suma > 250._r4) then
-          write (6,*) subname, ' error: sum of pctlak, pctwet,', &
-               'pcturb, pctgla, and pctcrop is greater than 250%'
-          write (6,*)'n,pctlak,pctwet,pcturb,pctgla,pctcrop= ', &
-               n,pctlak(n),pctwet(n),pcturb(n),pctgla(n),pctcft(n)%get_pct_l2g()
-          call abort()
-       else if (suma > 100._r4) then
+       if (suma > 100._r4) then
           pctlak(n) = pctlak(n) * 100._r8/suma
           pctwet(n) = pctwet(n) * 100._r8/suma
           pcturb(n) = pcturb(n) * 100._r8/suma
@@ -1196,13 +1190,7 @@ program mksurfdat
 
           do n = 1,ns_o
              suma = pctlak(n) + pctwet(n) + pcturb(n) + pctgla(n) + pctcft(n)%get_pct_l2g()
-             if (suma > 250._r4) then
-                write (6,*) subname, ' error: sum of pctlak, pctwet,', &
-                     'pcturb, pctgla, and pctcrop is greater than 250%'
-                write (6,*)'n,pctlak,pctwet,pcturb,pctgla,pctcrop= ', &
-                     n,pctlak(n),pctwet(n),pcturb(n),pctgla(n),pctcft(n)%get_pct_l2g()
-                call abort()
-             else if (suma > 100._r4) then
+             if (suma > 100._r4) then
                 pctlak(n) = pctlak(n) * 100._r8/suma
                 pctwet(n) = pctwet(n) * 100._r8/suma
                 pcturb(n) = pcturb(n) * 100._r8/suma


### PR DESCRIPTION
### Description of changes

This PR is based on code branched off of ctsm5.1.dev062.
Per Issue #1555 the following problems are corrected:
1)	Urban no longer adjusts bare ground or PCT_NAT_PFT in general.  Urban is now treated the same as other special landunits.
2)	The areas of all landunits (including crop) other than natural veg are now treated symmetrically; in places where we assure sums don't exceed 100% and in places where we adjust all other landunits proportionally.  This is accomplished by replacing the suma rescaling code that is done just before calling normalizencheck_landuse.  This rewritten section of code is also inserted in the time loop for transient landcover, also just before calling normalizencheck_landuse.
3)	For determining landunit areas, PCT_NATVEG is now set to 100 minus the sum of the other landunits.  This replaces the current rescaling code in normalizencheck_landuse.

### Specific notes

There is an existing subroutine called adjust_total_veg_area that adjusts the total vegetated area (natural veg & crop) to a new specified total, which is no longer appropriate since crops are treated symmetrically as with other landunits.  Instead of modifying this subroutine, I created a new one, adjust_total_natveg_area that adjusts only the natural vegetated area to a new specified total.  I haven’t removed the old subroutine for now even though it is no longer used.
There are two errors checks I’ve left in (marked with “!KO”) that may no longer be useful or necessary or correct.  It may be that they need to be changed with respect to the crop landunit, but I’m not quite sure what the intended purpose of these are.  I’ve left these in unmodified for now since they are simply error checks and don’t actually change any of the landcover variables. And they don’t seem to be triggered in my testing.

Contributors other than yourself, if any:  Bill Sacks

CTSM Issues Fixed (include github issue #):
Resolves #1555

Are answers expected to change (and if so in what way)? Yes, surface datasets will be different

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:

For initial testing, I’ve created a 0.9x1.25 surface dataset and landuse file from ctsm5.1.dev062 and then the same set of files from the modified mksurfdata_map.  The new surface dataset has 7 variables that are different: PCT_NATVEG, PCT_CROP, PCT_NAT_PFT, PCT_CFT, PCT_LAKE, PCT_GLACIER, PCT_URBAN.  The MAXimum (increase) and MINimum (decrease) of these differences are:

(0)     MAX pct_natveg: 2.842170943040401e-14
(0)     MIN pct_natveg: -10.67630993642207
(0)     MAX pct_crop: 10.67630993642206
(0)     MIN pct_crop: -1.4210854715202e-14
(0)     MAX pct_lake: 1.55750967678614e-11
(0)     MIN pct_lake: -0.2633625082721949
(0)     MAX pct_glacier: 4.760636329592671e-13
(0)     MIN pct_glacier: -7.105427357601002e-15
(0)     MAX pct_urban: 6.350475700855895e-13
(0)     MIN pct_urban: -0.03106996610432056
(0)     MAX pct_wetland: 0
(0)     MIN pct_wetland: 0
(0)     MAX pct_nat_pft: 90.21452585120576
(0)     MIN pct_nat_pft: -52.42969544487663
(0)     MAX pct_cft: 2.81071874515417e-09
(0)     MIN pct_cft: -9.416396551387152e-10
The largest differences are in PCT_NAT_PFT.  The largest increase is associated with bare soil because urban is no longer replacing bare soil preferentially.  Glacier has roundoff differences.  Lake and Urban show a small decrease, presumably because Crop is now included in the initial normalization.  The largest increase is crop is equivalent to the largest decrease in natural vegetation.  I might not expect PCT_CFT to change but the largest changes are on the order of e-09 (roundoff?).
The new landuse timeseries has 6 variables that are different: PCT_CROP_MAX, PCT_NAT_PFT_MAX, PCT_CFT_MAX, PCT_CROP, PCT_NAT_PFT, PCT_CFT.  The MAXimum (increase) and MINimum (decrease) of these differences are:
(0)     MAX pct_crop: 16.4328269096183
(0)     MIN pct_crop: -5.684341886080801e-14
(0)     MAX pct_crop_max: 16.4328269096183
(0)     MIN pct_crop_max: -2.842170943040401e-14
(0)     MAX pct_nat_pft: 98.50930869418386
(0)     MIN pct_nat_pft: -77.092800323726
(0)     MAX pct_nat_pft_max: 90.6516908188529
(0)     MIN pct_nat_pft_max: -77.092800323726
(0)     MAX pct_cft: 0.2290990088236286
(0)     MIN pct_cft: -0.2965845809809196
(0)     MAX pct_cft_max: 0.172655463450238
(0)     MIN pct_cft_max: -0.2965845427981293

I ran a short historical simulation with the new files successfully.
Are there any mksurdata unit tests or other tests that should be run to check functionality?
