### PR TITLE
Add consistency checks for mesh_nx mesh_ny relative to mesh_file in gen_mksurfdata_namelist.py

### DIFF
--- a/python/ctsm/mksurfdata_download_input_data.py
+++ b/python/ctsm/mksurfdata_download_input_data.py
@@ -76,8 +76,10 @@ Script to download any missing input data for mksurfdata_esmf
     return args
 
 def _create_input_data_list(rundir):
-    with open(os.path.join(rundir, 'surfdata.namelist')) as namelist:
-        with open(os.path.join(rundir, '.input_data_list'), 'w') as input_data_list:
+    with open(os.path.join(rundir, 'surfdata.namelist'),
+              encoding='utf-8') as namelist:
+        with open(os.path.join(rundir, '.input_data_list'), 'w',
+                  encoding='utf-8') as input_data_list:
             for line in namelist:
                 if re.search(_FILENAME, line):
                     # Remove quotes from filename, then output this line

--- a/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_single.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_single.py
@@ -140,12 +140,20 @@ def main ():
         # Obtain mpirun command from env_mach_specific.xml
         # --------------------------
         bld_path = './tool_bld'
+        # Get the ems_file object with standalone_configure=True
+        # and the fake_case object with mpilib=attribs['mpilib']
+        # so as to use the get_mpirun function pointing to fake_case
         ems_file = EnvMachSpecific(bld_path, standalone_configure=True)
         fake_case = FakeCase(compiler=None, mpilib=attribs['mpilib'],
                              debug=False, comp_interface=None)
         total_tasks = int(tasks_per_node) * int(number_of_nodes)
         cmd = ems_file.get_mpirun(fake_case, attribs, job='name',
                                   overrides = {"total_tasks" : total_tasks,})
+        # cmd is a tuple:
+        # cmd[0] contains the mpirun command (eg mpirun, mpiexe, etc) as string
+        # cmd[1] contains a list of strings that we append as options to cmd[0]
+        # The replace function removes unnecessary characters that appear in
+        # some such options
         executable = f'{cmd[0]} {" ".join(cmd[1])}'.replace('ENV{', ''). \
                                                     replace('}', '')
 

--- a/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_single.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_single.py
@@ -123,7 +123,8 @@ def main ():
             runfile.write('#PBS -l walltime=1:00:00 \n')
             runfile.write(f"#PBS -A {account} \n")
             runfile.write('#PBS -q casper \n')
-            runfile.write(f"#PBS -l select={number_of_nodes}:ncpus=12:mpiprocs={tasks_per_node}:mem=80GB \n")
+            runfile.write(f'#PBS -l select={number_of_nodes}:ncpus=12:' \
+                          f'mpiprocs={tasks_per_node}:mem=80GB \n')
         elif machine == 'izumi':
             attribs = {'mpilib': 'mvapich2'}
             runfile.write('#PBS -l walltime=2:00:00 \n')
@@ -162,7 +163,7 @@ def main ():
                       'on your system and the arguments it requires \n')
         output = f'{executable} {mksurfdata_path} < {namelist_file}'
         runfile.write(f"{output} \n")
-        logger.info(f'run command is {output} ')
+        logger.info('run command is %s', output)
 
     print (f"Successfully created jobscript {jobscript_file}")
     sys.exit(0)

--- a/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_single.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_single.py
@@ -7,22 +7,35 @@ instructions, see README.
 import os
 import sys
 import argparse
+import logging
+
+_CTSM_PYTHON = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                            os.pardir,
+                            os.pardir,
+                            'python')
+sys.path.insert(1, _CTSM_PYTHON)
+
+from ctsm import add_cime_to_path  # pylint: disable=unused-import
+from ctsm.ctsm_logging import setup_logging_pre_config, add_logging_args, process_logging_args
+from CIME.XML.env_mach_specific import EnvMachSpecific
+from CIME.BuildTools.configure import FakeCase
+
+logger = logging.getLogger(__name__)
 
 def get_parser():
     """
     Get parser object for this script.
     """
+    # set up logging allowing user control
+    setup_logging_pre_config()
+
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
     parser.print_usage = parser.print_help
+    add_logging_args(parser)
 
-    parser.add_argument(
-        '-v', '--verbose',
-        help="increase output verbosity",
-        action="store_true",
-    )
     parser.add_argument(
         "--account",
         help="""account number (default: %(default)s)""",
@@ -82,6 +95,7 @@ def main ():
     # Obtain input args
     # --------------------------
     args = get_parser().parse_args()
+    process_logging_args(args)
     namelist_file = args.namelist_file
     jobscript_file = args.jobscript_file
     number_of_nodes = args.number_of_nodes
@@ -90,25 +104,28 @@ def main ():
     account = args.account
 
     # --------------------------
-    # Write run script
+    # Write run script (part 1)
     # --------------------------
     with open(jobscript_file, "w",encoding='utf-8') as runfile:
         runfile.write('#!/bin/bash \n')
         runfile.write('# Edit the batch directives for your batch system \n')
-        runfile.write('# Below are the batch directives used on cheyenne \n')
+        runfile.write(f'# Below are default batch directives for {machine} \n')
         runfile.write('#PBS -N mksurfdata \n')
         runfile.write('#PBS -j oe \n')
         if machine == 'cheyenne':
+            attribs = {'mpilib': 'default'}
             runfile.write('#PBS -l walltime=30:00 \n')
             runfile.write(f"#PBS -A {account} \n")
             runfile.write('#PBS -q regular \n')
             runfile.write(f"#PBS -l select={number_of_nodes}:ncpus=36:mpiprocs={tasks_per_node} \n")
         elif machine == 'casper':
+            attribs = {'mpilib': 'default'}
             runfile.write('#PBS -l walltime=1:00:00 \n')
             runfile.write(f"#PBS -A {account} \n")
             runfile.write('#PBS -q casper \n')
             runfile.write(f"#PBS -l select={number_of_nodes}:ncpus=12:mpiprocs={tasks_per_node}:mem=80GB \n")
         elif machine == 'izumi':
+            attribs = {'mpilib': 'mvapich2'}
             runfile.write('#PBS -l walltime=2:00:00 \n')
             runfile.write('#PBS -q medium \n')
             runfile.write(f'#PBS -l nodes={number_of_nodes}:ppn={tasks_per_node},mem=555GB -r n \n')
@@ -118,22 +135,34 @@ def main ():
 
         runfile.write("\n")
 
-        n_p = int(tasks_per_node) * int(number_of_nodes)
-        mksurfdata_path = './tool_bld/mksurfdata'
+        # --------------------------
+        # Obtain mpirun command from env_mach_specific.xml
+        # --------------------------
+        bld_path = './tool_bld'
+        ems_file = EnvMachSpecific(bld_path, standalone_configure=True)
+        fake_case = FakeCase(compiler=None, mpilib=attribs['mpilib'],
+                             debug=False, comp_interface=None)
+        total_tasks = int(tasks_per_node) * int(number_of_nodes)
+        cmd = ems_file.get_mpirun(fake_case, attribs, job='name',
+                                  overrides = {"total_tasks" : total_tasks,})
+        executable = f'{cmd[0]} {" ".join(cmd[1])}'.replace('ENV{', ''). \
+                                                    replace('}', '')
 
-        # Run env_mach_specific.sh to control the machine dependent environment
-        # including the paths to compilers and libraries external to cime such
-        # as netcdf
-        runfile.write('. ./tool_bld/.env_mach_specific.sh \n')
+        mksurfdata_path = os.path.join(bld_path, 'mksurfdata')
+        env_mach_path = os.path.join(bld_path, '.env_mach_specific.sh')
+
+        # --------------------------
+        # Write run script (part 2)
+        # --------------------------
+        runfile.write('# Run env_mach_specific.sh to control the machine ' \
+                      'dependent environment including the paths to ' \
+                      'compilers and libraries external to cime such as netcdf')
+        runfile.write(f'\n. {env_mach_path}\n')
         runfile.write('# Edit the mpirun command to use the MPI executable ' \
                       'on your system and the arguments it requires \n')
-        if machine == 'cheyenne':
-            output = f"mpiexec_mpt -p \"%g:\" -np {n_p} {mksurfdata_path} < {namelist_file}"
-        elif machine == 'casper':
-            output = f"mpiexec -np {n_p} {mksurfdata_path} < {namelist_file}"
-        elif machine == 'izumi':
-            output = f"mpiexec --machinefile $PBS_NODEFILE -n {n_p} --prepend-rank {mksurfdata_path} < {namelist_file}"
+        output = f'{executable} {mksurfdata_path} < {namelist_file}'
         runfile.write(f"{output} \n")
+        logger.info(f'run command is {output} ')
 
     print (f"Successfully created jobscript {jobscript_file}")
     sys.exit(0)

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -285,16 +285,18 @@ def main ():
         element_count = mesh_file.dimensions['elementCount'].size
         if 'origGridDims' in mesh_file.variables:
             orig_grid_dims = mesh_file.variables['origGridDims']
-            force_model_mesh_nx = orig_grid_dims[0]
-            force_model_mesh_ny = orig_grid_dims[1]
-            mesh_file.close()
-            important_msg = 'Found data for force_model_mesh_nx and ' \
-                            'force_model_mesh_ny in the mesh file so ' \
-                            'IGNORING ANY CORRESPONDING USER-ENTERED VALUES.'
-            logger.info(important_msg)
+            if int(force_model_mesh_nx) == orig_grid_dims[0] and \
+               int(force_model_mesh_ny) == orig_grid_dims[1]:
+                mesh_file.close()
+            else:
+                error_msg = 'ERROR: Found variable origGridDims in ' \
+                            f'{force_model_mesh_file} with values ' \
+                            f'{orig_grid_dims[:]} that do not agree with the ' \
+                            'user-entered mesh_nx and mesh_ny values of ' \
+                            f'{[force_model_mesh_nx, force_model_mesh_ny]}.'
+                sys.exit(error_msg)
         elif force_model_mesh_nx is None or force_model_mesh_ny is None:
-            error_msg = 'ERROR: You set --model-mesh but the file does not ' \
-                        'contain the variable origGridDims, so you MUST ALSO ' \
+            error_msg = 'ERROR: You set --model-mesh so you MUST ALSO ' \
                         'SET --model-mesh-nx AND --model-mesh-ny'
             sys.exit(error_msg)
 
@@ -478,8 +480,10 @@ def main ():
         'file. For a regular regional or 1x1 grid, you may generate the ' \
         'fsurdat file using the subset_data tool instead. Alternatively ' \
         'and definitely for curvilinear grids, you may generate ' \
-        'a mesh file using the workflow currently (2022/7/6) described in ' \
-        'https://github.com/ESCOMP/CTSM/issues/1773#issuecomment-1163432584'
+        'a mesh file using the workflow currently (2022/7) described in ' \
+        'https://github.com/ESCOMP/CTSM/issues/1773#issuecomment-1163432584' \
+        'TODO Reminder to ultimately place these workflow instructions in ' \
+        "the User's Guide."
             sys.exit(error_msg)
         else:
             error_msg = f'ERROR: invalid input res {res}; ' \

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -67,11 +67,12 @@ def get_parser():
         help="""
             model resolution [default: %(default)s]
             To see available supported resolutions, simply invoke this command
-            with a --res unknown option
+            with a --res unknown option. For custom resolutions, provide a grid
+            name of your choosing to be used in the name of the fsurdat file.
             """,
         action="store",
         dest="res",
-        required=False,
+        required=True,
         default="4x5",
     )
     parser.add_argument(
@@ -305,8 +306,6 @@ def main ():
                         '--model-mesh-nx x --model-mesh-ny must equal ' \
                         'exactly elementCount in --model-mesh'
             sys.exit(error_msg)
-        else:
-            res = f'{force_model_mesh_nx}x{force_model_mesh_ny}'
 
     hostname = os.getenv("HOSTNAME")
     logname = os.getenv("LOGNAME")
@@ -469,9 +468,19 @@ def main ():
         for child1 in root:  # this is domain tag
             for _, value in child1.attrib.items():
                 valid_grids.append(value)
-        error_msg = f'ERROR: invalid input res {res};' \
-                    f'valid grid values are {valid_grids}'
-        sys.exit(error_msg)
+        if res in valid_grids:
+            error_msg = 'ERROR: You have requested a valid grid for which ' \
+        '../../ccs_config/component_grids_nuopc.xml does not include a mesh ' \
+        'file. For a regular regional or 1x1 grid, you may generate the ' \
+        'fsurdat file using the subset_data tool instead. Alternatively ' \
+        'and definitely for curvilinear grids, you may generate ' \
+        'a mesh file using the workflow currently (2022/7/6) described in ' \
+        'https://github.com/ESCOMP/CTSM/issues/1773#issuecomment-1163432584'
+            sys.exit(error_msg)
+        else:
+            error_msg = f'ERROR: invalid input res {res}; ' \
+                        f'valid grid values are {valid_grids}'
+            sys.exit(error_msg)
 
     # Determine num_pft
     if nocrop_flag:

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -280,6 +280,7 @@ def main ():
         hires_pft = 'off'
 
     if force_model_mesh_file is not None:
+        # open mesh_file to read element_count and, if available, orig_grid_dims
         mesh_file = netCDF4.Dataset(force_model_mesh_file, 'r')
         element_count = mesh_file.dimensions['elementCount'].size
         if 'origGridDims' in mesh_file.variables:
@@ -289,7 +290,7 @@ def main ():
             mesh_file.close()
             important_msg = 'Found data for force_model_mesh_nx and ' \
                             'force_model_mesh_ny in the mesh file so ' \
-                            'IGNORING ANY USER-ENTERED VALUES.'
+                            'IGNORING ANY CORRESPONDING USER-ENTERED VALUES.'
             logger.info(important_msg)
         elif force_model_mesh_nx is None or force_model_mesh_ny is None:
             error_msg = 'ERROR: You set --model-mesh but the file does not ' \

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -423,16 +423,21 @@ def main ():
                 rawdata_files[child1.tag] = os.path.join(input_path, item.text)
                 if '%y' not in rawdata_files[child1.tag]:
                     if not os.path.isfile(rawdata_files[child1.tag]):
-                        print(f"WARNING: input data file {rawdata_files[child1.tag]} for {child1.tag} does not exist")
-                        print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
+                        print('WARNING: input data file ' \
+                              f'{rawdata_files[child1.tag]} for {child1.tag} ' \
+                              'does not exist')
+                        print('WARNING: run ./download_input_data to try TO ' \
+                              'OBTAIN MISSING FILES')
                         _must_run_download_input_data = True
 
             if item.tag == 'mesh_filename':
                 new_key = f"{child1.tag}_mesh"
                 rawdata_files[new_key] = os.path.join(input_path, item.text)
                 if not os.path.isfile(rawdata_files[new_key]):
-                    print(f"WARNING: input mesh file {rawdata_files[new_key]} does not exist")
-                    print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
+                    print('WARNING: input mesh file ' \
+                          f'{rawdata_files[new_key]} does not exist')
+                    print('WARNING: run ./download_input_data to try TO ' \
+                          'OBTAIN MISSING FILES')
                     _must_run_download_input_data = True
 
             if item.tag == 'lake_filename':
@@ -518,17 +523,23 @@ def main ():
                 landuse_input_fnam2 = file2.replace("%y", year_str)
                 landuse_input_fnam3 = file3.replace("%y", year_str)
                 if not os.path.isfile(landuse_input_fname):
-                     print(f"WARNING: landunit_input_fname: {landuse_input_fname} does not exist")
-                     print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
-                     _must_run_download_input_data = True
+                    print('WARNING: landunit_input_fname: ' \
+                          f'{landuse_input_fname} does not exist')
+                    print('WARNING: run ./download_input_data to try TO ' \
+                          'OBTAIN MISSING FILES')
+                    _must_run_download_input_data = True
                 if not os.path.isfile(landuse_input_fnam2):
-                     print(f"WARNING: landunit_input_fnam2: {landuse_input_fnam2} does not exist")
-                     print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
-                     _must_run_download_input_data = True
+                    print('WARNING: landunit_input_fnam2: ' \
+                          f'{landuse_input_fnam2} does not exist')
+                    print('WARNING: run ./download_input_data to try TO ' \
+                          'OBTAIN MISSING FILES')
+                    _must_run_download_input_data = True
                 if not os.path.isfile(landuse_input_fnam3):
-                     print(f"WARNING: landunit_input_fnam3: {landuse_input_fnam3} does not exist")
-                     print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
-                     _must_run_download_input_data = True
+                    print('WARNING: landunit_input_fnam3: ' \
+                          f'{landuse_input_fnam3} does not exist')
+                    print('WARNING: run ./download_input_data to try TO ' \
+                          'OBTAIN MISSING FILES')
+                    _must_run_download_input_data = True
 
                 # -- Each line is written twice in the original perl code:
                 landuse_line = f"{landuse_input_fname:<196}{year_str}\n"
@@ -572,7 +583,7 @@ def main ():
         # In case the "git -C" option is unavailable, as on casper (2022/5/24)
         # Still, this does NOT allow the system test to work on machines
         # without git -C
-        logger.info('git -C option unavailable on casper as of 2022/7/2', e)
+        logger.info('git -C option unavailable on casper as of 2022/7/2 %s', e)
         gitdescribe = subprocess.check_output('git describe', shell=True).strip()
     gitdescribe = gitdescribe.decode('utf-8')
 
@@ -631,12 +642,16 @@ def main ():
         if '%y' in mksrf_fhrvtyp:
             mksrf_fhrvtyp = mksrf_fhrvtyp.replace("%y",str(start_year))
         if not os.path.isfile(mksrf_fvegtyp):
-            print(f"WARNING: input mksrf_fvegtyp file {mksrf_fvegtyp} does not exist")
-            print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
+            print('WARNING: input mksrf_fvegtyp file ' \
+                  f'{mksrf_fvegtyp} does not exist')
+            print('WARNING: run ./download_input_data to try TO ' \
+                  'OBTAIN MISSING FILES')
             _must_run_download_input_data = True
         if not os.path.isfile(mksrf_fhrvtyp):
-            print(f"WARNING: input mksrf_fhrvtyp file {mksrf_fhrvtyp} does not exist")
-            print(f"WARNING: run ./download_input_data to try TO OBTAIN MISSING FILES")
+            print('WARNING: input mksrf_fhrvtyp file ' \
+                  f'{mksrf_fhrvtyp} does not exist')
+            print('WARNING: run ./download_input_data to try TO ' \
+                  'OBTAIN MISSING FILES')
             _must_run_download_input_data = True
         nlfile.write( f"  mksrf_fvegtyp = \'{mksrf_fvegtyp}\' \n")
         nlfile.write( f"  mksrf_fvegtyp_mesh = \'{mksrf_fvegtyp_mesh}\' \n")

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -65,7 +65,7 @@ def get_parser():
     parser.add_argument(
         "--res",
         help="""
-            model resolution [default: %(default)s]
+            Model resolution (required) 
             To see available supported resolutions, simply invoke this command
             with a --res unknown option. For custom resolutions, provide a grid
             name of your choosing to be used in the name of the fsurdat file.
@@ -73,7 +73,6 @@ def get_parser():
         action="store",
         dest="res",
         required=True,
-        default="4x5",
     )
     parser.add_argument(
         "--model-mesh",


### PR DESCRIPTION
### Description of changes
If mesh_file contains mesh_nx mesh_ny info, read it from the file.
Else abort and require user to enter it at the command line.
Confirm that the product of mesh_nx x mesh_ny (user-entered or from mesh_file) = elementCount (from mesh_file).

Address #1791 here, so as to name fsurdat files by their site/grid name rather than by their NX x NY.

Also address #1776 here, so as to stop hardwiring the mpirun command according to --machine in gen_mksurfdata_jobscript_single.py. Now get the mpirun command from env_mach_specific.xml.

### Specific notes

Contributors other than yourself, if any: @ekluzek 

CTSM Issues Fixed (include github issue #): #1790 #1791 #1776 

Are answers expected to change (and if so in what way)? No.

Any User Interface Changes (namelist or namelist defaults changes)? No.

Testing performed, if any:
Running gen_mksurfdata_namelist.py for cases with and without --model_mesh in the user-entered arguments and confirming expected behavior.