### PR TITLE
Removing checks for dompft and include-nonveg

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,80 @@
 ===============================================================
+Tag name: ctsm5.1.dev094
+Originator(s): negins (Negin Sobhani,UCAR/TSS,303-497-1224)
+Date: Fri May  6 00:04:54 MDT 2022
+One-line Summary: subset_data allows zeroing out nonveg landunits without any dompft selected
+
+Purpose and description of changes
+----------------------------------
+Previously subset_data explicitly checked to make sure the user has chosen at
+least one of the following options:
+
+dominant pft(s) or
+--include-nonveg (overrides default setting non-veg units to 0%)
+
+However, Adrianna pointed out that this limits FATES users who would not
+want to set a dominant pft(s) and would also want all 100% vegetated at the
+single point. So I removed this capability. This needed recalculating
+PCT_CROP and PCT_NATVEG while zero-ing out other land unit types.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+Bugs fixed or introduced
+------------------------
+Issues fixed (include CTSM Issue #):
+ Fixes CTSM/#1707 -- Allowing the user to zero non-veg landunits without any
+ dominant pft given by the user.
+
+
+Notes of particular relevance for users
+---------------------------------------
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+ Previously the user needed to choose at least one of the following options
+ for subsetting at single points:
+ --dompft
+ --include-nonveg
+ Now the user is not required to specify either options and can still zero out
+ non-veg landunits without any dominant pft given by the user.
+
+
+Notes of particular relevance for developers:
+---------------------------------------------
+Changes to tests or testing:
+ Added 4 new tests to python/ctsm/test/test_unit_singlept_data_surfdata.py
+ to test recalculation of PCT_CROP and PCT_NATVEG while zero-ing out non-veg
+ land units. 
+
+Testing summary:
+----------------
+here is guidance on different available levels of system testing:
+
+  python testing (if python code has changed; see instructions in python/README.md; document testing done):
+
+    clm_pymods test suite on cheyenne - PASS
+	pylint -- PASS (10.00/10) (cheyenne + python/3.7.9)
+	Python unit tests -- PASS (cheyenne)
+	Python system tests -- FAIL (cheyenne) (CTSM/Issue #1739)
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/CTSM/pull/1727
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev093
 Originator(s): slevis (Samuel Levis)
 Date: Tue May  3 21:50:20 MDT 2022

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev094   negins 05/06/2022 subset_data allows zeroing out nonveg landunits without any dompft selected
     ctsm5.1.dev093   slevis 05/03/2022 Modifications for FATES-MIMICS to work
     ctsm5.1.dev092    sacks 04/29/2022 Refactor NutrientCompetition / CNAllocation to provide hooks for AgSys
     ctsm5.1.dev091   rgknox 04/22/2022 clm decomp method is now passed to fates to enabled mimics coupling

--- a/python/ctsm/site_and_regional/single_point_case.py
+++ b/python/ctsm/site_and_regional/single_point_case.py
@@ -136,7 +136,7 @@ class SinglePointCase(BaseCase):
 
         self.create_tag()
         self.check_dom_pft()
-        self.check_nonveg()
+        #self.check_nonveg()
         self.check_pct_pft()
 
     def create_tag(self):
@@ -434,13 +434,14 @@ class SinglePointCase(BaseCase):
             f_mod["PCT_URBAN"][:, :, :] = 0.0
             f_mod["PCT_GLACIER"][:, :] = 0.0
 
-            max_dom_pft = max(self.dom_pft)
-            if max_dom_pft < NAT_PFT:
-                f_mod["PCT_NATVEG"][:, :] = 100
-                f_mod["PCT_CROP"][:, :] = 0
-            else:
-                f_mod["PCT_NATVEG"][:, :] = 0
-                f_mod["PCT_CROP"][:, :] = 100
+            if self.dom_pft is not None:
+                max_dom_pft = max(self.dom_pft)
+                if max_dom_pft < NAT_PFT:
+                    f_mod["PCT_NATVEG"][:, :] = 100
+                    f_mod["PCT_CROP"][:, :] = 0
+                else:
+                    f_mod["PCT_NATVEG"][:, :] = 0
+                    f_mod["PCT_CROP"][:, :] = 100
 
         else:
             logger.info(

--- a/python/ctsm/site_and_regional/single_point_case.py
+++ b/python/ctsm/site_and_regional/single_point_case.py
@@ -442,6 +442,12 @@ class SinglePointCase(BaseCase):
                 else:
                     f_mod["PCT_NATVEG"][:, :] = 0
                     f_mod["PCT_CROP"][:, :] = 100
+            else:
+                #-- recalculate percentages after zeroing out non-veg landunits
+                #-- so they add up to 100%.
+                tot_pct = f_mod["PCT_CROP"]+f_mod['PCT_NATVEG']
+                f_mod ["PCT_CROP"] = f_mod ["PCT_CROP"]/tot_pct * 100
+                f_mod ["PCT_NATVEG"] = f_mod ["PCT_NATVEG"]/tot_pct * 100
 
         else:
             logger.info(

--- a/python/ctsm/test/test_unit_singlept_data_surfdata.py
+++ b/python/ctsm/test/test_unit_singlept_data_surfdata.py
@@ -27,7 +27,7 @@ from ctsm import unit_testing
 from ctsm.site_and_regional.single_point_case import SinglePointCase
 
 # pylint: disable=invalid-name
-
+# pylint: disable=too-many-lines
 
 class TestSinglePointCaseSurfaceNoCrop(unittest.TestCase):
     """
@@ -1128,7 +1128,6 @@ class TestSinglePointCaseSurfaceCrop(unittest.TestCase):
         ds_out = single_point.modify_surfdata_atpoint(self.ds_test)
 
         self.assertEqual(ds_out["PCT_NATVEG"].data[:, :], 40)
-
 
 if __name__ == "__main__":
     unit_testing.setup_for_tests()

--- a/python/ctsm/test/test_unit_singlept_data_surfdata.py
+++ b/python/ctsm/test/test_unit_singlept_data_surfdata.py
@@ -229,6 +229,9 @@ class TestSinglePointCaseSurfaceNoCrop(unittest.TestCase):
 
         self.assertEqual(ds_out["PCT_CROP"].data[:, :], 0)
 
+
+
+
     def test_modify_surfdata_atpoint_nocrop_1pft_glacier(self):
         """
         Test modify_surfdata_atpoint
@@ -513,6 +516,72 @@ class TestSinglePointCaseSurfaceNoCrop(unittest.TestCase):
 
         self.assertNotEqual(ds_out["PCT_WETLAND"].data[:, :], 0)
 
+
+    def test_modify_surfdata_atpoint_nocrop_nopft_zero_nonveg(self):
+        """
+        Test modify_surfdata_atpoint
+        Checks PCT_CROP for no pft and zero nonveg
+        """
+        single_point = SinglePointCase(
+            plat=self.plat,
+            plon=self.plon,
+            site_name=self.site_name,
+            create_domain=self.create_domain,
+            create_surfdata=self.create_surfdata,
+            create_landuse=self.create_landuse,
+            create_datm=self.create_datm,
+            create_user_mods=self.create_user_mods,
+            dom_pft=self.dom_pft,
+            pct_pft=self.pct_pft,
+            num_pft=self.num_pft,
+            include_nonveg=self.include_nonveg,
+            uni_snow=self.uni_snow,
+            cap_saturation=self.cap_saturation,
+            out_dir=self.out_dir,
+            overwrite=self.overwrite,
+        )
+        single_point.dom_pft = None
+        single_point.include_nonveg = False
+        self.ds_test['PCT_CROP'].values = [[40]]
+        self.ds_test['PCT_LAKE'].values = [[10]]
+        self.ds_test['PCT_WETLAND'].values = [[10]]
+        self.ds_test['PCT_NATVEG'].values = [[40]]
+        ds_out = single_point.modify_surfdata_atpoint(self.ds_test)
+
+        self.assertEqual(ds_out["PCT_CROP"].data[:, :], 50)
+
+    def test_modify_surfdata_atpoint_nocrop_nopft_include_nonveg(self):
+        """
+        Test modify_surfdata_atpoint
+        Checks PCT_CROP for no pft and include nonveg
+        """
+        single_point = SinglePointCase(
+            plat=self.plat,
+            plon=self.plon,
+            site_name=self.site_name,
+            create_domain=self.create_domain,
+            create_surfdata=self.create_surfdata,
+            create_landuse=self.create_landuse,
+            create_datm=self.create_datm,
+            create_user_mods=self.create_user_mods,
+            dom_pft=self.dom_pft,
+            pct_pft=self.pct_pft,
+            num_pft=self.num_pft,
+            include_nonveg=self.include_nonveg,
+            uni_snow=self.uni_snow,
+            cap_saturation=self.cap_saturation,
+            out_dir=self.out_dir,
+            overwrite=self.overwrite,
+        )
+        single_point.dom_pft = None
+        single_point.include_nonveg = True
+        self.ds_test['PCT_CROP'].values = [[40]]
+        self.ds_test['PCT_LAKE'].values = [[10]]
+        self.ds_test['PCT_WETLAND'].values = [[10]]
+        self.ds_test['PCT_NATVEG'].values = [[40]]
+        ds_out = single_point.modify_surfdata_atpoint(self.ds_test)
+
+        self.assertEqual(ds_out["PCT_CROP"].data[:, :], 40)
 
 class TestSinglePointCaseSurfaceCrop(unittest.TestCase):
     """
@@ -993,6 +1062,72 @@ class TestSinglePointCaseSurfaceCrop(unittest.TestCase):
         ds_out = single_point.modify_surfdata_atpoint(self.ds_test)
 
         self.assertNotEqual(ds_out["PCT_LAKE"].data[:, :], 0)
+
+    def test_modify_surfdata_atpoint_crop_nopft_zero_nonveg(self):
+        """
+        Test modify_surfdata_atpoint
+        Checks PCT_NATVEG for no pft and zero nonveg
+        """
+        single_point = SinglePointCase(
+            plat=self.plat,
+            plon=self.plon,
+            site_name=self.site_name,
+            create_domain=self.create_domain,
+            create_surfdata=self.create_surfdata,
+            create_landuse=self.create_landuse,
+            create_datm=self.create_datm,
+            create_user_mods=self.create_user_mods,
+            dom_pft=self.dom_pft,
+            pct_pft=self.pct_pft,
+            num_pft=self.num_pft,
+            include_nonveg=self.include_nonveg,
+            uni_snow=self.uni_snow,
+            cap_saturation=self.cap_saturation,
+            out_dir=self.out_dir,
+            overwrite=self.overwrite,
+        )
+        single_point.dom_pft = None
+        single_point.include_nonveg = False
+        self.ds_test['PCT_CROP'].values = [[40]]
+        self.ds_test['PCT_LAKE'].values = [[10]]
+        self.ds_test['PCT_WETLAND'].values = [[10]]
+        self.ds_test['PCT_NATVEG'].values = [[40]]
+        ds_out = single_point.modify_surfdata_atpoint(self.ds_test)
+
+        self.assertEqual(ds_out["PCT_NATVEG"].data[:, :], 50)
+
+    def test_modify_surfdata_atpoint_crop_nopft_include_nonveg(self):
+        """
+        Test modify_surfdata_atpoint
+        Checks PCT_NATVEG for no pft and include nonveg
+        """
+        single_point = SinglePointCase(
+            plat=self.plat,
+            plon=self.plon,
+            site_name=self.site_name,
+            create_domain=self.create_domain,
+            create_surfdata=self.create_surfdata,
+            create_landuse=self.create_landuse,
+            create_datm=self.create_datm,
+            create_user_mods=self.create_user_mods,
+            dom_pft=self.dom_pft,
+            pct_pft=self.pct_pft,
+            num_pft=self.num_pft,
+            include_nonveg=self.include_nonveg,
+            uni_snow=self.uni_snow,
+            cap_saturation=self.cap_saturation,
+            out_dir=self.out_dir,
+            overwrite=self.overwrite,
+        )
+        single_point.dom_pft = None
+        single_point.include_nonveg = True
+        self.ds_test['PCT_CROP'].values = [[40]]
+        self.ds_test['PCT_LAKE'].values = [[10]]
+        self.ds_test['PCT_WETLAND'].values = [[10]]
+        self.ds_test['PCT_NATVEG'].values = [[40]]
+        ds_out = single_point.modify_surfdata_atpoint(self.ds_test)
+
+        self.assertEqual(ds_out["PCT_NATVEG"].data[:, :], 40)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of changes
Previously `subset_data` explicitly checked to make sure the user has chosen at least one of the following options:
 1) dominant pft(s)    or 
 2) --include-nonveg (overrides default setting non-veg units to 0%)

However, @adrifoster pointed out that this limits FATES users who would not want to set a dominant pft(s) and would also want all 100% vegetated at the single point. So I removed this capability. 

 
### Specific notes

Contributors other than yourself, if any: @adrifoster 

CTSM Issues Fixed (include github issue #): #1707

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
