### PR TITLE
Fix albgrd_col value in SurfaceAlbedoType

### DIFF
--- a/src/biogeophys/SurfaceAlbedoType.F90
+++ b/src/biogeophys/SurfaceAlbedoType.F90
@@ -188,7 +188,7 @@ contains
          avgflag='A', long_name='cosine of solar zenith angle', &
          ptr_col=this%coszen_col, default='inactive')
 
-    this%albgri_col(begc:endc,:) = spval
+    this%albgrd_col(begc:endc,:) = spval
     call hist_addfld2d (fname='ALBGRD', units='proportion', type2d='numrad', &
          avgflag='A', long_name='ground albedo (direct)', &
          ptr_col=this%albgrd_col, default='inactive')


### PR DESCRIPTION
### Description of changes
Fix value of albgrd_col in SurfaceAlbefdoType.F90.
Previously, the wrong value (albgri_col) was being set in InitHistory.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Fixes #1788

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any:

Just for testing, I activated ALBGRD in hist_addfld2d to output the var and tested for SMS_Ld1_PS.f09_g17.I2000Clm50BgcCru.cheyenne_gnu.clm-datm_bias_correct_cruv7.
The tests passed on cheyenne.