### PR TITLE
Fix get_curr_yearfrac and get_prev_yearfrac with Gregorian calendar

### DIFF
--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1258,6 +1258,16 @@
       <option name="tput_tolerance">0.5</option>
     </options>
   </test>
+  <test name="SMS_Ly5_Mmpi-serial" grid="1x1_smallvilleIA" compset="IHistClm50BgcCropQianRs" testmods="clm/gregorian_cropMonthOutput">
+    <machines>
+      <machine name="cheyenne" compiler="gnu" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment"  >Multi-year Gregorian test with transient and crop to test code that might break in leap years.</option>
+      <option name="tput_tolerance">0.5</option>
+    </options>
+  </test>
   <test name="LII_D_Ld3" grid="f19_g17" compset="I2000Clm50BgcCrop" testmods="clm/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_clm"/>

--- a/cime_config/testdefs/testmods_dirs/clm/gregorian_cropMonthOutput/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/gregorian_cropMonthOutput/include_user_mods
@@ -1,0 +1,1 @@
+../cropMonthOutput

--- a/cime_config/testdefs/testmods_dirs/clm/gregorian_cropMonthOutput/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/gregorian_cropMonthOutput/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange CALENDAR=GREGORIAN

--- a/src/biogeochem/CNAnnualUpdateMod.F90
+++ b/src/biogeochem/CNAnnualUpdateMod.F90
@@ -28,7 +28,7 @@ contains
     ! On the radiation time step, update annual summation variables
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size_real, get_days_per_year
+    use clm_time_manager, only: get_step_size_real, get_curr_days_per_year
     use clm_varcon      , only: secspday
     use SubgridAveMod   , only: p2c
     !
@@ -51,7 +51,7 @@ contains
     !-----------------------------------------------------------------------
 
     dt = get_step_size_real()
-    secspyear = get_days_per_year() * secspday
+    secspyear = get_curr_days_per_year() * secspday
 
     do fc = 1,num_soilc
        c = filter_soilc(fc)

--- a/src/biogeochem/CNC14DecayMod.F90
+++ b/src/biogeochem/CNC14DecayMod.F90
@@ -5,7 +5,7 @@ module CNC14DecayMod
   !
   ! !USES:
   use shr_kind_mod                       , only : r8 => shr_kind_r8
-  use clm_time_manager                   , only : get_step_size_real, get_days_per_year
+  use clm_time_manager                   , only : get_step_size_real, get_curr_days_per_year
   use clm_varpar                         , only : nlevdecomp, ndecomp_pools
   use clm_varcon                         , only : secspday
   use clm_varctl                         , only : spinup_state
@@ -87,7 +87,7 @@ contains
 
       ! set time steps
       dt = get_step_size_real()
-      days_per_year = get_days_per_year()
+      days_per_year = get_curr_days_per_year()
 
       half_life = 5730._r8 * secspday * days_per_year
       decay_const = - log(0.5_r8) / half_life

--- a/src/biogeochem/CNCIsoAtmTimeSeriesReadMod.F90
+++ b/src/biogeochem/CNCIsoAtmTimeSeriesReadMod.F90
@@ -5,7 +5,7 @@ module CIsoAtmTimeseriesMod
   !
   ! !USES:
   use shr_kind_mod     , only : r8 => shr_kind_r8
-  use clm_time_manager , only : get_curr_date,get_days_per_year, get_curr_yearfrac
+  use clm_time_manager , only : get_curr_date, get_curr_yearfrac
   use clm_varcon       , only : c14ratio, secspday
   use shr_const_mod    , only : SHR_CONST_PDB                    ! Ratio of C13/C12
   use clm_varctl       , only : iulog

--- a/src/biogeochem/CNFUNMod.F90
+++ b/src/biogeochem/CNFUNMod.F90
@@ -124,7 +124,7 @@ module CNFUNMod
   !
   ! !USES:
   use clm_varcon      , only: secspday, fun_period
-  use clm_time_manager, only: get_step_size_real,get_nstep,get_curr_date,get_days_per_year
+  use clm_time_manager, only: get_step_size_real,get_nstep,get_curr_date,get_curr_days_per_year
   !
   ! !ARGUMENTS:
   type(bounds_type)             , intent(in)    :: bounds
@@ -166,7 +166,7 @@ module CNFUNMod
   !---
   ! set time steps
   dt           = get_step_size_real()
-  dayspyr      = get_days_per_year()
+  dayspyr      = get_curr_days_per_year()
   nstep        = get_nstep()
   timestep_fun = real(secspday * fun_period)
   nstep_fun    = int(secspday * dayspyr / dt) 
@@ -210,7 +210,7 @@ module CNFUNMod
        & soilbiogeochem_nitrogenstate_inst)
 
 ! !USES:
-   use clm_time_manager, only : get_step_size_real, get_curr_date, get_days_per_year 
+   use clm_time_manager, only : get_step_size_real, get_curr_date
    use clm_varpar      , only : nlevdecomp
    use clm_varcon      , only : secspday, smallValue, fun_period, tfrz, dzsoi_decomp, spval
    use clm_varctl      , only : use_nitrif_denitrif

--- a/src/biogeochem/CNFireBaseMod.F90
+++ b/src/biogeochem/CNFireBaseMod.F90
@@ -440,7 +440,7 @@ contains
    ! seconds_per_year is the number of seconds in a year.
    !
    ! !USES:
-   use clm_time_manager     , only: get_step_size_real,get_days_per_year,get_curr_date
+   use clm_time_manager     , only: get_step_size_real,get_curr_days_per_year,get_curr_date
    use clm_varctl           , only: use_cndv
    use clm_varcon           , only: secspday
    use pftconMod            , only: nc3crop
@@ -683,7 +683,7 @@ contains
      ! calculate burned area fraction per sec
      dt = get_step_size_real()
 
-     dayspyr = get_days_per_year()
+     dayspyr = get_curr_days_per_year()
      !
      ! patch loop
      !

--- a/src/biogeochem/CNFireLi2014Mod.F90
+++ b/src/biogeochem/CNFireLi2014Mod.F90
@@ -91,7 +91,7 @@ contains
     ! Computes column-level burned area
     !
     ! !USES:
-    use clm_time_manager     , only: get_step_size_real, get_days_per_year, get_curr_date, get_nstep
+    use clm_time_manager     , only: get_step_size_real, get_curr_days_per_year, get_curr_date, get_nstep
     use clm_varcon           , only: secspday, secsphr
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
     use pftconMod            , only: nbrdlf_evr_trp_tree, nbrdlf_dcd_trp_tree, nbrdlf_evr_shrub
@@ -247,7 +247,7 @@ contains
            leafc_col(bounds%begc:bounds%endc))
 
      call get_curr_date (kyr, kmo, kda, mcsec)
-     dayspyr = get_days_per_year()
+     dayspyr = get_curr_days_per_year()
      ! Get model step size
      dt      = get_step_size_real()
      !
@@ -646,7 +646,7 @@ contains
    ! seconds_per_year is the number of seconds in a year.
    !
    ! !USES:
-   use clm_time_manager     , only: get_step_size_real,get_days_per_year,get_curr_date
+   use clm_time_manager     , only: get_step_size_real,get_curr_days_per_year,get_curr_date
    use clm_varctl           , only: use_cndv
    use clm_varcon           , only: secspday
    use clm_varpar           , only: i_met_lit, i_litr_max
@@ -886,7 +886,7 @@ contains
      ! calculate burned area fraction per sec
      dt = get_step_size_real()
 
-     dayspyr = get_days_per_year()
+     dayspyr = get_curr_days_per_year()
      !
      ! patch loop
      !

--- a/src/biogeochem/CNFireLi2016Mod.F90
+++ b/src/biogeochem/CNFireLi2016Mod.F90
@@ -95,7 +95,7 @@ contains
     ! Computes column-level burned area
     !
     ! !USES:
-    use clm_time_manager     , only: get_step_size_real, get_days_per_year, get_curr_date, get_nstep
+    use clm_time_manager     , only: get_step_size_real, get_curr_days_per_year, get_curr_date, get_nstep
     use clm_varcon           , only: secspday, secsphr
     use clm_varctl           , only: spinup_state
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
@@ -268,7 +268,7 @@ contains
            deadstemc_col(bounds%begc:bounds%endc))
 
      call get_curr_date (kyr, kmo, kda, mcsec)
-     dayspyr = get_days_per_year()
+     dayspyr = get_curr_days_per_year()
      ! Get model step size
      dt      = get_step_size_real()
      !

--- a/src/biogeochem/CNFireLi2021Mod.F90
+++ b/src/biogeochem/CNFireLi2021Mod.F90
@@ -95,7 +95,7 @@ contains
     ! Computes column-level burned area
     !
     ! !USES:
-    use clm_time_manager     , only: get_step_size_real, get_days_per_year, get_curr_date, get_nstep
+    use clm_time_manager     , only: get_step_size_real, get_curr_days_per_year, get_curr_date, get_nstep
     use clm_varcon           , only: secspday, secsphr
     use clm_varctl           , only: spinup_state
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
@@ -267,7 +267,7 @@ contains
            deadstemc_col(bounds%begc:bounds%endc))
 
      call get_curr_date (kyr, kmo, kda, mcsec)
-     dayspyr = get_days_per_year()
+     dayspyr = get_curr_days_per_year()
      ! Get model step size
      dt      = get_step_size_real()
      !

--- a/src/biogeochem/CNGapMortalityMod.F90
+++ b/src/biogeochem/CNGapMortalityMod.F90
@@ -88,7 +88,7 @@ contains
     ! Gap-phase mortality routine for coupled carbon-nitrogen code (CN)
     !
     ! !USES:
-    use clm_time_manager , only: get_days_per_year
+    use clm_time_manager , only: get_curr_days_per_year
     use clm_varpar       , only: nlevdecomp_full
     use clm_varcon       , only: secspday
     use clm_varctl       , only: use_cndv, spinup_state
@@ -180,7 +180,7 @@ contains
 
          end if
 
-         m  = am/(get_days_per_year() * secspday)
+         m  = am/(get_curr_days_per_year() * secspday)
 
          !------------------------------------------------------
          ! patch-level gap mortality carbon fluxes

--- a/src/biogeochem/CNNDynamicsMod.F90
+++ b/src/biogeochem/CNNDynamicsMod.F90
@@ -156,7 +156,7 @@ contains
        waterfluxbulk_inst, soilbiogeochem_nitrogenflux_inst)
 
 
-    use clm_time_manager , only : get_days_per_year
+    use clm_time_manager , only : get_curr_days_per_year
     use shr_sys_mod      , only : shr_sys_flush
     use clm_varcon       , only : secspday, spval
  
@@ -178,7 +178,7 @@ contains
                   ffix_to_sminn    => soilbiogeochem_nitrogenflux_inst%ffix_to_sminn_col & ! Output: [real(:)  ] : free living N fixation to soil mineral N (gN/m2/s)
                 ) 
        
-       dayspyr = get_days_per_year()
+       dayspyr = get_curr_days_per_year()
        secs_per_year = dayspyr*24_r8*3600_r8
 
        do fc = 1,num_soilc
@@ -200,7 +200,7 @@ contains
     ! All N fixation goes to the soil mineral N pool.
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year
+    use clm_time_manager , only : get_curr_days_per_year
     use shr_sys_mod      , only : shr_sys_flush
     use clm_varcon       , only : secspday, spval
     use CNSharedParamsMod    , only: use_fun
@@ -224,7 +224,7 @@ contains
          nfix_to_sminn  => soilbiogeochem_nitrogenflux_inst%nfix_to_sminn_col & ! Output: [real(r8) (:)]  symbiotic/asymbiotic N fixation to soil mineral N (gN/m2/s)
          )
 
-      dayspyr = get_days_per_year()
+      dayspyr = get_curr_days_per_year()
 
       if ( nfix_timeconst > 0._r8 .and. nfix_timeconst < 500._r8 ) then
          ! use exponential relaxation with time constant nfix_timeconst for NPP - NFIX relation

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -497,7 +497,7 @@ contains
     ! For coupled carbon-nitrogen code (CN).
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year
+    use clm_time_manager , only : get_curr_days_per_year
     use clm_time_manager , only : get_curr_date, is_first_step
     !
     ! !ARGUMENTS:
@@ -537,7 +537,7 @@ contains
 
       ! set time steps
       
-      dayspyr = get_days_per_year()
+      dayspyr = get_curr_days_per_year()
 
       do fp = 1,num_soilp
          p = filter_soilp(fp)
@@ -589,7 +589,7 @@ contains
     !
     ! !USES:
     use clm_varcon       , only : secspday
-    use clm_time_manager , only : get_days_per_year
+    use clm_time_manager , only : get_curr_days_per_year
     use clm_varctl       , only : CN_evergreen_phenology_opt   
     !
     ! !ARGUMENTS:
@@ -677,7 +677,7 @@ contains
          lgsf       => cnveg_state_inst%lgsf_patch    & ! Output: [real(r8) (:) ]  long growing season factor [0-1]                  
          )
 
-      dayspyr   = get_days_per_year()
+      dayspyr   = get_curr_days_per_year()
 
       do fp = 1,num_soilp
          p = filter_soilp(fp)
@@ -1204,7 +1204,7 @@ contains
     ! per year.
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year
+    use clm_time_manager , only : get_curr_days_per_year
     use CNSharedParamsMod, only : use_fun
     use clm_varcon       , only : secspday
     use shr_const_mod    , only : SHR_CONST_TKFRZ, SHR_CONST_PI
@@ -1323,7 +1323,7 @@ contains
          )
 
       ! set time steps
-      dayspyr = get_days_per_year()
+      dayspyr = get_curr_days_per_year()
 
       ! specify rain threshold for leaf onset
       rain_threshold = 20._r8
@@ -1644,7 +1644,7 @@ contains
     ! handle CN fluxes during the phenological onset                       & offset periods.
     
     ! !USES:
-    use clm_time_manager , only : get_curr_date, get_curr_calday, get_days_per_year, get_rad_step_size
+    use clm_time_manager , only : get_curr_date, get_curr_calday, get_curr_days_per_year, get_rad_step_size
     use pftconMod        , only : ntmp_corn, nswheat, nwwheat, ntmp_soybean
     use pftconMod        , only : nirrig_tmp_corn, nirrig_swheat, nirrig_wwheat, nirrig_tmp_soybean
     use pftconMod        , only : ntrp_corn, nsugarcane, ntrp_soybean, ncotton, nrice
@@ -1749,7 +1749,7 @@ contains
          )
 
       ! get time info
-      dayspyr = get_days_per_year()
+      dayspyr = get_curr_days_per_year()
       jday    = get_curr_calday()
       call get_curr_date(kyr, kmo, kda, mcsec)
       dtrad   = real( get_rad_step_size(), r8 )

--- a/src/biogeochem/ch4Mod.F90
+++ b/src/biogeochem/ch4Mod.F90
@@ -4261,7 +4261,7 @@ contains
     ! !DESCRIPTION: Annual mean fields.
     !
     ! !USES:
-    use clm_time_manager, only: get_step_size_real, get_days_per_year, get_nstep
+    use clm_time_manager, only: get_step_size_real, get_curr_days_per_year, get_nstep
     use clm_varcon      , only: secspday
     !
     ! !ARGUMENTS:
@@ -4303,7 +4303,7 @@ contains
 
       ! set time steps
       dt = get_step_size_real()
-      secsperyear = real( get_days_per_year() * secspday, r8)
+      secsperyear = real( get_curr_days_per_year() * secspday, r8)
 
       do fc = 1,num_methc
          c = filter_methc(fc)

--- a/src/cpl/lilac/lnd_comp_esmf.F90
+++ b/src/cpl/lilac/lnd_comp_esmf.F90
@@ -621,8 +621,8 @@ contains
        ! Determine calendar day info
        !--------------------------------
 
-       calday = get_curr_calday()
-       caldayp1 = get_curr_calday(offset=dtime)
+       calday = get_curr_calday(reuse_day_365_for_day_366=.true.)
+       caldayp1 = get_curr_calday(offset=dtime, reuse_day_365_for_day_366=.true.)
 
        !--------------------------------
        ! Get time of next atmospheric shortwave calculation

--- a/src/cpl/mct/lnd_comp_mct.F90
+++ b/src/cpl/mct/lnd_comp_mct.F90
@@ -422,7 +422,7 @@ contains
        ! Determine doalb based on nextsw_cday sent from atm model
 
        nstep = get_nstep()
-       caldayp1 = get_curr_calday(offset=dtime)
+       caldayp1 = get_curr_calday(offset=dtime, reuse_day_365_for_day_366=.true.)
        if (nstep == 0) then
           doalb = .false.
        else if (nstep == 1) then
@@ -444,7 +444,7 @@ contains
        call t_barrierf('sync_clm_run1', mpicom)
        call t_startf ('clm_run')
        call t_startf ('shr_orb_decl')
-       calday = get_curr_calday()
+       calday = get_curr_calday(reuse_day_365_for_day_366=.true.)
        call shr_orb_decl( calday     , eccen, mvelpp, lambm0, obliqr, declin  , eccf )
        call shr_orb_decl( nextsw_cday, eccen, mvelpp, lambm0, obliqr, declinp1, eccf )
        call t_stopf ('shr_orb_decl')

--- a/src/cpl/mct/ndepStreamMod.F90
+++ b/src/cpl/mct/ndepStreamMod.F90
@@ -219,7 +219,7 @@ contains
  subroutine ndep_interp(bounds, atm2lnd_inst)
 
    !-----------------------------------------------------------------------
-   use clm_time_manager, only : get_curr_date, get_days_per_year
+   use clm_time_manager, only : get_curr_date, get_curr_days_per_year
    use clm_varcon      , only : secspday
    use atm2lndType     , only : atm2lnd_type
    !
@@ -244,7 +244,7 @@ contains
 
    if ( divide_by_secs_per_yr )then
       ig = 0
-      dayspyr = get_days_per_year( )
+      dayspyr = get_curr_days_per_year( )
       do g = bounds%begg,bounds%endg
          ig = ig+1
          atm2lnd_inst%forc_ndep_grc(g) = sdat%avs(1)%rAttr(1,ig) / (secspday * dayspyr)

--- a/src/cpl/nuopc/lnd_comp_nuopc.F90
+++ b/src/cpl/nuopc/lnd_comp_nuopc.F90
@@ -813,7 +813,7 @@ contains
        ! Determine doalb based on nextsw_cday sent from atm model
        !--------------------------------
 
-       caldayp1 = get_curr_calday(offset=dtime)
+       caldayp1 = get_curr_calday(offset=dtime, reuse_day_365_for_day_366=.true.)
 
        if (nstep == 0) then
           doalb = .false.
@@ -870,7 +870,7 @@ contains
        ! Note - the orbital inquiries set the values in clm_varorb via the module use statements
        call  clm_orbital_update(clock, iulog, masterproc, eccen, obliqr, lambm0, mvelpp, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       calday = get_curr_calday()
+       calday = get_curr_calday(reuse_day_365_for_day_366=.true.)
        call shr_orb_decl( calday     , eccen, mvelpp, lambm0, obliqr, declin  , eccf )
        call shr_orb_decl( nextsw_cday, eccen, mvelpp, lambm0, obliqr, declinp1, eccf )
        call t_stopf ('shr_orb_decl')

--- a/src/cpl/share_esmf/ndepStreamMod.F90
+++ b/src/cpl/share_esmf/ndepStreamMod.F90
@@ -213,7 +213,7 @@ contains
   subroutine ndep_interp(bounds, atm2lnd_inst)
 
     !-----------------------------------------------------------------------
-    use clm_time_manager , only : get_curr_date, get_days_per_year
+    use clm_time_manager , only : get_curr_date, get_curr_days_per_year
     use clm_varcon       , only : secspday
     use atm2lndType      , only : atm2lnd_type
     use dshr_methods_mod , only : dshr_fldbun_getfldptr
@@ -252,7 +252,7 @@ contains
     ! Fill in atm2lnd_inst%forc_ndep_grc
     if ( divide_by_secs_per_yr )then
        ig = 0
-       dayspyr = get_days_per_year( )
+       dayspyr = get_curr_days_per_year( )
        do g = bounds%begg,bounds%endg
           ig = ig+1
           atm2lnd_inst%forc_ndep_grc(g) = dataptr1d(ig) / (secspday * dayspyr)

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -317,10 +317,10 @@ contains
     
     ! Initialize daylength from the previous time step (needed so prev_dayl can be set correctly)
     call t_startf('init_orbd')
-    calday = get_curr_calday()
+    calday = get_curr_calday(reuse_day_365_for_day_366=.true.)
     call shr_orb_decl( calday, eccen, mvelpp, lambm0, obliqr, declin, eccf )
     dtime = get_step_size_real()
-    caldaym1 = get_curr_calday(offset=-int(dtime))
+    caldaym1 = get_curr_calday(offset=-int(dtime), reuse_day_365_for_day_366=.true.)
     call shr_orb_decl( caldaym1, eccen, mvelpp, lambm0, obliqr, declinm1, eccf )
     call t_stopf('init_orbd')
     call InitDaylength(bounds_proc, declin=declin, declinm1=declinm1, obliquity=obliqr)

--- a/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90
@@ -582,7 +582,7 @@ contains
     !  written by C. Koven based on original CLM4 decomposition cascade
     !
     ! !USES:
-    use clm_time_manager , only : get_days_per_year
+    use clm_time_manager , only : get_curr_days_per_year
     use shr_const_mod    , only : SHR_CONST_PI
     use clm_varcon       , only : secspday
     !
@@ -654,7 +654,7 @@ contains
               errMsg(sourcefile, __LINE__))
       endif
 
-      days_per_year = get_days_per_year()
+      days_per_year = get_curr_days_per_year()
 
       ! set "Q10" parameter
       Q10 = CNParamsShareInst%Q10

--- a/src/unit_test_shr/unittestTimeManagerMod.F90
+++ b/src/unit_test_shr/unittestTimeManagerMod.F90
@@ -40,7 +40,7 @@ module unittestTimeManagerMod
 contains
 
   !-----------------------------------------------------------------------
-  subroutine unittest_timemgr_setup(dtime)
+  subroutine unittest_timemgr_setup(dtime, use_gregorian_calendar)
     !
     ! !DESCRIPTION:
     ! Set up the time manager for each unit test.
@@ -49,13 +49,16 @@ contains
     !
     ! !USES:
     use ESMF, only : ESMF_Initialize, ESMF_SUCCESS
-    use clm_time_manager, only : set_timemgr_init, timemgr_init, NO_LEAP_C
+    use clm_time_manager, only : set_timemgr_init, timemgr_init, NO_LEAP_C, GREGORIAN_C
     !
     ! !ARGUMENTS:
     integer, intent(in), optional :: dtime  ! time step (seconds)
+    logical, intent(in), optional :: use_gregorian_calendar
     !
     ! !LOCAL VARIABLES:
     integer :: l_dtime  ! local version of dtime
+    logical :: l_use_gregorian_calendar  ! local version of use_gregorian_calendar
+    character(len=:), allocatable :: calendar
     integer :: rc ! return code
 
     integer, parameter :: dtime_default = 1800  ! time step (seconds)
@@ -80,13 +83,25 @@ contains
        l_dtime = dtime_default
     end if
 
+    if (present(use_gregorian_calendar)) then
+       l_use_gregorian_calendar = use_gregorian_calendar
+    else
+       l_use_gregorian_calendar = .false.
+    end if
+
     call ESMF_Initialize(rc=rc)
     if (rc /= ESMF_SUCCESS) then
        stop 'Error in ESMF_Initialize'
     end if
 
+    if (l_use_gregorian_calendar) then
+       calendar = GREGORIAN_C
+    else
+       calendar = NO_LEAP_C
+    end if
+
     call set_timemgr_init( &
-         calendar_in = NO_LEAP_C, &
+         calendar_in = calendar, &
          start_ymd_in = start_ymd, &
          start_tod_in = 0, &
          ref_ymd_in = ref_ymd, &

--- a/src/utils/AnnualFluxDribbler.F90
+++ b/src/utils/AnnualFluxDribbler.F90
@@ -316,8 +316,14 @@ contains
     end_index = get_end(bounds, this%bounds_subgrid_level)
     SHR_ASSERT_ALL_FL((ubound(flux) == (/end_index/)), sourcefile, __LINE__)
 
-    secs_per_year = get_days_per_year() * secspday
     dtime = get_step_size_real()
+
+    ! On the last time step of the year, get_days_per_year would use the "current" date
+    ! (i.e., time 0 of the next year) and so would give the number of days per year in the
+    ! next year. But what we actually want is the number of days per year in the
+    ! just-ending year; we achieve this by using an offset of -dtime in the call to
+    ! get_days_per_year.
+    secs_per_year = get_days_per_year(offset=-dtime) * secspday
 
     do i = beg_index, end_index
        flux_from_dribbling = this%amount_to_dribble(i) / secs_per_year

--- a/src/utils/AnnualFluxDribbler.F90
+++ b/src/utils/AnnualFluxDribbler.F90
@@ -64,7 +64,7 @@ module AnnualFluxDribbler
   use decompMod        , only : bounds_type, get_beg, get_end
   use decompMod        , only : subgrid_level_gridcell, subgrid_level_patch
   use clm_varcon       , only : secspday, nameg, namep
-  use clm_time_manager , only : get_days_per_year, get_step_size_real, is_beg_curr_year
+  use clm_time_manager , only : get_prev_days_per_year, get_step_size_real, is_beg_curr_year
   use clm_time_manager , only : get_curr_yearfrac, get_prev_yearfrac, get_prev_date
   use clm_time_manager , only : is_first_step
   !
@@ -316,14 +316,8 @@ contains
     end_index = get_end(bounds, this%bounds_subgrid_level)
     SHR_ASSERT_ALL_FL((ubound(flux) == (/end_index/)), sourcefile, __LINE__)
 
+    secs_per_year = get_prev_days_per_year() * secspday
     dtime = get_step_size_real()
-
-    ! On the last time step of the year, get_days_per_year would use the "current" date
-    ! (i.e., time 0 of the next year) and so would give the number of days per year in the
-    ! next year. But what we actually want is the number of days per year in the
-    ! just-ending year; we achieve this by using an offset of -dtime in the call to
-    ! get_days_per_year.
-    secs_per_year = get_days_per_year(offset=-dtime) * secspday
 
     do i = beg_index, end_index
        flux_from_dribbling = this%amount_to_dribble(i) / secs_per_year

--- a/src/utils/clm_time_manager.F90
+++ b/src/utils/clm_time_manager.F90
@@ -1244,7 +1244,7 @@ contains
     if ( .not. check_timemgr_initialized(sub) ) return
 
     cday          = get_curr_calday(offset=offset)
-    days_per_year = get_days_per_year()
+    days_per_year = get_days_per_year(offset=offset)
 
     get_curr_yearfrac = (cday - 1._r8)/days_per_year
 

--- a/src/utils/clm_time_manager.F90
+++ b/src/utils/clm_time_manager.F90
@@ -1140,6 +1140,10 @@ contains
     ! Return calendar day corresponding to specified time instant.
     ! Calendar day 1.0 = 0Z on Jan 1.
 
+    ! If the current run is using a Gregorian calendar, then the year is important, in
+    ! that it determines whether or not we're in a leap year for the sake of determining
+    ! the calendar day.
+
     ! Arguments
     integer, intent(in) :: &
          ymd,   &! date in yearmmdd format
@@ -1157,19 +1161,8 @@ contains
     date = TimeSetymd( ymd, tod, "get_calday" )
     call ESMF_TimeGet( date, dayOfYear_r8=get_calday, rc=rc )
     call chkrc(rc, sub//': error return from ESMF_TimeGet')
-    !----------------------------------------------------------------------------------------!
-!!!!!!!!!!!!!! WARNING HACK TO ENABLE Gregorian CALENDAR WITH SHR_ORB !!!!!!!!!!!!!!!!!!!!
-!!!! The following hack fakes day 366 by reusing day 365. This is just because the  !!!!!!
-!!!! current shr_orb_decl calculation can't handle days > 366.                      !!!!!!
-!!!!       Dani Bundy-Coleman and Erik Kluzek Aug/2008                              !!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    if ( (get_calday > 366.0) .and. (get_calday <= 367.0) .and. &
-         (trim(calendar) == GREGORIAN_C) )then
-       get_calday = get_calday - 1.0_r8
-    end if
-!!!!!!!!!!!!!! END HACK TO ENABLE Gregorian CALENDAR WITH SHR_ORB !!!!!!!!!!!!!!!!!!!!!!!!
-    !----------------------------------------------------------------------------------------!
-    if ( (get_calday < 1.0) .or. (get_calday > 366.0) )then
+
+    if ( (get_calday < 1.0) .or. (get_calday > 367.0) )then
        write(iulog,*) sub, ' = ', get_calday
        call shr_sys_abort( sub//': error calday out of range' )
     end if

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -83,7 +83,7 @@ module CLMFatesInterfaceMod
    use clm_time_manager  , only : is_restart
    use ncdio_pio         , only : file_desc_t, ncd_int, ncd_double
    use restUtilMod,        only : restartvar
-   use clm_time_manager  , only : get_days_per_year, &
+   use clm_time_manager  , only : get_curr_days_per_year, &
                                   get_curr_date,     &
                                   get_ref_date,      &
                                   timemgr_datediff,  &
@@ -3082,7 +3082,7 @@ module CLMFatesInterfaceMod
  subroutine GetAndSetTime()
 
    ! CLM MODULES
-   use clm_time_manager  , only : get_days_per_year, &
+   use clm_time_manager  , only : get_curr_days_per_year, &
                                   get_curr_date,     &
                                   get_ref_date,      &
                                   timemgr_datediff
@@ -3118,7 +3118,7 @@ module CLMFatesInterfaceMod
    reference_date = yr*10000 + mon*100 + day
 
    ! Get the defined number of days per year
-   days_per_year = get_days_per_year()
+   days_per_year = get_curr_days_per_year()
 
    ! Determine the model day
    call timemgr_datediff(reference_date, sec, current_date, current_tod, model_day)

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -74,6 +74,18 @@ contains
   end subroutine getCalday_leapYearDec31_returnsCorrectValue
 
   @Test
+  subroutine getCalday_leapYearDec31Reuse365_returnsCorrectValue(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: calday
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar=.true.)
+
+    calday = get_calday(41231, 43200, reuse_day_365_for_day_366=.true.)
+
+    @assertEqual(365.5_r8, calday)
+  end subroutine getCalday_leapYearDec31Reuse365_returnsCorrectValue
+
+  @Test
   subroutine getCurrCalday_jan1_returns1(this)
     class(TestTimeManager), intent(inout) :: this
     real(r8) :: calday
@@ -100,6 +112,20 @@ contains
 
     @assertEqual(366.5_r8, calday)
   end subroutine getCurrCalday_leapYearDec31_returnsCorrectValue
+
+  @Test
+  subroutine getCurrCalday_leapYearDec31Reuse365_returnsCorrectValue(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: calday
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar=.true.)
+
+    call set_date(yr=2000, mon=12, day=31, tod=43200)
+
+    calday = get_curr_calday(reuse_day_365_for_day_366=.true.)
+
+    @assertEqual(365.5_r8, calday)
+  end subroutine getCurrCalday_leapYearDec31Reuse365_returnsCorrectValue
 
   @Test
   subroutine getCurrYearfrac_atYearBoundary_returns0(this)

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -74,6 +74,34 @@ contains
   end subroutine getCalday_leapYearDec31_returnsCorrectValue
 
   @Test
+  subroutine getCurrCalday_jan1_returns1(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: calday
+
+    call unittest_timemgr_setup(dtime=dtime)
+
+    call set_date(yr=2000, mon=1, day=1, tod=0)
+
+    calday = get_curr_calday()
+
+    @assertEqual(1._r8, calday)
+  end subroutine getCurrCalday_jan1_returns1
+
+  @Test
+  subroutine getCurrCalday_leapYearDec31_returnsCorrectValue(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: calday
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar=.true.)
+
+    call set_date(yr=2000, mon=12, day=31, tod=43200)
+
+    calday = get_curr_calday()
+
+    @assertEqual(366.5_r8, calday)
+  end subroutine getCurrCalday_leapYearDec31_returnsCorrectValue
+
+  @Test
   subroutine getCurrYearfrac_atYearBoundary_returns0(this)
     class(TestTimeManager), intent(inout) :: this
     real(r8) :: yearfrac
@@ -102,6 +130,22 @@ contains
     yearfrac_expected = 59.5_r8 / 365._r8
     @assertEqual(yearfrac_expected, yearfrac)
   end subroutine getCurrYearfrac_inMiddleOfYear_returnsCorrectValue
+
+  @Test
+  subroutine getCurrYearfrac_leapYearDec31_returnsCorrectValue(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: yearfrac
+    real(r8) :: yearfrac_expected
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar=.true.)
+
+    call set_date(yr=2000, mon=12, day=31, tod=43200)
+
+    yearfrac = get_curr_yearfrac()
+
+    yearfrac_expected = 365.5_r8 / 366._r8
+    @assertEqual(yearfrac_expected, yearfrac)
+  end subroutine getCurrYearfrac_leapYearDec31_returnsCorrectValue
 
   @Test
   subroutine getPrevYearfrac_atYearBoundary_returnsLargeValue(this)

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -29,7 +29,6 @@ contains
   subroutine setUp(this)
     class(TestTimeManager), intent(inout) :: this
     
-    call unittest_timemgr_setup(dtime=dtime)
   end subroutine setUp
 
   subroutine tearDown(this)
@@ -43,6 +42,8 @@ contains
     class(TestTimeManager), intent(inout) :: this
     integer :: step_size
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     step_size = get_step_size()
 
     @assertEqual(dtime, step_size)
@@ -52,6 +53,8 @@ contains
   subroutine getCurrYearfrac_atYearBoundary_returns0(this)
     class(TestTimeManager), intent(inout) :: this
     real(r8) :: yearfrac
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     call set_date(yr=2, mon=1, day=1, tod=0)
     
@@ -66,6 +69,8 @@ contains
     real(r8) :: yearfrac
     real(r8) :: yearfrac_expected
     
+    call unittest_timemgr_setup(dtime=dtime)
+
     call set_date(yr=2, mon=3, day=1, tod=43200)
 
     yearfrac = get_curr_yearfrac()
@@ -80,6 +85,8 @@ contains
     real(r8) :: yearfrac
     integer, parameter :: secs_in_day = 86400
     real(r8) :: yearfrac_expected
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     call set_date(yr=2, mon=1, day=1, tod=0)
     
@@ -96,6 +103,8 @@ contains
     integer, parameter :: secs_in_day = 86400
     real(r8) :: yearfrac_expected
     
+    call unittest_timemgr_setup(dtime=dtime)
+
     call set_date(yr=2, mon=3, day=1, tod=43200)
 
     yearfrac = get_prev_yearfrac()
@@ -105,9 +114,48 @@ contains
   end subroutine getPrevYearfrac_inMiddleOfYear_returnsCorrectValue
 
   @Test
+  subroutine getPrevYearfrac_leapYearInMiddleOfYear_returnsCorrectValue(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: yearfrac
+    integer, parameter :: secs_in_day = 86400
+    real(r8) :: yearfrac_expected
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar = .true.)
+
+    call set_date(yr=2000, mon=3, day=1, tod=43200)
+
+    yearfrac = get_prev_yearfrac()
+
+    yearfrac_expected = (60.5_r8 - real(dtime, r8) / real(secs_in_day, r8)) / 366._r8
+    @assertEqual(yearfrac_expected, yearfrac)
+  end subroutine getPrevYearfrac_leapYearInMiddleOfYear_returnsCorrectValue
+
+  @Test
+  subroutine getPrevYearfrac_leapYearAtYearBoundary_returnsCorrectValue(this)
+    ! This ensures that the correct year is used in determining the number of days in the year
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: yearfrac
+    integer, parameter :: secs_in_day = 86400
+    real(r8) :: yearfrac_expected
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar = .true.)
+
+    call set_date(yr=2000, mon=1, day=1, tod=0)
+
+    yearfrac = get_prev_yearfrac()
+
+    ! In the following, note that we have 365 and not 366, because the prev_yearfrac uses
+    ! year 1999, which is not a leap year:
+    yearfrac_expected = (365._r8 - real(dtime, r8) / real(secs_in_day, r8)) / 365._r8
+    @assertEqual(yearfrac_expected, yearfrac)
+  end subroutine getPrevYearfrac_leapYearAtYearBoundary_returnsCorrectValue
+
+  @Test
   subroutine getNstep_step0(this)
     class(TestTimeManager), intent(inout) :: this
     integer :: nstep
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     nstep = get_nstep()
 
@@ -119,6 +167,8 @@ contains
     class(TestTimeManager), intent(inout) :: this
     integer, parameter :: expected_nstep = 3
     integer :: nstep
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     call set_nstep(expected_nstep)
 
@@ -132,6 +182,8 @@ contains
     class(TestTimeManager), intent(inout) :: this
     logical :: is_beg
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     call set_date(yr=2, mon=1, day=1, tod=dtime)
 
     is_beg = is_beg_curr_year()
@@ -143,6 +195,8 @@ contains
   subroutine isBegCurrYear_notAtBeg(this)
     class(TestTimeManager), intent(inout) :: this
     logical :: is_beg
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     call set_date(yr=2, mon=1, day=2, tod=dtime)
 
@@ -156,6 +210,8 @@ contains
     class(TestTimeManager), intent(inout) :: this
     logical :: is_end
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     call set_date(yr=2, mon=1, day=1, tod=0)
 
     is_end = is_end_curr_year()
@@ -167,6 +223,8 @@ contains
   subroutine isEndCurrYear_notAtEnd(this)
     class(TestTimeManager), intent(inout) :: this
     logical :: is_end
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     call set_date(yr=2, mon=1, day=2, tod=0)
 
@@ -180,6 +238,8 @@ contains
     class(TestTimeManager), intent(inout) :: this
     logical :: is_first
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     is_first = is_first_step()
 
     @assertTrue(is_first)
@@ -189,6 +249,8 @@ contains
   subroutine isFirstStep_notAtFirstStep(this)
     class(TestTimeManager), intent(inout) :: this
     logical :: is_first
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     call set_nstep(1)
 
@@ -201,6 +263,8 @@ contains
   subroutine check_DA_nstep(this)
     class(TestTimeManager), intent(inout) :: this
     integer :: nstep
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     nstep = 100
     call set_nstep(nstep)
@@ -229,6 +293,8 @@ contains
     real(r8) :: londeg
     integer  :: expected
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     ! Check for local noon at Greenich
     londeg = 0.0_r8
     secs = 3600*12
@@ -254,6 +320,8 @@ contains
     integer :: secs
     real(r8) :: londeg
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     londeg = 0.0_r8
     do while ( londeg <= 360.0_r8 )
        londeg = londeg + 0.1_r8
@@ -276,6 +344,8 @@ contains
     real(r8) :: londeg
     integer  :: expected
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     ! Check for local noon at Greenich for 1 time step ahead
     londeg = 0.0_r8
     secs = 3600*12 + dtime
@@ -293,6 +363,8 @@ contains
 
     integer :: secs
     real(r8) :: londeg
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     ! Check for local noon at Greenich will be true from 11 to 1pm
     londeg = 0.0_r8
@@ -330,6 +402,8 @@ contains
     integer :: secs
     logical :: check
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     londeg = 0.0_r8
     secs = get_local_time( londeg )
     secs = 3600*24 - 1
@@ -349,6 +423,8 @@ contains
     real(r8) :: londeg
     integer :: secs
 
+    call unittest_timemgr_setup(dtime=dtime)
+
     londeg = -200.0_r8
     secs = get_local_time( londeg )
     expected_msg = endrun_msg( &
@@ -364,6 +440,8 @@ contains
     character(len=256) :: expected_msg
     real(r8) :: londeg
     integer :: secs
+
+    call unittest_timemgr_setup(dtime=dtime)
 
     londeg = 400.0_r8
     secs = get_local_time( londeg )

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -50,6 +50,30 @@ contains
   end subroutine getStepSize_returnsCorrectValue
 
   @Test
+  subroutine getCalday_jan1_returns1(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: calday
+
+    call unittest_timemgr_setup(dtime=dtime)
+
+    calday = get_calday(101, 0)
+
+    @assertEqual(1._r8, calday)
+  end subroutine getCalday_jan1_returns1
+
+  @Test
+  subroutine getCalday_leapYearDec31_returnsCorrectValue(this)
+    class(TestTimeManager), intent(inout) :: this
+    real(r8) :: calday
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar=.true.)
+
+    calday = get_calday(41231, 43200)
+
+    @assertEqual(366.5_r8, calday)
+  end subroutine getCalday_leapYearDec31_returnsCorrectValue
+
+  @Test
   subroutine getCurrYearfrac_atYearBoundary_returns0(this)
     class(TestTimeManager), intent(inout) :: this
     real(r8) :: yearfrac


### PR DESCRIPTION
### Description of changes

Fix get_curr_yearfrac and get_prev_yearfrac with Gregorian calendar.

Also add unit tests of get_prev_yearfrac with a Gregorian calendar.

### Specific notes

Contributors other than yourself, if any: @olyson gets most of the credit here

CTSM Issues Fixed (include github issue #):
- Resolves ESCOMP/CTSM#1590

Are answers expected to change (and if so in what way)? YES, but very limited: From a search through the code, I think this will only impact CNDV cases when run with the Gregorian calendar. (The changed code is also used by the AnnualFluxDribbler, but only to set some values in gridcell-level balance checks; this can cause a run failure as in #1590 but I don't think it will actually cause any answer changes. The changed code is also used for time-interpolated prescribed dynamic landuse (dyn_var_time_interp_type), but we currently don't use that for any variables.) **I think (but am not 100% sure) that these changes won't show up in any tests, so I'm marking this PR as bfb, since I think it will be bfb from a testing standpoint.**

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: Only unit tests so far
