### PR TITLE
Introduce LEAFCN_TARGET as time-evolving parameter

### DIFF
--- a/src/biogeophys/CanopyStateType.F90
+++ b/src/biogeophys/CanopyStateType.F90
@@ -173,6 +173,11 @@ contains
     begp = bounds%begp; endp= bounds%endp
     begc = bounds%begc; endc= bounds%endc
 
+    this%leafcn_patch(begp:endp) = spval
+    call hist_addfld1d (fname='LEAFCN_TARGET', units='gC/gN', &
+        avgflag='A', long_name='Target leaf C:N; compare against leafC/leafN', &
+        ptr_patch=this%leafcn_patch)
+
     this%elai_patch(begp:endp) = spval
     call hist_addfld1d (fname='ELAI', units='m^2/m^2', &
         avgflag='A', long_name='exposed one-sided leaf area index', &
@@ -233,11 +238,6 @@ contains
 
 
     endif !fates or CN
-
-    this%leafcn_patch(begp:endp) = spval
-    call hist_addfld1d (fname='LEAFCN_TARGET', units='gC/gN', &
-        avgflag='A', long_name='Target leaf C:N; compare against leafC/leafN', &
-        ptr_patch=this%leafcn_patch)
 
     if(use_fates_sp)then
       this%tlai_hist_patch(begp:endp) = spval
@@ -609,8 +609,8 @@ contains
          dim1name='pft', long_name='fraction of vegetation not covered by snow (0 or 1)', units='', &
          interpinic_flag='interp', readvar=readvar, data=this%frac_veg_nosno_alb_patch)
 
-!   call restartvar(ncid=ncid, flag=flag, varname='LEAFCN', xtype=ncd_double,  &
-!        dim1name='pft', long_name='leaf C:N', units='gC/gN', &
+!   call restartvar(ncid=ncid, flag=flag, varname='LEAFCN_TARGET', xtype=ncd_double,  &
+!        dim1name='pft', long_name='Target leaf C:N; compare against leafC/leafN', units='gC/gN', &
 !        interpinic_flag='interp', readvar=readvar, data=this%leafcn_patch)
 
     call restartvar(ncid=ncid, flag=flag, varname='tlai', xtype=ncd_double,  &

--- a/src/biogeophys/CanopyStateType.F90
+++ b/src/biogeophys/CanopyStateType.F90
@@ -235,8 +235,8 @@ contains
     endif !fates or CN
 
     this%leafcn_patch(begp:endp) = spval
-    call hist_addfld1d (fname='leafcn', units='gC/gN', &
-        avgflag='A', long_name='Leaf C:N', &
+    call hist_addfld1d (fname='LEAFCN_TARGET', units='gC/gN', &
+        avgflag='A', long_name='Target leaf C:N; compare against leafC/leafN', &
         ptr_patch=this%leafcn_patch)
 
     if(use_fates_sp)then

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -165,6 +165,11 @@ contains
     call get_proc_bounds(bounds_proc)
     nclumps = get_proc_clumps()
 
+    ! -------------------------------------------------
+    ! Obtain updated values of time-evolving parameters
+    ! -------------------------------------------------
+    call canopystate_inst%time_evolv_params(bounds_proc, atm2lnd_inst)
+
     ! ========================================================================
     ! In the first time step of a startup or hybrid run, we want to update CLM's glacier
     ! areas to match those given by GLC. This is because, in initialization, we do not yet


### PR DESCRIPTION
### Description of changes

From clm_driver I call new `subr. time_evolv_params` located in `CanopyStateType.F90` where I calc. the new variable `leafcn_patch` (history field LEAFCN_TARGET).

### Specific notes

Contributors other than yourself, if any:
@wwieder @ekluzek 

CTSM Issues Fixed (include github issue #):
#1646 

Are answers expected to change (and if so in what way)?
Yes, once I replace all pftcon%leafcn with canopystate_inst%leafcn_patch(p)

Any User Interface Changes (namelist or namelist defaults changes)?
New history field LEAFCN_TARGET

Testing performed, if any:
In /glade/scratch/slevis, both of these tests PASS:
SMS_Ly3_Mmpi-serial.1x1_numaIA.IHistClm50BgcCropQianRs.cheyenne_intel.clm-default.20220218_111830_bodlmh
SMS_Ly3_Mmpi-serial.1x1_numaIA.I2000Clm50BgcCropQianRs.cheyenne_intel.clm-default.20220218_105852_zphwfb
I will plot timeseries of LEAFCN_TARGET to compare the IHist case to the I2000 case.
For now I have only looked at a single hist. file (SMS...I2000...clm2.h0.2002-02-28-00000.nc) and found:
leafcn_target = 26.0
leafc / leafn = 55.4
leafcn = 34.7