### PR TITLE
For CLM45 apply peaklai to aleaf in grainfill

### DIFF
--- a/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -854,7 +854,11 @@ contains
                           huigrain(p))/((gddmaturity(p)*declfact(ivt(p)))- &
                           huigrain(p)),1._r8)**allconss(ivt(p)) )))
                   end if
-                  if (aleafi(p) > aleaff(ivt(p))) then
+
+                  ! If crops have hit peaklai, then set leaf allocation to small value
+                  if (peaklai(p) == 1) then
+                     aleaf(p) = 1.e-5_r8
+                  else if (aleafi(p) > aleaff(ivt(p))) then
                      aleaf(p) = max(1.e-5_r8, max(aleaff(ivt(p)), aleaf(p) * &
                           (1._r8 - min((hui(p)-                    &
                           huigrain(p))/((gddmaturity(p)*declfact(ivt(p)))- &


### PR DESCRIPTION
### Description of changes

This makes the crop allocation code in
NutrientCompetitionCLM45defaultMod consistent with that in
NutrientCompetitionFlexibleCNMod. This will be helpful so that I can
extract these into a shared subroutine.

From a 5-year run of IHistClm45BgcCrop at f19_g17 resolution, it seems
like this won't change answers: whenever peaklai is 1 during the
grainfill period, aleaf is already exactly 1e-5. I don't understand why
this is always the case; maybe, in Clm45, if peaklai isn't reached
before grainfill then it is never reached that growing season? I have
come to suspect that the difference between Clm45 and Clm50 in this
respect may actually be due to whether you're running with FUN, since
running with FUN changes some relevant driver sequencing. So it's
possible that this would change answers for the atypical situation where
someone was running with FUN but not FlexibleCN; in this case, I think
this change would be the right thing to do.

### Specific notes

Contributors other than yourself, if any: @danicalombardozzi 

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? Possibility of answer changes in some cases that use Crop without FlexibleCN, though no potential for answer changes was observed in a 5-year run of IHistClm45BgcCrop at f19_g17 resolution. It may be that answers would only change if running with Crop with FUN but not FlexibleCN, but I haven't tested that.

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: none yet
