### PR TITLE
Remove accumulation fields' PERIOD from the restart file

### DIFF
--- a/src/main/accumulMod.F90
+++ b/src/main/accumulMod.F90
@@ -764,17 +764,6 @@ contains
                data=accum(nf)%nsteps, readvar=readvar)
        end if
 
-       if (accum(nf)%old_name /= "") then
-          varname = trim(accum(nf)%name) // '_PERIOD:' // trim(accum(nf)%old_name) // '_PERIOD'
-       else
-          varname = trim(accum(nf)%name) // '_PERIOD'
-       end if
-       call restartvar(ncid=ncid, flag=flag, varname=varname, xtype=ncd_int, &
-            long_name='', units='time steps', &
-            imissing_value=ispval, ifill_value=huge(1), &
-            interpinic_flag='copy', &
-            data=accum(nf)%period, readvar=readvar)
-
     end do
 
   end subroutine accumulRest


### PR DESCRIPTION
### Description of changes

This doesn't need to be on the restart file, and having it read from the
restart file causes wrong behavior when changing the model time step.

See https://github.com/ESCOMP/CTSM/issues/1789 for details

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Resolves ESCOMP/CTSM#1789

Are answers expected to change (and if so in what way)? YES - for any case where the time step differs from the one originally used to create the initial conditions file. This typically means changing answers for any case with a time step other than 1/2 hour.

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None yet; about to run test suite