### PR TITLE
Change repo_url from git@... to https:... for ccs_config

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -39,7 +39,7 @@ required = True
 hash = 29a06a80a5f411f3ed001d5b2cb34d2aab685cbe
 protocol = git
 #repo_url = https://github.com/ESMCI/ccs_config_cesm.git
-repo_url = git@github.com:ekluzek/ccs_config_cesm.git
+repo_url = https://github.com/ekluzek/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 


### PR DESCRIPTION
### Description of changes
`tools/mksurfdata_esmf/gen_mksurfdata_build.sh` was failing for me on izumi with this error:
```
COMPILER = intel, MPILIB = mvapich2, DEBUG = FALSE, OS = LINUX
The PIO directory for the PIO build is required and was not set in the configure
Make sure a PIO build is provided for intel with mvapich2 in config_machines
```
Next `./manage_externals/checkout_externals` was giving a permission error because I don't have ssh keys set up on github.

Changing repo_url from git@... to https:... for ccs_config eliminates the need for the ssh keys.

### Specific notes

Contributors other than yourself, if any:
@ekluzek 

CTSM Issues Fixed (include github issue #):
Didn't open a corresponding issue.

Are answers expected to change (and if so in what way)?
No.

Any User Interface Changes (namelist or namelist defaults changes)?
No.

Testing performed, if any:
`./manage_externals/checkout_externals` works now for me on izumi
`tools/mksurfdata_esmf/gen_mksurfdata_build.sh` also works now for me on izumi