### PR TITLE
Connect DATM ozone to CTSM

### DIFF
--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1598,7 +1598,7 @@ bioms:   do f = 1, fn
               rssha     = photosyns_inst%rssha_patch(bounds%begp:bounds%endp), &
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
-              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp),
+              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp), &
               forc_o3   = atm2lnd_inst%forc_o3_grc(bounds%begc:bounds%endc))
 
          !---------------------------------------------------------

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1598,8 +1598,7 @@ bioms:   do f = 1, fn
               rssha     = photosyns_inst%rssha_patch(bounds%begp:bounds%endp), &
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
-              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp),
-              ozone_atm = atm2lnd_inst%forc_o3_grc(bounds%begc:bounds%endc))
+              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp))
 
          !---------------------------------------------------------
          !update Vc,max and Jmax by LUNA model

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1598,7 +1598,8 @@ bioms:   do f = 1, fn
               rssha     = photosyns_inst%rssha_patch(bounds%begp:bounds%endp), &
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
-              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp))
+              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp),
+              forc_o3   = atm2lnd_inst%forc_o3_grc(bounds%begc:bounds%endc))
 
          !---------------------------------------------------------
          !update Vc,max and Jmax by LUNA model

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -5,7 +5,7 @@ module CanopyFluxesMod
   !------------------------------------------------------------------------------
   ! !DESCRIPTION:
   ! Performs calculation of leaf temperature and surface fluxes.
-  ! SoilFluxes then determines soil/snow and ground temperatures and updates the surface 
+  ! SoilFluxes then determines soil/snow and ground temperatures and updates the surface
   ! fluxes for the new ground temperature.
   !
   ! !USES:
@@ -41,9 +41,9 @@ module CanopyFluxesMod
   use HumanIndexMod         , only : humanindex_type
   use ch4Mod                , only : ch4_type
   use PhotosynthesisMod     , only : photosyns_type
-  use GridcellType          , only : grc                
-  use ColumnType            , only : col                
-  use PatchType             , only : patch                
+  use GridcellType          , only : grc
+  use ColumnType            , only : col
+  use PatchType             , only : patch
   use EDTypesMod            , only : ed_site_type
   use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
   use LunaMod               , only : Update_Photosynthesis_Capacity, Acc24_Climate_LUNA,Acc240_Climate_LUNA,Clear24_Climate_LUNA
@@ -70,11 +70,11 @@ module CanopyFluxesMod
   !
   ! !PUBLIC DATA MEMBERS:
   ! true => btran is based only on unfrozen soil levels
-  logical,  public :: perchroot     = .false.  
+  logical,  public :: perchroot     = .false.
 
-  ! true  => btran is based on active layer (defined over two years); 
+  ! true  => btran is based on active layer (defined over two years);
   ! false => btran is based on currently unfrozen levels
-  logical,  public :: perchroot_alt = .false.  
+  logical,  public :: perchroot_alt = .false.
   !
   ! !PRIVATE DATA MEMBERS:
   logical, private :: use_undercanopy_stability = .false.      ! use undercanopy stability term or not
@@ -239,7 +239,7 @@ contains
     use LunaMod            , only : is_time_to_run_LUNA
     !
     ! !ARGUMENTS:
-    type(bounds_type)                      , intent(in)            :: bounds 
+    type(bounds_type)                      , intent(in)            :: bounds
     integer                                , intent(in)            :: num_exposedvegp        ! number of points in filter_exposedvegp
     integer                                , intent(in)            :: filter_exposedvegp(:)  ! patch filter for non-snow-covered veg
     type(hlm_fates_interface_type)         , intent(inout)         :: clm_fates
@@ -395,7 +395,7 @@ contains
     real(r8) :: delq_snow
     real(r8) :: delq_soil
     real(r8) :: delq_h2osfc
-    real(r8) :: dt_veg(bounds%begp:bounds%endp)          ! change in t_veg, last iteration (Kelvin)                              
+    real(r8) :: dt_veg(bounds%begp:bounds%endp)          ! change in t_veg, last iteration (Kelvin)
     integer  :: jtop(bounds%begc:bounds%endc)            ! lbning
     integer  :: filterc_tmp(bounds%endp-bounds%begp+1)   ! temporary variable
     integer  :: ft                                       ! plant functional type index
@@ -435,7 +435,7 @@ contains
     SHR_ASSERT_ALL_FL((ubound(downreg_patch) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(leafn_patch) == (/bounds%endp/)), sourcefile, __LINE__)
 
-    associate(                                                                    & 
+    associate(                                                                    &
          t_stem                 => temperature_inst%t_stem_patch                , & ! Output: [real(r8) (:)   ]  stem temperature (Kelvin)
          dhsdt_canopy           => energyflux_inst%dhsdt_canopy_patch           , & ! Output: [real(r8) (:)   ]  change in heat storage of stem (W/m**2) [+ to atm]
          soilresis              => soilstate_inst%soilresis_col                 , & ! Input:  [real(r8) (:)   ]  soil evaporative resistance
@@ -452,17 +452,17 @@ contains
          rstem_per_dbh          => pftcon%rstem_per_dbh                         , & ! Input:  stem resistance per stem diameter (s/m**2)
          wood_density           => pftcon%wood_density                          , & ! Input:  dry wood density (kg/m3)
 
-         forc_lwrad             => atm2lnd_inst%forc_lwrad_downscaled_col       , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)                       
+         forc_lwrad             => atm2lnd_inst%forc_lwrad_downscaled_col       , & ! Input:  [real(r8) (:)   ]  downward infrared (longwave) radiation (W/m**2)
          forc_q                 => wateratm2lndbulk_inst%forc_q_downscaled_col  , & ! Input:  [real(r8) (:)   ]  atmospheric specific humidity (kg/kg)
-         forc_pbot              => atm2lnd_inst%forc_pbot_downscaled_col        , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)                                             
-         forc_th                => atm2lnd_inst%forc_th_downscaled_col          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)                            
-         forc_rho               => atm2lnd_inst%forc_rho_downscaled_col         , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)                                                     
-         forc_t                 => atm2lnd_inst%forc_t_downscaled_col           , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)                                      
-         forc_u                 => atm2lnd_inst%forc_u_grc                      , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)                        
-         forc_v                 => atm2lnd_inst%forc_v_grc                      , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)                       
-         forc_pco2              => atm2lnd_inst%forc_pco2_grc                   , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)                                             
-         forc_pc13o2            => atm2lnd_inst%forc_pc13o2_grc                 , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)                                           
-         forc_po2               => atm2lnd_inst%forc_po2_grc                    , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)                                              
+         forc_pbot              => atm2lnd_inst%forc_pbot_downscaled_col        , & ! Input:  [real(r8) (:)   ]  atmospheric pressure (Pa)
+         forc_th                => atm2lnd_inst%forc_th_downscaled_col          , & ! Input:  [real(r8) (:)   ]  atmospheric potential temperature (Kelvin)
+         forc_rho               => atm2lnd_inst%forc_rho_downscaled_col         , & ! Input:  [real(r8) (:)   ]  density (kg/m**3)
+         forc_t                 => atm2lnd_inst%forc_t_downscaled_col           , & ! Input:  [real(r8) (:)   ]  atmospheric temperature (Kelvin)
+         forc_u                 => atm2lnd_inst%forc_u_grc                      , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in east direction (m/s)
+         forc_v                 => atm2lnd_inst%forc_v_grc                      , & ! Input:  [real(r8) (:)   ]  atmospheric wind speed in north direction (m/s)
+         forc_pco2              => atm2lnd_inst%forc_pco2_grc                   , & ! Input:  [real(r8) (:)   ]  partial pressure co2 (Pa)
+         forc_pc13o2            => atm2lnd_inst%forc_pc13o2_grc                 , & ! Input:  [real(r8) (:)   ]  partial pressure c13o2 (Pa)
+         forc_po2               => atm2lnd_inst%forc_po2_grc                    , & ! Input:  [real(r8) (:)   ]  partial pressure o2 (Pa)
 
          tc_ref2m               => humanindex_inst%tc_ref2m_patch               , & ! Output: [real(r8) (:)   ]  2 m height surface air temperature (C)
          vap_ref2m              => humanindex_inst%vap_ref2m_patch              , & ! Output: [real(r8) (:)   ]  2 m height vapor pressure (Pa)
@@ -495,104 +495,104 @@ contains
          swmp80_ref2m           => humanindex_inst%swmp80_ref2m_patch           , & ! Output: [real(r8) (:)   ]  2 m Swamp Cooler temperature 80% effi (C)
          swmp80_ref2m_r         => humanindex_inst%swmp80_ref2m_r_patch         , & ! Output: [real(r8) (:)   ]  Rural 2 m Swamp Cooler temperature 80% effi (C)
 
-         sabv                   => solarabs_inst%sabv_patch                     , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed by vegetation (W/m**2)                       
+         sabv                   => solarabs_inst%sabv_patch                     , & ! Input:  [real(r8) (:)   ]  solar radiation absorbed by vegetation (W/m**2)
          par_z_sun              => solarabs_inst%parsun_z_patch                 , & ! Input:  [real(r8) (:,:) ]  par absorbed per unit lai for canopy layer (w/m**2)
 
          frac_veg_nosno         => canopystate_inst%frac_veg_nosno_patch        , & ! Input:  [integer  (:)   ]  fraction of vegetation not covered by snow (0 OR 1) [-]
-         elai                   => canopystate_inst%elai_patch                  , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow                        
-         esai                   => canopystate_inst%esai_patch                  , & ! Input:  [real(r8) (:)   ]  one-sided stem area index with burying by snow                        
-         laisun                 => canopystate_inst%laisun_patch                , & ! Input:  [real(r8) (:)   ]  sunlit leaf area                                                      
-         laisha                 => canopystate_inst%laisha_patch                , & ! Input:  [real(r8) (:)   ]  shaded leaf area                                                      
-         displa                 => canopystate_inst%displa_patch                , & ! Input:  [real(r8) (:)   ]  displacement height (m)                                               
+         elai                   => canopystate_inst%elai_patch                  , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow
+         esai                   => canopystate_inst%esai_patch                  , & ! Input:  [real(r8) (:)   ]  one-sided stem area index with burying by snow
+         laisun                 => canopystate_inst%laisun_patch                , & ! Input:  [real(r8) (:)   ]  sunlit leaf area
+         laisha                 => canopystate_inst%laisha_patch                , & ! Input:  [real(r8) (:)   ]  shaded leaf area
+         displa                 => canopystate_inst%displa_patch                , & ! Input:  [real(r8) (:)   ]  displacement height (m)
          stem_biomass           => canopystate_inst%stem_biomass_patch          , & ! Output: [real(r8) (:)   ]  Aboveground stem biomass  (kg/m**2)
          leaf_biomass           => canopystate_inst%leaf_biomass_patch          , & ! Output: [real(r8) (:)   ]  Aboveground leaf biomass  (kg/m**2)
-         htop                   => canopystate_inst%htop_patch                  , & ! Input:  [real(r8) (:)   ]  canopy top(m)                                                         
+         htop                   => canopystate_inst%htop_patch                  , & ! Input:  [real(r8) (:)   ]  canopy top(m)
          dleaf_patch            => canopystate_inst%dleaf_patch                 , & ! Output: [real(r8) (:)   ]  mean leaf diameter for this patch/pft
-         
-         watsat                 => soilstate_inst%watsat_col                    , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)   (constant)                     
-         watdry                 => soilstate_inst%watdry_col                    , & ! Input:  [real(r8) (:,:) ]  btran parameter for btran=0                      (constant)                                        
-         watopt                 => soilstate_inst%watopt_col                    , & ! Input:  [real(r8) (:,:) ]  btran parameter for btran=1                      (constant)                                      
+
+         watsat                 => soilstate_inst%watsat_col                    , & ! Input:  [real(r8) (:,:) ]  volumetric soil water at saturation (porosity)   (constant)
+         watdry                 => soilstate_inst%watdry_col                    , & ! Input:  [real(r8) (:,:) ]  btran parameter for btran=0                      (constant)
+         watopt                 => soilstate_inst%watopt_col                    , & ! Input:  [real(r8) (:,:) ]  btran parameter for btran=1                      (constant)
          eff_porosity           => soilstate_inst%eff_porosity_col              , & ! Output: [real(r8) (:,:) ]  effective soil porosity
-         soilbeta               => soilstate_inst%soilbeta_col                  , & ! Input:  [real(r8) (:)   ]  soil wetness relative to field capacity                               
+         soilbeta               => soilstate_inst%soilbeta_col                  , & ! Input:  [real(r8) (:)   ]  soil wetness relative to field capacity
 
          u10_clm                => frictionvel_inst%u10_clm_patch               , & ! Input:  [real(r8) (:)   ]  10 m height winds (m/s)
-         forc_hgt_u_patch       => frictionvel_inst%forc_hgt_u_patch            , & ! Input:  [real(r8) (:)   ]  observational height of wind at patch level [m]                          
-         z0mg                   => frictionvel_inst%z0mg_col                    , & ! Input:  [real(r8) (:)   ]  roughness length of ground, momentum [m]                              
+         forc_hgt_u_patch       => frictionvel_inst%forc_hgt_u_patch            , & ! Input:  [real(r8) (:)   ]  observational height of wind at patch level [m]
+         z0mg                   => frictionvel_inst%z0mg_col                    , & ! Input:  [real(r8) (:)   ]  roughness length of ground, momentum [m]
          zetamax                => frictionvel_inst%zetamaxstable               , & ! Input:  [real(r8)       ]  max zeta value under stable conditions
-         ram1                   => frictionvel_inst%ram1_patch                  , & ! Output: [real(r8) (:)   ]  aerodynamical resistance (s/m)                                        
-         z0mv                   => frictionvel_inst%z0mv_patch                  , & ! Output: [real(r8) (:)   ]  roughness length over vegetation, momentum [m]                        
-         z0hv                   => frictionvel_inst%z0hv_patch                  , & ! Output: [real(r8) (:)   ]  roughness length over vegetation, sensible heat [m]                   
-         z0qv                   => frictionvel_inst%z0qv_patch                  , & ! Output: [real(r8) (:)   ]  roughness length over vegetation, latent heat [m]                     
-         rb1                    => frictionvel_inst%rb1_patch                   , & ! Output: [real(r8) (:)   ]  boundary layer resistance (s/m)                                       
+         ram1                   => frictionvel_inst%ram1_patch                  , & ! Output: [real(r8) (:)   ]  aerodynamical resistance (s/m)
+         z0mv                   => frictionvel_inst%z0mv_patch                  , & ! Output: [real(r8) (:)   ]  roughness length over vegetation, momentum [m]
+         z0hv                   => frictionvel_inst%z0hv_patch                  , & ! Output: [real(r8) (:)   ]  roughness length over vegetation, sensible heat [m]
+         z0qv                   => frictionvel_inst%z0qv_patch                  , & ! Output: [real(r8) (:)   ]  roughness length over vegetation, latent heat [m]
+         rb1                    => frictionvel_inst%rb1_patch                   , & ! Output: [real(r8) (:)   ]  boundary layer resistance (s/m)
 
-         t_h2osfc               => temperature_inst%t_h2osfc_col                , & ! Input:  [real(r8) (:)   ]  surface water temperature                                             
-         t_soisno               => temperature_inst%t_soisno_col                , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)                                           
-         t_grnd                 => temperature_inst%t_grnd_col                  , & ! Input:  [real(r8) (:)   ]  ground surface temperature [K]                                        
-         thv                    => temperature_inst%thv_col                     , & ! Input:  [real(r8) (:)   ]  virtual potential temperature (kelvin)                                
-         thm                    => temperature_inst%thm_patch                   , & ! Input:  [real(r8) (:)   ]  intermediate variable (forc_t+0.0098*forc_hgt_t_patch)                  
-         emv                    => temperature_inst%emv_patch                   , & ! Input:  [real(r8) (:)   ]  vegetation emissivity                                                     
-         emg                    => temperature_inst%emg_col                     , & ! Input:  [real(r8) (:)   ]  vegetation emissivity                                                 
-         t_veg                  => temperature_inst%t_veg_patch                 , & ! Output: [real(r8) (:)   ]  vegetation temperature (Kelvin)                                       
-         t_ref2m                => temperature_inst%t_ref2m_patch               , & ! Output: [real(r8) (:)   ]  2 m height surface air temperature (Kelvin)                           
-         t_ref2m_r              => temperature_inst%t_ref2m_r_patch             , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface air temperature (Kelvin)                     
-         t_skin_patch           => temperature_inst%t_skin_patch                , & ! Output: [real(r8) (:)   ]  patch skin temperature (K)  
+         t_h2osfc               => temperature_inst%t_h2osfc_col                , & ! Input:  [real(r8) (:)   ]  surface water temperature
+         t_soisno               => temperature_inst%t_soisno_col                , & ! Input:  [real(r8) (:,:) ]  soil temperature (Kelvin)
+         t_grnd                 => temperature_inst%t_grnd_col                  , & ! Input:  [real(r8) (:)   ]  ground surface temperature [K]
+         thv                    => temperature_inst%thv_col                     , & ! Input:  [real(r8) (:)   ]  virtual potential temperature (kelvin)
+         thm                    => temperature_inst%thm_patch                   , & ! Input:  [real(r8) (:)   ]  intermediate variable (forc_t+0.0098*forc_hgt_t_patch)
+         emv                    => temperature_inst%emv_patch                   , & ! Input:  [real(r8) (:)   ]  vegetation emissivity
+         emg                    => temperature_inst%emg_col                     , & ! Input:  [real(r8) (:)   ]  vegetation emissivity
+         t_veg                  => temperature_inst%t_veg_patch                 , & ! Output: [real(r8) (:)   ]  vegetation temperature (Kelvin)
+         t_ref2m                => temperature_inst%t_ref2m_patch               , & ! Output: [real(r8) (:)   ]  2 m height surface air temperature (Kelvin)
+         t_ref2m_r              => temperature_inst%t_ref2m_r_patch             , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface air temperature (Kelvin)
+         t_skin_patch           => temperature_inst%t_skin_patch                , & ! Output: [real(r8) (:)   ]  patch skin temperature (K)
 
-         frac_h2osfc            => waterdiagnosticbulk_inst%frac_h2osfc_col              , & ! Input:  [real(r8) (:)   ]  fraction of surface water                                             
-         fwet                   => waterdiagnosticbulk_inst%fwet_patch                   , & ! Input:  [real(r8) (:)   ]  fraction of canopy that is wet (0 to 1)                               
-         fdry                   => waterdiagnosticbulk_inst%fdry_patch                   , & ! Input:  [real(r8) (:)   ]  fraction of foliage that is green and dry [-]                         
-         frac_sno               => waterdiagnosticbulk_inst%frac_sno_eff_col             , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)                           
-         snow_depth             => waterdiagnosticbulk_inst%snow_depth_col               , & ! Input:  [real(r8) (:)   ]  snow height (m)                                                       
-         qg_snow                => waterdiagnosticbulk_inst%qg_snow_col                  , & ! Input:  [real(r8) (:)   ]  specific humidity at snow surface [kg/kg]                             
-         qg_soil                => waterdiagnosticbulk_inst%qg_soil_col                  , & ! Input:  [real(r8) (:)   ]  specific humidity at soil surface [kg/kg]                             
-         qg_h2osfc              => waterdiagnosticbulk_inst%qg_h2osfc_col                , & ! Input:  [real(r8) (:)   ]  specific humidity at h2osfc surface [kg/kg]                           
-         qg                     => waterdiagnosticbulk_inst%qg_col                       , & ! Input:  [real(r8) (:)   ]  specific humidity at ground surface [kg/kg]                           
-         dqgdT                  => waterdiagnosticbulk_inst%dqgdT_col                    , & ! Input:  [real(r8) (:)   ]  temperature derivative of "qg"                                        
+         frac_h2osfc            => waterdiagnosticbulk_inst%frac_h2osfc_col              , & ! Input:  [real(r8) (:)   ]  fraction of surface water
+         fwet                   => waterdiagnosticbulk_inst%fwet_patch                   , & ! Input:  [real(r8) (:)   ]  fraction of canopy that is wet (0 to 1)
+         fdry                   => waterdiagnosticbulk_inst%fdry_patch                   , & ! Input:  [real(r8) (:)   ]  fraction of foliage that is green and dry [-]
+         frac_sno               => waterdiagnosticbulk_inst%frac_sno_eff_col             , & ! Input:  [real(r8) (:)   ]  fraction of ground covered by snow (0 to 1)
+         snow_depth             => waterdiagnosticbulk_inst%snow_depth_col               , & ! Input:  [real(r8) (:)   ]  snow height (m)
+         qg_snow                => waterdiagnosticbulk_inst%qg_snow_col                  , & ! Input:  [real(r8) (:)   ]  specific humidity at snow surface [kg/kg]
+         qg_soil                => waterdiagnosticbulk_inst%qg_soil_col                  , & ! Input:  [real(r8) (:)   ]  specific humidity at soil surface [kg/kg]
+         qg_h2osfc              => waterdiagnosticbulk_inst%qg_h2osfc_col                , & ! Input:  [real(r8) (:)   ]  specific humidity at h2osfc surface [kg/kg]
+         qg                     => waterdiagnosticbulk_inst%qg_col                       , & ! Input:  [real(r8) (:)   ]  specific humidity at ground surface [kg/kg]
+         dqgdT                  => waterdiagnosticbulk_inst%dqgdT_col                    , & ! Input:  [real(r8) (:)   ]  temperature derivative of "qg"
 
-         h2osoi_ice             => waterstatebulk_inst%h2osoi_ice_col               , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)                                                    
+         h2osoi_ice             => waterstatebulk_inst%h2osoi_ice_col               , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
          h2osoi_vol             => waterstatebulk_inst%h2osoi_vol_col               , & ! Input:  [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3] by F. Li and S. Levis
-         h2osoi_liq             => waterstatebulk_inst%h2osoi_liq_col               , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)                                                
-         h2osoi_liqvol          => waterdiagnosticbulk_inst%h2osoi_liqvol_col            , & ! Output: [real(r8) (:,:) ]  volumetric liquid water (v/v) 
-         snocan                 => waterstatebulk_inst%snocan_patch                 , & ! Output: [real(r8) (:)   ]  canopy snow (mm H2O)                                                 
-         liqcan                 => waterstatebulk_inst%liqcan_patch                 , & ! Output: [real(r8) (:)   ]  canopy liquid (mm H2O)                                                 
+         h2osoi_liq             => waterstatebulk_inst%h2osoi_liq_col               , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
+         h2osoi_liqvol          => waterdiagnosticbulk_inst%h2osoi_liqvol_col            , & ! Output: [real(r8) (:,:) ]  volumetric liquid water (v/v)
+         snocan                 => waterstatebulk_inst%snocan_patch                 , & ! Output: [real(r8) (:)   ]  canopy snow (mm H2O)
+         liqcan                 => waterstatebulk_inst%liqcan_patch                 , & ! Output: [real(r8) (:)   ]  canopy liquid (mm H2O)
 
-         q_ref2m                => waterdiagnosticbulk_inst%q_ref2m_patch                , & ! Output: [real(r8) (:)   ]  2 m height surface specific humidity (kg/kg)                          
-         rh_ref2m_r             => waterdiagnosticbulk_inst%rh_ref2m_r_patch             , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface relative humidity (%)                        
-         rh_ref2m               => waterdiagnosticbulk_inst%rh_ref2m_patch               , & ! Output: [real(r8) (:)   ]  2 m height surface relative humidity (%)                              
-         rhaf                   => waterdiagnosticbulk_inst%rh_af_patch                  , & ! Output: [real(r8) (:)   ]  fractional humidity of canopy air [dimensionless]                     
+         q_ref2m                => waterdiagnosticbulk_inst%q_ref2m_patch                , & ! Output: [real(r8) (:)   ]  2 m height surface specific humidity (kg/kg)
+         rh_ref2m_r             => waterdiagnosticbulk_inst%rh_ref2m_r_patch             , & ! Output: [real(r8) (:)   ]  Rural 2 m height surface relative humidity (%)
+         rh_ref2m               => waterdiagnosticbulk_inst%rh_ref2m_patch               , & ! Output: [real(r8) (:)   ]  2 m height surface relative humidity (%)
+         rhaf                   => waterdiagnosticbulk_inst%rh_af_patch                  , & ! Output: [real(r8) (:)   ]  fractional humidity of canopy air [dimensionless]
          vpd_ref2m              => waterdiagnosticbulk_inst%vpd_ref2m_patch              , & ! Output: [real(r8) (:)   ]  2 m height surface vapor pressure deficit (Pa)
          iwue_ln                => waterdiagnosticbulk_inst%iwue_ln_patch                , & ! Output: [real(r8) (:)   ]  local noon ecosystem-scale inherent water use efficiency (gC kgH2O-1 hPa)
 
-         qflx_tran_veg          => waterfluxbulk_inst%qflx_tran_veg_patch           , & ! Output: [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)                      
-         qflx_evap_veg          => waterfluxbulk_inst%qflx_evap_veg_patch           , & ! Output: [real(r8) (:)   ]  vegetation evaporation (mm H2O/s) (+ = to atm)                        
-         qflx_evap_soi          => waterfluxbulk_inst%qflx_evap_soi_patch           , & ! Output: [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)                              
-         qflx_ev_snow           => waterfluxbulk_inst%qflx_ev_snow_patch            , & ! Output: [real(r8) (:)   ]  evaporation flux from snow (mm H2O/s) [+ to atm]                        
-         qflx_ev_soil           => waterfluxbulk_inst%qflx_ev_soil_patch            , & ! Output: [real(r8) (:)   ]  evaporation flux from soil (mm H2O/s) [+ to atm]                        
-         qflx_ev_h2osfc         => waterfluxbulk_inst%qflx_ev_h2osfc_patch          , & ! Output: [real(r8) (:)   ]  evaporation flux from h2osfc (mm H2O/s) [+ to atm]                      
+         qflx_tran_veg          => waterfluxbulk_inst%qflx_tran_veg_patch           , & ! Output: [real(r8) (:)   ]  vegetation transpiration (mm H2O/s) (+ = to atm)
+         qflx_evap_veg          => waterfluxbulk_inst%qflx_evap_veg_patch           , & ! Output: [real(r8) (:)   ]  vegetation evaporation (mm H2O/s) (+ = to atm)
+         qflx_evap_soi          => waterfluxbulk_inst%qflx_evap_soi_patch           , & ! Output: [real(r8) (:)   ]  soil evaporation (mm H2O/s) (+ = to atm)
+         qflx_ev_snow           => waterfluxbulk_inst%qflx_ev_snow_patch            , & ! Output: [real(r8) (:)   ]  evaporation flux from snow (mm H2O/s) [+ to atm]
+         qflx_ev_soil           => waterfluxbulk_inst%qflx_ev_soil_patch            , & ! Output: [real(r8) (:)   ]  evaporation flux from soil (mm H2O/s) [+ to atm]
+         qflx_ev_h2osfc         => waterfluxbulk_inst%qflx_ev_h2osfc_patch          , & ! Output: [real(r8) (:)   ]  evaporation flux from h2osfc (mm H2O/s) [+ to atm]
          gs_mol_sun             => photosyns_inst%gs_mol_sun_patch              , & ! Input: [real(r8) (:)   ]  patch sunlit leaf stomatal conductance (umol H2O/m**2/s)
          gs_mol_sha             => photosyns_inst%gs_mol_sha_patch              , & ! Input: [real(r8) (:)   ]  patch shaded leaf stomatal conductance (umol H2O/m**2/s)
          rssun                  => photosyns_inst%rssun_patch                   , & ! Output: [real(r8) (:)   ]  leaf sunlit stomatal resistance (s/m) (output from Photosynthesis)
          rssha                  => photosyns_inst%rssha_patch                   , & ! Output: [real(r8) (:)   ]  leaf shaded stomatal resistance (s/m) (output from Photosynthesis)
          fpsn                   => photosyns_inst%fpsn_patch                    , & ! Input:  [real(r8) (:)   ]  photosynthesis (umol CO2 /m**2 /s)
 
-         grnd_ch4_cond          => ch4_inst%grnd_ch4_cond_patch                 , & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s] 
+         grnd_ch4_cond          => ch4_inst%grnd_ch4_cond_patch                 , & ! Output: [real(r8) (:)   ]  tracer conductance for boundary layer [m/s]
 
-         htvp                   => energyflux_inst%htvp_col                     , & ! Input:  [real(r8) (:)   ]  latent heat of evaporation (/sublimation) [J/kg] (constant)                      
-         btran                  => energyflux_inst%btran_patch                  , & ! Output: [real(r8) (:)   ]  transpiration wetness factor (0 to 1)                                 
-         rresis                 => energyflux_inst%rresis_patch                 , & ! Output: [real(r8) (:,:) ]  root resistance by layer (0-1)  (nlevgrnd)                          
-         taux                   => energyflux_inst%taux_patch                   , & ! Output: [real(r8) (:)   ]  wind (shear) stress: e-w (kg/m/s**2)                                  
-         tauy                   => energyflux_inst%tauy_patch                   , & ! Output: [real(r8) (:)   ]  wind (shear) stress: n-s (kg/m/s**2)                                  
-         canopy_cond            => energyflux_inst%canopy_cond_patch            , & ! Output: [real(r8) (:)   ]  tracer conductance for canopy [m/s] 
-         cgrnds                 => energyflux_inst%cgrnds_patch                 , & ! Output: [real(r8) (:)   ]  deriv. of soil sensible heat flux wrt soil temp [w/m2/k]              
-         cgrndl                 => energyflux_inst%cgrndl_patch                 , & ! Output: [real(r8) (:)   ]  deriv. of soil latent heat flux wrt soil temp [w/m**2/k]              
-         dlrad                  => energyflux_inst%dlrad_patch                  , & ! Output: [real(r8) (:)   ]  downward longwave radiation below the canopy [W/m2]                   
-         ulrad                  => energyflux_inst%ulrad_patch                  , & ! Output: [real(r8) (:)   ]  upward longwave radiation above the canopy [W/m2]                     
-         cgrnd                  => energyflux_inst%cgrnd_patch                  , & ! Output: [real(r8) (:)   ]  deriv. of soil energy flux wrt to soil temp [w/m2/k]                  
-         eflx_sh_snow           => energyflux_inst%eflx_sh_snow_patch           , & ! Output: [real(r8) (:)   ]  sensible heat flux from snow (W/m**2) [+ to atm]                      
-         eflx_sh_h2osfc         => energyflux_inst%eflx_sh_h2osfc_patch         , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]                      
-         eflx_sh_soil           => energyflux_inst%eflx_sh_soil_patch           , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]                      
+         htvp                   => energyflux_inst%htvp_col                     , & ! Input:  [real(r8) (:)   ]  latent heat of evaporation (/sublimation) [J/kg] (constant)
+         btran                  => energyflux_inst%btran_patch                  , & ! Output: [real(r8) (:)   ]  transpiration wetness factor (0 to 1)
+         rresis                 => energyflux_inst%rresis_patch                 , & ! Output: [real(r8) (:,:) ]  root resistance by layer (0-1)  (nlevgrnd)
+         taux                   => energyflux_inst%taux_patch                   , & ! Output: [real(r8) (:)   ]  wind (shear) stress: e-w (kg/m/s**2)
+         tauy                   => energyflux_inst%tauy_patch                   , & ! Output: [real(r8) (:)   ]  wind (shear) stress: n-s (kg/m/s**2)
+         canopy_cond            => energyflux_inst%canopy_cond_patch            , & ! Output: [real(r8) (:)   ]  tracer conductance for canopy [m/s]
+         cgrnds                 => energyflux_inst%cgrnds_patch                 , & ! Output: [real(r8) (:)   ]  deriv. of soil sensible heat flux wrt soil temp [w/m2/k]
+         cgrndl                 => energyflux_inst%cgrndl_patch                 , & ! Output: [real(r8) (:)   ]  deriv. of soil latent heat flux wrt soil temp [w/m**2/k]
+         dlrad                  => energyflux_inst%dlrad_patch                  , & ! Output: [real(r8) (:)   ]  downward longwave radiation below the canopy [W/m2]
+         ulrad                  => energyflux_inst%ulrad_patch                  , & ! Output: [real(r8) (:)   ]  upward longwave radiation above the canopy [W/m2]
+         cgrnd                  => energyflux_inst%cgrnd_patch                  , & ! Output: [real(r8) (:)   ]  deriv. of soil energy flux wrt to soil temp [w/m2/k]
+         eflx_sh_snow           => energyflux_inst%eflx_sh_snow_patch           , & ! Output: [real(r8) (:)   ]  sensible heat flux from snow (W/m**2) [+ to atm]
+         eflx_sh_h2osfc         => energyflux_inst%eflx_sh_h2osfc_patch         , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]
+         eflx_sh_soil           => energyflux_inst%eflx_sh_soil_patch           , & ! Output: [real(r8) (:)   ]  sensible heat flux from soil (W/m**2) [+ to atm]
          eflx_sh_stem           => energyflux_inst%eflx_sh_stem_patch            , & ! Output: [real(r8) (:)   ]  sensible heat flux from stems (W/m**2) [+ to atm]
-         eflx_sh_veg            => energyflux_inst%eflx_sh_veg_patch            , & ! Output: [real(r8) (:)   ]  sensible heat flux from leaves (W/m**2) [+ to atm]                    
-         eflx_sh_grnd           => energyflux_inst%eflx_sh_grnd_patch           , & ! Output: [real(r8) (:)   ]  sensible heat flux from ground (W/m**2) [+ to atm]                    
+         eflx_sh_veg            => energyflux_inst%eflx_sh_veg_patch            , & ! Output: [real(r8) (:)   ]  sensible heat flux from leaves (W/m**2) [+ to atm]
+         eflx_sh_grnd           => energyflux_inst%eflx_sh_grnd_patch           , & ! Output: [real(r8) (:)   ]  sensible heat flux from ground (W/m**2) [+ to atm]
          rah1                   => frictionvel_inst%rah1_patch                  , & ! Output: [real(r8) (:)   ]  aerodynamical  resistance [s/m]
          rah2                   => frictionvel_inst%rah2_patch                  , & ! Output: [real(r8) (:)   ]  aerodynamical  resistance [s/m]
          raw1                   => frictionvel_inst%raw1_patch                  , & ! Output: [real(r8) (:)   ]  aerodynamical  resistance [s/m]
@@ -603,7 +603,7 @@ contains
          taf                    => frictionvel_inst%taf_patch                   , & ! Output: [real(r8) (:)   ]  canopy air temperature [K]
          qaf                    => frictionvel_inst%qaf_patch                   , & ! Output: [real(r8) (:)   ]  canopy air humidity [kg/kg]
          obu                    => frictionvel_inst%obu_patch                   , & ! Output: [real(r8) (:)   ]  Monin-Obukhov length [m]
-         zeta                   => frictionvel_inst%zeta_patch                  , & ! Output: [real(r8) (:)   ]  dimensionless stability parameter 
+         zeta                   => frictionvel_inst%zeta_patch                  , & ! Output: [real(r8) (:)   ]  dimensionless stability parameter
          vpd                    => frictionvel_inst%vpd_patch                   , & ! Output: [real(r8) (:)   ]  vapor pressure deficit [Pa]
          num_iter               => frictionvel_inst%num_iter_patch              , & ! Output: [real(r8) (:)   ]  number of iterations
 
@@ -617,7 +617,7 @@ contains
         bsha                    => energyflux_inst%bsha_patch                       ! Output: [real(r8) (:)   ]  sunlit canopy transpiration wetness factor (0 to 1)
       end if
 
-      
+
       ! Determine step size
 
       dtime = get_step_size_real()
@@ -632,7 +632,7 @@ contains
 
       fn = num_exposedvegp
       filterp(1:fn) = filter_exposedvegp(1:fn)
-      
+
       ! -----------------------------------------------------------------
       ! Time step initialization of photosynthesis variables
       ! -----------------------------------------------------------------
@@ -642,21 +642,21 @@ contains
 
       ! -----------------------------------------------------------------
       ! Prep some IO variables and some checks on patch pointers if FATES
-      ! is running. 
+      ! is running.
       ! Filter explanation: The patch filter in this routine identifies all
       ! non-lake, non-urban patches that are not covered by ice. The
       ! filter is set over a few steps:
       !
-      ! 1a) for CN: 
-      !             clm_drv() -> 
+      ! 1a) for CN:
+      !             clm_drv() ->
       !             bgc_vegetation_inst%EcosystemDynamicsPostDrainage() ->
       !             CNVegStructUpdate()
       !    if(elai(p)+esai(p)>0) frac_veg_nosno_alb(p) = 1
-      !    
+      !
       ! 1b) for FATES:
-      !              clm_drv() -> 
-      !              clm_fates%dynamics_driv() -> 
-      !              ed_clm_link() -> 
+      !              clm_drv() ->
+      !              clm_fates%dynamics_driv() ->
+      !              ed_clm_link() ->
       !              ed_clm_leaf_area_profile():
       !    if(elai(p)+esai(p)>0) frac_veg_nosno_alb(p) = 1
       !
@@ -664,7 +664,7 @@ contains
       !    frac_veg_nosno_alb(p) is then combined with the active(p)
       !    flag via union to create frac_veg_nosno_patch(p)
       ! 3) immediately after, during clm_drv()->setExposedvegpFilter()
-      !    the list used here "exposedvegp(fe)" is incremented if 
+      !    the list used here "exposedvegp(fe)" is incremented if
       !    frac_veg_nosno_patch > 0
       ! -----------------------------------------------------------------
 
@@ -703,9 +703,9 @@ bioms:   do f = 1, fn
             ! if using Satellite Phenology mode, use values in parameter file
             ! otherwise calculate dbh from stem biomass
             if(use_cn) then
-               if(stem_biomass(p) > 0._r8) then 
+               if(stem_biomass(p) > 0._r8) then
                   dbh(p) = 2._r8 * sqrt(stem_biomass(p) * (1._r8 - fbw(patch%itype(p))) &
-                       / ( shr_const_pi * htop(p) * k_cyl_vol & 
+                       / ( shr_const_pi * htop(p) * k_cyl_vol &
                        * nstem(patch%itype(p)) *  wood_density(patch%itype(p))))
                else
                   dbh(p) = 0._r8
@@ -755,7 +755,7 @@ bioms:   do f = 1, fn
             ! calculate specify heat capacity of vegetation
             ! as weighted averaged of dry biomass and water
             ! lma_dry has units of kg dry mass/m2 here
-            ! (Appendix B of Bonan et al., GMD, 2018) 
+            ! (Appendix B of Bonan et al., GMD, 2018)
 
             cp_leaf(p)  = leaf_biomass(p) * (c_dry_biomass*(1._r8-fbw(patch%itype(p))) + (fbw(patch%itype(p)))*c_water)
 
@@ -764,7 +764,7 @@ bioms:   do f = 1, fn
             ! adjust for departure from cylindrical stem model
             cp_stem(p) = k_cyl_vol * cp_stem(p)
 
-            ! resistance between internal stem temperature and canopy air 
+            ! resistance between internal stem temperature and canopy air
             rstem(p) = rstem_per_dbh(patch%itype(p))*dbh(p)
 
          enddo bioms
@@ -799,7 +799,7 @@ bioms:   do f = 1, fn
          p = filterp(f)
          filterc_tmp(f)=patch%column(p)
       enddo
-      
+
       !compute effective soil porosity
       call calc_effective_soilporosity(bounds,                          &
             ubj = nlevgrnd,                                              &
@@ -809,10 +809,10 @@ bioms:   do f = 1, fn
             h2osoi_ice = h2osoi_ice(bounds%begc:bounds%endc,1:nlevgrnd), &
             denice = denice,                                             &
             eff_por=eff_porosity(bounds%begc:bounds%endc, 1:nlevgrnd) )
-      
+
       !compute volumetric liquid water content
       jtop(bounds%begc:bounds%endc) = 1
-      
+
       call calc_volumetric_h2oliq(bounds,                                    &
             jtop = jtop(bounds%begc:bounds%endc),                             &
             lbj = 1,                                                          &
@@ -823,7 +823,7 @@ bioms:   do f = 1, fn
             h2osoi_liq = h2osoi_liq(bounds%begc:bounds%endc, 1:nlevgrnd),     &
             denh2o = denh2o,                                                  &
             vol_liq = h2osoi_liqvol(bounds%begc:bounds%endc, 1:nlevgrnd) )
-      
+
       !set up perchroot options
       call set_perchroot_opt(perchroot, perchroot_alt)
 
@@ -832,19 +832,19 @@ bioms:   do f = 1, fn
       ! ask fates to calculate btran functions and distribution of uptake
       ! this will require boundary conditions from CLM, boundary conditions which
       ! may only be available from a smaller subset of patches that meet the
-      ! exposed veg.  
+      ! exposed veg.
       ! calc_root_moist_stress already calculated root soil water stress 'rresis'
       ! this is the input boundary condition to calculate the transpiration
       ! wetness factor btran and the root weighting factors for FATES.  These
       ! values require knowledge of the belowground root structure.
       ! --------------------------------------------------------------------------
-      
+
       if(use_fates)then
          call clm_fates%wrap_btran(nc, fn, filterc_tmp(1:fn), soilstate_inst, &
                waterdiagnosticbulk_inst, temperature_inst, energyflux_inst, soil_water_retention_curve)
-         
+
       else
-         
+
          !calculate root moisture stress
          call calc_root_moist_stress(bounds,     &
             nlevgrnd = nlevgrnd,               &
@@ -857,7 +857,7 @@ bioms:   do f = 1, fn
             waterstatebulk_inst=waterstatebulk_inst,   &
             waterdiagnosticbulk_inst=waterdiagnosticbulk_inst,   &
               soil_water_retention_curve=soil_water_retention_curve)
-     
+
       end if
 
       !! Modify aerodynamic parameters for sparse/dense canopy (X. Zeng)
@@ -949,7 +949,7 @@ bioms:   do f = 1, fn
 
       ! Set counter for leaf temperature iteration (itlef)
 
-      itlef = 0    
+      itlef = 0
       fnorig = fn
       fporig(1:fn) = filterp(1:fn)
 
@@ -991,7 +991,7 @@ bioms:   do f = 1, fn
             ! dleaf_patch if this is not an fates patch.
             ! Otherwise, the value has already been loaded
             ! during the FATES dynamics call
-            if(.not.patch%is_fates(p)) then  
+            if(.not.patch%is_fates(p)) then
                dleaf_patch(p) = dleaf(patch%itype(p))
             end if
 
@@ -1052,8 +1052,8 @@ bioms:   do f = 1, fn
 
          end do
 
-         if ( use_fates ) then      
-            
+         if ( use_fates ) then
+
             call clm_fates%wrap_photosynthesis(nc, bounds, fn, filterp(1:fn), &
                  svpts(begp:endp), eah(begp:endp), o2(begp:endp), &
                  co2(begp:endp), rb(begp:endp), dayl_factor(begp:endp), &
@@ -1133,7 +1133,7 @@ bioms:   do f = 1, fn
             else
                rppdry = 0._r8
             end if
-            
+
             ! Calculate canopy conductance for methane / oxygen (e.g. stomatal conductance & leaf bdy cond)
             if (use_lch4) then
                canopy_cond(p) = (laisun(p)/(rb(p)+rssun(p)) + laisha(p)/(rb(p)+rssha(p)))/max(elai(p), 0.01_r8)
@@ -1272,10 +1272,10 @@ bioms:   do f = 1, fn
             ! during the timestep.  This energy is later added to the
             ! sensible heat flux.
 
-            ! Note that when the hydraulic stress parameterization is active we don't 
+            ! Note that when the hydraulic stress parameterization is active we don't
             ! adjust transpiration for the new values of potential evaporation and rppdry
-            ! as calculated above because transpiration would then no longer be consistent 
-            ! with the vertical transpiration sink terms that are passed to Compute_VertTranSink_PHS, 
+            ! as calculated above because transpiration would then no longer be consistent
+            ! with the vertical transpiration sink terms that are passed to Compute_VertTranSink_PHS,
             ! thereby causing a water balance error. However, because this adjustment occurs
             ! within the leaf temperature iteration, this ends up being a small inconsistency.
             if ( use_hydrstress ) then
@@ -1329,8 +1329,8 @@ bioms:   do f = 1, fn
             zeta(p) = zldis(p)*vkc*grav*thvstar/(ustar(p)**2*thv(c))
 
             if (zeta(p) >= 0._r8) then     !stable
-               ! remove stability cap when biomass heat storage is active 
-               if(use_biomass_heat_storage) then 
+               ! remove stability cap when biomass heat storage is active
+               if(use_biomass_heat_storage) then
                   zeta(p) = min(100._r8,max(zeta(p),0.01_r8))
                else
                   zeta(p) = min(zetamax,max(zeta(p),0.01_r8))
@@ -1514,7 +1514,7 @@ bioms:   do f = 1, fn
               + emg(c)*(1._r8-emv(p))*sb*lw_grnd)
 
          ! Calculate the skin temperature as a weighted sum of all the ground and vegetated fraction
-         ! The weight is the so-called vegetation emissivity, but not that emv is actually an attentuation 
+         ! The weight is the so-called vegetation emissivity, but not that emv is actually an attentuation
          ! function that goes to zero as LAI (ELAI + ESAI) go to zero.
 
          t_skin_patch(p)  =  emv(p)*t_veg(p)  +  (1._r8 - emv(p))*sqrt(sqrt(lw_grnd))
@@ -1529,7 +1529,7 @@ bioms:   do f = 1, fn
          if (t_veg(p) > tfrz ) then ! above freezing, update accumulation in liqcan
             if ((qflx_evap_veg(p)-qflx_tran_veg(p))*dtime > liqcan(p)) then ! all liq evap
                ! In this case, all liqcan will evap. Take remainder from snocan
-               snocan(p)=snocan(p)+liqcan(p)+(qflx_tran_veg(p)-qflx_evap_veg(p))*dtime	 
+               snocan(p)=snocan(p)+liqcan(p)+(qflx_tran_veg(p)-qflx_evap_veg(p))*dtime
             end if
             liqcan(p) = max(0._r8,liqcan(p)+(qflx_tran_veg(p)-qflx_evap_veg(p))*dtime)
 
@@ -1542,10 +1542,10 @@ bioms:   do f = 1, fn
          end if
 
       end do
-      
+
       if ( use_fates ) then
-         
-         
+
+
          call clm_fates%wrap_accumulatefluxes(nc,fn,filterp(1:fn))
          call clm_fates%wrap_hydraulics_drive(bounds,nc,soilstate_inst, &
                waterstatebulk_inst,waterdiagnosticbulk_inst,waterfluxbulk_inst, &
@@ -1554,18 +1554,18 @@ bioms:   do f = 1, fn
       else
 
          ! Determine total photosynthesis
-         
+
          call PhotosynthesisTotal(fn, filterp, &
               atm2lnd_inst, canopystate_inst, photosyns_inst)
-         
+
          ! Calculate water use efficiency
          !   does not support multi-layer canopy
-         if (nlevcan == 1) then 
+         if (nlevcan == 1) then
             do f = 1, fn
                p = filterp(f)
                c = patch%column(p)
                g = patch%gridcell(p)
-               
+
                if ( is_near_local_noon( grc%londeg(g), deltasec=3600 ) .and. fpsn(p)>0._r8 )then
                   gs        = 1.e-6_r8*(laisun(p)*gs_mol_sun(p,iv)+laisha(p)*gs_mol_sha(p,iv))    ! 1e-6  converts umolH2O->molH2O
                   if ( gs>0._r8 ) then
@@ -1585,7 +1585,7 @@ bioms:   do f = 1, fn
          ! computed by the Photosynthesis routine. The updated ozone uptake computed here
          ! will be used in the next time step to calculate ozone stress for the next time
          ! step's photosynthesis calculations.
-         
+
          ! COMPILER_BUG(wjs, 2014-11-29, pgi 14.7) The following dummy variable assignment is
          ! needed with pgi 14.7 on yellowstone; without it, forc_pbot_downscaled_col gets
          ! resized inappropriately in the following subroutine call, due to a compiler bug.
@@ -1598,7 +1598,8 @@ bioms:   do f = 1, fn
               rssha     = photosyns_inst%rssha_patch(bounds%begp:bounds%endp), &
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
-              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp))
+              tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp),
+              ozone_atm = atm2lnd_inst%forc_o3_grc(bounds%begc:bounds%endc))
 
          !---------------------------------------------------------
          !update Vc,max and Jmax by LUNA model
@@ -1607,25 +1608,25 @@ bioms:   do f = 1, fn
                  canopystate_inst, photosyns_inst, &
                  surfalb_inst, solarabs_inst, &
                  temperature_inst)
-            
+
             if(is_time_to_run_LUNA())then
-               
+
                call Acc240_Climate_LUNA(bounds, fn, filterp, &
                     o2(begp:endp), &
                     co2(begp:endp), &
                     rb(begp:endp), &
                     rhaf(begp:endp),&
-                    temperature_inst, & 
+                    temperature_inst, &
                     photosyns_inst, &
                     surfalb_inst, &
                     solarabs_inst, &
                     waterdiagnosticbulk_inst,&
-                    frictionvel_inst) 
-               
+                    frictionvel_inst)
+
                call Update_Photosynthesis_Capacity(bounds, fn, filterp, &
                     dayl_factor(begp:endp), &
                     atm2lnd_inst, &
-                    temperature_inst, & 
+                    temperature_inst, &
                     canopystate_inst, &
                     photosyns_inst, &
                     surfalb_inst, &
@@ -1633,13 +1634,13 @@ bioms:   do f = 1, fn
                     waterdiagnosticbulk_inst,&
                     frictionvel_inst, &
                     ozone_inst)
-               
+
                call Clear24_Climate_LUNA(bounds, fn, filterp, &
                     canopystate_inst, photosyns_inst, &
                     surfalb_inst, solarabs_inst, &
                     temperature_inst)
             endif
-            
+
          endif
       end if
 
@@ -1666,4 +1667,3 @@ bioms:   do f = 1, fn
   end subroutine CanopyFluxes
 
 end module CanopyFluxesMod
-

--- a/src/biogeophys/OzoneBaseMod.F90
+++ b/src/biogeophys/OzoneBaseMod.F90
@@ -51,10 +51,10 @@ module OzoneBaseMod
        character(len=*),        intent(in) :: o3_veg_stress_method
 
      end subroutine Init_interface
-  
+
      subroutine Restart_interface(this, bounds, ncid, flag)
        use decompMod , only : bounds_type
-       use ncdio_pio , only : file_desc_t       
+       use ncdio_pio , only : file_desc_t
        import :: ozone_base_type
 
        class(ozone_base_type)            :: this
@@ -64,7 +64,7 @@ module OzoneBaseMod
      end subroutine Restart_interface
 
      subroutine CalcOzoneUptake_interface(this, bounds, num_exposedvegp, filter_exposedvegp, &
-          forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
+          forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3)
        use decompMod    , only : bounds_type
        use shr_kind_mod , only : r8 => shr_kind_r8
        import :: ozone_base_type
@@ -80,6 +80,7 @@ module OzoneBaseMod
        real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
        real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
        real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
+       real(r8) , intent(in) :: forc_o3( bounds%begc: )  ! atmospheric ozone (mol/mol)
      end subroutine CalcOzoneUptake_interface
 
      subroutine CalcOzoneStress_interface(this, bounds, &
@@ -96,9 +97,9 @@ module OzoneBaseMod
        integer                , intent(in)    :: filter_noexposedvegp(:) ! patch filter for veg where frac_veg_nosno is 0
      end subroutine CalcOzoneStress_interface
   end interface
-     
+
 contains
-  
+
   !-----------------------------------------------------------------------
   subroutine InitAllocateBase(this, bounds)
     !
@@ -114,7 +115,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer :: begp, endp
-    
+
     character(len=*), parameter :: subname = 'InitAllocateBase'
     !-----------------------------------------------------------------------
 
@@ -127,7 +128,7 @@ contains
     allocate(this%o3coefgsun_patch(begp:endp))  ; this%o3coefgsun_patch(:)               = nan
     allocate(this%o3coefjmaxsha_patch(begp:endp))  ; this%o3coefjmaxsha_patch(:) = nan
     allocate(this%o3coefjmaxsun_patch(begp:endp))  ; this%o3coefjmaxsun_patch(:) = nan
-    
+
 
   end subroutine InitAllocateBase
 
@@ -148,7 +149,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer :: begp, endp
-    
+
     character(len=*), parameter :: subname = 'InitColdBase'
     !-----------------------------------------------------------------------
 

--- a/src/biogeophys/OzoneBaseMod.F90
+++ b/src/biogeophys/OzoneBaseMod.F90
@@ -80,7 +80,7 @@ module OzoneBaseMod
        real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
        real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
        real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
-       real(r8) , intent(in) :: forc_o3( bounds%begc: )  ! atmospheric ozone (mol/mol)
+       real(r8) , intent(in) :: forc_o3( bounds%begg: )   ! atmospheric ozone (mol/mol)
      end subroutine CalcOzoneUptake_interface
 
      subroutine CalcOzoneStress_interface(this, bounds, &

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -388,6 +388,7 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL_FL((ubound(forc_pbot) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(forc_th) == (/bounds%endc/)), sourcefile, __LINE__)
+    SHR_ASSERT_ALL_FL((ubound(ozone_atm) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssun) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssha) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rb) == (/bounds%endp/)), sourcefile, __LINE__)

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -375,7 +375,7 @@ contains
     real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
     real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
     real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
-    real(r8) , intent(in) :: forc_o3( bounds%begc: )   ! ozone partial pressure (mol/mol)
+    real(r8) , intent(in) :: forc_o3( bounds%begg: )   ! ozone partial pressure (mol/mol)
     !
     ! !LOCAL VARIABLES:
     integer  :: fp             ! filter index
@@ -388,7 +388,7 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL_FL((ubound(forc_pbot) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(forc_th) == (/bounds%endc/)), sourcefile, __LINE__)
-    SHR_ASSERT_ALL_FL((ubound(forc_o3) == (/bounds%endc/)), sourcefile, __LINE__)
+    SHR_ASSERT_ALL_FL((ubound(forc_o3) == (/bounds%endg/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssun) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssha) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rb) == (/bounds%endp/)), sourcefile, __LINE__)
@@ -404,17 +404,18 @@ contains
       do fp = 1, num_exposedvegp
          p = filter_exposedvegp(fp)
          c = patch%column(p)
+         g = patch%gridcell(p)
 
          ! Ozone uptake for shaded leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=forc_o3, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=forc_o3(g), forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssha(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesha(p))
 
          ! Ozone uptake for sunlit leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=forc_o3, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=forc_o3(g), forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssun(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesun(p))

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -86,7 +86,7 @@ module OzoneMod
 
   ! TODO(wjs, 2014-09-29) This parameter will eventually become a spatially-varying
   ! value, obtained from ATM
-  !real(r8), parameter :: forc_ozone = 100._r8 * 1.e-9_r8  ! ozone partial pressure [mol/mol]
+  real(r8), parameter :: forc_ozone = 100._r8 * 1.e-9_r8  ! ozone partial pressure [mol/mol]
 
   ! TODO(wjs, 2014-09-29) The following parameters should eventually be moved to the
   ! params file. Parameters differentiated on veg type should be put on the params file
@@ -358,7 +358,7 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
-       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, ozone_atm)
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
     !
     ! !DESCRIPTION:
     ! Calculate ozone uptake.
@@ -375,7 +375,7 @@ contains
     real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
     real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
     real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
-    real(r8) , intent(in) :: ozone_atm( bounds%begc: ) ! ozone partial pressure (mol/mol)
+    !real(r8) , intent(in) :: ozone_atm( bounds%begc: ) ! ozone partial pressure (mol/mol)
     !
     ! !LOCAL VARIABLES:
     integer  :: fp             ! filter index
@@ -388,7 +388,7 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL_FL((ubound(forc_pbot) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(forc_th) == (/bounds%endc/)), sourcefile, __LINE__)
-    SHR_ASSERT_ALL_FL((ubound(ozone_atm) == (/bounds%endc/)), sourcefile, __LINE__)
+    !SHR_ASSERT_ALL_FL((ubound(ozone_atm) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssun) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssha) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rb) == (/bounds%endp/)), sourcefile, __LINE__)
@@ -407,14 +407,14 @@ contains
 
          ! Ozone uptake for shaded leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=ozone_atm(c), forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=forc_ozone, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssha(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesha(p))
 
          ! Ozone uptake for sunlit leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=ozone_atm(c), forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=forc_ozone, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssun(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesun(p))

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -358,7 +358,7 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
-       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3)
     !
     ! !DESCRIPTION:
     ! Calculate ozone uptake.
@@ -375,7 +375,7 @@ contains
     real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
     real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
     real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
-    !real(r8) , intent(in) :: ozone_atm( bounds%begc: ) ! ozone partial pressure (mol/mol)
+    real(r8) , intent(in) :: forc_o3( bounds%begc: )   ! ozone partial pressure (mol/mol)
     !
     ! !LOCAL VARIABLES:
     integer  :: fp             ! filter index
@@ -388,7 +388,7 @@ contains
     ! Enforce expected array sizes
     SHR_ASSERT_ALL_FL((ubound(forc_pbot) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(forc_th) == (/bounds%endc/)), sourcefile, __LINE__)
-    !SHR_ASSERT_ALL_FL((ubound(ozone_atm) == (/bounds%endc/)), sourcefile, __LINE__)
+    SHR_ASSERT_ALL_FL((ubound(forc_o3) == (/bounds%endc/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssun) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rssha) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(rb) == (/bounds%endp/)), sourcefile, __LINE__)
@@ -407,14 +407,14 @@ contains
 
          ! Ozone uptake for shaded leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=forc_ozone, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=forc_o3, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssha(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesha(p))
 
          ! Ozone uptake for sunlit leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=forc_ozone, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=forc_o3, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssun(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesun(p))

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -40,11 +40,11 @@ module OzoneMod
      ! NOTE(wjs, 2014-09-29) tlai_old_patch really belongs alongside tlai_patch in
      ! CanopyStateType.  But there are problems with any way I can think to implement
      ! that:
-     ! 
+     !
      ! - Updating tlai_old from a call in clm_driver, just before tlai is updated: This
      !   is problematic to do correctly because tlai is updated in different places
      !   depending on whether you're using SP, CN or ED.
-     ! 
+     !
      ! - Updating tlai_old within each routine that updates tlai: This feels fragile,
      !   since it depends on each scheme remembering to do this update at the correct
      !   time.
@@ -71,11 +71,11 @@ module OzoneMod
      procedure, private, nopass :: CalcOzoneUptakeOnePoint
 
      ! Original ozone stress functions from Danica Lombardozzi 2015
-     procedure, private         :: CalcOzoneStressLombardozzi2015           ! Stress parameterization 
-     procedure, private, nopass :: CalcOzoneStressLombardozzi2015OnePoint   ! Ozone stress calculation for single point 
+     procedure, private         :: CalcOzoneStressLombardozzi2015           ! Stress parameterization
+     procedure, private, nopass :: CalcOzoneStressLombardozzi2015OnePoint   ! Ozone stress calculation for single point
 
-     ! Ozone stress functions from Stefanie Falk 
-     procedure, private         :: CalcOzoneStressFalk          ! Stress parameterization 
+     ! Ozone stress functions from Stefanie Falk
+     procedure, private         :: CalcOzoneStressFalk          ! Stress parameterization
      procedure, private, nopass :: CalcOzoneStressFalkOnePoint  ! Ozone stress calculation for single point
 
   end type ozone_type
@@ -86,7 +86,7 @@ module OzoneMod
 
   ! TODO(wjs, 2014-09-29) This parameter will eventually become a spatially-varying
   ! value, obtained from ATM
-  real(r8), parameter :: forc_ozone = 100._r8 * 1.e-9_r8  ! ozone partial pressure [mol/mol]
+  !real(r8), parameter :: forc_ozone = 100._r8 * 1.e-9_r8  ! ozone partial pressure [mol/mol]
 
   ! TODO(wjs, 2014-09-29) The following parameters should eventually be moved to the
   ! params file. Parameters differentiated on veg type should be put on the params file
@@ -102,9 +102,9 @@ module OzoneMod
   real(r8), parameter :: o3_flux_threshold = 0.8_r8
 
   ! o3 intercepts and slopes for photosynthesis
-  real(r8), parameter :: needleleafPhotoInt   = 0.8390_r8  ! units = unitless 
+  real(r8), parameter :: needleleafPhotoInt   = 0.8390_r8  ! units = unitless
   real(r8), parameter :: needleleafPhotoSlope = 0._r8      ! units = per mmol m^-2
-  real(r8), parameter :: broadleafPhotoInt    = 0.8752_r8  ! units = unitless  
+  real(r8), parameter :: broadleafPhotoInt    = 0.8752_r8  ! units = unitless
   real(r8), parameter :: broadleafPhotoSlope  = 0._r8      ! units = per mmol m^-2
   real(r8), parameter :: nonwoodyPhotoInt     = 0.8021_r8  ! units = unitless
   real(r8), parameter :: nonwoodyPhotoSlope   = -0.0009_r8 ! units = per mmol m^-2
@@ -116,10 +116,10 @@ module OzoneMod
   real(r8), parameter :: broadleafCondSlope   = 0._r8      ! units = per mmol m^-2
   real(r8), parameter :: nonwoodyCondInt      = 0.7511_r8  ! units = unitless
   real(r8), parameter :: nonwoodyCondSlope    = 0._r8      ! units = per mmol m^-2
-  
+
   ! Data is currently only available for broadleaf species (Dec 2020)
   ! o3 intercepts and slopes for JmaxO3/Jmax0
-  real(r8), parameter :: needleleafJmaxInt   = 1._r8                ! units = unitless 
+  real(r8), parameter :: needleleafJmaxInt   = 1._r8                ! units = unitless
   real(r8), parameter :: needleleafJmaxSlope = 0._r8                ! units = per mmol m^-2
   real(r8), parameter :: broadleafJmaxInt    = 1._r8                ! units = unitless
   real(r8), parameter :: broadleafJmaxSlope  = -0.0037_r8           ! units = per mmol m^-2
@@ -144,19 +144,19 @@ contains
     !
     ! !USES:
    use clm_varctl   , only : use_luna
-    ! 
+    !
     ! !ARGUMENTS:
     class(ozone_type), intent(inout) :: this
     type(bounds_type), intent(in)    :: bounds
-    character(len=*),  intent(in)    :: o3_veg_stress_method 
+    character(len=*),  intent(in)    :: o3_veg_stress_method
     !-----------------------------------------------------------------------
 
-    if (o3_veg_stress_method=='stress_lombardozzi2015') then 
+    if (o3_veg_stress_method=='stress_lombardozzi2015') then
        this%stress_method = stress_method_lombardozzi2015
-    else if (o3_veg_stress_method=='stress_falk') then 
+    else if (o3_veg_stress_method=='stress_falk') then
        this%stress_method = stress_method_falk
        if (.not. use_luna ) call endrun(' use_luna=.true. is required when o3_veg_stress_method = stress_falk.')
-    else 
+    else
        call endrun('unknown ozone stress method')
     end if
 
@@ -280,7 +280,7 @@ contains
        call hist_addfld1d (fname='O3COEFJMAXSUN', units='unitless', &
             avgflag='A', long_name='ozone coefficient for maximum electron transport rate sunlit leaves', &
             ptr_patch=this%o3coefjmaxsun_patch, l2g_scale_type='veg')
-    else 
+    else
        call endrun('unknown ozone stress method')
     end if
 
@@ -349,7 +349,7 @@ contains
          dim1name='pft', &
          long_name='ozone uptake for sunlit leaves', units='mmol m^-3', &
          readvar=readvar, interpinic_flag='interp', data=this%o3uptakesun_patch)
-         
+
   end subroutine Restart
 
   ! ========================================================================
@@ -358,7 +358,7 @@ contains
 
   !-----------------------------------------------------------------------
   subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
-       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, ozone_atm)
     !
     ! !DESCRIPTION:
     ! Calculate ozone uptake.
@@ -375,6 +375,7 @@ contains
     real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
     real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
     real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
+    real(r8) , intent(in) :: ozone_atm( bounds%begc: ) ! ozone partial pressure (mol/mol)
     !
     ! !LOCAL VARIABLES:
     integer  :: fp             ! filter index
@@ -405,14 +406,14 @@ contains
 
          ! Ozone uptake for shaded leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=forc_ozone, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=ozone_atm, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssha(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesha(p))
 
          ! Ozone uptake for sunlit leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=forc_ozone, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=ozone_atm, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssun(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesun(p))
@@ -670,7 +671,7 @@ contains
 
   end subroutine CalcOzoneStressLombardozzi2015OnePoint
 
-  
+
   !-----------------------------------------------------------------------
   subroutine CalcOzoneStressFalk(this, bounds, &
        num_exposedvegp, filter_exposedvegp, &
@@ -683,7 +684,7 @@ contains
     !
     ! !USES:
     use LunaMod        , only : is_time_to_run_LUNA
-    !   
+    !
     ! !ARGUMENTS:
     class(ozone_type), intent(inout) :: this
     type(bounds_type), intent(in)    :: bounds
@@ -698,16 +699,16 @@ contains
 
     character(len=*), parameter :: subname = 'CalcOzoneStressFalk'
     !-----------------------------------------------------------------------
-    
-    if (is_time_to_run_LUNA()) then 
-      
+
+    if (is_time_to_run_LUNA()) then
+
       associate( &
          o3uptakesha => this%o3uptakesha_patch                 , & ! Input:  [real(r8) (:)] ozone dose
          o3uptakesun => this%o3uptakesun_patch                 , & ! Input:  [real(r8) (:)] ozone dose
          o3coefjmaxsha => this%o3coefjmaxsha_patch             , & ! Output: [real(r8) (:)] ozone coef jmax sha
          o3coefjmaxsun => this%o3coefjmaxsun_patch               & ! Output: [real(r8) (:)] ozone coef jmax sun
          )
-      
+
       do fp = 1, num_exposedvegp
          p = filter_exposedvegp(fp)
 
@@ -734,7 +735,7 @@ contains
 
       end associate
 
-   end if 
+   end if
 
   end subroutine CalcOzoneStressFalk
 
@@ -750,13 +751,13 @@ contains
     integer  , intent(in)        :: pft_type   ! vegetation type, for indexing into pftvarcon arrays
     real(r8) , intent(in)        :: o3uptake   ! ozone entering the leaf
     real(r8) , intent(inout)     :: o3coefjmax ! ozone coefficient for max. electron transport rate
-    !    
+    !
     ! !LOCAL VARIABLES:
     real(r8) :: jmaxInt        ! intercept for max. electron transport rate
     real(r8) :: jmaxSlope      ! slope for max. electron transport rate
     character(len=*), parameter :: subname = 'CalcOzoneStressFalkOnePoint'
     !-----------------------------------------------------------------------
-   
+
     if (o3uptake == 0._r8) then
        o3coefjmax = 1._r8
     else
@@ -776,7 +777,7 @@ contains
           jmaxSlope  = needleleafJmaxSlope
        end if
        ! Apply parameter values to compute o3 coefficients
-       o3coefjmax = max(0._r8, min(1._r8, jmaxInt  + jmaxSlope  * o3uptake)) 
+       o3coefjmax = max(0._r8, min(1._r8, jmaxInt  + jmaxSlope  * o3uptake))
     end if
 
   end subroutine CalcOzoneStressFalkOnePoint

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -381,6 +381,7 @@ contains
     integer  :: fp             ! filter index
     integer  :: p              ! patch index
     integer  :: c              ! column index
+    integer  :: g              ! gridcell index
 
     character(len=*), parameter :: subname = 'CalcOzoneUptake'
     !-----------------------------------------------------------------------

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -86,7 +86,7 @@ module OzoneMod
 
   ! TODO(wjs, 2014-09-29) This parameter will eventually become a spatially-varying
   ! value, obtained from ATM
-  real(r8), parameter :: forc_ozone = 100._r8 * 1.e-9_r8  ! ozone partial pressure [mol/mol]
+  !real(r8), parameter :: forc_ozone = 100._r8 * 1.e-9_r8  ! ozone partial pressure [mol/mol]
 
   ! TODO(wjs, 2014-09-29) The following parameters should eventually be moved to the
   ! params file. Parameters differentiated on veg type should be put on the params file

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -406,14 +406,14 @@ contains
 
          ! Ozone uptake for shaded leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=ozone_atm, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=ozone_atm(c), forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssha(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesha(p))
 
          ! Ozone uptake for sunlit leaves
          call CalcOzoneUptakeOnePoint( &
-              forc_ozone=ozone_atm, forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
+              forc_ozone=ozone_atm(c), forc_pbot=forc_pbot(c), forc_th=forc_th(c), &
               rs=rssun(p), rb=rb(p), ram=ram(p), &
               tlai=tlai(p), tlai_old=tlai_old(p), pft_type=patch%itype(p), &
               o3uptake=o3uptakesun(p))

--- a/src/biogeophys/OzoneOffMod.F90
+++ b/src/biogeophys/OzoneOffMod.F90
@@ -34,7 +34,7 @@ module OzoneOffMod
        __FILE__
 
 contains
-  
+
   !-----------------------------------------------------------------------
   function constructor() result(ozone_off)
     !
@@ -47,7 +47,7 @@ contains
     type(ozone_off_type) :: ozone_off  ! function result
     !
     ! !LOCAL VARIABLES:
-    
+
     character(len=*), parameter :: subname = 'constructor'
     !-----------------------------------------------------------------------
 
@@ -56,7 +56,7 @@ contains
     ! Eventually this should call the Init routine (or replace the Init routine
     ! entirely). But I think it would be confusing to do that until we switch everything
     ! to use a constructor rather than the init routine.
-    
+
   end function constructor
 
 
@@ -71,30 +71,30 @@ contains
     ! !ARGUMENTS:
     class(ozone_off_type) , intent(inout) :: this
     type(bounds_type)     , intent(in)           :: bounds
-    character(len=*), intent(in)                      :: o3_veg_stress_method 
+    character(len=*), intent(in)                      :: o3_veg_stress_method
     !-----------------------------------------------------------------------
 
     if (o3_veg_stress_method /= 'unset' ) call endrun(' unconsistent choice of o3_veg_stress_method in init OzoneOffMod.')
-    
+
     call this%InitAllocateBase(bounds)
     call this%InitColdBase(bounds)
 
   end subroutine Init
 
   subroutine Restart(this, bounds, ncid, flag)
-    use ncdio_pio , only : file_desc_t       
+    use ncdio_pio , only : file_desc_t
 
     class(ozone_off_type) :: this
     type(bounds_type), intent(in) :: bounds
     type(file_desc_t) , intent(inout) :: ncid ! netcdf id
     character(len=*)  , intent(in)    :: flag ! 'read', 'write' or 'define'
-    
+
     ! DO NOTHING
 
   end subroutine Restart
 
   subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
-       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai)
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, foc_o3)
 
     class(ozone_off_type) , intent(inout) :: this
     type(bounds_type)      , intent(in)    :: bounds
@@ -107,6 +107,7 @@ contains
     real(r8) , intent(in) :: rb( bounds%begp: )        ! boundary layer resistance (s/m)
     real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
     real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
+    real(r8) , intent(in) :: forc_o3( bounds%begg: )   ! atmospheric ozone (mol/mol)
 
     ! Enforce expected array sizes (mainly so that a debug-mode threaded test with
     ! ozone-off can pick up problems with the call to this routine)
@@ -117,6 +118,7 @@ contains
     SHR_ASSERT_ALL_FL((ubound(rb) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(ram) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(tlai) == (/bounds%endp/)), sourcefile, __LINE__)
+    SHR_ASSERT_ALL_FL((ubound(forc_o3) == (/bounds%endg/)), sourcefile, __LINE__)
 
     ! Do nothing: In the ozone off case, we don't need to track ozone uptake
 

--- a/src/biogeophys/OzoneOffMod.F90
+++ b/src/biogeophys/OzoneOffMod.F90
@@ -94,7 +94,7 @@ contains
   end subroutine Restart
 
   subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
-       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, foc_o3)
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3)
 
     class(ozone_off_type) , intent(inout) :: this
     type(bounds_type)      , intent(in)    :: bounds

--- a/src/cpl/nuopc/lnd_import_export.F90
+++ b/src/cpl/nuopc/lnd_import_export.F90
@@ -93,6 +93,7 @@ module lnd_import_export
   character(*), parameter :: Faxa_dstdry         = 'Faxa_dstdry'
   character(*), parameter :: Sa_methane          = 'Sa_methaneaxa_ndep'
   character(*), parameter :: Faxa_ndep           = 'Faxa_ndep'
+  character(*), parameter :: Sa_o3               = 'Sa_o3'
   character(*), parameter :: Sa_co2prog          = 'Sa_co2prog'
   character(*), parameter :: Sa_co2diag          = 'Sa_co2diag'
   character(*), parameter :: Flrr_flood          = 'Flrr_flood'
@@ -311,7 +312,7 @@ contains
     end if
     if (send_lnd2glc) then
        ! lnd->glc states from land all lnd->glc elevation classes (1:glc_nec) plus bare land (index 0).
-       ! The following puts all of the elevation class fields as an! undistributed dimension in 
+       ! The following puts all of the elevation class fields as an! undistributed dimension in
        ! the export state field
        call fldlist_add(fldsFrLnd_num, fldsFrLnd, Sl_tsrf_elev  , ungridded_lbound=1, ungridded_ubound=glc_nec+1)
        call fldlist_add(fldsFrLnd_num, fldsFrLnd, Sl_topo_elev  , ungridded_lbound=1, ungridded_ubound=glc_nec+1)
@@ -350,6 +351,7 @@ contains
     call fldlist_add(fldsToLnd_num, fldsToLnd, Faxa_swvdr   )
     call fldlist_add(fldsToLnd_num, fldsToLnd, Faxa_swndf   )
     call fldlist_add(fldsToLnd_num, fldsToLnd, Faxa_swvdf   )
+    call fldlist_add(fldsToLnd_num, fldsToLnd, Sa_o3        )
 
     ! from atm - black carbon deposition fluxes (3)
     ! (1) => bcphidry, (2) => bcphodry, (3) => bcphiwet
@@ -534,6 +536,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call state_getimport_1d(importState, Sa_tbot   , atm2lnd_inst%forc_t_not_downscaled_grc(begg:), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call state_getimport_1d(importState, Sa_o3     , atm2lnd_inst%forc_ozone_grc(begg:), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call state_getimport_1d(importState, Faxa_rainc, forc_rainc(begg:), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call state_getimport_1d(importState, Faxa_rainl, forc_rainl(begg:), rc=rc)
@@ -713,7 +717,7 @@ contains
 
     ! input/output variables
     type(ESMF_GridComp)                         :: gcomp
-    type(bounds_type)           , intent(in)    :: bounds      
+    type(bounds_type)           , intent(in)    :: bounds
     logical                     , intent(in)    :: glc_present
     logical                     , intent(in)    :: rof_prognostic
     type(waterlnd2atmbulk_type) , intent(inout) :: waterlnd2atmbulk_inst
@@ -759,7 +763,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call state_setexport_1d(exportState, Sl_snowh  , waterlnd2atmbulk_inst%h2osno_grc(begg:), &
             init_spval=.false., rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return       
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call state_setexport_1d(exportState, Sl_avsdr  , lnd2atm_inst%albd_grc(begg:,1), &
             init_spval=.true., rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/cpl/nuopc/lnd_import_export.F90
+++ b/src/cpl/nuopc/lnd_import_export.F90
@@ -536,7 +536,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call state_getimport_1d(importState, Sa_tbot   , atm2lnd_inst%forc_t_not_downscaled_grc(begg:), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call state_getimport_1d(importState, Sa_o3     , atm2lnd_inst%forc_ozone_grc(begg:), rc=rc)
+    call state_getimport_1d(importState, Sa_o3     , atm2lnd_inst%forc_o3_grc(begg:), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call state_getimport_1d(importState, Faxa_rainc, forc_rainc(begg:), rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/main/atm2lndType.F90
+++ b/src/main/atm2lndType.F90
@@ -89,13 +89,14 @@ module atm2lndType
      real(r8), pointer :: forc_po2_240_patch            (:)   => null() ! 10-day mean O2 partial pressure (Pa)
      real(r8), pointer :: forc_aer_grc                  (:,:) => null() ! aerosol deposition array
      real(r8), pointer :: forc_pch4_grc                 (:)   => null() ! CH4 partial pressure (Pa)
+     real(r8), pointer :: forc_ozone_grc                (:)   => null() ! Ozone partial pressure (mol/mol)
 
-     real(r8), pointer :: forc_t_not_downscaled_grc     (:)   => null() ! not downscaled atm temperature (Kelvin)       
-     real(r8), pointer :: forc_th_not_downscaled_grc    (:)   => null() ! not downscaled atm potential temperature (Kelvin)    
-     real(r8), pointer :: forc_pbot_not_downscaled_grc  (:)   => null() ! not downscaled atm pressure (Pa)   
-     real(r8), pointer :: forc_pbot240_downscaled_patch (:)   => null() ! 10-day mean downscaled atm pressure (Pa)           
-     real(r8), pointer :: forc_rho_not_downscaled_grc   (:)   => null() ! not downscaled atm density (kg/m**3)                      
-     real(r8), pointer :: forc_lwrad_not_downscaled_grc (:)   => null() ! not downscaled atm downwrd IR longwave radiation (W/m**2) 
+     real(r8), pointer :: forc_t_not_downscaled_grc     (:)   => null() ! not downscaled atm temperature (Kelvin)
+     real(r8), pointer :: forc_th_not_downscaled_grc    (:)   => null() ! not downscaled atm potential temperature (Kelvin)
+     real(r8), pointer :: forc_pbot_not_downscaled_grc  (:)   => null() ! not downscaled atm pressure (Pa)
+     real(r8), pointer :: forc_pbot240_downscaled_patch (:)   => null() ! 10-day mean downscaled atm pressure (Pa)
+     real(r8), pointer :: forc_rho_not_downscaled_grc   (:)   => null() ! not downscaled atm density (kg/m**3)
+     real(r8), pointer :: forc_lwrad_not_downscaled_grc (:)   => null() ! not downscaled atm downwrd IR longwave radiation (W/m**2)
 
      ! atm->lnd downscaled
      real(r8), pointer :: forc_t_downscaled_col         (:)   => null() ! downscaled atm temperature (Kelvin)
@@ -106,10 +107,10 @@ module atm2lndType
 
 
      ! time averaged quantities
-     real(r8) , pointer :: fsd24_patch                  (:)   => null() ! patch 24hr average of direct beam radiation 
-     real(r8) , pointer :: fsd240_patch                 (:)   => null() ! patch 240hr average of direct beam radiation 
-     real(r8) , pointer :: fsi24_patch                  (:)   => null() ! patch 24hr average of diffuse beam radiation 
-     real(r8) , pointer :: fsi240_patch                 (:)   => null() ! patch 240hr average of diffuse beam radiation 
+     real(r8) , pointer :: fsd24_patch                  (:)   => null() ! patch 24hr average of direct beam radiation
+     real(r8) , pointer :: fsd240_patch                 (:)   => null() ! patch 240hr average of direct beam radiation
+     real(r8) , pointer :: fsi24_patch                  (:)   => null() ! patch 24hr average of diffuse beam radiation
+     real(r8) , pointer :: fsi240_patch                 (:)   => null() ! patch 240hr average of diffuse beam radiation
      real(r8) , pointer :: wind24_patch                 (:)   => null() ! patch 24-hour running mean of wind
      real(r8) , pointer :: t_mo_patch                   (:)   => null() ! patch 30-day average temperature (Kelvin)
      real(r8) , pointer :: t_mo_min_patch               (:)   => null() ! patch annual min of t_mo (Kelvin)
@@ -120,7 +121,7 @@ module atm2lndType
      procedure, public  :: InitForTesting  ! version of Init meant for unit testing
      procedure, private :: ReadNamelist
      procedure, private :: InitAllocate
-     procedure, private :: InitHistory  
+     procedure, private :: InitHistory
      procedure, public  :: InitAccBuffer
      procedure, public  :: InitAccVars
      procedure, public  :: UpdateAccVars
@@ -289,7 +290,7 @@ contains
     call this%InitAllocate(bounds)
     call this%ReadNamelist(NLFilename)
     call this%InitHistory(bounds)
-    
+
   end subroutine Init
 
   !-----------------------------------------------------------------------
@@ -450,7 +451,7 @@ contains
     !
     ! !ARGUMENTS:
     class(atm2lnd_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     real(r8) :: ival  = 0.0_r8  ! initial value
@@ -494,7 +495,7 @@ contains
     allocate(this%forc_th_not_downscaled_grc    (begg:endg))        ; this%forc_th_not_downscaled_grc    (:)   = ival
     allocate(this%forc_rho_not_downscaled_grc   (begg:endg))        ; this%forc_rho_not_downscaled_grc   (:)   = ival
     allocate(this%forc_lwrad_not_downscaled_grc (begg:endg))        ; this%forc_lwrad_not_downscaled_grc (:)   = ival
-    
+
     ! atm->lnd downscaled
     allocate(this%forc_t_downscaled_col         (begc:endc))        ; this%forc_t_downscaled_col         (:)   = ival
     allocate(this%forc_pbot_downscaled_col      (begc:endc))        ; this%forc_pbot_downscaled_col      (:)   = ival
@@ -522,7 +523,7 @@ contains
     !
     ! !ARGUMENTS:
     class(atm2lnd_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     integer  :: begg, endg
@@ -668,13 +669,13 @@ contains
     ! This routine set defaults values that are then overwritten by the
     ! restart file for restart or branch runs
     !
-    ! !USES 
+    ! !USES
     use clm_varcon  , only : spval
     use accumulMod  , only : init_accum_field
     !
     ! !ARGUMENTS:
     class(atm2lnd_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !---------------------------------------------------------------------
 
     this%fsd24_patch(bounds%begp:bounds%endp) = spval
@@ -729,16 +730,16 @@ contains
     ! !DESCRIPTION:
     ! Initialize module variables that are associated with
     ! time accumulated fields. This routine is called for both an initial run
-    ! and a restart run (and must therefore must be called after the restart file 
+    ! and a restart run (and must therefore must be called after the restart file
     ! is read in and the accumulation buffer is obtained)
     !
-    ! !USES 
+    ! !USES
     use accumulMod       , only : extract_accum_field
     use clm_time_manager , only : get_nstep
     !
     ! !ARGUMENTS:
     class(atm2lnd_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     integer  :: begp, endp
@@ -783,7 +784,7 @@ contains
     this%fsi240_patch(begp:endp) = rbufslp(begp:endp)
 
     if (use_cndv) then
-       call extract_accum_field ('TDA', rbufslp, nstep) 
+       call extract_accum_field ('TDA', rbufslp, nstep)
        this%t_mo_patch(begp:endp) = rbufslp(begp:endp)
     end if
 
@@ -797,11 +798,11 @@ contains
        this%forc_po2_240_patch(begp:endp) = rbufslp(begp:endp)
 
        call extract_accum_field ('pco2_240', rbufslp, nstep)
-       this%forc_pco2_240_patch(begp:endp) = rbufslp(begp:endp)   
+       this%forc_pco2_240_patch(begp:endp) = rbufslp(begp:endp)
 
        call extract_accum_field ('pbot240', rbufslp, nstep)
-       this%forc_pbot240_downscaled_patch(begp:endp) = rbufslp(begp:endp)  
- 
+       this%forc_pbot240_downscaled_patch(begp:endp) = rbufslp(begp:endp)
+
     endif
 
     deallocate(rbufslp)
@@ -818,7 +819,7 @@ contains
     !
     ! !ARGUMENTS:
     class(atm2lnd_type)                 :: this
-    type(bounds_type)      , intent(in) :: bounds  
+    type(bounds_type)      , intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     integer :: g,c,p                     ! indices
@@ -849,7 +850,7 @@ contains
        call endrun(msg=errMsg(sourcefile, __LINE__))
     endif
 
-    ! Accumulate and extract forc_solad24 & forc_solad240 
+    ! Accumulate and extract forc_solad24 & forc_solad240
     do p = begp,endp
        g = patch%gridcell(p)
        rbufslp(p) = this%forc_solad_grc(g,1)
@@ -859,7 +860,7 @@ contains
     call update_accum_field  ('FSD24' , rbufslp               , nstep)
     call extract_accum_field ('FSD24' , this%fsd24_patch      , nstep)
 
-    ! Accumulate and extract forc_solai24 & forc_solai240 
+    ! Accumulate and extract forc_solai24 & forc_solai240
     do p = begp,endp
        g = patch%gridcell(p)
        rbufslp(p) = this%forc_solai_grc(g,1)
@@ -872,9 +873,9 @@ contains
 
     if (use_cndv) then
 
-       ! Accumulate and extract TDA (accumulates TBOT as 30-day average) and 
+       ! Accumulate and extract TDA (accumulates TBOT as 30-day average) and
        ! also determines t_mo_min
-       
+
        do p = begp,endp
           c = patch%column(p)
           rbufslp(p) = this%forc_t_downscaled_col(c)
@@ -890,8 +891,8 @@ contains
 
     if (use_fates) then
        do p = bounds%begp,bounds%endp
-          g = patch%gridcell(p) 
-          rbufslp(p) = this%forc_wind_grc(g) 
+          g = patch%gridcell(p)
+          rbufslp(p) = this%forc_wind_grc(g)
        end do
        call update_accum_field  ('WIND24', rbufslp, nstep)
        call extract_accum_field ('WIND24', this%wind24_patch, nstep)
@@ -901,21 +902,21 @@ contains
     if(use_luna) then
      do p = bounds%begp,bounds%endp
        g = patch%gridcell(p)
-       rbufslp(p) = this%forc_pco2_grc(g) 
+       rbufslp(p) = this%forc_pco2_grc(g)
      enddo
      call update_accum_field  ('pco2_240', rbufslp, nstep)
      call extract_accum_field ('pco2_240', this%forc_pco2_240_patch, nstep)
 
      do p = bounds%begp,bounds%endp
        g = patch%gridcell(p)
-       rbufslp(p) = this%forc_po2_grc(g) 
+       rbufslp(p) = this%forc_po2_grc(g)
      enddo
      call update_accum_field  ('po2_240', rbufslp, nstep)
      call extract_accum_field ('po2_240', this%forc_po2_240_patch, nstep)
 
      do p = bounds%begp,bounds%endp
        c = patch%column(p)
-       rbufslp(p) = this%forc_pbot_downscaled_col(c) 
+       rbufslp(p) = this%forc_pbot_downscaled_col(c)
      enddo
      call update_accum_field  ('pbot240', rbufslp, nstep)
      call extract_accum_field ('pbot240', this%forc_pbot240_downscaled_patch, nstep)
@@ -929,19 +930,19 @@ contains
 
   !------------------------------------------------------------------------
   subroutine Restart(this, bounds, ncid, flag)
-    ! 
+    !
     ! !USES:
     use restUtilMod
     use ncdio_pio
     !
     ! !ARGUMENTS:
     class(atm2lnd_type) :: this
-    type(bounds_type), intent(in) :: bounds  
-    type(file_desc_t), intent(inout) :: ncid   
-    character(len=*) , intent(in)    :: flag   
+    type(bounds_type), intent(in) :: bounds
+    type(file_desc_t), intent(inout) :: ncid
+    character(len=*) , intent(in)    :: flag
     !
     ! !LOCAL VARIABLES:
-    logical            :: readvar 
+    logical            :: readvar
     !------------------------------------------------------------------------
 
     if (use_cndv) then
@@ -1006,7 +1007,7 @@ contains
     deallocate(this%forc_th_not_downscaled_grc)
     deallocate(this%forc_rho_not_downscaled_grc)
     deallocate(this%forc_lwrad_not_downscaled_grc)
-    
+
     ! atm->lnd downscaled
     deallocate(this%forc_t_downscaled_col)
     deallocate(this%forc_pbot_downscaled_col)

--- a/src/main/atm2lndType.F90
+++ b/src/main/atm2lndType.F90
@@ -89,7 +89,7 @@ module atm2lndType
      real(r8), pointer :: forc_po2_240_patch            (:)   => null() ! 10-day mean O2 partial pressure (Pa)
      real(r8), pointer :: forc_aer_grc                  (:,:) => null() ! aerosol deposition array
      real(r8), pointer :: forc_pch4_grc                 (:)   => null() ! CH4 partial pressure (Pa)
-     real(r8), pointer :: forc_ozone_grc                (:)   => null() ! Ozone partial pressure (mol/mol)
+     real(r8), pointer :: forc_o3_grc                   (:)   => null() ! ozone partial pressure (mol/mol)
 
      real(r8), pointer :: forc_t_not_downscaled_grc     (:)   => null() ! not downscaled atm temperature (Kelvin)
      real(r8), pointer :: forc_th_not_downscaled_grc    (:)   => null() ! not downscaled atm potential temperature (Kelvin)

--- a/src/main/atm2lndType.F90
+++ b/src/main/atm2lndType.F90
@@ -483,6 +483,7 @@ contains
     allocate(this%forc_po2_grc                  (begg:endg))        ; this%forc_po2_grc                  (:)   = ival
     allocate(this%forc_aer_grc                  (begg:endg,14))     ; this%forc_aer_grc                  (:,:) = ival
     allocate(this%forc_pch4_grc                 (begg:endg))        ; this%forc_pch4_grc                 (:)   = ival
+    allocate(this%forc_o3_grc                   (begg:endg))        ; this%forc_o3_grc                   (:)   = ival
     if(use_luna)then
      allocate(this%forc_pco2_240_patch          (begp:endp))        ; this%forc_pco2_240_patch           (:)   = ival
      allocate(this%forc_po2_240_patch           (begp:endp))        ; this%forc_po2_240_patch            (:)   = ival
@@ -553,6 +554,10 @@ contains
     call hist_addfld1d (fname='ATM_TOPO', units='m', &
          avgflag='A', long_name='atmospheric surface height', &
          ptr_lnd=this%forc_topo_grc)
+
+    call hist_addfld1d (fname='ATM_O3', units='mol/mol', &
+         avgflag='A', long_name='atmospheric ozone partial pressure', &
+         ptr_lnd=this%forc_o3_grc)
 
     this%forc_solar_grc(begg:endg) = spval
     call hist_addfld1d (fname='FSDS', units='W/m^2',  &
@@ -1000,6 +1005,7 @@ contains
     deallocate(this%forc_po2_grc)
     deallocate(this%forc_aer_grc)
     deallocate(this%forc_pch4_grc)
+    deallocate(this%forc_o3_grc)
 
     ! atm->lnd not downscaled
     deallocate(this%forc_t_not_downscaled_grc)


### PR DESCRIPTION
### Description of changes

Allow DATM input of ozone partial pressure (monthly, mol/mol) to CTSM and use this ozone in the `OzoneMod` module.

### Specific notes

- Add ozone to [`atm2lndType`](https://github.com/adrifoster/CTSM/blob/ozone_update/src/main/atm2lndType.F90) and also add as an output history variable ([`ATM_O3`](https://github.com/adrifoster/CTSM/blob/ea4bb8351440e90ceb5eb69fe79e1fcfa42587dc/src/main/atm2lndType.F90#L558))
- Read in O3 in [`lnd_import_export` ](https://github.com/adrifoster/CTSM/blob/ea4bb8351440e90ceb5eb69fe79e1fcfa42587dc/src/cpl/nuopc/lnd_import_export.F90#L539)
- Connect to the `OzoneMod` module: in [`CalcOzoneUptakeOnePoint`](https://github.com/adrifoster/CTSM/blob/ea4bb8351440e90ceb5eb69fe79e1fcfa42587dc/src/biogeophys/OzoneMod.F90#L412) we now use this input ozone, rather than a static parameter.

**_Currently we do not downscale input ozone to sub-daily values, but this will be completed in a subsequent PR._**

**_This PR also depends on a CDEPS CMEPS PRs_**:  [CMEPS 309](https://github.com/ESCOMP/CMEPS/pull/309), [CDEPS 188](https://github.com/ESCOMP/CDEPS/pull/188)

Contributors other than yourself, if any: @billsacks @mvertens 

CTSM Issues Fixed: #270

Are answers expected to change (and if so in what way)? Yes - ozone uptake and impact on photosynthesis will change because the ozone partial pressure now varies in time and space (rather than a static input parameter).

Any User Interface Changes (namelist or namelist defaults changes)? Yes - new ozone streams created (`DATM_O3` can be `clim_2000`, `clim_2010`, `clim_1850`, `hist`, `SSP2-4.5`, `SSP3-7.0`, or `SSP5-8.5`).

Testing performed, if any:

### General Testing
Performed tests to ensure the input ozone files matched reasonably well with output O3 from CTSM (see testing script /glade/u/home/afoster/analysis_scripts/Ozone_damage.ipynb). Example plots (global input/output difference at one time slice and then both input and output over one year at a single latitude and longitude)

![bokeh_plot](https://user-images.githubusercontent.com/13225250/187228441-e24ce486-f793-426b-aee1-5c425879d860.png)

![bokeh_plot (1)](https://user-images.githubusercontent.com/13225250/187228474-29f8f74c-411e-4961-ac55-2425328c9a8f.png)

To check that these changes did indeed impact the ozone functioning - global plot of ozone coefficient for sunlit leaves for one time point (for `master` branch), and year-long plot of same variable for `master` and updated branch.

![bokeh_plot (2)](https://user-images.githubusercontent.com/13225250/187230030-a77fd308-4e68-4f4d-a541-af917582c9ce.png)

![bokeh_plot (3)](https://user-images.githubusercontent.com/13225250/187230050-2c079e6d-b746-48ef-a3f9-6f9767829b64.png)

### System Testing

- `aux_clm` on Cheyenne (/glade/scratch/afoster/tests_0829-082121ch ) and izumi (/scratch/cluster/afoster/tests_0829-094849iz ). One on izumi includes an ozone test (`ERP_D_Ld5_P48x1`)

Will report back after tests finish
