### PR TITLE
correct the path to cime python code

### DIFF
--- a/python/ctsm/path_utils.py
+++ b/python/ctsm/path_utils.py
@@ -82,6 +82,7 @@ def add_cime_lib_to_path(standalone_only=False):
     cime_path = path_to_cime(standalone_only=standalone_only)
     prepend_to_python_path(cime_path)
     cime_lib_path = os.path.join(cime_path,
+                                 'CIME',
                                  'Tools')
     prepend_to_python_path(cime_lib_path)
     return cime_path


### PR DESCRIPTION
### Description of changes
Correct CIME path in ctsm 

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue 
  Fixes #1749 -- fixes path

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
