### PR TITLE
FATES MIMICS coupling prep work

### DIFF
--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -1,8 +1,8 @@
 [fates]
 local_path = src/fates
 protocol = git
-repo_url = https://github.com/NGEET/fates
-tag = sci.1.55.4_api.22.1.0
+repo_url = https://github.com/rgknox/fates
+branch = pass-nclignan-bcout
 required = True
 
 [externals_description]

--- a/Externals_CLM.cfg
+++ b/Externals_CLM.cfg
@@ -1,8 +1,8 @@
 [fates]
 local_path = src/fates
 protocol = git
-repo_url = https://github.com/rgknox/fates
-branch = pass-nclignan-bcout
+repo_url = https://github.com/NGEET/fates
+tag = sci.1.56.0_api.23.0.0
 required = True
 
 [externals_description]

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,67 @@
 ===============================================================
+Tag name: ctsm5.1.dev091
+Originator(s): rgknox (Ryan Knox,rgknox@lbl.gov)
+Date: Fri Apr 22 14:11:50 EDT 2022
+One-line Summary: clm decomp method is now passed to fates to enabled mimics coupling
+
+Purpose and description of changes
+----------------------------------
+
+This is a small changeset, which only adds the passing of a text based flag to FATES, that defines which soil decomposition method is active. This setting is needed by FATES, so that it can pass specific boundary conditions to CLM (and potentially ELM in the future). This change was necessitated because MIMICS requires a Nitrogen to lignin-carbon ratio in the litter flux, yet other decomposition schemes do not. Moreover, the generation of this boundary condition is not trivial, so it is worth it to avoid its computation if mimics is not on.  This change should have NO impact on any tests.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed or introduced
+------------------------
+
+None
+
+
+Notes of particular relevance for users
+---------------------------------------
+
+None, this does not currently have an affect on any functionality, it simply lays groundwork for FATES-MIMICS coupling.  There are no changes to memory usage or run-time.
+
+
+Notes of particular relevance for developers:
+---------------------------------------------
+
+No changes in testing. These changes will enable completion (or progress) on CTSM #1643
+
+Testing summary:
+----------------
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    cheyenne ---- aux_clm, PASS, b4b against ctsm5.1.dev090
+    izumi ------- aux_clm, PASS, b4b against ctsm5.1.dev090
+
+
+Answer changes
+--------------
+None
+
+Pull Requests that document the changes (include PR ids): #1700
+(https://github.com/ESCOMP/ctsm/pull/1700)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev090
 Originator(s): samrabin (Sam Rabin)
 Date: Thu Mar 31 15:03:34 MDT 2022

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev091   rgknox 04/22/2022 clm decomp method is now passed to fates to enabled mimics coupling
     ctsm5.1.dev090 samrabin 03/31/2022 Fix misleading name of "gddplant"
     ctsm5.1.dev089    sacks 03/31/2022 For CLM45 apply peaklai to aleaf in grainfill
     ctsm5.1.dev088 samrabin 03/28/2022 Add outputs for annual crop sowing and harvest dates

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -94,6 +94,8 @@ module CLMFatesInterfaceMod
    use decompMod         , only : get_proc_bounds,   &
                                   get_proc_clumps,   &
                                   get_clump_bounds
+   use SoilBiogeochemDecompCascadeConType , only : mimics_decomp, decomp_method
+   use SoilBiogeochemDecompCascadeConType , only : no_soil_decomp, century_decomp
    use GridCellType      , only : grc
    use ColumnType        , only : col
    use LandunitType      , only : lun
@@ -298,6 +300,14 @@ module CLMFatesInterfaceMod
         ! which has fewer boundary conditions (simpler)
         call set_fates_ctrlparms('nu_com',cval='RD')
 
+        if (decomp_method == mimics_decomp) then
+           call set_fates_ctrlparms('decomp_method',cval='MIMICS')
+        elseif(decomp_method == century_decomp ) then
+           call set_fates_ctrlparms('decomp_method',cval='CENTURY')
+        elseif(decomp_method == no_soil_decomp ) then
+           call set_fates_ctrlparms('decomp_method',cval='NONE')
+        end if
+        
         ! These may be in a non-limiting status (ie when supplements)
         ! are added, but they are always allocated and cycled non-the less
         ! FATES may want to interact differently with other models


### PR DESCRIPTION
### Description of changes

This PR lays groundwork for enabling FATES MIMICS coupling. The soil decomposition namelist setting (ie none, century or mimics) is passed to FATES. If MIMICS is designated, FATES will prep new boundary conditions for use in MIMICS. Currently, it is generating one new output boundary condition for litter quality, which is the lignan carbon over total nitrogen ratio in the litter flux.

### Specific notes

This should be integrated prior to #1643
This is synchronized with FATES PR: https://github.com/NGEET/fates/pull/850

Contributors other than yourself, if any:

@slevisconsulting @ekluzek @wwieder 

CTSM Issues Fixed (include github issue #):  None, #1643 completes the work though

Are answers expected to change (and if so in what way)?  No, this will only enable future FATES-MIMICS tests, but won't change results of any other configurations.

Any User Interface Changes (namelist or namelist defaults changes)? none

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

TBD

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
