### PR TITLE
1655 rename gddplant2

### DIFF
--- a/src/biogeochem/CNNDynamicsMod.F90
+++ b/src/biogeochem/CNNDynamicsMod.F90
@@ -333,7 +333,7 @@ contains
     associate(                                                                      & 
          wf               =>  waterdiagnosticbulk_inst%wf_col                      ,         & ! Input:  [real(r8) (:) ]  soil water as frac. of whc for top 0.5 m          
 
-         hui              =>  crop_inst%gddplant_patch                    ,         & ! Input:  [real(r8) (:) ]  gdd since planting (gddplant)                    
+         hui              =>  crop_inst%hui_patch                         ,         & ! Input:  [real(r8) (:) ]  hui accumulated since planting (growing degree-days)    
          croplive         =>  crop_inst%croplive_patch                    ,         & ! Input:  [logical  (:) ]  true if planted and not harvested                  
 
          gddmaturity      =>  cnveg_state_inst%gddmaturity_patch          ,         & ! Input:  [real(r8) (:) ]  gdd needed to harvest                             

--- a/src/biogeochem/CNNDynamicsMod.F90
+++ b/src/biogeochem/CNNDynamicsMod.F90
@@ -333,7 +333,7 @@ contains
     associate(                                                                      & 
          wf               =>  waterdiagnosticbulk_inst%wf_col                      ,         & ! Input:  [real(r8) (:) ]  soil water as frac. of whc for top 0.5 m          
 
-         hui              =>  crop_inst%hui_patch                         ,         & ! Input:  [real(r8) (:) ]  hui accumulated since planting (growing degree-days)    
+         hui              =>  crop_inst%hui_patch                         ,         & ! Input:  [real(r8) (:) ]  patch heat unit index (growing degree-days)    
          croplive         =>  crop_inst%croplive_patch                    ,         & ! Input:  [logical  (:) ]  true if planted and not harvested                  
 
          gddmaturity      =>  cnveg_state_inst%gddmaturity_patch          ,         & ! Input:  [real(r8) (:) ]  gdd needed to harvest                             

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1730,7 +1730,7 @@ contains
          gdd1020           =>    temperature_inst%gdd1020_patch                , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd10                               
 
          fertnitro         =>    crop_inst%fertnitro_patch                     , & ! Input:  [real(r8) (:) ]  fertilizer nitrogen
-         hui               =>    crop_inst%hui_patch                           , & ! Input:  [real(r8) (:) ]  hui accumulated since planting (growing degree-days)                    
+         hui               =>    crop_inst%hui_patch                           , & ! Input:  [real(r8) (:) ]  crop patch heat unit index (growing degree-days)                    
          leafout           =>    crop_inst%gddtsoi_patch                       , & ! Input:  [real(r8) (:) ]  gdd from top soil layer temperature              
          harvdate          =>    crop_inst%harvdate_patch                      , & ! Output: [integer  (:) ]  harvest date                                       
          croplive          =>    crop_inst%croplive_patch                      , & ! Output: [logical  (:) ]  Flag, true if planted, not harvested               

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1730,7 +1730,7 @@ contains
          gdd1020           =>    temperature_inst%gdd1020_patch                , & ! Input:  [real(r8) (:) ]  20 yr mean of gdd10                               
 
          fertnitro         =>    crop_inst%fertnitro_patch                     , & ! Input:  [real(r8) (:) ]  fertilizer nitrogen
-         hui               =>    crop_inst%gddplant_patch                      , & ! Input:  [real(r8) (:) ]  gdd since planting (gddplant)                    
+         hui               =>    crop_inst%hui_patch                           , & ! Input:  [real(r8) (:) ]  hui accumulated since planting (growing degree-days)                    
          leafout           =>    crop_inst%gddtsoi_patch                       , & ! Input:  [real(r8) (:) ]  gdd from top soil layer temperature              
          harvdate          =>    crop_inst%harvdate_patch                      , & ! Output: [integer  (:) ]  harvest date                                       
          croplive          =>    crop_inst%croplive_patch                      , & ! Output: [logical  (:) ]  Flag, true if planted, not harvested               
@@ -2032,7 +2032,7 @@ contains
 
             ! call vernalization if winter temperate cereal planted, living, and the
             ! vernalization factor is not 1;
-            ! vf affects the calculation of gddtsoi & gddplant
+            ! vf affects the calculation of gddtsoi & hui
 
             if (t_ref2m_min(p) < 1.e30_r8 .and. vf(p) /= 1._r8 .and. &
                (ivt(p) == nwwheat .or. ivt(p) == nirrig_wwheat)) then
@@ -2363,7 +2363,7 @@ contains
       ! vernalization factor calculation
       ! if vf(p) = 1.  then plant is fully vernalized - and thermal time
       ! accumulation in phase 1 will be unaffected
-      ! refers to gddtsoi & gddplant, defined in the accumulation routines (slevis)
+      ! refers to gddtsoi & hui, defined in the accumulation routines (slevis)
       ! reset vf, cumvd, and hdidx to 0 at planting of crop (slevis)
 
       if (t_ref2m_max(p) > tfrz) then

--- a/src/biogeochem/CNRootDynMod.F90
+++ b/src/biogeochem/CNRootDynMod.F90
@@ -97,7 +97,7 @@ subroutine CNRootDyn(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
     soilpsi                => soilstate_inst%soilpsi_col                        , & ! Input:  soil water potential in each soil layer (MPa)
     sminn_vr               => soilbiogeochem_nitrogenstate_inst%sminn_vr_col    , & ! Iniput:  [real(r8) (:,:)]  (gN/m3) soil mineral N
     frootc                 => cnveg_carbonstate_inst%frootc_patch               , & ! Input:  [real(r8) (:)]  (gC/m2) fine root C
-    hui                    => crop_inst%gddplant_patch                          , & ! Input:  [real(r8) (:)]  =gdd since planting (gddplant)
+    hui                    => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)]  =hui accumulated since planting (growing degree-days)
     croplive               => crop_inst%croplive_patch                          , & ! Input:  [logical (:)]  flag, true if planted, not harvested
     huigrain               => cnveg_state_inst%huigrain_patch                     & ! Input: [real(r8) (:)]  same to reach vegetative maturity
     )

--- a/src/biogeochem/CNRootDynMod.F90
+++ b/src/biogeochem/CNRootDynMod.F90
@@ -97,7 +97,7 @@ subroutine CNRootDyn(bounds, num_soilc, filter_soilc, num_soilp, filter_soilp, &
     soilpsi                => soilstate_inst%soilpsi_col                        , & ! Input:  soil water potential in each soil layer (MPa)
     sminn_vr               => soilbiogeochem_nitrogenstate_inst%sminn_vr_col    , & ! Iniput:  [real(r8) (:,:)]  (gN/m3) soil mineral N
     frootc                 => cnveg_carbonstate_inst%frootc_patch               , & ! Input:  [real(r8) (:)]  (gC/m2) fine root C
-    hui                    => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)]  =hui accumulated since planting (growing degree-days)
+    hui                    => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)]  crop patch heat unit index (growing degree-days)
     croplive               => crop_inst%croplive_patch                          , & ! Input:  [logical (:)]  flag, true if planted, not harvested
     huigrain               => cnveg_state_inst%huigrain_patch                     & ! Input: [real(r8) (:)]  same to reach vegetative maturity
     )

--- a/src/biogeochem/CropType.F90
+++ b/src/biogeochem/CropType.F90
@@ -228,7 +228,7 @@ contains
          ptr_patch=this%fertnitro_patch, default='inactive')
 
     this%hui_patch(begp:endp) = spval
-    call hist_addfld1d (fname='GDDPLANT', units='ddays', &
+    call hist_addfld1d (fname='HUI', units='ddays', &
          avgflag='A', long_name='Accumulated heat unit index since planting for crop', &
          ptr_patch=this%hui_patch, default='inactive')
 
@@ -342,7 +342,7 @@ contains
 
     !---------------------------------------------------------------------
 
-    call init_accum_field (name='GDDPLANT', units='K', &
+    call init_accum_field (name='HUI', units='K', &
          desc='heat unit index accumulated since planting', accum_type='runaccum', accum_period=not_used,  &
          subgrid_type='pft', numlev=1, init_value=0._r8)
 
@@ -394,7 +394,7 @@ contains
 
     nstep = get_nstep()
 
-    call extract_accum_field ('GDDPLANT', rbufslp, nstep) 
+    call extract_accum_field ('HUI', rbufslp, nstep) 
     this%hui_patch(begp:endp) = rbufslp(begp:endp)
 
     call extract_accum_field ('GDDACCUM', rbufslp, nstep) 
@@ -590,15 +590,15 @@ contains
        call endrun(msg=errMsg(sourcefile, __LINE__))
     endif
 
-    ! Accumulate and extract GDDPLANT and GDDACCUM
+    ! Accumulate and extract HUI and GDDACCUM
     
-    call extract_accum_field ('GDDPLANT', rbufslp, nstep)
+    call extract_accum_field ('HUI', rbufslp, nstep)
     call extract_accum_field ('GDDACCUM', rbufslp2, nstep)
     do p = begp,endp
       rbufslp(p) = max(0.0_r8,this%hui_patch(p)-rbufslp(p))
       rbufslp2(p) = max(0.0_r8,this%gddaccum_patch(p)-rbufslp2(p))
     end do
-    call update_accum_field  ('GDDPLANT', rbufslp, nstep)
+    call update_accum_field  ('HUI', rbufslp, nstep)
     call update_accum_field  ('GDDACCUM', rbufslp2, nstep)
     do p = begp,endp
        if (this%croplive_patch(p)) then ! relative to planting date
@@ -622,8 +622,8 @@ contains
        end if
        rbufslp2(p) = rbufslp(p)
     end do
-    call update_accum_field  ('GDDPLANT', rbufslp, nstep)
-    call extract_accum_field ('GDDPLANT', this%hui_patch, nstep)
+    call update_accum_field  ('HUI', rbufslp, nstep)
+    call extract_accum_field ('HUI', this%hui_patch, nstep)
     call update_accum_field  ('GDDACCUM', rbufslp2, nstep)
     call extract_accum_field ('GDDACCUM', this%gddaccum_patch, nstep)
     deallocate(rbufslp2)

--- a/src/biogeochem/CropType.F90
+++ b/src/biogeochem/CropType.F90
@@ -33,7 +33,7 @@ module CropType
      logical , pointer :: cropplant_patch         (:)   ! patch Flag, true if planted
      integer , pointer :: harvdate_patch          (:)   ! patch harvest date
      real(r8), pointer :: fertnitro_patch         (:)   ! patch fertilizer nitrogen
-     real(r8), pointer :: hui_patch               (:)   ! patch accum hui past planting date for crop       (ddays)
+     real(r8), pointer :: hui_patch               (:)   ! crop patch heat unit index (ddays)
      real(r8), pointer :: gddaccum_patch          (:)   ! patch growing degree-days from planting (air) (ddays)
      real(r8), pointer :: gddtsoi_patch           (:)   ! patch growing degree-days from planting (top two soil layers) (ddays)
      real(r8), pointer :: vf_patch                (:)   ! patch vernalization factor for cereal
@@ -229,7 +229,7 @@ contains
 
     this%hui_patch(begp:endp) = spval
     call hist_addfld1d (fname='HUI', units='ddays', &
-         avgflag='A', long_name='Accumulated heat unit index since planting for crop', &
+         avgflag='A', long_name='Crop patch heat unit index', &
          ptr_patch=this%hui_patch, default='inactive')
 
     this%gddaccum_patch(begp:endp) = spval

--- a/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -587,7 +587,7 @@ contains
          laisun                => canopystate_inst%laisun_patch                     , & ! Input:  [real(r8) (:)   ]  sunlit projected leaf area index        
          laisha                => canopystate_inst%laisha_patch                     , & ! Input:  [real(r8) (:)   ]  shaded projected leaf area index        
 
-         hui                   => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)   ]  =hui accumulated since planting (growing degree-days)
+         hui                   => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)   ]  crop patch heat unit index (growing degree-days)
          leafout               => crop_inst%gddtsoi_patch                           , & ! Input:  [real(r8) (:)   ]  =gdd from top soil layer temperature    
          croplive              => crop_inst%croplive_patch                          , & ! Input:  [logical  (:)   ]  flag, true if planted, not harvested     
 

--- a/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -587,7 +587,7 @@ contains
          laisun                => canopystate_inst%laisun_patch                     , & ! Input:  [real(r8) (:)   ]  sunlit projected leaf area index        
          laisha                => canopystate_inst%laisha_patch                     , & ! Input:  [real(r8) (:)   ]  shaded projected leaf area index        
 
-         hui                   => crop_inst%gddplant_patch                          , & ! Input:  [real(r8) (:)   ]  =gdd since planting (gddplant)          
+         hui                   => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)   ]  =hui accumulated since planting (growing degree-days)
          leafout               => crop_inst%gddtsoi_patch                           , & ! Input:  [real(r8) (:)   ]  =gdd from top soil layer temperature    
          croplive              => crop_inst%croplive_patch                          , & ! Input:  [logical  (:)   ]  flag, true if planted, not harvested     
 

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -1300,7 +1300,7 @@ contains
          laisun                => canopystate_inst%laisun_patch                     , & ! Input:  [real(r8) (:)   ]  sunlit projected leaf area index
          laisha                => canopystate_inst%laisha_patch                     , & ! Input:  [real(r8) (:)   ]  shaded projected leaf area index
 
-         hui                   => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)   ]  =hui accumulated since planting (growing degree-days)
+         hui                   => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)   ]  crop patch heat unit index (growing degree-days)
          leafout               => crop_inst%gddtsoi_patch                           , & ! Input:  [real(r8) (:)   ]  =gdd from top soil layer temperature
          croplive              => crop_inst%croplive_patch                          , & ! Input:  [logical  (:)   ]  flag, true if planted, not harvested
 

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -1300,7 +1300,7 @@ contains
          laisun                => canopystate_inst%laisun_patch                     , & ! Input:  [real(r8) (:)   ]  sunlit projected leaf area index
          laisha                => canopystate_inst%laisha_patch                     , & ! Input:  [real(r8) (:)   ]  shaded projected leaf area index
 
-         hui                   => crop_inst%gddplant_patch                          , & ! Input:  [real(r8) (:)   ]  =gdd since planting (gddplant)
+         hui                   => crop_inst%hui_patch                               , & ! Input:  [real(r8) (:)   ]  =hui accumulated since planting (growing degree-days)
          leafout               => crop_inst%gddtsoi_patch                           , & ! Input:  [real(r8) (:)   ]  =gdd from top soil layer temperature
          croplive              => crop_inst%croplive_patch                          , & ! Input:  [logical  (:)   ]  flag, true if planted, not harvested
 


### PR DESCRIPTION
### Description of changes
1. Rename `gddplant_patch` to `hui_patch` (and `GDDPLANT` to `HUI`).
2. Add new variable `gddaccum_patch` (output `GDDACCUM`).

### Specific notes

CTSM Issues Fixed: #1655

**Are answers expected to change (and if so in what way)?** No.

**Any User Interface Changes (namelist or namelist defaults changes)?** Yes. Output variable `GDDPLANT` (not included by default) is now `HUI`, and new output `GDDACCUM` has been added to track _actual_ accumulation of GDDs since planting without any modifications such as occurs here:
https://github.com/ESCOMP/CTSM/blob/d9ae4b48d9c55fe3c998019bcf76817da570db87/src/biogeochem/CNPhenologyMod.F90#L2044-L2046

#### Testing performed
As expected, `GDDACCUM` was never greater than `HUI` in any patch.

Looking at 30 patches with discrepancies between `GDDACCUM` and `HUI`, the time series look as expected. E.g.:
![patch547-temperate_corn](https://user-images.githubusercontent.com/10454527/157924458-e18940ae-301a-4909-a9a8-f1dfb1eecb4e.png)

Diffs when testing with `SMS_D_Ld10_P72x1.f10_f10_mg37.IHistClm51BgcCrop.cheyenne_intel.clm-ciso_decStart.C.0311-123808ch` and `SMS_P72x1_Lm25.f10_f10_mg37.I2000Clm51BgcCrop.cheyenne_intel.clm-monthly.C.0311-123808ch` are due to the rename of `GDDPLANT` to `HUI`.