### PR TITLE
Use UNSTRUCT mesh files instead of SCRIP when running mkmapdata.sh

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -112,27 +112,30 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <scripgriddata hgrid="tx0.1v2"    lmask="tx0.1v2"   >/glade/proj3/cseg/mapping/grids/tx0.1v2_090127.nc</scripgriddata>
 
 <!-- UNSTRUCT grid data files -->
-<!--scripgriddata frm_hgrid="0.5x0.5"   lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.5x0.5_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="0.5x0.5" lmask="nomask">UNSTRUCT</scripgriddata_type>
-<scripgriddata frm_hgrid="0.25x0.25" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="0.25x0.25" lmask="nomask">UNSTRUCT</scripgriddata_type>
-<scripgriddata frm_hgrid="0.125x0.125" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.125x0.125_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="0.125x0.125" lmask="nomask">UNSTRUCT</scripgriddata_type>
-<scripgriddata frm_hgrid="10x10min" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_10x10min_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="10x10min" lmask="nomask">UNSTRUCT</scripgriddata_type>
-<scripgriddata frm_hgrid="5x5min"    lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_5x5min_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="5x5min" lmask="nomask">UNSTRUCT</scripgriddata_type>
-<scripgriddata frm_hgrid="3x3min"    lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="3x3min" lmask="nomask">UNSTRUCT</scripgriddata_type>
-<scripgriddata frm_hgrid="0.9x1.25"  lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.9x1.25_nomask_c200129.nc</scripgriddata>
-<scripgriddata_type frm_hgrid="0.9x1.25" lmask="nomask">UNSTRUCT</scripgriddata_type-->
+<unstructdata frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
+   >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</unstructdata>
+<unstructdata_type frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">UGRID</unstructdata_type>
+<unstructdata frm_hgrid="0.5x0.5"   lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.5x0.5_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="0.5x0.5" lmask="nomask">UNSTRUCT</unstructdata_type>
+<unstructdata frm_hgrid="0.25x0.25" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="0.25x0.25" lmask="nomask">UNSTRUCT</unstructdata_type>
+<unstructdata frm_hgrid="0.125x0.125" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.125x0.125_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="0.125x0.125" lmask="nomask">UNSTRUCT</unstructdata_type>
+<unstructdata frm_hgrid="10x10min" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_10x10min_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="10x10min" lmask="nomask">UNSTRUCT</unstructdata_type>
+<unstructdata frm_hgrid="5x5min"    lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_5x5min_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="5x5min" lmask="nomask">UNSTRUCT</unstructdata_type>
+<unstructdata frm_hgrid="3x3min"    lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="3x3min" lmask="nomask">UNSTRUCT</unstructdata_type>
+<unstructdata frm_hgrid="0.9x1.25"  lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.9x1.25_nomask_c200129.nc</unstructdata>
+<unstructdata_type frm_hgrid="0.9x1.25" lmask="nomask">UNSTRUCT</unstructdata_type>
 
 <!-- land masks for different types of mksurfdata_map input files -->
 <lmask type="lak"              >nomask</lmask>

--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -22,44 +22,44 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Finite-Volume grids -->
 <scripgriddata hgrid="0.23x0.31" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.23x0.31_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="0.47x0.63" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.47x0.63_nomask_c170914.nc</scripgriddata>
-<scripgriddata hgrid="0.9x1.25"  lmask="nomask" >lnd/clm2/mappingdata/grids/0.9x1.25_c110307.nc</scripgriddata>
-<scripgriddata hgrid="1.9x2.5"   lmask="nomask" >lnd/clm2/mappingdata/grids/1.9x2.5_c110308.nc</scripgriddata>
+<scripgriddata hgrid="0.9x1.25"  lmask="nomask" >share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="1.9x2.5"   lmask="nomask" >share/meshes/fv1.9x2.5_141008_ESMFmesh.nc</scripgriddata>
 <scripgriddata hgrid="2.5x3.33"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_2.5x3.33_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="4x5"       lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_4x5_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="10x15"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_10x15_nomask_c110308.nc</scripgriddata>
+<scripgriddata hgrid="4x5"       lmask="nomask" >share/meshes/fv4x5_050615_polemod_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="10x15"     lmask="nomask" >share/meshes/10x15_nomask_c110308_ESMFmesh.nc</scripgriddata>
 
 <!-- Spectral Eulerian grids -->
 <scripgriddata hgrid="512x1024"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_512x1024_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="128x256"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_128x256_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="94x192"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_94x192_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="64x128"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_64x128_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="48x96"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_48x96_nomask_c110308.nc</scripgriddata>
+<scripgriddata hgrid="94x192"    lmask="nomask" >share/meshes/T62_040121_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="64x128"    lmask="nomask" >share/meshes/T42_ESMFmesh_c20200629.nc</scripgriddata>
+<scripgriddata hgrid="48x96"     lmask="nomask" >share/meshes/T31_040122_ESMFmesh.nc</scripgriddata>
 <scripgriddata hgrid="32x64"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_32x64_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="8x16"      lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_8x16_nomask_c110308.nc</scripgriddata>
 
 <!-- FV3 grids -->
-<scripgriddata hgrid="C384" lmask="nomask" >atm/cam/coords/C384_SCRIP_desc.181018.nc</scripgriddata>
-<scripgriddata hgrid="C192" lmask="nomask" >atm/cam/coords/C192_SCRIP_desc.181018.nc</scripgriddata>
-<scripgriddata hgrid="C96"  lmask="nomask" >atm/cam/coords/C96_SCRIP_desc.181018.nc</scripgriddata>
-<scripgriddata hgrid="C48"  lmask="nomask" >atm/cam/coords/C48_SCRIP_desc.181018.nc</scripgriddata>
-<scripgriddata hgrid="C24"  lmask="nomask" >atm/cam/coords/C24_SCRIP_desc.181018.nc</scripgriddata>
+<scripgriddata hgrid="C384" lmask="nomask" >share/meshes/C384_181018_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="C192" lmask="nomask" >share/meshes/C192_181018_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="C96"  lmask="nomask" >share/meshes/C96_181018_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="C48"  lmask="nomask" >share/meshes/C48_181018_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="C24"  lmask="nomask" >share/meshes/C24_181018_ESMFmesh.nc</scripgriddata>
 
 <!-- HOMME grids -->
-<scripgriddata hgrid="ne240np4"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne240np4_nomask_c091227.nc</scripgriddata>
-<scripgriddata hgrid="ne120np4"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne120np4_nomask_c101123.nc</scripgriddata>
-<scripgriddata hgrid="ne60np4"      lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne60np4_nomask_c100408.nc</scripgriddata>
-<scripgriddata hgrid="ne30np4"      lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne30np4_nomask_c101123.nc</scripgriddata>
-<scripgriddata hgrid="ne16np4"      lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_ne16np4_nomask_c110512.nc</scripgriddata>
+<scripgriddata hgrid="ne240np4"     lmask="nomask" >share/meshes/ne240np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne120np4"     lmask="nomask" >share/meshes/ne120np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne60np4"      lmask="nomask" >share/meshes/ne60np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne30np4"      lmask="nomask" >share/meshes/ne30np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne16np4"      lmask="nomask" >share/meshes/ne16np4_scrip_171002_ESMFmesh.nc</scripgriddata>
 <!-- HOMME SE dycore Physics grids -->
-<scripgriddata hgrid="ne30np4.pg2"  lmask="nomask" >atm/cam/coords/ne30pg2_scrip_c170608.nc</scripgriddata>
-<scripgriddata hgrid="ne30np4.pg3"  lmask="nomask" >atm/cam/coords/ne30pg3_scrip_170604.nc</scripgriddata>
-<scripgriddata hgrid="ne120np4.pg2" lmask="nomask" >atm/cam/coords/ne120pg2_scrip_c170629.nc</scripgriddata>
-<scripgriddata hgrid="ne120np4.pg3" lmask="nomask" >atm/cam/coords/ne120pg3_scrip_c170628.nc</scripgriddata>
+<scripgriddata hgrid="ne30np4.pg2"  lmask="nomask" >share/meshes/ne30pg2_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne30np4.pg3"  lmask="nomask" >share/meshes/ne30pg3_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne120np4.pg2" lmask="nomask" >share/meshes/ne120pg2_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<scripgriddata hgrid="ne120np4.pg3" lmask="nomask" >share/meshes/ne120pg3_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
 
 <!-- Refined mesh grids -->
-<scripgriddata hgrid="ne0np4CONUS.ne30x8"      lmask="nomask" >atm/cam/coords/ne0CONUSne30x8_scrip_c200107.nc</scripgriddata>
-<scripgriddata hgrid="ne0np4ARCTICGRIS.ne30x8" lmask="nomask" >atm/cam/coords/ne0ARCTICGRISne30x8_scrip_c191209.nc</scripgriddata>
-<scripgriddata hgrid="ne0np4ARCTIC.ne30x4"     lmask="nomask" >atm/cam/coords/ne0ARCTICne30x4_scrip_c191212.nc</scripgriddata>
+<scripgriddata hgrid="ne0np4CONUS.ne30x8"      lmask="nomask" >share/meshes/ne0CONUSne30x8_ESMFmesh_c20200727.nc</scripgriddata>
+<scripgriddata hgrid="ne0np4ARCTICGRIS.ne30x8" lmask="nomask" >share/meshes/ne0ARCTICGRISne30x8_ESMFmesh_c20200730.nc</scripgriddata>
+<scripgriddata hgrid="ne0np4ARCTIC.ne30x4"     lmask="nomask" >share/meshes/ne0ARCTICne30x4_ESMFmesh_c20200727.nc</scripgriddata>
 
 <!-- Regular lat/lon grids -->
 <scripgriddata hgrid="0.125x0.125" lmask="nomask"    
@@ -68,7 +68,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
    >lnd/clm2/mappingdata/grids/SCRIPgrid_0.33x0.33_navy_c111207.nc</scripgriddata>
 <!-- The 360x720cru grid is on 0-360 longitude grid and is important for running the model -->
 <scripgriddata hgrid="360x720cru" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_360x720_nomask_c120830.nc</scripgriddata>
+   >share/meshes/360x720_120830_ESMFmesh_c20210507.nc</scripgriddata>
 <!-- The half degree grid is on -180-180 longitude and is important for mksurfdata_map grids -->
 <scripgriddata hgrid="0.5x0.5"   lmask="nomask"
    >lnd/clm2/mappingdata/grids/SCRIPgrid_0.5x0.5_nomask_c110308.nc</scripgriddata>
@@ -93,7 +93,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <scripgriddata_meshname hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">landmesh</scripgriddata_meshname>
 
 <!-- Single-point / Regional grids -->
-<scripgriddata hgrid="0.125nldas2"         lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.125nldas2_nomask_c190328.nc</scripgriddata>
+<scripgriddata hgrid="0.125nldas2"         lmask="nomask" >share/meshes/0.125nldas2_ESMFmesh_cd5_241220.nc</scripgriddata>
 <scripgriddata hgrid="1x1_brazil"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_brazil_nomask_c20211211.nc</scripgriddata>
 <scripgriddata hgrid="1x1_mexicocityMEX"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_mexicocityMEX_nomask_c110308.nc</scripgriddata>
 <scripgriddata hgrid="1x1_numaIA"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_numaIA_nomask_c110308.nc</scripgriddata>
@@ -104,11 +104,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- Ocean grids -->
 <scripgriddata hgrid="0.33x0.33"  lmask="0.33x0.33" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.33x0.33_navy_c111207.nc</scripgriddata>
-<scripgriddata hgrid="5x5_amazon" lmask="navy"      >lnd/clm2/mappingdata/grids/SCRIPgrid_5x5_amazon_navy_c111207.nc</scripgriddata>
-<scripgriddata hgrid="gx1v6"      lmask="gx1v6"     >/glade/proj3/cseg/mapping/grids/gx1v6_090205.nc</scripgriddata>
-<scripgriddata hgrid="gx3v7"      lmask="gx3v7"     >/glade/proj3/cseg/mapping/grids/gx3v7_090903.nc</scripgriddata>
-<scripgriddata hgrid="tx1v1"      lmask="tx1v1"     >/glade/proj3/cseg/mapping/grids/tx1v1_090122.nc</scripgriddata>
-<scripgriddata hgrid="tx0.1v2"    lmask="tx0.1v2"   >/glade/proj3/cseg/mapping/grids/tx0.1v2_090127.nc</scripgriddata>
+<scripgriddata hgrid="5x5_amazon" lmask="navy"      >share/meshes/5x5pt-amazon_navy_ESMFmesh_cd5_c20210107.nc</scripgriddata>
+<scripgriddata hgrid="gx1v6"      lmask="gx1v6"     >share/meshes/gx1v6_090205_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="gx3v7"      lmask="gx3v7"     >share/meshes/gx3v7_120309_ESMFmesh.nc</scripgriddata>
+<scripgriddata hgrid="tx1v1"      lmask="tx1v1"     >share/meshes/tx1v1_ESMFMesh_cd5_c20210105.nc</scripgriddata>
+<scripgriddata hgrid="tx0.1v2"    lmask="tx0.1v2"   >share/meshes/tx0.1v2_ESMFmesh_cd5_c20210105.nc</scripgriddata>
 
 <!-- UNSTRUCT grid data files -->
 <unstructdata frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"

--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -18,7 +18,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- Set default values for grid attributes -->
 <scripgriddata_lrgfile_needed>none</scripgriddata_lrgfile_needed>
-<scripgriddata_type>SCRIP</scripgriddata_type>
 
 <!-- Finite-Volume grids -->
 <scripgriddata hgrid="0.23x0.31" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.23x0.31_nomask_c110308.nc</scripgriddata>
@@ -114,28 +113,20 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- UNSTRUCT grid data files -->
 <unstructdata frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
    >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</unstructdata>
-<unstructdata_type frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">UGRID</unstructdata_type>
 <unstructdata frm_hgrid="0.5x0.5"   lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.5x0.5_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="0.5x0.5" lmask="nomask">UNSTRUCT</unstructdata_type>
 <unstructdata frm_hgrid="0.25x0.25" lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="0.25x0.25" lmask="nomask">UNSTRUCT</unstructdata_type>
 <unstructdata frm_hgrid="0.125x0.125" lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.125x0.125_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="0.125x0.125" lmask="nomask">UNSTRUCT</unstructdata_type>
 <unstructdata frm_hgrid="10x10min" lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_10x10min_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="10x10min" lmask="nomask">UNSTRUCT</unstructdata_type>
 <unstructdata frm_hgrid="5x5min"    lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_5x5min_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="5x5min" lmask="nomask">UNSTRUCT</unstructdata_type>
 <unstructdata frm_hgrid="3x3min"    lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="3x3min" lmask="nomask">UNSTRUCT</unstructdata_type>
 <unstructdata frm_hgrid="0.9x1.25"  lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.9x1.25_nomask_c200129.nc</unstructdata>
-<unstructdata_type frm_hgrid="0.9x1.25" lmask="nomask">UNSTRUCT</unstructdata_type>
 
 <!-- land masks for different types of mksurfdata_map input files -->
 <lmask type="lak"              >nomask</lmask>

--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -17,116 +17,116 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- SCRIP grid data files -->
 
 <!-- Set default values for grid attributes -->
-<scripgriddata_lrgfile_needed>none</scripgriddata_lrgfile_needed>
+<meshdata_lrgfile_needed>none</meshdata_lrgfile_needed>
 
 <!-- Finite-Volume grids -->
-<scripgriddata hgrid="0.23x0.31" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.23x0.31_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="0.47x0.63" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.47x0.63_nomask_c170914.nc</scripgriddata>
-<scripgriddata hgrid="0.9x1.25"  lmask="nomask" >share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="1.9x2.5"   lmask="nomask" >share/meshes/fv1.9x2.5_141008_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="2.5x3.33"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_2.5x3.33_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="4x5"       lmask="nomask" >share/meshes/fv4x5_050615_polemod_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="10x15"     lmask="nomask" >share/meshes/10x15_nomask_c110308_ESMFmesh.nc</scripgriddata>
+<dstmeshdata hgrid="0.23x0.31" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.23x0.31_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="0.47x0.63" lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.47x0.63_nomask_c170914.nc</dstmeshdata>
+<dstmeshdata hgrid="0.9x1.25"  lmask="nomask" >share/meshes/fv0.9x1.25_141008_polemod_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="1.9x2.5"   lmask="nomask" >share/meshes/fv1.9x2.5_141008_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="2.5x3.33"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_2.5x3.33_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="4x5"       lmask="nomask" >share/meshes/fv4x5_050615_polemod_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="10x15"     lmask="nomask" >share/meshes/10x15_nomask_c110308_ESMFmesh.nc</dstmeshdata>
 
 <!-- Spectral Eulerian grids -->
-<scripgriddata hgrid="512x1024"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_512x1024_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="128x256"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_128x256_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="94x192"    lmask="nomask" >share/meshes/T62_040121_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="64x128"    lmask="nomask" >share/meshes/T42_ESMFmesh_c20200629.nc</scripgriddata>
-<scripgriddata hgrid="48x96"     lmask="nomask" >share/meshes/T31_040122_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="32x64"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_32x64_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="8x16"      lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_8x16_nomask_c110308.nc</scripgriddata>
+<dstmeshdata hgrid="512x1024"  lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_512x1024_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="128x256"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_128x256_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="94x192"    lmask="nomask" >share/meshes/T62_040121_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="64x128"    lmask="nomask" >share/meshes/T42_ESMFmesh_c20200629.nc</dstmeshdata>
+<dstmeshdata hgrid="48x96"     lmask="nomask" >share/meshes/T31_040122_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="32x64"     lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_32x64_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="8x16"      lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_8x16_nomask_c110308.nc</dstmeshdata>
 
 <!-- FV3 grids -->
-<scripgriddata hgrid="C384" lmask="nomask" >share/meshes/C384_181018_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="C192" lmask="nomask" >share/meshes/C192_181018_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="C96"  lmask="nomask" >share/meshes/C96_181018_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="C48"  lmask="nomask" >share/meshes/C48_181018_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="C24"  lmask="nomask" >share/meshes/C24_181018_ESMFmesh.nc</scripgriddata>
+<dstmeshdata hgrid="C384" lmask="nomask" >share/meshes/C384_181018_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="C192" lmask="nomask" >share/meshes/C192_181018_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="C96"  lmask="nomask" >share/meshes/C96_181018_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="C48"  lmask="nomask" >share/meshes/C48_181018_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="C24"  lmask="nomask" >share/meshes/C24_181018_ESMFmesh.nc</dstmeshdata>
 
 <!-- HOMME grids -->
-<scripgriddata hgrid="ne240np4"     lmask="nomask" >share/meshes/ne240np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne120np4"     lmask="nomask" >share/meshes/ne120np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne60np4"      lmask="nomask" >share/meshes/ne60np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne30np4"      lmask="nomask" >share/meshes/ne30np4_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne16np4"      lmask="nomask" >share/meshes/ne16np4_scrip_171002_ESMFmesh.nc</scripgriddata>
+<dstmeshdata hgrid="ne240np4"     lmask="nomask" >share/meshes/ne240np4_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne120np4"     lmask="nomask" >share/meshes/ne120np4_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne60np4"      lmask="nomask" >share/meshes/ne60np4_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne30np4"      lmask="nomask" >share/meshes/ne30np4_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne16np4"      lmask="nomask" >share/meshes/ne16np4_scrip_171002_ESMFmesh.nc</dstmeshdata>
 <!-- HOMME SE dycore Physics grids -->
-<scripgriddata hgrid="ne30np4.pg2"  lmask="nomask" >share/meshes/ne30pg2_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne30np4.pg3"  lmask="nomask" >share/meshes/ne30pg3_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne120np4.pg2" lmask="nomask" >share/meshes/ne120pg2_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
-<scripgriddata hgrid="ne120np4.pg3" lmask="nomask" >share/meshes/ne120pg3_ESMFmesh_cdf5_c20211018.nc</scripgriddata>
+<dstmeshdata hgrid="ne30np4.pg2"  lmask="nomask" >share/meshes/ne30pg2_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne30np4.pg3"  lmask="nomask" >share/meshes/ne30pg3_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne120np4.pg2" lmask="nomask" >share/meshes/ne120pg2_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
+<dstmeshdata hgrid="ne120np4.pg3" lmask="nomask" >share/meshes/ne120pg3_ESMFmesh_cdf5_c20211018.nc</dstmeshdata>
 
 <!-- Refined mesh grids -->
-<scripgriddata hgrid="ne0np4CONUS.ne30x8"      lmask="nomask" >share/meshes/ne0CONUSne30x8_ESMFmesh_c20200727.nc</scripgriddata>
-<scripgriddata hgrid="ne0np4ARCTICGRIS.ne30x8" lmask="nomask" >share/meshes/ne0ARCTICGRISne30x8_ESMFmesh_c20200730.nc</scripgriddata>
-<scripgriddata hgrid="ne0np4ARCTIC.ne30x4"     lmask="nomask" >share/meshes/ne0ARCTICne30x4_ESMFmesh_c20200727.nc</scripgriddata>
+<dstmeshdata hgrid="ne0np4CONUS.ne30x8"      lmask="nomask" >share/meshes/ne0CONUSne30x8_ESMFmesh_c20200727.nc</dstmeshdata>
+<dstmeshdata hgrid="ne0np4ARCTICGRIS.ne30x8" lmask="nomask" >share/meshes/ne0ARCTICGRISne30x8_ESMFmesh_c20200730.nc</dstmeshdata>
+<dstmeshdata hgrid="ne0np4ARCTIC.ne30x4"     lmask="nomask" >share/meshes/ne0ARCTICne30x4_ESMFmesh_c20200727.nc</dstmeshdata>
 
 <!-- Regular lat/lon grids -->
-<scripgriddata hgrid="0.125x0.125" lmask="nomask"    
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.125x0.125_nomask_c140702.nc</scripgriddata>
-<scripgriddata hgrid="0.33x0.33" lmask="navy"    
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.33x0.33_navy_c111207.nc</scripgriddata>
+<dstmeshdata hgrid="0.125x0.125" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.125x0.125_nomask_c140702.nc</dstmeshdata>
+<dstmeshdata hgrid="0.33x0.33" lmask="navy"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.33x0.33_navy_c111207.nc</dstmeshdata>
 <!-- The 360x720cru grid is on 0-360 longitude grid and is important for running the model -->
-<scripgriddata hgrid="360x720cru" lmask="nomask"
-   >share/meshes/360x720_120830_ESMFmesh_c20210507.nc</scripgriddata>
+<dstmeshdata hgrid="360x720cru" lmask="nomask"
+   >share/meshes/360x720_120830_ESMFmesh_c20210507.nc</dstmeshdata>
 <!-- The half degree grid is on -180-180 longitude and is important for mksurfdata_map grids -->
-<scripgriddata hgrid="0.5x0.5"   lmask="nomask"
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.5x0.5_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="0.25x0.25" lmask="nomask"     
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.25x0.25_nomask_c200309.nc</scripgriddata>
-<scripgriddata hgrid="5x5min"    lmask="nomask"    
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_5x5min_nomask_c200309.nc</scripgriddata>
-<scripgriddata hgrid="10x10min" lmask="nomask"    
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_10x10min_nomask_c110228.nc</scripgriddata>
-<scripgriddata hgrid="3x3min"    lmask="nomask"    
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_3x3min_nomask_c200309.nc</scripgriddata>
-<scripgriddata_lrgfile_needed hgrid="3x3min" lmask="nomask">64bit_offset</scripgriddata_lrgfile_needed>
-<!--scripgriddata hgrid="0.9x1.25"  lmask="nomask"
-   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.9x1.25_nomask_c191014.nc</scripgriddata-->
+<dstmeshdata hgrid="0.5x0.5"   lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.5x0.5_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="0.25x0.25" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.25x0.25_nomask_c200309.nc</dstmeshdata>
+<dstmeshdata hgrid="5x5min"    lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_5x5min_nomask_c200309.nc</dstmeshdata>
+<dstmeshdata hgrid="10x10min" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_10x10min_nomask_c110228.nc</dstmeshdata>
+<dstmeshdata hgrid="3x3min"    lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_3x3min_nomask_c200309.nc</dstmeshdata>
+<meshdata_lrgfile_needed hgrid="3x3min" lmask="nomask">64bit_offset</meshdata_lrgfile_needed>
+<!--dstmeshdata hgrid="0.9x1.25"  lmask="nomask"
+   >lnd/clm2/mappingdata/grids/SCRIPgrid_0.9x1.25_nomask_c191014.nc</dstmeshdata-->
 
 <!-- Other raw data grids -->
 <!-- Note that the following is a UGRID file rather than a SCRIP grid file -->
-<scripgriddata hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
-   >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</scripgriddata>
-<scripgriddata_lrgfile_needed hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">netcdf4</scripgriddata_lrgfile_needed>
-<scripgriddata_type hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">UGRID</scripgriddata_type>
-<scripgriddata_meshname hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">landmesh</scripgriddata_meshname>
+<dstmeshdata hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
+   >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</dstmeshdata>
+<meshdata_lrgfile_needed hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">netcdf4</meshdata_lrgfile_needed>
+<meshdata_type hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">UGRID</meshdata_type>
+<meshdata_meshname hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask">landmesh</meshdata_meshname>
 
 <!-- Single-point / Regional grids -->
-<scripgriddata hgrid="0.125nldas2"         lmask="nomask" >share/meshes/0.125nldas2_ESMFmesh_cd5_241220.nc</scripgriddata>
-<scripgriddata hgrid="1x1_brazil"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_brazil_nomask_c20211211.nc</scripgriddata>
-<scripgriddata hgrid="1x1_mexicocityMEX"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_mexicocityMEX_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="1x1_numaIA"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_numaIA_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="1x1_smallvilleIA"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_smallvilleIA_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="1x1_urbanc_alpha"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_urbanc_alpha_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="1x1_vancouverCAN"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_vancouverCAN_nomask_c110308.nc</scripgriddata>
-<scripgriddata hgrid="5x5_amazon"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_5x5pt_amazon_nomask_c110308.nc</scripgriddata>
+<dstmeshdata hgrid="0.125nldas2"         lmask="nomask" >share/meshes/0.125nldas2_ESMFmesh_cd5_241220.nc</dstmeshdata>
+<dstmeshdata hgrid="1x1_brazil"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_brazil_nomask_c20211211.nc</dstmeshdata>
+<dstmeshdata hgrid="1x1_mexicocityMEX"   lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_mexicocityMEX_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="1x1_numaIA"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_numaIA_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="1x1_smallvilleIA"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_smallvilleIA_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="1x1_urbanc_alpha"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_urbanc_alpha_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="1x1_vancouverCAN"    lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_1x1pt_vancouverCAN_nomask_c110308.nc</dstmeshdata>
+<dstmeshdata hgrid="5x5_amazon"          lmask="nomask" >lnd/clm2/mappingdata/grids/SCRIPgrid_5x5pt_amazon_nomask_c110308.nc</dstmeshdata>
 
 <!-- Ocean grids -->
-<scripgriddata hgrid="0.33x0.33"  lmask="0.33x0.33" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.33x0.33_navy_c111207.nc</scripgriddata>
-<scripgriddata hgrid="5x5_amazon" lmask="navy"      >share/meshes/5x5pt-amazon_navy_ESMFmesh_cd5_c20210107.nc</scripgriddata>
-<scripgriddata hgrid="gx1v6"      lmask="gx1v6"     >share/meshes/gx1v6_090205_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="gx3v7"      lmask="gx3v7"     >share/meshes/gx3v7_120309_ESMFmesh.nc</scripgriddata>
-<scripgriddata hgrid="tx1v1"      lmask="tx1v1"     >share/meshes/tx1v1_ESMFMesh_cd5_c20210105.nc</scripgriddata>
-<scripgriddata hgrid="tx0.1v2"    lmask="tx0.1v2"   >share/meshes/tx0.1v2_ESMFmesh_cd5_c20210105.nc</scripgriddata>
+<dstmeshdata hgrid="0.33x0.33"  lmask="0.33x0.33" >lnd/clm2/mappingdata/grids/SCRIPgrid_0.33x0.33_navy_c111207.nc</dstmeshdata>
+<dstmeshdata hgrid="5x5_amazon" lmask="navy"      >share/meshes/5x5pt-amazon_navy_ESMFmesh_cd5_c20210107.nc</dstmeshdata>
+<dstmeshdata hgrid="gx1v6"      lmask="gx1v6"     >share/meshes/gx1v6_090205_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="gx3v7"      lmask="gx3v7"     >share/meshes/gx3v7_120309_ESMFmesh.nc</dstmeshdata>
+<dstmeshdata hgrid="tx1v1"      lmask="tx1v1"     >share/meshes/tx1v1_ESMFMesh_cd5_c20210105.nc</dstmeshdata>
+<dstmeshdata hgrid="tx0.1v2"    lmask="tx0.1v2"   >share/meshes/tx0.1v2_ESMFmesh_cd5_c20210105.nc</dstmeshdata>
 
-<!-- UNSTRUCT grid data files -->
-<unstructdata frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
-   >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</unstructdata>
-<unstructdata frm_hgrid="0.5x0.5"   lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.5x0.5_nomask_c200129.nc</unstructdata>
-<unstructdata frm_hgrid="0.25x0.25" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_c200129.nc</unstructdata>
-<unstructdata frm_hgrid="0.125x0.125" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.125x0.125_nomask_c200129.nc</unstructdata>
-<unstructdata frm_hgrid="10x10min" lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_10x10min_nomask_c200129.nc</unstructdata>
-<unstructdata frm_hgrid="5x5min"    lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_5x5min_nomask_c200129.nc</unstructdata>
-<unstructdata frm_hgrid="3x3min"    lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_c200129.nc</unstructdata>
-<unstructdata frm_hgrid="0.9x1.25"  lmask="nomask"
-   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.9x1.25_nomask_c200129.nc</unstructdata>
+<!-- SRC grid data files -->
+<srcmeshdata frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
+   >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="0.5x0.5"   lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.5x0.5_nomask_c200129.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="0.25x0.25" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_c200129.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="0.125x0.125" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.125x0.125_nomask_c200129.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="10x10min" lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_10x10min_nomask_c200129.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="5x5min"    lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_5x5min_nomask_c200129.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="3x3min"    lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_c200129.nc</srcmeshdata>
+<srcmeshdata frm_hgrid="0.9x1.25"  lmask="nomask"
+   >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.9x1.25_nomask_c200129.nc</srcmeshdata>
 
 <!-- land masks for different types of mksurfdata_map input files -->
 <lmask type="lak"              >nomask</lmask>

--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -111,21 +111,21 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <dstmeshdata hgrid="tx0.1v2"    lmask="tx0.1v2"   >share/meshes/tx0.1v2_ESMFmesh_cd5_c20210105.nc</dstmeshdata>
 
 <!-- SRC grid data files -->
-<srcmeshdata frm_hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
+<srcmeshdata hgrid="1km-merge-10min" lmask="HYDRO1K-merge-nomask"
    >lnd/clm2/mappingdata/grids/UGRID_1km-merge-10min_HYDRO1K-merge-nomask_c130402.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="0.5x0.5"   lmask="nomask"
+<srcmeshdata hgrid="0.5x0.5"   lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.5x0.5_nomask_c200129.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="0.25x0.25" lmask="nomask"
+<srcmeshdata hgrid="0.25x0.25" lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_c200129.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="0.125x0.125" lmask="nomask"
+<srcmeshdata hgrid="0.125x0.125" lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.125x0.125_nomask_c200129.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="10x10min" lmask="nomask"
+<srcmeshdata hgrid="10x10min" lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_10x10min_nomask_c200129.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="5x5min"    lmask="nomask"
+<srcmeshdata hgrid="5x5min"    lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_5x5min_nomask_c200129.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="3x3min"    lmask="nomask"
+<srcmeshdata hgrid="3x3min"    lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_c200129.nc</srcmeshdata>
-<srcmeshdata frm_hgrid="0.9x1.25"  lmask="nomask"
+<srcmeshdata hgrid="0.9x1.25"  lmask="nomask"
    >lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.9x1.25_nomask_c200129.nc</srcmeshdata>
 
 <!-- land masks for different types of mksurfdata_map input files -->

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1205,33 +1205,33 @@ Toggle to turn on on diagnostic Snow Radiative Effect
 <!--                                                   -->
 <!-- mkmapdata  namelist                               -->
 <!--                                                   -->
-<entry id="scripgriddata" type="char*256" category="mkmapdata"
+<entry id="dstmeshdata" type="char*256" category="mkmapdata"
        input_pathname="abs" group="clmexp" valid_values="" >
-SCRIP format grid data file
+DST (destination, i.e. associated with fsurdat) grid data file
 </entry>
-<entry id="unstructdata" type="char*256" category="mkmapdata"
+<entry id="srcmeshdata" type="char*256" category="mkmapdata"
        input_pathname="abs" group="clmexp" valid_values="" >
-UNSTRUCT format grid data file
+SRC (source, i.e. associated with raw datasets) grid data file
 </entry>
 
-<entry id="scripgriddata_lrgfile_needed" type="char*256" category="mkmapdata"
+<entry id="meshdata_lrgfile_needed" type="char*256" category="mkmapdata"
        group="clmexp" valid_values="none,64bit_offset,netcdf4" >
 Flag to pass to the ESMF mapping utility, telling it what kind of large
 file support is needed for an output file generated with this grid as
 either the source or destination ('none', '64bit_offset' or 'netcdf4'). 
 </entry>
 
-<entry id="scripgriddata_type" type="char*256" category="mkmapdata"
+<entry id="meshdata_type" type="char*256" category="mkmapdata"
        group="clmexp" valid_values="UGRID" >
 Flag used in mkmapdata.sh; otherwise specifying this for the ESMF mapping
 utility is redundant because -src_type and -dst_type are ignored
 </entry>
 
-<entry id="scripgriddata_meshname" type="char*256" category="mkmapdata"
+<entry id="meshdata_meshname" type="char*256" category="mkmapdata"
        group="clmexp" valid_values="" >
 For UGRID files, flag to pass to the ESMF mapping utility, telling it the
 name of the dummy variable that has all of the topology information stored
-in its attributes. (Only used if scripgriddata_src_type = UGRID.)
+in its attributes. (Only used if meshdata_type = UGRID.)
 </entry>
 
 <!--                                                   -->

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1209,6 +1209,10 @@ Toggle to turn on on diagnostic Snow Radiative Effect
        input_pathname="abs" group="clmexp" valid_values="" >
 SCRIP format grid data file
 </entry>
+<entry id="unstructdata" type="char*256" category="mkmapdata"
+       input_pathname="abs" group="clmexp" valid_values="" >
+UNSTRUCT format grid data file
+</entry>
 
 <entry id="scripgriddata_lrgfile_needed" type="char*256" category="mkmapdata"
        group="clmexp" valid_values="none,64bit_offset,netcdf4" >
@@ -1220,7 +1224,12 @@ either the source or destination ('none', '64bit_offset' or 'netcdf4').
 <entry id="scripgriddata_type" type="char*256" category="mkmapdata"
        group="clmexp" valid_values="SCRIP,UGRID" >
 Flag to pass to the ESMF mapping utility, telling it what kind of grid
-file this is (SCRIP or UGRID).
+file this is (SCRIP or UGRID). LIKELY REDUNDANT. TRY REMOVING?
+</entry>
+<entry id="unstructdata_type" type="char*256" category="mkmapdata"
+       group="clmexp" valid_values="UNSTRUCT" >
+Flag to pass to the ESMF mapping utility, telling it what kind of grid
+file this is (UNSTRUCT). LIKELY REDUNDANT. TRY REMOVING?
 </entry>
 
 <entry id="scripgriddata_meshname" type="char*256" category="mkmapdata"

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1222,14 +1222,9 @@ either the source or destination ('none', '64bit_offset' or 'netcdf4').
 </entry>
 
 <entry id="scripgriddata_type" type="char*256" category="mkmapdata"
-       group="clmexp" valid_values="SCRIP,UGRID" >
-Flag to pass to the ESMF mapping utility, telling it what kind of grid
-file this is (SCRIP or UGRID). LIKELY REDUNDANT. TRY REMOVING?
-</entry>
-<entry id="unstructdata_type" type="char*256" category="mkmapdata"
-       group="clmexp" valid_values="UNSTRUCT" >
-Flag to pass to the ESMF mapping utility, telling it what kind of grid
-file this is (UNSTRUCT). LIKELY REDUNDANT. TRY REMOVING?
+       group="clmexp" valid_values="UGRID" >
+Flag used in mkmapdata.sh; otherwise specifying this for the ESMF mapping
+utility is redundant because -src_type and -dst_type are ignored
 </entry>
 
 <entry id="scripgriddata_meshname" type="char*256" category="mkmapdata"

--- a/tools/mkmapdata/mkmapdata.sh
+++ b/tools/mkmapdata/mkmapdata.sh
@@ -319,7 +319,7 @@ do
 
    QUERYARGS="-res $grid -options lmask=$lmask,glc_nec=10 "
 
-   QUERYFIL="$QUERY -var scripgriddata $QUERYARGS -onlyfiles"
+   QUERYFIL="$QUERY -var unstructdata $QUERYARGS -onlyfiles"
    if [ "$verbose" = "YES" ]; then
       echo $QUERYFIL
    fi
@@ -334,7 +334,7 @@ do
    # Determine extra information about the source grid file
    SRC_EXTRA_ARGS[nfile]=""
    SRC_LRGFIL[nfile]=`$QUERY -var scripgriddata_lrgfile_needed $QUERYARGS`
-   SRC_TYPE[nfile]=`$QUERY -var scripgriddata_type $QUERYARGS`
+   SRC_TYPE[nfile]=`$QUERY -var unstructdata_type $QUERYARGS`
    if [ "${SRC_TYPE[nfile]}" = "UGRID" ]; then
        # For UGRID, we need extra information: the meshname variable
        src_meshname=`$QUERY -var scripgriddata_meshname $QUERYARGS`

--- a/tools/mkmapdata/mkmapdata.sh
+++ b/tools/mkmapdata/mkmapdata.sh
@@ -334,7 +334,7 @@ do
    # Determine extra information about the source grid file
    SRC_EXTRA_ARGS[nfile]=""
    SRC_LRGFIL[nfile]=`$QUERY -var scripgriddata_lrgfile_needed $QUERYARGS`
-   SRC_TYPE[nfile]=`$QUERY -var unstructdata_type $QUERYARGS`
+   SRC_TYPE[nfile]=`$QUERY -var scripgriddata_type $QUERYARGS`
    if [ "${SRC_TYPE[nfile]}" = "UGRID" ]; then
        # For UGRID, we need extra information: the meshname variable
        src_meshname=`$QUERY -var scripgriddata_meshname $QUERYARGS`

--- a/tools/mkmapdata/mkmapdata.sh
+++ b/tools/mkmapdata/mkmapdata.sh
@@ -238,7 +238,7 @@ else
     QUERYARGS="-res $res -options lmask=nomask"
 
     # Find the output grid file for this resolution using the XML database
-    QUERYFIL="$QUERY -var scripgriddata $QUERYARGS -onlyfiles"
+    QUERYFIL="$QUERY -var dstmeshdata $QUERYARGS -onlyfiles"
     if [ "$verbose" = "YES" ]; then
 	echo $QUERYFIL
     fi
@@ -246,11 +246,11 @@ else
     echo "Using default scrip grid file: $GRIDFILE" 
 
     # Determine extra information about the destination grid file
-    DST_LRGFIL=`$QUERY -var scripgriddata_lrgfile_needed $QUERYARGS`
-    DST_TYPE=`$QUERY -var scripgriddata_type $QUERYARGS`
+    DST_LRGFIL=`$QUERY -var meshdata_lrgfile_needed $QUERYARGS`
+    DST_TYPE=`$QUERY -var meshdata_type $QUERYARGS`
     if [ "$DST_TYPE" = "UGRID" ]; then
         # For UGRID, we need extra information: the meshname variable
-	dst_meshname=`$QUERY -var scripgriddata_meshname $QUERYARGS`
+	dst_meshname=`$QUERY -var meshdata_meshname $QUERYARGS`
 	DST_EXTRA_ARGS="$DST_EXTRA_ARGS --dst_meshname $dst_meshname"
     fi
 fi
@@ -319,7 +319,7 @@ do
 
    QUERYARGS="-res $grid -options lmask=$lmask,glc_nec=10 "
 
-   QUERYFIL="$QUERY -var unstructdata $QUERYARGS -onlyfiles"
+   QUERYFIL="$QUERY -var srcmeshdata $QUERYARGS -onlyfiles"
    if [ "$verbose" = "YES" ]; then
       echo $QUERYFIL
    fi
@@ -333,11 +333,11 @@ do
 
    # Determine extra information about the source grid file
    SRC_EXTRA_ARGS[nfile]=""
-   SRC_LRGFIL[nfile]=`$QUERY -var scripgriddata_lrgfile_needed $QUERYARGS`
-   SRC_TYPE[nfile]=`$QUERY -var scripgriddata_type $QUERYARGS`
+   SRC_LRGFIL[nfile]=`$QUERY -var meshdata_lrgfile_needed $QUERYARGS`
+   SRC_TYPE[nfile]=`$QUERY -var meshdata_type $QUERYARGS`
    if [ "${SRC_TYPE[nfile]}" = "UGRID" ]; then
        # For UGRID, we need extra information: the meshname variable
-       src_meshname=`$QUERY -var scripgriddata_meshname $QUERYARGS`
+       src_meshname=`$QUERY -var meshdata_meshname $QUERYARGS`
        SRC_EXTRA_ARGS[nfile]="${SRC_EXTRA_ARGS[nfile]} --src_meshname $src_meshname"
    fi
 


### PR DESCRIPTION
### Description of changes

Switching from SCRIP to UNSTRUCT mesh files saves computation time when running mkmapdata.sh.

I have started by making the switch for the SRC mesh files used by mkmapdata.sh.

Repeating for the DST mesh files requires generating the UNSTRUCT mesh files for every DST resolution. Since the switch to UNSTRUCT changes answers, it seems worth completing the work for both the SRC and the DST mesh files.

As part of this PR, I will add (i.e. rimport) the UNSTRUCT files to the repository.

### Specific notes

Contributors other than yourself, if any:
@billsacks @mvertens 

CTSM Issues Fixed (include github issue #):
#648 

Are answers expected to change (and if so in what way)?
Yes. We expect diffs in the mkmapdata.sh output files (known as mapping or weight files), which means diffs in the resulting fsurdat files. We agreed (2022/1/12) that an eyeball check will tell us whether we must perform more rigorous checks.

Any User Interface Changes (namelist or namelist defaults changes)?
Changes should be transparent to users who will use the mesh files that we provide. Even users who use their own raw datasets to generate their own fsurdat files, should not notice a change. They will still generate their own respective mesh files. Ideally they will generate UNSTRUCT mesh files, but codes will still work with SCRIP.

Testing performed, if any:
My original time estimate here was incorrect. Updated time estimate provided later in the PR.