### PR TITLE
FATES parameter file API update to align PFT optical properties to CLM

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.5
+tag = ccs_config_cesm0.0.14
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.14
+tag = ccs_config_cesm0.0.5
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config

--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.55.3_api.22.0.0
+tag = sci.1.55.4_api.22.1.0
 required = True
 
 [externals_description]

--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -2,7 +2,7 @@
 local_path = src/fates
 protocol = git
 repo_url = https://github.com/NGEET/fates
-tag = sci.1.54.0_api.22.0.0
+tag = sci.1.55.3_api.22.0.0
 required = True
 
 [externals_description]

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -488,7 +488,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.16.1.0_12pft_c210630.nc  </fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.22.2.0_12pft_c220307.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -488,7 +488,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.22.2.0_12pft_c220307.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.22.1.0_12pft_c220307.nc</fates_paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name: ctsm5.1.dev084
 Originator(s): glemieux (Gregory Lemieux,LBL/NGEET,510-486-5049)
-Date: Thu 10 Mar 2022 03:19:51 PM MST
+Date: Thu 14 Mar 2022 19:00:00 MST
 One-line Summary: FATES parameter file updated to align with clm pft optical parameters
 
 Purpose and description of changes
@@ -9,9 +9,7 @@ Purpose and description of changes
 
 This tag incorporates updates to the FATES parameter file which now align the FATES
 PFT optical parameters with the CLM PFT optical parameters.  These parameters are
-sourced from the recommended parameters in Majasalmi & Bright 2019.  This tag
-also updates the FATES tag to the most recent version.
-
+sourced from the recommended parameters in Majasalmi & Bright 2019.  
 
 Significant changes to scientifically-supported configurations
 --------------------------------------------------------------

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,91 @@
 ===============================================================
+Tag name: ctsm5.1.dev084
+Originator(s): glemieux (Gregory Lemieux,LBL/NGEET,510-486-5049)
+Date: Thu 10 Mar 2022 03:19:51 PM MST
+One-line Summary: FATES parameter file updated to align with clm pft optical parameters
+
+Purpose and description of changes
+----------------------------------
+
+This tag incorporates updates to the FATES parameter file which now align the FATES
+PFT optical parameters with the CLM PFT optical parameters.  These parameters are
+sourced from the recommended parameters in Majasalmi & Bright 2019.  This tag
+also updates the FATES tag to the most recent version.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+
+  Given that the FATES PFT optical parameters have been updated, FATES users updating to this 
+  tag will differences results in FATES cases.
+
+Testing summary:
+----------------
+
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    cheyenne ---- OK
+    izumi ------- OK
+
+  fates tests: (give name of baseline if different from CTSM tagname, normally fates baselines are fates-<FATES TAG>-<CTSM TAG>)
+    cheyenne ---- OK
+    izumi ------- OK
+
+  any other testing (give details below):
+    ILAMB benchmarking was conduct to help evaluate the differences resulting from the parameter
+    file updates.  See FATES #831 for details.
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+  
+  [ If a tag changes answers relative to baseline comparison the
+    following should be filled in (otherwise remove this section).
+    And always remove these three lines and parts that don't apply. ]
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: FATES
+    - what platforms/compilers: All
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): larger than roundoff
+
+   If this tag changes climate describe the run(s) done to evaluate the new
+   climate (put details of the simulations in the experiment database)
+      See FATES #831 for discussion
+
+Other details
+-------------
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+  fates: sci.1.54.0_api.22.0.0 -> fates-sci.1.55.4_api.22.1.0
+
+Pull Requests that document the changes (include PR ids):
+  https://github.com/ESCOMP/CTSM/pull/1681
+  https://github.com/NGEET/fates/pull/831
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev083
 Originator(s): fang-bowen (Bowen Fang) / oleson (Keith Oleson,UCAR/TSS,303-497-1332)
                / Face2sea (Lei Zhao) / keerzhang1 (Keer Zhang) / sacks (Bill Sacks)

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev084 glemieux 03/10/2022 FATES parameter file updated to align with clm pft optical parameters
     ctsm5.1.dev083 multiple 03/08/2022 Implement PCT_URBAN_MAX to minimize dynamic urban memory
     ctsm5.1.dev082   slevis 02/28/2022 Replace dom_nat_pft with dom_plant to enable crop in fsurdat_modifier tool
     ctsm5.1.dev081 swensosc 02/24/2022 Do not subtract irrigation from QRUNOFF diagnostic

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-    ctsm5.1.dev084 glemieux 03/10/2022 FATES parameter file updated to align with clm pft optical parameters
+    ctsm5.1.dev084 glemieux 03/14/2022 FATES parameter file updated to align with clm pft optical parameters
     ctsm5.1.dev083 multiple 03/08/2022 Implement PCT_URBAN_MAX to minimize dynamic urban memory
     ctsm5.1.dev082   slevis 02/28/2022 Replace dom_nat_pft with dom_plant to enable crop in fsurdat_modifier tool
     ctsm5.1.dev081 swensosc 02/24/2022 Do not subtract irrigation from QRUNOFF diagnostic


### PR DESCRIPTION
### Description of changes

Minor FATES API update to point to the latest fates parameter file.  This PR is associated with https://github.com/NGEET/fates/pull/831.  This parameter file update aligns the FATES PFT optical properties to the CLM PFT optical properties.

### Specific notes

Contributors other than yourself, if any: 

CTSM Issues Fixed (include github issue #): 
   Note, #1683 is now not an issue since cheyenne modules were changed

Are answers expected to change (and if so in what way)? Yes.  FATES only DIFFs due to updates to the PFT optical properties.

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: regular
