### PR TITLE
correct perched water table calculation

### DIFF
--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -2082,7 +2082,7 @@ contains
              
              !--  remove residual rsub_top  --------------------------------
              ! make sure no extra water removed from soil column
-             rsub_top(c) = rsub_top(c) - rsub_top_tot/dtime
+             rsub_top(c) = rsub_top(c) + rsub_top_tot/dtime
           endif
           
           zwt(c) = max(0.0_r8,zwt(c))

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -1670,7 +1670,6 @@ contains
      character(len=32) :: subname = 'PerchedLateralFlow' ! subroutine name
      integer  :: c,j,fc,i                                ! indices
      real(r8) :: dtime                                   ! land model time step (sec)
-     real(r8) :: dzmm(bounds%begc:bounds%endc,1:nlevsoi) ! layer thickness (mm)
      real(r8) :: wtsub                                   ! summation of hk*dzmm for layers below water table (mm**2/s)
      real(r8) :: h2osoi_vol
      real(r8) :: drainage_tot

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -1552,6 +1552,7 @@ contains
      associate(                                                            & 
           dz                 =>    col%dz                                , & ! Input:  [real(r8) (:,:) ]  layer depth (m)                                 
           z                  =>    col%z                                 , & ! Input:  [real(r8) (:,:) ]  layer depth (m)                                 
+          zi                 =>    col%zi                                , & ! Input:  [real(r8) (:,:) ] interface level below a "z" level (m)
           t_soisno           =>    temperature_inst%t_soisno_col         , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)                       
 
           h2osoi_liq         =>    waterstatebulk_inst%h2osoi_liq_col        , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)                            
@@ -1582,35 +1583,37 @@ contains
              endif
           enddo
 
-          frost_table(c)=z(c,k_frz)
+          ! frost table is top of frozen layer
+          frost_table(c) = zi(c,k_frz-1)
 
-          ! initialize perched water table to frost table, and qflx_drain_perched(c) to zero
-          zwt_perched(c)=frost_table(c)
+          ! initialize perched water table to frost table
+          zwt_perched(c) = frost_table(c)
 
           !=======  water table above frost table  ===================
           ! if water table is above frost table, do nothing 
           if (zwt(c) < frost_table(c) .and. t_soisno(c,k_frz) <= tfrz &
                .and. origflag == 0) then
-          else 
+          else if (k_frz > 1) then
              !==========  water table below frost table  ============
              ! locate perched water table from bottom up starting at 
              ! frost table sat_lev is an arbitrary saturation level 
              ! used to determine perched water table
 
-             sat_lev=0.9
+             sat_lev = 0.9
 
-             k_perch=1
+             k_perch = 1
              do k=k_frz,1,-1
                 h2osoi_vol(c,k) = h2osoi_liq(c,k)/(dz(c,k)*denh2o) &
                      + h2osoi_ice(c,k)/(dz(c,k)*denice)
 
                 if (h2osoi_vol(c,k)/watsat(c,k) <= sat_lev) then 
-                   k_perch=k
+                   k_perch = k
                    exit
                 endif
              enddo
 
-             ! if frost_table = nlevsoi, only compute perched water table if frozen
+             ! if frost_table = nlevsoi, check temperature of layer, 
+             ! and only compute perched water table if frozen
              if (t_soisno(c,k_frz) > tfrz) k_perch=k_frz
 
              ! if perched water table exists
@@ -1622,9 +1625,13 @@ contains
                 s2 = (h2osoi_liq(c,k_perch+1)/(dz(c,k_perch+1)*denh2o) &
                      + h2osoi_ice(c,k_perch+1)/(dz(c,k_perch+1)*denice))/watsat(c,k_perch+1)
 
-                m=(z(c,k_perch+1)-z(c,k_perch))/(s2-s1)
-                b=z(c,k_perch+1)-m*s2
-                zwt_perched(c)=max(0._r8,m*sat_lev+b)
+                if (s1 > s2) then 
+                   zwt_perched(c) = zi(c,k_perch-1)
+                else
+                   m=(z(c,k_perch+1)-z(c,k_perch))/(s2-s1)
+                   b=z(c,k_perch+1)-m*s2
+                   zwt_perched(c)=max(0._r8,m*sat_lev+b)
+                endif
 
              endif !k_frz > k_perch 
           endif
@@ -1665,22 +1672,21 @@ contains
      real(r8) :: dtime                                   ! land model time step (sec)
      real(r8) :: dzmm(bounds%begc:bounds%endc,1:nlevsoi) ! layer thickness (mm)
      real(r8) :: wtsub                                   ! summation of hk*dzmm for layers below water table (mm**2/s)
-     real(r8) :: icefracsum                              ! summation of icefrac*dzmm of layers below water table (-)
-     real(r8) :: fracice_rsub(bounds%begc:bounds%endc)   ! fractional impermeability of soil layers (-)
      real(r8) :: h2osoi_vol
-     real(r8) :: imped
      real(r8) :: drainage_tot
      real(r8) :: drainage_layer
      real(r8) :: s_y
-     integer  :: k,k_frz,k_perch
+     integer  :: k
+     integer  :: k_frost(bounds%begc:bounds%endc)
+     integer  :: k_perch(bounds%begc:bounds%endc)
      real(r8) :: sat_lev
      real(r8) :: s1, s2, m, b
      real(r8) :: q_perch
      real(r8) :: q_perch_max
-     real(r8) :: vol_ice
      !-----------------------------------------------------------------------
 
      associate(                                                            & 
+          nbedrock           =>    col%nbedrock                          , & ! Input:  [real(r8) (:,:) ]  depth to bedrock (m)
           z                  =>    col%z                                 , & ! Input:  [real(r8) (:,:) ] layer depth (m)                                 
           zi                 =>    col%zi                                , & ! Input:  [real(r8) (:,:) ] interface level below a "z" level (m)           
           dz                 =>    col%dz                                , & ! Input:  [real(r8) (:,:) ] layer depth (m)                                 
@@ -1689,11 +1695,9 @@ contains
           sucsat             =>    soilstate_inst%sucsat_col             , & ! Input:  [real(r8) (:,:) ] minimum soil suction (mm)                       
           watsat             =>    soilstate_inst%watsat_col             , & ! Input:  [real(r8) (:,:) ] volumetric soil water at saturation (porosity)  
 
-          icefrac            =>    soilhydrology_inst%icefrac_col        , & ! Output: [real(r8) (:,:) ] fraction of ice in layer                         
           frost_table        =>    soilhydrology_inst%frost_table_col    , & ! Input:  [real(r8) (:)   ] frost table depth (m)                             
           zwt                =>    soilhydrology_inst%zwt_col            , & ! Input:  [real(r8) (:)   ] water table depth (m)                             
           zwt_perched        =>    soilhydrology_inst%zwt_perched_col    , & ! Input:  [real(r8) (:)   ] perched water table depth (m)                     
-          origflag           =>    soilhydrology_inst%origflag           , & ! Input:  logical
           
           qflx_drain_perched =>    waterfluxbulk_inst%qflx_drain_perched_col , & ! Output: [real(r8) (:)   ] perched wt sub-surface runoff (mm H2O /s)         
 
@@ -1705,89 +1709,77 @@ contains
 
        dtime = get_step_size_real()
 
-       ! Compute ice fraction in each layer
+       ! locate frost table and perched water table
+       do fc = 1, num_hydrologyc
+          c = filter_hydrologyc(fc)
+          k_frost(c) = nbedrock(c)
+          k_perch(c) = nbedrock(c)
+          do k = 1, nbedrock(c)
+             if (frost_table(c) >= zi(c,k-1) .and. frost_table(c) < zi(c,k)) then
+                k_frost(c) = k
+                exit
+             endif
+          enddo
 
-       do j = 1,nlevsoi
-          do fc = 1, num_hydrologyc
-             c = filter_hydrologyc(fc)
-             dzmm(c,j) = dz(c,j)*1.e3_r8
-
-             vol_ice = min(watsat(c,j), h2osoi_ice(c,j)/(dz(c,j)*denice))
-             icefrac(c,j) = min(1._r8,vol_ice/watsat(c,j))          
-          end do
-       end do
+          do k = 1, nbedrock(c)
+             if (zwt_perched(c) >= zi(c,k-1) .and. zwt_perched(c) < zi(c,k)) then
+                k_perch(c) = k
+                exit
+             endif
+          enddo
+       enddo
 
        ! compute drainage from perched saturated region
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)
 
           qflx_drain_perched(c) = 0._r8
+          if (frost_table(c) > zwt_perched(c)) then
 
-          if ((frost_table(c) > zwt_perched(c)) .and. origflag == 0) then
-
-             !  specify maximum drainage rate
-             q_perch_max = 1.e-5_r8 * sin(col%topo_slope(c) * (rpi/180._r8))
-             
-             ! calculate frost table and perched water table locations
-             do k=1, nlevsoi
-                if (frost_table(c) >= zi(c,k-1) .and. frost_table(c) <= zi(c,k)) then
-                   k_frz=k
-                   exit
-                endif
-             enddo
-             
-             do k=1, nlevsoi
-                if (zwt_perched(c) >= zi(c,k-1) .and. zwt_perched(c) <= zi(c,k)) then
-                   k_perch=k
-                   exit
-                endif
-             enddo
+             ! specify maximum drainage rate
+             q_perch_max = params_inst%perched_baseflow_scalar &
+                  * sin(col%topo_slope(c) * (rpi/180._r8))
 
              wtsub = 0._r8
              q_perch = 0._r8
-             do k = k_perch, k_frz
-                imped=10._r8**(-params_inst%e_ice*(0.5_r8*(icefrac(c,k)+icefrac(c,min(nlevsoi, k+1)))))
-                q_perch = q_perch + imped*hksat(c,k)*dzmm(c,k)
-                wtsub = wtsub + dzmm(c,k)
+             do k = k_perch(c), k_frost(c)-1
+                q_perch = q_perch + hksat(c,k)*dz(c,k)
+                wtsub = wtsub + dz(c,k)
              end do
              if (wtsub > 0._r8) q_perch = q_perch/wtsub
-             
+
              qflx_drain_perched(c) = q_perch_max * q_perch &
                   *(frost_table(c) - zwt_perched(c))
-             
-             ! no perched water table drainage if using original formulation
-             if(origflag == 1) qflx_drain_perched(c) = 0._r8
-             
-             ! if perched water table exists
-             if (k_frz > k_perch) then
-                ! remove drainage from perched saturated layers
-                drainage_tot = -  qflx_drain_perched(c) * dtime
-                do k = k_perch+1, k_frz
-                   drainage_layer=max(drainage_tot,-(h2osoi_liq(c,k)-watmin))
-                   drainage_layer=min(drainage_layer,0._r8)
-                   drainage_tot = drainage_tot - drainage_layer
-                   
-                   h2osoi_liq(c,k) = h2osoi_liq(c,k) + drainage_layer
-                   
-                   s_y = watsat(c,k) &
-                        * ( 1. - (1.+1.e3*zwt(c)/sucsat(c,k))**(-1./bsw(c,k)))
-                   s_y=max(s_y, params_inst%aq_sp_yield_min)
-                   if (drainage_tot >= 0.) then 
-                      zwt_perched(c) = zwt_perched(c) - drainage_layer/s_y/1000._r8
-                      exit
-                   else
-                      zwt_perched(c) = zi(c,k)
-                   endif
-                enddo
-          
-                ! if drainage_tot is greater than available water 
-                ! (above frost table), then decrease qflx_drain_perched 
-                ! by residual amount for water balance
-                qflx_drain_perched(c) = qflx_drain_perched(c) + drainage_tot/dtime          
-             else
-                qflx_drain_perched(c) = 0._r8
-             endif !k_frz > k_perch 
           endif
+       enddo
+             
+       ! remove drainage from soil moisture storage
+       do fc = 1, num_hydrologyc
+          c = filter_hydrologyc(fc)
+          
+          ! remove drainage from perched saturated layers
+          drainage_tot =  qflx_drain_perched(c) * dtime
+
+          do k = k_perch(c), k_frost(c)-1
+             s_y = watsat(c,k) &
+                  * ( 1. - (1.+1.e3*zwt_perched(c)/sucsat(c,k))**(-1./bsw(c,k)))
+             s_y=max(s_y,params_inst%aq_sp_yield_min)
+
+             if (k == k_perch(c)) then
+                drainage_layer=min(drainage_tot,(s_y*(zi(c,k) - zwt_perched(c))*1.e3))
+             else
+                drainage_layer=min(drainage_tot,(s_y*(dz(c,k))*1.e3))
+             endif
+
+             drainage_layer=max(drainage_layer,0._r8)
+             drainage_tot = drainage_tot - drainage_layer
+             h2osoi_liq(c,k) = h2osoi_liq(c,k) - drainage_layer
+          enddo
+
+          ! if drainage_tot is greater than available water
+          ! (above frost table), then decrease qflx_drain_perched
+          ! by residual amount for water balance
+          qflx_drain_perched(c) = qflx_drain_perched(c) - drainage_tot/dtime
        enddo
 
      end associate


### PR DESCRIPTION
### Description of changes
Modifying the calculation of the frost table and perched water table layers.
### Specific notes
* PerchedWaterTable

1) Frost table depth

a) original frost table determination looped from the top 
of the soil column downward to the index of the first layer 
whose temperature was <= freezing, and whose neighbor above 
had a temperature above freezing.  The frost table depth is 
then given by the node of that soil layer, i.e. z(k_frz).  

b) in the new method, the same index is found, but the 
depth of the frost table is given by the depth of the top 
of the frozen layer, i.e. zi(k_frz-1).  Note zi(k_frz) would 
be the bottom of layer k_frz.  

2) Perched water table depth

a) in the original formulation, a loop from k_frz to layer 1 
was used to identify the deepest layer in 1:k_frz whose 
volumetric soil moisture was greater than a threshold given 
by sat_lev (e.g. sat_lev = 0.9).  

b) in the new method, the search is only done if k_frz is 
greater than 1.  The rationale is that if k_frz = 1, then 
zwt_perched has already been initialized to the frost_table 
depth (which is equal to the top of the uppermost soil layer), 
and therefore no search is required.

3) Determining perched water table depth within layer 
identified by index k_perch in 2)

a) in the original formulation, the perched water table 
depth was calculated by linearly interpolating between layers 
k_perch and k_perch+1, with no consideration of their relative 
values.  In the case where the deeper layer was drier than the 
layer above it, this could result in values far outside the 
soil layer.

b) in the new formulation, if the deeper layer is drier than the 
layer above it (s1 > s2), then the perched water table depth is 
simply given by the depth of the upper surface of layer k_perch, 
i.e. zi(c,k_perch-1).

* PerchedLateralFlow

1) Removal of icefrac calculation

a) in the original calculation, the frozen layer was included, 
so an ice impedance factor was calculated using icefrac.  If 
only unfrozen layers are used, no ice impedance factor is needed.

b) in the new formulation, the icefrac variable and loop are 
removed.

2) Move loop calculating frost and perched water table depths

a) in the original formulation, the frost and perched water 
table depths were calculated in the same loop as the calculation 
of the lateral flow from the perched saturated zone.

b) in preparation for the hillslope hydrology branch, this 
calculation is moved into its own loop.

3) q_perch calculation 

a)in the original formulation, q_perch was calculated by summing 
over layers k_perch to k_frost.  However, because k_frost is now 
identified as the frozen layer, and its depth the top of the frozen 
layer, it should not be included in the calculation; only the 
unfrozen layers above it should be included.

b) in the new formulation, the loop is bounded by k_frost-1 instead 
of k_frost.

4) Removal of water from perched saturated zone

a) the in the original method, the frozen layer (k_frost) 
was included in the loop.  Also, the drainage was defined to be 
negative, which was confusing.  

b) in the new method, the frozen layer is not included in the 
loop; water is only removed from the unfrozen layers above k_frost.  
Calculate drainage as positive values, which are then subtracted 
from the soil moisture in each layer.  



Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
yes, small changes to surface climate due to differences originating in soil moisture

Any User Interface Changes (namelist or namelist defaults changes)?
no
Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)
two five year simulations w/ and w/o changes to show that variables are broadly the same.  For example, 
ground temperatures (TG) showed maximum mean differences of around 0.05C at some high latitude locations.  
Differences in QDRAI_PERCH were around 1e-10.

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
