### PR TITLE
Remove reference to LND_DOMAIN_FILE and LND_DOMAIN_PATH for nuopc cases

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -87,7 +87,7 @@ required = True
 local_path = doc/doc-builder
 protocol = git
 repo_url = https://github.com/ESMCI/doc-builder
-tag = v1.0.5
+tag = v1.0.8
 required = False
 
 [externals_description]

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -130,8 +130,10 @@ class LILACSMOKE(SystemTestsCommon):
     def _create_runtime_inputs(self):
         caseroot = self._case.get_value('CASEROOT')
         runtime_inputs = self._runtime_inputs_dir()
-        lnd_domain_file = os.path.join(self._case.get_value('LND_DOMAIN_PATH'),
-                                       self._case.get_value('LND_DOMAIN_FILE'))
+
+        # NOTE: *** this test is currently tied to this single 4x5 grid resolution ***
+        lnd_domain_file = os.path.join(self._case.get_value('DIN_LOC_ROOT'),"share","domains",
+                                       'domain.lnd.fv4x5_gx3v7.091218.nc')
 
         # Cheat a bit here: Get the fsurdat file from the already-generated lnd_in file in
         # the host test case - i.e., from the standard cime-based preview_namelists. But

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -156,10 +156,8 @@ class LILACSMOKE(SystemTestsCommon):
         # The user_nl_ctsm in the case directory is set up based on the standard testmods
         # mechanism. We use that one in place of the standard user_nl_ctsm, since the one
         # in the case directory may contain test-specific modifications.
-        print ("DEBUG: caseroot is {}".format(caseroot))
-        print ("DEBUG: runtime_inputs is {}".format(runtime_inputs))
-        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_clm'),
-                        dst=os.path.join(runtime_inputs, 'user_nl_clm'))
+        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_ctsm'),
+                        dst=os.path.join(runtime_inputs, 'user_nl_ctsm'))
 
         script_to_run = os.path.join(runtime_inputs, 'make_runtime_inputs')
         self._run_build_cmd('{} --rundir {}'.format(script_to_run, runtime_inputs),

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -131,9 +131,12 @@ class LILACSMOKE(SystemTestsCommon):
         caseroot = self._case.get_value('CASEROOT')
         runtime_inputs = self._runtime_inputs_dir()
 
-        # NOTE: *** this test is currently tied to this single 4x5 grid resolution ***
+        # NOTE: *** this test is currently tied to this single 10x15 grid resolution ***
+        lnd_grid = self._case.get_value('LND_GRID') 
+        expect(lnd_grid == '10x15',
+               "this test is currently tied to this single 10x15 grid resolution")
         lnd_domain_file = os.path.join(self._case.get_value('DIN_LOC_ROOT'),"share","domains",
-                                       'domain.lnd.fv4x5_gx3v7.091218.nc')
+                                       "domain.lnd.fv10x15_gx3v7.180321.nc")
 
         # Cheat a bit here: Get the fsurdat file from the already-generated lnd_in file in
         # the host test case - i.e., from the standard cime-based preview_namelists. But
@@ -153,8 +156,10 @@ class LILACSMOKE(SystemTestsCommon):
         # The user_nl_ctsm in the case directory is set up based on the standard testmods
         # mechanism. We use that one in place of the standard user_nl_ctsm, since the one
         # in the case directory may contain test-specific modifications.
-        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_ctsm'),
-                        dst=os.path.join(runtime_inputs, 'user_nl_ctsm'))
+        print ("DEBUG: caseroot is {}".format(caseroot))
+        print ("DEBUG: runtime_inputs is {}".format(runtime_inputs))
+        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_clm'),
+                        dst=os.path.join(runtime_inputs, 'user_nl_clm'))
 
         script_to_run = os.path.join(runtime_inputs, 'make_runtime_inputs')
         self._run_build_cmd('{} --rundir {}'.format(script_to_run, runtime_inputs),

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -50,8 +50,6 @@ def buildnml(case, caseroot, compname):
     clm_accelerated_spinup = case.get_value("CLM_ACCELERATED_SPINUP")
     comp_atm = case.get_value("COMP_ATM")
     lnd_grid = case.get_value("LND_GRID")
-    lnd_domain_path = case.get_value("LND_DOMAIN_PATH")
-    lnd_domain_file = case.get_value("LND_DOMAIN_FILE")
     ninst_lnd = case.get_value("NINST_LND")
     rundir = case.get_value("RUNDIR")
     run_type = case.get_value("RUN_TYPE")
@@ -176,6 +174,8 @@ def buildnml(case, caseroot, compname):
     if driver == "nuopc":
         lndfrac_setting = " "
     else:
+        lnd_domain_path = case.get_value("LND_DOMAIN_PATH")
+        lnd_domain_file = case.get_value("LND_DOMAIN_FILE")
         lndfrac_file = os.path.join(lnd_domain_path,lnd_domain_file)
         lndfrac_setting = "-lnd_frac "+lndfrac_file
 

--- a/doc/.ChangeLog_template
+++ b/doc/.ChangeLog_template
@@ -111,10 +111,13 @@ infrastructure should be run when appropriate, as described below.
 
     (any machine) -
 
-    [If python code has changed and you aren't running aux_clm (e.g., because the only changes are in python
+    [If python code has changed and you are NOT running aux_clm (e.g., because the only changes are in python
      code) then also run the clm_pymods test suite; this is a small subset of aux_clm that runs the system
-     tests impacted by python changes. If you are already running the full aux_clm then this is unnecessary
-     and you can remove the following line.]
+     tests impacted by python changes. The best way to do this, if you expect no changes from the last tag in
+     either model output or namelists, is: create sym links pointing to the last tag's baseline directory,
+     named with the upcoming tag; then run the clm_pymods test suite comparing against these baselines but NOT
+     doing their own baseline generation. If you are already running the full aux_clm then you do NOT need to
+     separately run the clm_pymods test suite, and you can remove the following line.]
 
     clm_pymods test suite on cheyenne - 
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,14 +12,12 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-# 'make fetch-images' should be run before building the
-# documentation. (If building via https://github.com/ESMCI/doc-builder,
-# this is run automatically for you.) This is needed because we have
-# configured this repository (via an .lfsconfig file at the top level)
-# to NOT automatically fetch any of the large files when cloning /
-# fetching.
+# 'make fetch-images' should be run before building the documentation. (If building via
+# the build_docs command, this is run automatically for you.) This is needed because we
+# have configured this repository (via an .lfsconfig file at the top level) to NOT
+# automatically fetch any of the large files when cloning / fetching.
 fetch-images:
-	git lfs pull --exclude=""
+	git lfs pull --exclude="" --include=""
 
 .PHONY: help fetch-images Makefile
 

--- a/doc/build_docs
+++ b/doc/build_docs
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 if [ -f doc-builder/build_docs ]; then
-    echo "Running: doc-builder/build_docs --fetch-images $@"
-    doc-builder/build_docs --fetch-images "$@"
+    echo "Running: make fetch-images"
+    make fetch-images
+    echo "Running: ./doc-builder/build_docs $@"
+    ./doc-builder/build_docs "$@"
 else
     echo "Obtain doc-builder by running ./manage_externals/checkout_externals -o from the top-level"
 fi


### PR DESCRIPTION
### Description of changes
Remove reference to LND_DOMAIN_FILE and LND_DOMAIN_PATH for nuopc

### Specific notes
Using NUOPC, the only need for having the xml variables LND_DOMAIN_FILE and LND_DOMAIN_PATH was for the LILAC smoke test. This PR removes that dependency by hard-wiring the path to the domain file for the test itself in lilacsmoke.py.
When LILAC is used in an external model (e.g. WRF), users will have to manually add the correct fatmlnd_frc and fsurdat entries for their particular resolution, so this will not come from CIME anyway. 

Contributors other than yourself, if any: @billsacks 

CTSM Issues Fixed: None

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any: ran LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.cheyenne_intel.clm-lilac successfully.
