### PR TITLE
remove this write to stdout

### DIFF
--- a/src/main/decompInitMod.F90
+++ b/src/main/decompInitMod.F90
@@ -566,8 +566,6 @@ contains
        call shr_sys_flush(iulog)
        call mpi_barrier(mpicom,ier)
     end do
-    write(iulog,*)
-    call shr_sys_flush(iulog)
 
   end subroutine decompInit_clumps
 


### PR DESCRIPTION
### Description of changes
Remove a write to stdout that was writing nothing to the cesm log on every ctsm task.
I also removed a shr_sys_flush call, shr_sys_flush should no longer be required.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:  Tested by hand with ERS_D.f19_g17.B1850.cheyenne_intel.allactive-defaultio
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
