### PR TITLE
Docs: Corrections to spinup instructions

### DIFF
--- a/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
+++ b/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
@@ -96,7 +96,6 @@ Example: Final CLMBGC Spinup Simulation for |version|-BGC
    > ./xmlchange RUN_TYPE=startup
    # And copy the rpointer files for datm and drv from the earlier case
    > cp /glade/scratch/$LOGIN/archive/BGC_spinup/rest/rpointer.atm /ptmp/$LOGIN/CN_finalspinup
-   > cp /glade/scratch/$LOGIN/archive/BGC_spinup/rest/rpointer.drv /ptmp/$LOGIN/CN_finalspinup
    # Set the finidat file to the last restart file saved in previous step
    > echo ' finidat = "BGC_spinup.clm2.r.0201-01-01-00000.nc"' > user_nl_clm
    # Now setup

--- a/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
+++ b/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
@@ -95,7 +95,7 @@ Example: Final CLMBGC Spinup Simulation for |version|-BGC
    # Set the runtype to startup
    > ./xmlchange RUN_TYPE=startup
    # And copy the rpointer files for datm and drv from the earlier case
-   > cp /glade/scratch/$LOGIN/archive/BGC_spinup/rest/rpointer.atm /ptmp/$LOGIN/CN_finalspinup
+   > cp /glade/scratch/$LOGIN/archive/BGC_spinup/rest/rpointer.atm /glade/scratch/$LOGIN/CN_finalspinup/run
    # Set the finidat file to the last restart file saved in previous step
    > echo ' finidat = "BGC_spinup.clm2.r.0201-01-01-00000.nc"' > user_nl_clm
    # Now setup

--- a/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
+++ b/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
@@ -3,7 +3,7 @@
 .. include:: ../substitutions.rst
 
 ==========================
- Spinup of CLM5.0-BGC-Crop
+ Spinup of |version|-BGC-Crop
 ==========================
 
 To get the |version|-BGC model to a steady state, you first run it from arbitrary initial conditions using the "accelerated decomposition spinup" (-bgc_spinup on in CLM **configure**, see example below) mode for about 200 simulation years. :numref:`Figure BGC AD spinup plot for 1850 GSWP3` shows spinup behavior for an 1850 
@@ -53,7 +53,7 @@ equilibrium (e.g., TOTECOSYSC, TOTSOMC, TOTVEGC), particularly at high latitudes
 reach a new equilibrium. In this configuration, this will also automatically reseed "dead" plant functional types in the initial file with a 
 bit of leaf carbon to give those plant functional types another chance to grow under the new atmospheric forcing or model conditions.
 
-**1. 50_AD_SPINUP**
+**1. |version| accelerated-decomposition (AD) spinup**
      For the first step of running 200+ years in "-bgc_spinup on" mode, you will setup a case, and then edit the values in env_build.xml and env_run.xml so that the right configuration is turned on and the simulation is setup to run for the required length of simulation time. So do the following:
    
 Example:: AD_SPINUP Simulation for |version|-BGC
@@ -70,7 +70,7 @@ Example:: AD_SPINUP Simulation for |version|-BGC
    # Now build
    > ./case.build
    # The following sets RESUBMIT to 3 times in env_run.xml (you could also use an editor)
-   # The following sets STOP_DATE,STOP_N and STOP_OPTION to Jan/1/0201, 20, "nyears" in env_run.xml (you could also use an       editor)
+   # The following sets STOP_DATE,STOP_N and STOP_OPTION to Jan/1/0201, 20, "nyears" in env_run.xml (you could also use an editor)
    > ./xmlchange RESUBMIT=3,STOP_N=50,STOP_OPTION=nyears,STOP_DATE=02010101
    # Now run normally
    > ./case.submit

--- a/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
+++ b/doc/source/users_guide/running-special-cases/Spinning-up-the-biogeochemistry-BGC-spinup.rst
@@ -91,7 +91,7 @@ Example: Final CLMBGC Spinup Simulation for |version|-BGC
    > cd BGC_finalspinup
    # Now, Copy the last CLM restart file from the earlier case into your run directory
    > cp /ptmp/$LOGIN/archive/BGC_spinup/rest/BGC_spinup.clm*.r*.0201-01-01-00000.nc \
-   /glade/scratch/$LOGIN/CN_finalspinup
+   /glade/scratch/$LOGIN/CN_finalspinup/run
    # Set the runtype to startup
    > ./xmlchange RUN_TYPE=startup
    # And copy the rpointer files for datm and drv from the earlier case


### PR DESCRIPTION
### Description of changes
Some minor corrections to instructions for spinning up CTSM. Branched from `ctsm5.1.dev092`.

### Specific notes

**Contributors other than yourself, if any:** None.

**CTSM Issues Fixed:** n/a

**Are answers expected to change (and if so in what way)?** No.

**Any User Interface Changes (namelist or namelist defaults changes)?** No.

**Testing performed, if any:**
I have a 2-degree (f19_g17) spinup going now on Cheyenne, and it's successfully running the second part.
