### PR TITLE
Fixes to run_neon 

### DIFF
--- a/tools/site_and_regional/run_neon.py
+++ b/tools/site_and_regional/run_neon.py
@@ -416,6 +416,8 @@ class NeonSite:
 
                 # --change any config for base_case:
                 # case.set_value("RUN_TYPE","startup")
+                case.set_value("PIO_TYPENAME", "netcdf")
+                case.set_value("PIO_REARRANGER_LND", 2)   # Possibly due to a PIO bug?  Unsure; will create an issue
 
                 print("---- base case setup ------")
                 case.case_setup()
@@ -519,6 +521,8 @@ class NeonSite:
             case.set_value("REST_OPTION", "end")
             case.set_value("CONTINUE_RUN", False)
             case.set_value("NEONVERSION", version)
+            case.set_value("PIO_TYPENAME", "netcdf")
+            case.set_value("PIO_REARRANGER_LND", 2)   # Possibly due to a PIO bug?  Unsure; will create an issue
 
             if run_type == "ad":
                 case.set_value("CLM_FORCE_COLDSTART", "on")

--- a/tools/site_and_regional/run_neon.py
+++ b/tools/site_and_regional/run_neon.py
@@ -416,8 +416,10 @@ class NeonSite:
 
                 # --change any config for base_case:
                 # case.set_value("RUN_TYPE","startup")
-                case.set_value("PIO_TYPENAME", "netcdf")
-                case.set_value("PIO_REARRANGER_LND", 2)   # Possibly due to a PIO bug?  Unsure; will create an issue
+                case.set_value("PIO_TYPENAME", "netcdf")  # BD:05/06/2022 - These single point runs should use NetCDF; this just makes it explicit.
+                case.set_value("PIO_REARRANGER_LND", 2)   # BD:05/06/2022 - And this explicitly sets the PIO_REARRANGER_LND value - for global runs, 
+                                                          # PIO_REARRANGER_LND = 1 is ideal, and a value of 2 results in slow I/O.  For point runs like
+                                                          # these, a value of 1 results in a crash (PIO bug, probably), so we explicitly set a value of 2.
 
                 print("---- base case setup ------")
                 case.case_setup()
@@ -521,8 +523,10 @@ class NeonSite:
             case.set_value("REST_OPTION", "end")
             case.set_value("CONTINUE_RUN", False)
             case.set_value("NEONVERSION", version)
-            case.set_value("PIO_TYPENAME", "netcdf")
-            case.set_value("PIO_REARRANGER_LND", 2)   # Possibly due to a PIO bug?  Unsure; will create an issue
+            case.set_value("PIO_TYPENAME", "netcdf")  # BD:05/06/2022 - These single point runs should use NetCDF; this just makes it explicit.
+            case.set_value("PIO_REARRANGER_LND", 2)   # BD:05/06/2022 - And this explicitly sets the PIO_REARRANGER_LND value - for global runs, 
+                                                      # PIO_REARRANGER_LND = 1 is ideal, and a value of 2 results in slow I/O.  For point runs like
+                                                      # these, a value of 1 results in a crash (PIO bug, probably), so we explicitly set a value of 2.
 
             if run_type == "ad":
                 case.set_value("CLM_FORCE_COLDSTART", "on")


### PR DESCRIPTION
### Description of changes

This change explicitly sets the NetCDF PIO mode and the PIO_REARRANGER_LND mode. 

### Specific notes


Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
No

Any User Interface Changes (namelist or namelist defaults changes)?
No

Testing performed, if any:

Tested simple ABBY runs on Cheyenne and AWS - both work.  (Previously, it would use the wrong PIO_REARRANGER_LND value on AWS, resulting in very slow writes or crashes.)
