### PR TITLE
 PR to fix #1752: issue with listing file in ./modify_singlept_site_neon.py 

### DIFF
--- a/tools/site_and_regional/modify_singlept_site_neon.py
+++ b/tools/site_and_regional/modify_singlept_site_neon.py
@@ -436,7 +436,7 @@ def check_neon_time():
             dictionary of *_surfaceData.csv files with the last modified
     """
     listing_file = "listing.csv"
-    url = "https://neon-ncar.s3.data.neonscience.org/listing.csv"
+    url = "https://storage.neonscience.org/neon-ncar/listing.csv"
 
     download_file(url, listing_file)
 


### PR DESCRIPTION
### Description of changes
Quick PR to fix #1752 (`./modify_singlept_site_neon.py`). This basically updates the links in this script to use the recent end points. 

### Specific notes

Contributors other than yourself, if any: Thanks to @ekluzek for reporting this issue

CTSM Issues Fixed (include github issue #): 
  Fixes #1752

Are answers expected to change (and if so in what way)? NA

Any User Interface Changes (namelist or namelist defaults changes)? NA

Testing performed, if any:

1. Tested it for all neon sites using `./neon_surf_wrapper.py`
./neon_surf_wrapper.py automatically subsets the data for all neon sites using `subset_data` and modify them using `./modify_singlept_site_neon.py`. 

2. Tested it for one neon site (BART) manually and it is working:
```
./modify_singlept_site_neon.py --neon_site BART --surf_dir subset_data_single_point 
```

