### PR TITLE
Remove reference to LND_DOMAIN_FILE and LND_DOMAIN_PATH for nuopc cases

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -37,7 +37,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime6.0.11
+tag = cime6.0.12
 required = True
 
 [cmeps]
@@ -48,7 +48,7 @@ local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.32
+tag = cdeps0.12.34
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -37,7 +37,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime6.0.12
+tag = branch_tags/cime6.0.12_a01
 required = True
 
 [cmeps]

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -130,8 +130,10 @@ class LILACSMOKE(SystemTestsCommon):
     def _create_runtime_inputs(self):
         caseroot = self._case.get_value('CASEROOT')
         runtime_inputs = self._runtime_inputs_dir()
-        lnd_domain_file = os.path.join(self._case.get_value('LND_DOMAIN_PATH'),
-                                       self._case.get_value('LND_DOMAIN_FILE'))
+
+        # NOTE: *** this test is currently tied to this single 4x5 grid resolution ***
+        lnd_domain_file = os.path.join(self._case.get_value('DIN_LOC_ROOT'),"share","domains",
+                                       'domain.lnd.fv4x5_gx3v7.091218.nc')
 
         # Cheat a bit here: Get the fsurdat file from the already-generated lnd_in file in
         # the host test case - i.e., from the standard cime-based preview_namelists. But

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -1,5 +1,4 @@
-"""
-Implementation of the CIME LILACSMOKE (LILAC smoke) test.
+"""Implementation of the CIME LILACSMOKE (LILAC smoke) test.
 
 This is a CTSM-specific test. It tests the building and running of CTSM via LILAC. Compset
 is ignored, but grid is important. Also, it's important that this test use the nuopc
@@ -15,6 +14,10 @@ Important directories under CASEROOT are:
 Note that namelists for this test are generated in the build phase; they are NOT
 regenerated when the test is submitted / run. This means that, if you have made any
 changes that will impact namelists, you will need to rebuild this test.
+
+Note that this test is tied to a specific resolution (10x15) and has a hard-coded domain
+file for this resolution: see the setting of lnd_domain_file below.
+
 """
 
 import glob

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -156,10 +156,8 @@ class LILACSMOKE(SystemTestsCommon):
         # The user_nl_ctsm in the case directory is set up based on the standard testmods
         # mechanism. We use that one in place of the standard user_nl_ctsm, since the one
         # in the case directory may contain test-specific modifications.
-        print ("DEBUG: caseroot is {}".format(caseroot))
-        print ("DEBUG: runtime_inputs is {}".format(runtime_inputs))
-        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_clm'),
-                        dst=os.path.join(runtime_inputs, 'user_nl_clm'))
+        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_ctsm'),
+                        dst=os.path.join(runtime_inputs, 'user_nl_ctsm'))
 
         script_to_run = os.path.join(runtime_inputs, 'make_runtime_inputs')
         self._run_build_cmd('{} --rundir {}'.format(script_to_run, runtime_inputs),

--- a/cime_config/SystemTests/lilacsmoke.py
+++ b/cime_config/SystemTests/lilacsmoke.py
@@ -131,9 +131,12 @@ class LILACSMOKE(SystemTestsCommon):
         caseroot = self._case.get_value('CASEROOT')
         runtime_inputs = self._runtime_inputs_dir()
 
-        # NOTE: *** this test is currently tied to this single 4x5 grid resolution ***
+        # NOTE: *** this test is currently tied to this single 10x15 grid resolution ***
+        lnd_grid = self._case.get_value('LND_GRID') 
+        expect(lnd_grid == '10x15',
+               "this test is currently tied to this single 10x15 grid resolution")
         lnd_domain_file = os.path.join(self._case.get_value('DIN_LOC_ROOT'),"share","domains",
-                                       'domain.lnd.fv4x5_gx3v7.091218.nc')
+                                       "domain.lnd.fv10x15_gx3v7.180321.nc")
 
         # Cheat a bit here: Get the fsurdat file from the already-generated lnd_in file in
         # the host test case - i.e., from the standard cime-based preview_namelists. But
@@ -153,8 +156,10 @@ class LILACSMOKE(SystemTestsCommon):
         # The user_nl_ctsm in the case directory is set up based on the standard testmods
         # mechanism. We use that one in place of the standard user_nl_ctsm, since the one
         # in the case directory may contain test-specific modifications.
-        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_ctsm'),
-                        dst=os.path.join(runtime_inputs, 'user_nl_ctsm'))
+        print ("DEBUG: caseroot is {}".format(caseroot))
+        print ("DEBUG: runtime_inputs is {}".format(runtime_inputs))
+        shutil.copyfile(src=os.path.join(caseroot, 'user_nl_clm'),
+                        dst=os.path.join(runtime_inputs, 'user_nl_clm'))
 
         script_to_run = os.path.join(runtime_inputs, 'make_runtime_inputs')
         self._run_build_cmd('{} --rundir {}'.format(script_to_run, runtime_inputs),

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -50,8 +50,6 @@ def buildnml(case, caseroot, compname):
     clm_accelerated_spinup = case.get_value("CLM_ACCELERATED_SPINUP")
     comp_atm = case.get_value("COMP_ATM")
     lnd_grid = case.get_value("LND_GRID")
-    lnd_domain_path = case.get_value("LND_DOMAIN_PATH")
-    lnd_domain_file = case.get_value("LND_DOMAIN_FILE")
     ninst_lnd = case.get_value("NINST_LND")
     rundir = case.get_value("RUNDIR")
     run_type = case.get_value("RUN_TYPE")
@@ -176,6 +174,8 @@ def buildnml(case, caseroot, compname):
     if driver == "nuopc":
         lndfrac_setting = " "
     else:
+        lnd_domain_path = case.get_value("LND_DOMAIN_PATH")
+        lnd_domain_file = case.get_value("LND_DOMAIN_FILE")
         lndfrac_file = os.path.join(lnd_domain_path,lnd_domain_file)
         lndfrac_setting = "-lnd_frac "+lndfrac_file
 

--- a/src/README.unit_testing
+++ b/src/README.unit_testing
@@ -5,7 +5,7 @@
 # time you ran them from this directory.
 
 # From a standalone CTSM checkout:
-../cime/scripts/fortran_unit_testing/run_tests.py --build-dir unit_tests.temp
+CIME_NO_CMAKE_MACRO=ON ../cime/scripts/fortran_unit_testing/run_tests.py --build-dir unit_tests.temp
 
 # If you are within a full CESM checkout, you would instead do:
 # ../../../cime/scripts/fortran_unit_testing/run_tests.py --build-dir unit_tests.temp


### PR DESCRIPTION
### Description of changes

Remove reference to LND_DOMAIN_FILE and LND_DOMAIN_PATH for nuopc

**These changes are from @mvertens . This is essentially a duplicate of #1589 but with fixed git history.**

### Specific notes
Using NUOPC, the only need for having the xml variables LND_DOMAIN_FILE and LND_DOMAIN_PATH was for the LILAC smoke test. This PR removes that dependency by hard-wiring the path to the domain file for the test itself in lilacsmoke.py.
When LILAC is used in an external model (e.g. WRF), users will have to manually add the correct fatmlnd_frc and fsurdat entries for their particular resolution, so this will not come from CIME anyway. 

Contributors other than yourself, if any: @mvertens 

CTSM Issues Fixed: None

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any: ran LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.cheyenne_intel.clm-lilac successfully.
