### PR TITLE
update externals to cdeps0.12.42

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -55,7 +55,7 @@ local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.41
+tag = cdeps0.12.42
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps


### PR DESCRIPTION
### Description of changes

Update of `Externals.cfg` to cdeps0.12.42, which brings in an answer-changing update to CDPES ([149](https://github.com/ESCOMP/CDEPS/pull/149))

### Specific notes

We are doing this tag first in a series of tag updates to get much of the answer-changing externals updates out of the way.

Contributors other than yourself, if any: @ekluzek @billsacks @mvertens 

Are answers expected to change (and if so in what way)? Yes - many DIFFs due to update of coszen angle time interpolation in CDEPS

Testing performed, if any:

Cheyenne - aux_clm - /glade/scratch/afoster/tests_0829-154954ch - all DIFFs, one expected RUN fail (`SMS_D.f10_f10_mg37.I2000Clm51BgcCrop.cheyenne_nvhpc.clm-crop`)
Izumi - aux_clm - /scratch/cluster/afoster/tests_0830-083251iz  - **still running, will update later today**
