### PR TITLE
Switch to shr_drydep_mod module

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -48,7 +48,7 @@ tag = cime6.0.45
 required = True
 
 [cmeps]
-tag = cmeps0.13.68
+tag = cmeps0.13.70
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
@@ -63,7 +63,7 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl7.0.13
+tag = cpl7.0.14
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2726,8 +2726,8 @@ sub setup_logic_do_transient_urban {
    # for them to be unset if that will be their final state):
    # - flanduse_timeseries
    #
-   # NOTE(kwo, 2021-08-11) I based this function on setup_logic_do_transient_lakes. 
-   # As in NOTE(wjs, 2020-08-23) I'm not sure if all of the checks here are truly important 
+   # NOTE(kwo, 2021-08-11) I based this function on setup_logic_do_transient_lakes.
+   # As in NOTE(wjs, 2020-08-23) I'm not sure if all of the checks here are truly important
    # for transient urban (in particular, my guess is that collapse_urban could probably be done with transient
    # urban - as well as transient pfts and transient crops for that matter), but some of
    # the checks probably are needed, and it seems best to keep transient urban consistent
@@ -3669,11 +3669,9 @@ sub setup_logic_dry_deposition {
                      "   Use the '--no-drydep' option when '-bgc fates' is activated");
     }
     add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'drydep_list');
-    add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'drydep_method');
   } else {
-    if ( defined($nl->get_value('drydep_list')) ||
-         defined($nl->get_value('drydep_method')) ) {
-      $log->fatal_error("drydep_list or drydep_method defined, but drydep option NOT set");
+    if ( defined($nl->get_value('drydep_list')) ) {
+      $log->fatal_error("drydep_list defined, but drydep option NOT set");
     }
   }
 }

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3669,6 +3669,7 @@ sub setup_logic_dry_deposition {
                      "   Use the '--no-drydep' option when '-bgc fates' is activated");
     }
     add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'drydep_list');
+    add_default($opts,  $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'dep_data_file');
   } else {
     if ( defined($nl->get_value('drydep_list')) ) {
       $log->fatal_error("drydep_list defined, but drydep option NOT set");

--- a/bld/namelist_files/namelist_defaults_drydep.xml
+++ b/bld/namelist_files/namelist_defaults_drydep.xml
@@ -18,6 +18,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <drydep_list>'O3','NO2','HNO3','NO','HO2NO2','CH3OOH','CH2O','CO','H2O2','CH3COOOH','PAN','MPAN','C2H5OOH','ONIT','POOH','C3H7OOH','ROOH','CH3COCHO','CH3COCH3','Pb','ONITR','MACROOH','XOOH','ISOPOOH','CH3OH','C2H5OH','CH3CHO','GLYALD','HYAC','HYDRALD','ALKOOH','MEKOOH','TOLOOH','TERPOOH','CH3COOH','CB1','CB2','OC1','OC2','SOA','SO2','SO4','NH3','NH4NO3'
 </drydep_list>
 
+<!-- effective Henry's coef data for wet and dry deposition -->
+<dep_data_file>atm/cam/chem/trop_mozart/dvel/dep_data_c201019.nc</dep_data_file>
+
 <!-- Defaults for megan_emis_nl -->
 
 <megan_specifier>'ISOP = isoprene', 'C10H16 = pinene_a + carene_3 + thujene_a', 'CH3OH = methanol', 'C2H5OH = ethanol', 'CH2O = formaldehyde', 'CH3CHO = acetaldehyde', 'CH3COOH = acetic_acid', 'CH3COCH3 = acetone'</megan_specifier>

--- a/bld/namelist_files/namelist_defaults_drydep.xml
+++ b/bld/namelist_files/namelist_defaults_drydep.xml
@@ -17,7 +17,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <drydep_list>'O3','NO2','HNO3','NO','HO2NO2','CH3OOH','CH2O','CO','H2O2','CH3COOOH','PAN','MPAN','C2H5OOH','ONIT','POOH','C3H7OOH','ROOH','CH3COCHO','CH3COCH3','Pb','ONITR','MACROOH','XOOH','ISOPOOH','CH3OH','C2H5OH','CH3CHO','GLYALD','HYAC','HYDRALD','ALKOOH','MEKOOH','TOLOOH','TERPOOH','CH3COOH','CB1','CB2','OC1','OC2','SOA','SO2','SO4','NH3','NH4NO3'
 </drydep_list>
-<drydep_method>xactive_lnd</drydep_method>
 
 <!-- Defaults for megan_emis_nl -->
 

--- a/bld/namelist_files/namelist_definition_drv_flds.xml
+++ b/bld/namelist_files/namelist_definition_drv_flds.xml
@@ -71,6 +71,15 @@
     List of species that undergo dry deposition.
   </entry>
 
+  <entry id="dep_data_file"
+         type="char*500"
+         input_pathname="abs"
+         category="dry_deposition"
+         group="drydep_inparm"
+         valid_values="" >
+    Full pathname of file containing gas phase deposition data including effective
+    Henry's law coefficients.
+  </entry>
 
   <!-- ========================================================================================  -->
   <!-- Fire emissions fluxes                                                                     -->

--- a/bld/namelist_files/namelist_definition_drv_flds.xml
+++ b/bld/namelist_files/namelist_definition_drv_flds.xml
@@ -63,21 +63,7 @@
   <!-- drydep Namelists                                                                          -->
   <!-- ========================================================================================  -->
 
-  <entry id="drydep_method"
-	 type="char*16"
-	 category="dry-deposition"
-	 group="drydep_inparm"
-	 valid_values="xactive_lnd,xactive_atm,table">
-    Where dry deposition is calculated (from land, atmosphere, or from a table)
-    This specifies the method used to calculate dry
-    deposition velocities of gas-phase chemical species.  The available methods
-    are:
-    'table'       - prescribed method in CAM
-    'xactive_atm' - interactive method in CAM
-    'xactive_lnd' - interactive method in CLM
-  </entry>
-
-<entry id="drydep_list"
+  <entry id="drydep_list"
        type="char*32(300)"
        category="dry-deposition"
        group="drydep_inparm"

--- a/src/biogeochem/DryDepVelocity.F90
+++ b/src/biogeochem/DryDepVelocity.F90
@@ -1,69 +1,68 @@
-Module DryDepVelocity                                              
+Module DryDepVelocity
 
-  !-----------------------------------------------------------------------  
-  !  
-  ! Purpose:  
-  ! Deposition velocity (m/s) 
-  !  
-  ! Method:  
-  ! This code simulates dry deposition velocities using the Wesely scheme.   
-  ! Details of this method can be found in:  
-  ! 
-  ! M.L Wesely. Parameterization of surface resistances to gaseous dry deposition 
-  ! in regional-scale numericl models. 1989. Atmospheric Environment vol.23 No.6  
-  ! pp. 1293-1304. 
-  ! 
-  ! In Wesely (1998) "the magnitude of the dry deposition velocity can be found 
-  ! as: 
-  ! 
-  !  |vd|=(ra+rb+rc)^-1 
-  ! 
-  ! where ra is the aerodynamic resistance (common to all gases) between a  
-  ! specific height and the surface, rb is the quasilaminar sublayer resistance 
-  ! (whose only dependence on the porperties of the gas of interest is its 
-  ! molecular diffusivity in air), and rc is the bulk surface resistance". 
-  ! 
-  ! In this subroutine both ra and rb are calculated elsewhere in CLM.  
-  ! 
-  ! In Wesely (1989) rc is estimated for five seasonal categories and 11 landuse 
-  ! types.  For each season and landuse type, Wesely compiled data into a  
-  ! look-up-table for several parameters used to calculate rc. In this subroutine 
-  ! the same values are used as found in wesely's look-up-tables, the only  
-  ! difference is that this subroutine uses a CLM generated LAI to select values 
-  ! from the look-up-table instead of seasonality.  Inaddition, Wesely(1989)  
+  !-----------------------------------------------------------------------
+  !
+  ! Purpose:
+  ! Deposition velocity (m/s)
+  !
+  ! Method:
+  ! This code simulates dry deposition velocities using the Wesely scheme.
+  ! Details of this method can be found in:
+  !
+  ! M.L Wesely. Parameterization of surface resistances to gaseous dry deposition
+  ! in regional-scale numericl models. 1989. Atmospheric Environment vol.23 No.6
+  ! pp. 1293-1304.
+  !
+  ! In Wesely (1998) "the magnitude of the dry deposition velocity can be found
+  ! as:
+  !
+  !  |vd|=(ra+rb+rc)^-1
+  !
+  ! where ra is the aerodynamic resistance (common to all gases) between a
+  ! specific height and the surface, rb is the quasilaminar sublayer resistance
+  ! (whose only dependence on the porperties of the gas of interest is its
+  ! molecular diffusivity in air), and rc is the bulk surface resistance".
+  !
+  ! In this subroutine both ra and rb are calculated elsewhere in CLM.
+  !
+  ! In Wesely (1989) rc is estimated for five seasonal categories and 11 landuse
+  ! types.  For each season and landuse type, Wesely compiled data into a
+  ! look-up-table for several parameters used to calculate rc. In this subroutine
+  ! the same values are used as found in wesely's look-up-tables, the only
+  ! difference is that this subroutine uses a CLM generated LAI to select values
+  ! from the look-up-table instead of seasonality.  Inaddition, Wesely(1989)
   ! land use types are "mapped" into CLM patch types.
-  ! 
-  ! Subroutine written to operate at the patch level. 
-  ! 
-  ! Output: 
-  ! 
-  ! vd(n_species) !Dry deposition velocity [m s-1] for each molecule or species 
-  !  
-  ! Author: Beth Holland and  James Sulzman 
-  ! 
+  !
+  ! Subroutine written to operate at the patch level.
+  !
+  ! Output:
+  !
+  ! vd(n_species) !Dry deposition velocity [m s-1] for each molecule or species
+  !
+  ! Author: Beth Holland and  James Sulzman
+  !
   ! Modified: Francis Vitt -- 30 Mar 2007
   ! Modified: Maria Val Martin -- 15 Jan 2014
   !  Corrected major bugs in the leaf and stomatal resitances. The code is now
-  !  coupled to LAI and Rs uses the Ball-Berry Scheme. Also, corrected minor 
-  !  bugs in rlu and rcl calculations. Added 
-  !  no vegetation removal for CO. See README for details and 
+  !  coupled to LAI and Rs uses the Ball-Berry Scheme. Also, corrected minor
+  !  bugs in rlu and rcl calculations. Added
+  !  no vegetation removal for CO. See README for details and
   !     Val Martin et al., 2014 GRL for major corrections
   ! Modified: Louisa Emmons -- 30 November 2017
   !  Corrected the equation calculating stomatal resistance from rssun and rssha,
   !     and removed factor that scaled Rs to match observations
   !
-  !----------------------------------------------------------------------- 
+  !-----------------------------------------------------------------------
 
   use shr_log_mod          , only : errMsg => shr_log_errMsg
-  use shr_kind_mod         , only : r8 => shr_kind_r8 
+  use shr_kind_mod         , only : r8 => shr_kind_r8
   use abortutils           , only : endrun
-  use clm_time_manager     , only : get_nstep, get_curr_date, get_curr_time 
+  use clm_time_manager     , only : get_nstep, get_curr_date, get_curr_time
   use spmdMod              , only : masterproc
-  use seq_drydep_mod       , only : n_drydep, drydep_list 
-  use seq_drydep_mod       , only : drydep_method, DD_XLND
-  use seq_drydep_mod       , only : index_o3=>o3_ndx, index_o3a=>o3a_ndx, index_so2=>so2_ndx, index_h2=>h2_ndx
-  use seq_drydep_mod       , only : index_co=>co_ndx, index_ch4=>ch4_ndx, index_pan=>pan_ndx
-  use seq_drydep_mod       , only : index_xpan=>xpan_ndx
+  use shr_drydep_mod       , only : n_drydep, drydep_list
+  use shr_drydep_mod       , only : index_o3=>o3_ndx, index_o3a=>o3a_ndx, index_so2=>so2_ndx, index_h2=>h2_ndx
+  use shr_drydep_mod       , only : index_co=>co_ndx, index_ch4=>ch4_ndx, index_pan=>pan_ndx
+  use shr_drydep_mod       , only : index_xpan=>xpan_ndx
   use decompMod            , only : bounds_type, subgrid_level_patch
   use atm2lndType          , only : atm2lnd_type
   use CanopyStateType      , only : canopystate_type
@@ -72,11 +71,11 @@ Module DryDepVelocity
   use WaterStateBulkType       , only : waterstatebulk_type
   use WaterDiagnosticBulkType       , only : waterdiagnosticbulk_type
   use Wateratm2lndBulkType       , only : wateratm2lndbulk_type
-  use GridcellType         , only : grc                
-  use LandunitType         , only : lun                
-  use PatchType            , only : patch                
+  use GridcellType         , only : grc
+  use LandunitType         , only : lun
+  use PatchType            , only : patch
   !
-  implicit none 
+  implicit none
   private
   !
   public :: depvel_compute
@@ -88,26 +87,26 @@ Module DryDepVelocity
 
    contains
 
-     procedure , public  :: Init 
-     procedure , private :: InitAllocate 
+     procedure , public  :: Init
+     procedure , private :: InitAllocate
      procedure , private :: InitHistory
 
   end type drydepvel_type
-  !----------------------------------------------------------------------- 
+  !-----------------------------------------------------------------------
 
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
 
-CONTAINS 
+CONTAINS
 
   !------------------------------------------------------------------------
   subroutine Init(this, bounds)
 
     use clm_varctl     , only : use_fates, use_fates_sp
     class(drydepvel_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
 
-    if ( (.not. use_fates_sp) .and. use_fates .and. (n_drydep > 0 .and. drydep_method == DD_XLND) )then
+    if ( (.not. use_fates_sp) .and. use_fates .and. (n_drydep > 0) ) then
        call endrun( msg='ERROR: Dry-deposition currently does NOT work with FATES outside of FATES-SP mode (see github issue #1044)'//&
                     errMsg(sourcefile, __LINE__))
     end if
@@ -121,11 +120,11 @@ CONTAINS
     !
     ! !USES:
     use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
-    use seq_drydep_mod , only : n_drydep, drydep_method, DD_XLND
+    use shr_drydep_mod , only : n_drydep
     !
     ! !ARGUMENTS:
     class(drydepvel_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     integer :: begp, endp
@@ -133,10 +132,10 @@ CONTAINS
 
     begp = bounds%begp; endp= bounds%endp
 
-    ! Dry Deposition Velocity 
-    if ( n_drydep > 0 .and. drydep_method == DD_XLND )then
-       allocate(this%velocity_patch(begp:endp, n_drydep));  this%velocity_patch(:,:) = nan 
-       allocate(this%rs_drydep_patch(begp:endp))         ;  this%rs_drydep_patch(:)  = nan 
+    ! Dry Deposition Velocity
+    if ( n_drydep > 0 )then
+       allocate(this%velocity_patch(begp:endp, n_drydep));  this%velocity_patch(:,:) = nan
+       allocate(this%rs_drydep_patch(begp:endp))         ;  this%rs_drydep_patch(:)  = nan
     end if
 
   end subroutine InitAllocate
@@ -147,10 +146,10 @@ CONTAINS
     ! !DESCRIPTION:
     ! Initialize history output fields for dry deposition diagnositics
     !
-    ! !USES 
+    ! !USES
     use clm_varcon     , only : spval
     use histFileMod    , only : hist_addfld1d
-    use seq_drydep_mod , only : mapping
+    use shr_drydep_mod , only : mapping
     !
     ! !ARGUMENTS:
     class(drydepvel_type) :: this
@@ -158,16 +157,16 @@ CONTAINS
     real(r8), pointer  :: ptr_1d(:)  ! pointer to 1d patch array
     !
     ! !LOCAL VARIABLES
-    integer :: ispec 
+    integer :: ispec
     integer :: begp, endp
     !---------------------------------------------------------------------
 
     begp = bounds%begp; endp = bounds%endp
 
-    if ( n_drydep == 0 .or. drydep_method /= DD_XLND ) return
+    if ( n_drydep == 0 ) return
 
-    do ispec=1,n_drydep 
-       if(mapping(ispec) <= 0) cycle 
+    do ispec=1,n_drydep
+       if(mapping(ispec) <= 0) cycle
 
        this%velocity_patch(begp:endp,ispec)= spval
        ptr_1d => this%velocity_patch(begp:endp,ispec)
@@ -183,7 +182,7 @@ CONTAINS
 
   end subroutine InitHistory
 
-  !----------------------------------------------------------------------- 
+  !-----------------------------------------------------------------------
   subroutine depvel_compute( bounds, &
        atm2lnd_inst, canopystate_inst, waterstatebulk_inst, waterdiagnosticbulk_inst, &
        wateratm2lndbulk_inst, frictionvel_inst, &
@@ -194,8 +193,8 @@ CONTAINS
     !
     ! !USES:
     use shr_const_mod  , only : tmelt => shr_const_tkfrz
-    use seq_drydep_mod , only : seq_drydep_setHCoeff, mapping, drat, foxd
-    use seq_drydep_mod , only : rcls, h2_a, h2_b, h2_c, ri, rac, rclo, rlu, rgss, rgso
+    use shr_drydep_mod , only : shr_drydep_setHCoeff, mapping, drat, foxd
+    use shr_drydep_mod , only : rcls, h2_a, h2_b, h2_c, ri, rac, rclo, rlu, rgss, rgso
     use landunit_varcon, only : istsoil, istice, istdlak, istwet
     use clm_varctl     , only : iulog
     use pftconMod      , only : noveg, ndllf_evr_tmp_tree, ndllf_evr_brl_tree
@@ -210,7 +209,7 @@ CONTAINS
 
     !
     ! !ARGUMENTS:
-    type(bounds_type)      , intent(in)    :: bounds  
+    type(bounds_type)      , intent(in)    :: bounds
     type(atm2lnd_type)     , intent(in)    :: atm2lnd_inst
     type(canopystate_type) , intent(in)    :: canopystate_inst
     type(waterstatebulk_type)  , intent(in)    :: waterstatebulk_inst
@@ -224,54 +223,54 @@ CONTAINS
     integer  :: c
     real(r8) :: soilw, var_soilw, fact_h2, dv_soil_h2
     integer  :: pi,g, l
-    integer  :: ispec 
-    integer  :: length 
-    integer  :: wesveg       !wesely vegegation index  
-    integer  :: clmveg       !clm veg index from ivegtype 
-    integer  :: i 
-    integer  :: index_season !seasonal index based on LAI.  This indexs wesely data tables 
-    integer  :: nstep        !current step 
-    integer  :: indexp 
+    integer  :: ispec
+    integer  :: length
+    integer  :: wesveg       !wesely vegegation index
+    integer  :: clmveg       !clm veg index from ivegtype
+    integer  :: i
+    integer  :: index_season !seasonal index based on LAI.  This indexs wesely data tables
+    integer  :: nstep        !current step
+    integer  :: indexp
 
-    real(r8) :: pg           ! surface pressure 
-    real(r8) :: tc           ! temperature in celsius  
-    real(r8) :: es           ! saturation vapor pressur 
-    real(r8) :: ws           ! saturation mixing ratio 
-    real(r8) :: rmx          ! resistance by vegetation 
-    real(r8) :: qs           ! saturation specific humidity 
-    real(r8) :: dewm         ! multiplier for rs when dew occurs 
-    real(r8) :: crs          ! multiplier to calculate crs 
-    real(r8) :: rdc          ! part of lower canopy resistance 
-    real(r8) :: rain         ! rain fall 
-    real(r8) :: spec_hum     ! specific humidity 
-    real(r8) :: solar_flux   ! solar radiation(direct beam) W/m2 
-    real(r8) :: lat          ! latitude in degrees 
-    real(r8) :: lon          ! longitude in degrees 
-    real(r8) :: sfc_temp     ! surface temp 
-    real(r8) :: minlai       ! minimum of monthly lai 
-    real(r8) :: maxlai       ! maximum of monthly lai 
+    real(r8) :: pg           ! surface pressure
+    real(r8) :: tc           ! temperature in celsius
+    real(r8) :: es           ! saturation vapor pressur
+    real(r8) :: ws           ! saturation mixing ratio
+    real(r8) :: rmx          ! resistance by vegetation
+    real(r8) :: qs           ! saturation specific humidity
+    real(r8) :: dewm         ! multiplier for rs when dew occurs
+    real(r8) :: crs          ! multiplier to calculate crs
+    real(r8) :: rdc          ! part of lower canopy resistance
+    real(r8) :: rain         ! rain fall
+    real(r8) :: spec_hum     ! specific humidity
+    real(r8) :: solar_flux   ! solar radiation(direct beam) W/m2
+    real(r8) :: lat          ! latitude in degrees
+    real(r8) :: lon          ! longitude in degrees
+    real(r8) :: sfc_temp     ! surface temp
+    real(r8) :: minlai       ! minimum of monthly lai
+    real(r8) :: maxlai       ! maximum of monthly lai
     real(r8) :: rds         ! resistance for aerosols
 
     !mvm 11/30/2013
     real(r8) :: rlu_lai      ! constant to calculate rlu over bulk canopy
-    
+
     logical  :: has_dew
     logical  :: has_rain
     real(r8), parameter :: rain_threshold      = 1.e-7_r8  ! of the order of 1cm/day expressed in m/s
 
-    ! local arrays: dependent on species only 
-    real(r8), dimension(n_drydep) :: rsmx  !vegetative resistance (plant mesophyll) 
-    real(r8), dimension(n_drydep) :: rclx !lower canopy resistance  
-    real(r8), dimension(n_drydep) :: rlux !vegetative resistance (upper canopy) 
-    real(r8), dimension(n_drydep) :: rgsx !gournd resistance 
-    real(r8), dimension(n_drydep) :: heff   
+    ! local arrays: dependent on species only
+    real(r8), dimension(n_drydep) :: rsmx  !vegetative resistance (plant mesophyll)
+    real(r8), dimension(n_drydep) :: rclx !lower canopy resistance
+    real(r8), dimension(n_drydep) :: rlux !vegetative resistance (upper canopy)
+    real(r8), dimension(n_drydep) :: rgsx !gournd resistance
+    real(r8), dimension(n_drydep) :: heff
     real(r8) :: rs    ! stomatal resistance associated with dry deposition velocity (s/m)
-    real(r8) :: rc    !combined surface resistance 
-    real(r8) :: cts   !correction to flu rcl and rgs for frost 
+    real(r8) :: rc    !combined surface resistance
+    real(r8) :: cts   !correction to flu rcl and rgs for frost
     real(r8) :: rlux_o3 !to calculate O3 leaf resistance in dew/rain conditions
 
-    ! constants 
-    real(r8), parameter :: slope = 0._r8      ! Used to calculate  rdc in (lower canopy resistance) 
+    ! constants
+    real(r8), parameter :: slope = 0._r8      ! Used to calculate  rdc in (lower canopy resistance)
     integer, parameter :: wveg_unset = -1     ! Unset Wesley vegetation type
     character(len=32), parameter :: subname = "depvel_compute"
 
@@ -281,77 +280,77 @@ CONTAINS
                                 0.006_r8, 0.000_r8, 0.000_r8, 0.000_r8, 0.002_r8, 0.002_r8 /)
     real(r8) :: k_pan (11) = (/ 0.000_r8, 0.010_r8, 0.005_r8, 0.004_r8, 0.003_r8, &
                                 0.005_r8, 0.000_r8, 0.000_r8, 0.000_r8, 0.075_r8, 0.002_r8 /)
-    !----------------------------------------------------------------------- 
+    !-----------------------------------------------------------------------
 
-    if ( n_drydep == 0 .or. drydep_method /= DD_XLND ) return
+    if ( n_drydep == 0 ) return
 
-    associate(                                                    & 
-         forc_solai =>    atm2lnd_inst%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
-         forc_solad =>    atm2lnd_inst%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)             
-         forc_t     =>    atm2lnd_inst%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric temperature (Kelvin)                   
-         forc_q     =>    wateratm2lndbulk_inst%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric specific humidity (kg/kg)              
-         forc_pbot  =>    atm2lnd_inst%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled surface pressure (Pa)                              
-         forc_rain  =>    wateratm2lndbulk_inst%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]                                   
+    associate(                                                    &
+         forc_solai =>    atm2lnd_inst%forc_solai_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)
+         forc_solad =>    atm2lnd_inst%forc_solad_grc           , & ! Input:  [real(r8) (:,:) ] direct beam radiation (visible only)
+         forc_t     =>    atm2lnd_inst%forc_t_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric temperature (Kelvin)
+         forc_q     =>    wateratm2lndbulk_inst%forc_q_downscaled_col    , & ! Input:  [real(r8) (:)   ] downscaled atmospheric specific humidity (kg/kg)
+         forc_pbot  =>    atm2lnd_inst%forc_pbot_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled surface pressure (Pa)
+         forc_rain  =>    wateratm2lndbulk_inst%forc_rain_downscaled_col , & ! Input:  [real(r8) (:)   ] downscaled rain rate [mm/s]
 
-         h2osoi_vol =>    waterstatebulk_inst%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ] volumetric soil water (0<=h2osoi_vol<=watsat)   
-         snow_depth =>    waterdiagnosticbulk_inst%snow_depth_col        , & ! Input:  [real(r8) (:)   ] snow height (m)                                   
+         h2osoi_vol =>    waterstatebulk_inst%h2osoi_vol_col        , & ! Input:  [real(r8) (:,:) ] volumetric soil water (0<=h2osoi_vol<=watsat)
+         snow_depth =>    waterdiagnosticbulk_inst%snow_depth_col        , & ! Input:  [real(r8) (:)   ] snow height (m)
 
-         ram1       =>    frictionvel_inst%ram1_patch           , & ! Input:  [real(r8) (:)   ] aerodynamical resistance                           
-         rb1        =>    frictionvel_inst%rb1_patch            , & ! Input:  [real(r8) (:)   ] leaf boundary layer resistance [s/m]               
-         vds        =>    frictionvel_inst%vds_patch            , & ! Input:  [real(r8) (:)   ] aerodynamical resistance                           
+         ram1       =>    frictionvel_inst%ram1_patch           , & ! Input:  [real(r8) (:)   ] aerodynamical resistance
+         rb1        =>    frictionvel_inst%rb1_patch            , & ! Input:  [real(r8) (:)   ] leaf boundary layer resistance [s/m]
+         vds        =>    frictionvel_inst%vds_patch            , & ! Input:  [real(r8) (:)   ] aerodynamical resistance
 
-         rssun      =>    photosyns_inst%rssun_patch            , & ! Input:  [real(r8) (:)   ] stomatal resistance                                
-         rssha      =>    photosyns_inst%rssha_patch            , & ! Input:  [real(r8) (:)   ] shaded stomatal resistance (s/m)                   
+         rssun      =>    photosyns_inst%rssun_patch            , & ! Input:  [real(r8) (:)   ] stomatal resistance
+         rssha      =>    photosyns_inst%rssha_patch            , & ! Input:  [real(r8) (:)   ] shaded stomatal resistance (s/m)
 
-         fsun       =>    canopystate_inst%fsun_patch           , & ! Input:  [real(r8) (:)   ] sunlit fraction of canopy                          
-         elai       =>    canopystate_inst%elai_patch           , & ! Input:  [real(r8) (:)   ] one-sided leaf area index with burying by snow     
-         mlaidiff   =>    canopystate_inst%mlaidiff_patch       , & ! Input:  [real(r8) (:)   ] difference in lai between month one and month two  
-         annlai     =>    canopystate_inst%annlai_patch         , & ! Input:  [real(r8) (:,:) ] 12 months of monthly lai from input data set     
-         
+         fsun       =>    canopystate_inst%fsun_patch           , & ! Input:  [real(r8) (:)   ] sunlit fraction of canopy
+         elai       =>    canopystate_inst%elai_patch           , & ! Input:  [real(r8) (:)   ] one-sided leaf area index with burying by snow
+         mlaidiff   =>    canopystate_inst%mlaidiff_patch       , & ! Input:  [real(r8) (:)   ] difference in lai between month one and month two
+         annlai     =>    canopystate_inst%annlai_patch         , & ! Input:  [real(r8) (:,:) ] 12 months of monthly lai from input data set
+
          velocity   =>    drydepvel_inst%velocity_patch         , & ! Output: [real(r8) (:,:) ] cm/sec
          rs_drydep  =>    drydepvel_inst%rs_drydep_patch          & ! Output: [real(r8) (:)   ]  stomatal resistance associated with Ozone dry deposition velocity (s/m)
          )
 
-      !_________________________________________________________________ 
+      !_________________________________________________________________
       ! Begin loop through patches
 
       pft_loop: do pi = bounds%begp,bounds%endp
          l = patch%landunit(pi)
-         
+
          active: if (patch%active(pi)) then
 
             c = patch%column(pi)
             g = patch%gridcell(pi)
-            pg         = forc_pbot(c)  
+            pg         = forc_pbot(c)
             spec_hum   = forc_q(c)
-            rain       = forc_rain(c) 
-            sfc_temp   = forc_t(c) 
-            solar_flux = forc_solad(g,1) 
-            lat        = grc%latdeg(g) 
-            lon        = grc%londeg(g) 
-            clmveg     = patch%itype(pi) 
+            rain       = forc_rain(c)
+            sfc_temp   = forc_t(c)
+            solar_flux = forc_solad(g,1)
+            lat        = grc%latdeg(g)
+            lon        = grc%londeg(g)
+            clmveg     = patch%itype(pi)
             soilw      = h2osoi_vol(c,1)
 
-            !map CLM veg type into Wesely veg type  
-            wesveg = wveg_unset 
-            if (clmveg == noveg                               ) wesveg = 8 
-            if (clmveg == ndllf_evr_tmp_tree                  ) wesveg = 5 
-            if (clmveg == ndllf_evr_brl_tree                  ) wesveg = 5 
-            if (clmveg == ndllf_dcd_brl_tree                  ) wesveg = 5 
-            if (clmveg == nbrdlf_evr_trp_tree                 ) wesveg = 4 
-            if (clmveg == nbrdlf_evr_tmp_tree                 ) wesveg = 4 
-            if (clmveg == nbrdlf_dcd_trp_tree                 ) wesveg = 4 
-            if (clmveg == nbrdlf_dcd_tmp_tree                 ) wesveg = 4 
-            if (clmveg == nbrdlf_dcd_brl_tree                 ) wesveg = 4 
-            if (clmveg == nbrdlf_evr_shrub                    ) wesveg = 11 
-            if (clmveg == nbrdlf_dcd_tmp_shrub                ) wesveg = 11 
-            if (clmveg == nbrdlf_dcd_brl_shrub                ) wesveg = 11 
-            if (clmveg == nc3_arctic_grass                    ) wesveg = 3 
-            if (clmveg == nc3_nonarctic_grass                 ) wesveg = 3 
-            if (clmveg == nc4_grass                           ) wesveg = 3 
-            if (clmveg == nc3crop                             ) wesveg = 2 
-            if (clmveg == nc3irrig                            ) wesveg = 2 
-            if (clmveg >= npcropmin .and. clmveg <= npcropmax ) wesveg = 2 
+            !map CLM veg type into Wesely veg type
+            wesveg = wveg_unset
+            if (clmveg == noveg                               ) wesveg = 8
+            if (clmveg == ndllf_evr_tmp_tree                  ) wesveg = 5
+            if (clmveg == ndllf_evr_brl_tree                  ) wesveg = 5
+            if (clmveg == ndllf_dcd_brl_tree                  ) wesveg = 5
+            if (clmveg == nbrdlf_evr_trp_tree                 ) wesveg = 4
+            if (clmveg == nbrdlf_evr_tmp_tree                 ) wesveg = 4
+            if (clmveg == nbrdlf_dcd_trp_tree                 ) wesveg = 4
+            if (clmveg == nbrdlf_dcd_tmp_tree                 ) wesveg = 4
+            if (clmveg == nbrdlf_dcd_brl_tree                 ) wesveg = 4
+            if (clmveg == nbrdlf_evr_shrub                    ) wesveg = 11
+            if (clmveg == nbrdlf_dcd_tmp_shrub                ) wesveg = 11
+            if (clmveg == nbrdlf_dcd_brl_shrub                ) wesveg = 11
+            if (clmveg == nc3_arctic_grass                    ) wesveg = 3
+            if (clmveg == nc3_nonarctic_grass                 ) wesveg = 3
+            if (clmveg == nc4_grass                           ) wesveg = 3
+            if (clmveg == nc3crop                             ) wesveg = 2
+            if (clmveg == nc3irrig                            ) wesveg = 2
+            if (clmveg >= npcropmin .and. clmveg <= npcropmax ) wesveg = 2
             if (wesveg == wveg_unset )then
                write(iulog,*) 'clmveg = ', clmveg, 'lun%itype = ', lun%itype(l)
                call endrun(subgrid_index=pi, subgrid_level=subgrid_level_patch, &
@@ -359,27 +358,27 @@ CONTAINS
                     errMsg(sourcefile, __LINE__))
             end if
 
-            ! create seasonality index used to index wesely data tables from LAI,  Bascially 
-            !if elai is between max lai from input data and half that max the index_season=1 
+            ! create seasonality index used to index wesely data tables from LAI,  Bascially
+            !if elai is between max lai from input data and half that max the index_season=1
 
 
-            !mail1j and mlai2j are the two monthly lai values pulled from a CLM input data set 
-            !/fs/cgd/csm/inputdata/lnd/clm2/rawdata/mksrf_lai.nc.  lai for dates in the middle  
-            !of the month are interpolated using using these values and stored in the variable  
-            !elai (done elsewhere).  If the difference between mlai1j and mlai2j is greater 
-            !than zero it is assumed to be fall and less than zero it is assumed to be spring. 
+            !mail1j and mlai2j are the two monthly lai values pulled from a CLM input data set
+            !/fs/cgd/csm/inputdata/lnd/clm2/rawdata/mksrf_lai.nc.  lai for dates in the middle
+            !of the month are interpolated using using these values and stored in the variable
+            !elai (done elsewhere).  If the difference between mlai1j and mlai2j is greater
+            !than zero it is assumed to be fall and less than zero it is assumed to be spring.
 
-            !wesely seasonal "index_season" 
-            ! 1 - midsummer with lush vegetation 
-            ! 2 - Autumn with unharvested cropland 
-            ! 3 - Late autumn after frost, no snow 
-            ! 4 - Winter, snow on ground and subfreezing 
-            ! 5 - Transitional spring with partially green short annuals 
+            !wesely seasonal "index_season"
+            ! 1 - midsummer with lush vegetation
+            ! 2 - Autumn with unharvested cropland
+            ! 3 - Late autumn after frost, no snow
+            ! 4 - Winter, snow on ground and subfreezing
+            ! 5 - Transitional spring with partially green short annuals
 
 
-            !mlaidiff=jan-feb 
-            minlai=minval(annlai(:,pi)) 
-            maxlai=maxval(annlai(:,pi)) 
+            !mlaidiff=jan-feb
+            minlai=minval(annlai(:,pi))
+            maxlai=maxval(annlai(:,pi))
 
             index_season = -1
 
@@ -399,35 +398,35 @@ CONTAINS
                end if
             else if ( snow_depth(c) > 0 ) then
                index_season = 4
-            else if(elai(pi) > 0.5_r8*maxlai) then  
-               index_season = 1  
+            else if(elai(pi) > 0.5_r8*maxlai) then
+               index_season = 1
             endif
 
-            if (index_season<0) then 
-               if (elai(pi) < (minlai+0.05_r8*(maxlai-minlai))) then  
-                  index_season = 3 
+            if (index_season<0) then
+               if (elai(pi) < (minlai+0.05_r8*(maxlai-minlai))) then
+                  index_season = 3
                endif
             endif
 
-            if (index_season<0) then 
-               if (mlaidiff(pi) > 0.0_r8) then 
-                  index_season = 2 
-               elseif (mlaidiff(pi) < 0.0_r8) then 
-                  index_season = 5 
-               elseif (mlaidiff(pi).eq.0.0_r8) then 
-                  index_season = 3 
+            if (index_season<0) then
+               if (mlaidiff(pi) > 0.0_r8) then
+                  index_season = 2
+               elseif (mlaidiff(pi) < 0.0_r8) then
+                  index_season = 5
+               elseif (mlaidiff(pi).eq.0.0_r8) then
+                  index_season = 3
                endif
             endif
 
-            if (index_season<0) then 
+            if (index_season<0) then
                call endrun('ERROR: not able to determine season'//errmsg(sourcefile, __LINE__))
             endif
 
-            ! saturation specific humidity 
-            ! 
-            es = 611_r8*exp(5414.77_r8*((1._r8/tmelt)-(1._r8/sfc_temp))) 
-            ws = .622_r8*es/(pg-es) 
-            qs = ws/(1._r8+ws) 
+            ! saturation specific humidity
+            !
+            es = 611_r8*exp(5414.77_r8*((1._r8/tmelt)-(1._r8/sfc_temp)))
+            ws = .622_r8*es/(pg-es)
+            qs = ws/(1._r8+ws)
 
             has_dew = .false.
             if( qs <= spec_hum ) then
@@ -448,34 +447,34 @@ CONTAINS
             !Define tc
             tc = sfc_temp - tmelt
 
-            ! 
-            ! rdc (lower canopy res) 
-            ! 
-            rdc=100._r8*(1._r8+1000._r8/(solar_flux+10._r8))/(1._r8+1000._r8*slope) 
+            !
+            ! rdc (lower canopy res)
+            !
+            rdc=100._r8*(1._r8+1000._r8/(solar_flux+10._r8))/(1._r8+1000._r8*slope)
 
-            ! surface resistance : depends on both land type and species 
-            ! land types are computed seperately, then resistance is computed as average of values 
-            ! following wesely rc=(1/(rs+rm) + 1/rlu +1/(rdc+rcl) + 1/(rac+rgs))**-1 
+            ! surface resistance : depends on both land type and species
+            ! land types are computed seperately, then resistance is computed as average of values
+            ! following wesely rc=(1/(rs+rm) + 1/rlu +1/(rdc+rcl) + 1/(rac+rgs))**-1
 
-            !******************************************************* 
-            call seq_drydep_setHCoeff( sfc_temp, heff(:n_drydep) )
-            !********************************************************* 
+            !*******************************************************
+            call shr_drydep_setHCoeff( sfc_temp, heff(:n_drydep) )
+            !*********************************************************
 
             species_loop1: do ispec=1, n_drydep
-               if(mapping(ispec) <= 0) cycle 
+               if(mapping(ispec) <= 0) cycle
 
-               if(ispec.eq.index_o3.or.ispec.eq.index_o3a.or.ispec.eq.index_so2) then 
+               if(ispec.eq.index_o3.or.ispec.eq.index_o3a.or.ispec.eq.index_so2) then
                   rmx=0._r8
-               else 
-                  rmx=1._r8/((heff(ispec)/3000._r8)+(100._r8*foxd(ispec))) 
+               else
+                  rmx=1._r8/((heff(ispec)/3000._r8)+(100._r8*foxd(ispec)))
                endif
 
-               ! correction for frost 
-               cts = 1000._r8*exp( -tc - 4._r8 ) 
+               ! correction for frost
+               cts = 1000._r8*exp( -tc - 4._r8 )
 
-               !ground resistance  
-               rgsx(ispec) = 1._r8/((heff(ispec)/(1.e5_r8*(rgss(index_season,wesveg)+cts))) + & 
-                    (foxd(ispec)/(rgso(index_season,wesveg)+cts))) 
+               !ground resistance
+               rgsx(ispec) = 1._r8/((heff(ispec)/(1.e5_r8*(rgss(index_season,wesveg)+cts))) + &
+                    (foxd(ispec)/(rgso(index_season,wesveg)+cts)))
 
                !-------------------------------------------------------------------------------------
                ! special case for H2 and CO;; CH4 is set ot a fraction of dv(H2)
@@ -517,10 +516,10 @@ CONTAINS
                   rlux(ispec)  = spval
                   rs           = spval
                else
-                  
-                  !Stomatal resistance  
-                  
-                  ! fvitt -- at midnight rssun and/or rssha can be zero in some places which sets rs to zero 
+
+                  !Stomatal resistance
+
+                  ! fvitt -- at midnight rssun and/or rssha can be zero in some places which sets rs to zero
                   ! --- this fix prevents divide by zero error (when rsmx is zero)
                   if (rssun(pi)>0._r8 .and. rssun(pi)<1.e30 .and. rssha(pi)>0._r8 .and. rssha(pi)<1.e30 ) then
                      !LKE: corrected rs to add rssun and rssha in parallel (11/30/2017)
@@ -529,20 +528,20 @@ CONTAINS
                      rs=spval
                   endif
 
-                  rsmx(ispec) = rs*drat(ispec)+rmx 
+                  rsmx(ispec) = rs*drat(ispec)+rmx
 
                   ! Leaf resistance
                   !MVM: adjusted rlu by LAI to get leaf resistance over bulk canopy (gao and wesely, 1995)
                   rlu_lai=cts+rlu(index_season,wesveg)/elai(pi)
-                  rlux(ispec) = rlu_lai/(1.e-5_r8*heff(ispec)+foxd(ispec))      
+                  rlux(ispec) = rlu_lai/(1.e-5_r8*heff(ispec)+foxd(ispec))
 
-                  !Lower canopy resistance 
+                  !Lower canopy resistance
                   rclx(ispec) = 1._r8/((heff(ispec)/(1.e5_r8*(rcls(index_season,wesveg)+cts))) + &
                        (foxd(ispec)/(rclo(index_season,wesveg)+cts)))
 
                   !-----------------------------------
                   !mvm 11/30/2013: special case for CO
-                  !Dry deposition of CO and hydrocarbons is negligibly 
+                  !Dry deposition of CO and hydrocarbons is negligibly
                   !small in vegetation [Mueller and Brasseur, 1995].
                   !------------------------------------
                   if( ispec == index_co ) then
@@ -573,18 +572,18 @@ CONTAINS
             !----------------------------------------------
             !Adjustment for dew and rain in leaf resitances
             !---------------------------------------------
-            ! no effect over water            
+            ! no effect over water
             no_water: if( wesveg.ne.7 ) then
                !MVM: effect only on vegetated areas (elai> 0)
                with_LAI: if (elai(pi).gt.0._r8) then
 
-                  ! 
-                  ! no effect if sfc_temp < O C 
-                  ! 
+                  !
+                  ! no effect if sfc_temp < O C
+                  !
                   non_freezing: if(sfc_temp.gt.tmelt) then
-                     if( has_dew ) then 
+                     if( has_dew ) then
                         rlu_lai=cts+rlu(index_season,wesveg)/elai(pi)
-                        rlux_o3 = 1._r8/((1._r8/3000._r8)+(1._r8/(3._r8*rlu_lai))) 
+                        rlux_o3 = 1._r8/((1._r8/3000._r8)+(1._r8/(3._r8*rlu_lai)))
 
                         if (index_o3 > 0) then
                            rlux(index_o3) = rlux_o3
@@ -594,7 +593,7 @@ CONTAINS
                         endif
                      endif
 
-                     if(has_rain) then 
+                     if(has_rain) then
                         rlu_lai=cts+rlu(index_season,wesveg)/elai(pi)
                         rlux_o3 = 1._r8/((1._r8/1000._r8)+(1._r8/(3._r8*rlu_lai)))
 
@@ -606,25 +605,25 @@ CONTAINS
                         endif
                      endif
 
-                     species_loop2: do ispec=1,n_drydep 
-                        if(mapping(ispec).le.0) cycle 
-                        if(ispec.ne.index_o3.and.ispec.ne.index_o3a.and.ispec.ne.index_so2) then 
+                     species_loop2: do ispec=1,n_drydep
+                        if(mapping(ispec).le.0) cycle
+                        if(ispec.ne.index_o3.and.ispec.ne.index_o3a.and.ispec.ne.index_so2) then
 
                            if( has_dew .or. has_rain) then
                               rlu_lai=cts+rlu(index_season,wesveg)/elai(pi)
-                              rlux(ispec)=1._r8/((1._r8/(3._r8*rlu_lai))+ & 
+                              rlux(ispec)=1._r8/((1._r8/(3._r8*rlu_lai))+ &
                                    (1.e-7_r8*heff(ispec))+(foxd(ispec)/rlux_o3))
                            endif
 
-                        elseif(ispec.eq.index_so2) then 
+                        elseif(ispec.eq.index_so2) then
 
                            if( has_dew ) then
                               rlux(ispec) = 100._r8
                            endif
 
-                           if(has_rain) then 
+                           if(has_rain) then
                               rlu_lai=cts+rlu(index_season,wesveg)/elai(pi)
-                              rlux(ispec) = 1._r8/((1._r8/5000._r8)+(1._r8/(3._r8*rlu_lai))) 
+                              rlux(ispec) = 1._r8/((1._r8/5000._r8)+(1._r8/(3._r8*rlu_lai)))
                            endif
 
                            if( has_dew .or. has_rain ) then
@@ -643,16 +642,16 @@ CONTAINS
                endif with_LAI
             endif no_water
 
-            ! resistance for aerosols 
+            ! resistance for aerosols
             rds = 1._r8/vds(pi)
 
-            species_loop3: do ispec=1,n_drydep 
-               if(mapping(ispec) <= 0) cycle 
+            species_loop3: do ispec=1,n_drydep
+               if(mapping(ispec) <= 0) cycle
 
-               ! 
-               ! compute rc 
-               ! 
-               rc = 1._r8/((1._r8/rsmx(ispec))+(1._r8/rlux(ispec)) + & 
+               !
+               ! compute rc
+               !
+               rc = 1._r8/((1._r8/rsmx(ispec))+(1._r8/rlux(ispec)) + &
                     (1._r8/(rdc+rclx(ispec)))+(1._r8/(rac(index_season,wesveg)+rgsx(ispec))))
                rc = max( 10._r8, rc)
                !
@@ -680,7 +679,7 @@ CONTAINS
          endif active
       end do pft_loop
 
-     end associate 
+     end associate
 
   end subroutine depvel_compute
 

--- a/src/cpl/mct/clm_cpl_indices.F90
+++ b/src/cpl/mct/clm_cpl_indices.F90
@@ -6,7 +6,7 @@ module clm_cpl_indices
   !    fields needed by the land-ice component (sno).
   !
   ! !USES:
-  
+
   use shr_sys_mod,    only : shr_sys_abort
   implicit none
 
@@ -18,7 +18,7 @@ module clm_cpl_indices
   !
   ! !PUBLIC DATA MEMBERS:
   !
-  integer , public :: glc_nec     ! number of elevation classes for glacier_mec landunits 
+  integer , public :: glc_nec     ! number of elevation classes for glacier_mec landunits
                                   ! (from coupler) - must equal maxpatch_glc from namelist
 
   ! lnd -> drv (required)
@@ -39,7 +39,7 @@ module clm_cpl_indices
   integer, public ::index_l2x_Sl_snowh        ! snow height
   integer, public ::index_l2x_Sl_u10          ! 10m wind
   integer, public ::index_l2x_Sl_ddvel        ! dry deposition velocities (optional)
-  integer, public ::index_l2x_Sl_fv           ! friction velocity  
+  integer, public ::index_l2x_Sl_fv           ! friction velocity
   integer, public ::index_l2x_Sl_ram1         ! aerodynamical resistance
   integer, public ::index_l2x_Sl_soilw        ! volumetric soil water
   integer, public ::index_l2x_Fall_taux       ! wind stress, zonal
@@ -48,11 +48,11 @@ module clm_cpl_indices
   integer, public ::index_l2x_Fall_sen        ! sensible        heat flux
   integer, public ::index_l2x_Fall_lwup       ! upward longwave heat flux
   integer, public ::index_l2x_Fall_evap       ! evaporation     water flux
-  integer, public ::index_l2x_Fall_swnet      ! heat flux       shortwave net       
+  integer, public ::index_l2x_Fall_swnet      ! heat flux       shortwave net
   integer, public ::index_l2x_Fall_fco2_lnd   ! co2 flux **For testing set to 0
-  integer, public ::index_l2x_Fall_flxdst1    ! dust flux size bin 1    
-  integer, public ::index_l2x_Fall_flxdst2    ! dust flux size bin 2    
-  integer, public ::index_l2x_Fall_flxdst3    ! dust flux size bin 3    
+  integer, public ::index_l2x_Fall_flxdst1    ! dust flux size bin 1
+  integer, public ::index_l2x_Fall_flxdst2    ! dust flux size bin 2
+  integer, public ::index_l2x_Fall_flxdst3    ! dust flux size bin 3
   integer, public ::index_l2x_Fall_flxdst4    ! dust flux size bin 4
   integer, public ::index_l2x_Fall_flxvoc     ! MEGAN fluxes
   integer, public ::index_l2x_Fall_flxfire    ! Fire fluxes
@@ -103,7 +103,7 @@ module clm_cpl_indices
   integer, public ::index_x2l_Faxa_dstdry2    ! flux: Size 2 dust -- dry deposition
   integer, public ::index_x2l_Faxa_dstdry3    ! flux: Size 3 dust -- dry deposition
   integer, public ::index_x2l_Faxa_dstdry4    ! flux: Size 4 dust -- dry deposition
- 
+
   integer, public ::index_x2l_Faxa_nhx        ! flux nhx from atm
   integer, public ::index_x2l_Faxa_noy        ! flux noy from atm
 
@@ -113,12 +113,12 @@ module clm_cpl_indices
 
   ! In the following, index 0 is bare land, other indices are glc elevation classes
   integer, allocatable, public ::index_x2l_Sg_ice_covered(:) ! Fraction of glacier from glc model
-  integer, allocatable, public ::index_x2l_Sg_topo(:)        ! Topo height from glc model 
+  integer, allocatable, public ::index_x2l_Sg_topo(:)        ! Topo height from glc model
   integer, allocatable, public ::index_x2l_Flgg_hflx(:)      ! Heat flux from glc model
-  
+
   integer, public ::index_x2l_Sg_icemask
   integer, public ::index_x2l_Sg_icemask_coupled_fluxes
-  
+
   integer, public :: nflds_x2l = 0
 
   !-----------------------------------------------------------------------
@@ -128,7 +128,7 @@ contains
   !-----------------------------------------------------------------------
   subroutine clm_cpl_indices_set( )
     !
-    ! !DESCRIPTION: 
+    ! !DESCRIPTION:
     ! Set the coupler indices needed by the land model coupler
     ! interface.
     !
@@ -136,7 +136,7 @@ contains
     use seq_flds_mod   , only: seq_flds_x2l_fields, seq_flds_l2x_fields
     use mct_mod        , only: mct_aVect, mct_aVect_init, mct_avect_indexra
     use mct_mod        , only: mct_aVect_clean, mct_avect_nRattr
-    use seq_drydep_mod , only: drydep_fields_token, lnd_drydep
+    use shr_drydep_mod , only: drydep_fields_token, n_drydep
     use shr_megan_mod  , only: shr_megan_fields_token, shr_megan_mechcomps_n
     use shr_fire_emis_mod,only: shr_fire_emis_fields_token, shr_fire_emis_ztop_token, shr_fire_emis_mechcomps_n
     use clm_varctl     , only:  ndep_from_cpl
@@ -152,7 +152,7 @@ contains
     ! !LOCAL VARIABLES:
     type(mct_aVect)   :: l2x      ! temporary, land to coupler
     type(mct_aVect)   :: x2l      ! temporary, coupler to land
-    integer           :: num 
+    integer           :: num
     character(len=:), allocatable :: nec_str  ! string version of glc elev. class number
     character(len=64) :: name
     character(len=32) :: subname = 'clm_cpl_indices_set'  ! subroutine name
@@ -168,7 +168,7 @@ contains
     nflds_l2x = mct_avect_nRattr(l2x)
 
     !-------------------------------------------------------------
-    ! clm -> drv 
+    ! clm -> drv
     !-------------------------------------------------------------
 
     index_l2x_Flrl_rofsur   = mct_avect_indexra(l2x,'Flrl_rofsur')
@@ -190,7 +190,7 @@ contains
     index_l2x_Sl_fv         = mct_avect_indexra(l2x,'Sl_fv')
     index_l2x_Sl_soilw      = mct_avect_indexra(l2x,'Sl_soilw',perrwith='quiet')
 
-    if ( lnd_drydep )then
+    if ( n_drydep>0 )then
        index_l2x_Sl_ddvel = mct_avect_indexra(l2x, trim(drydep_fields_token))
     else
        index_l2x_Sl_ddvel = 0

--- a/src/cpl/mct/lnd_import_export.F90
+++ b/src/cpl/mct/lnd_import_export.F90
@@ -223,7 +223,7 @@ contains
     use shr_kind_mod       , only : r8 => shr_kind_r8
     use seq_flds_mod       , only : seq_flds_l2x_fields
     use clm_varctl         , only : iulog
-    use seq_drydep_mod     , only : n_drydep
+    use shr_drydep_mod     , only : n_drydep
     use shr_megan_mod      , only : shr_megan_mechcomps_n
     use shr_fire_emis_mod  , only : shr_fire_emis_mechcomps_n
     use lnd_import_export_utils, only : check_for_nans

--- a/src/cpl/nuopc/lnd_import_export.F90
+++ b/src/cpl/nuopc/lnd_import_export.F90
@@ -18,7 +18,7 @@ module lnd_import_export
   use glc2lndMod              , only : glc2lnd_type
   use domainMod               , only : ldomain
   use spmdMod                 , only : masterproc
-  use seq_drydep_mod          , only : seq_drydep_readnl, n_drydep
+  use shr_drydep_mod          , only : shr_drydep_readnl, n_drydep
   use shr_megan_mod           , only : shr_megan_readnl, shr_megan_mechcomps_n
   use nuopc_shr_methods       , only : chkerr
   use lnd_import_export_utils , only : check_for_errors, check_for_nans
@@ -234,7 +234,7 @@ contains
     ! The following namelist reads should always be called regardless of the send_to_atm value
 
     ! Dry Deposition velocities from land - ALSO initialize drydep here
-    call seq_drydep_readnl("drv_flds_in", drydep_nflds)
+    call shr_drydep_readnl("drv_flds_in", drydep_nflds)
 
     ! Fire emissions fluxes from land
     call shr_fire_emis_readnl('drv_flds_in', emis_nflds)
@@ -311,7 +311,7 @@ contains
     end if
     if (send_lnd2glc) then
        ! lnd->glc states from land all lnd->glc elevation classes (1:glc_nec) plus bare land (index 0).
-       ! The following puts all of the elevation class fields as an! undistributed dimension in 
+       ! The following puts all of the elevation class fields as an! undistributed dimension in
        ! the export state field
        call fldlist_add(fldsFrLnd_num, fldsFrLnd, Sl_tsrf_elev  , ungridded_lbound=1, ungridded_ubound=glc_nec+1)
        call fldlist_add(fldsFrLnd_num, fldsFrLnd, Sl_topo_elev  , ungridded_lbound=1, ungridded_ubound=glc_nec+1)
@@ -713,7 +713,7 @@ contains
 
     ! input/output variables
     type(ESMF_GridComp)                         :: gcomp
-    type(bounds_type)           , intent(in)    :: bounds      
+    type(bounds_type)           , intent(in)    :: bounds
     logical                     , intent(in)    :: glc_present
     logical                     , intent(in)    :: rof_prognostic
     type(waterlnd2atmbulk_type) , intent(inout) :: waterlnd2atmbulk_inst
@@ -759,7 +759,7 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call state_setexport_1d(exportState, Sl_snowh  , waterlnd2atmbulk_inst%h2osno_grc(begg:), &
             init_spval=.false., rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return       
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call state_setexport_1d(exportState, Sl_avsdr  , lnd2atm_inst%albd_grc(begg:,1), &
             init_spval=.true., rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -69,7 +69,7 @@ module clm_driver
   use lnd2atmMod             , only : lnd2atm
   use lnd2glcMod             , only : lnd2glc_type
   !
-  use seq_drydep_mod         , only : n_drydep, drydep_method, DD_XLND
+  use shr_drydep_mod         , only : n_drydep
   use DryDepVelocity         , only : depvel_compute
   !
   use DaylengthMod           , only : UpdateDaylength
@@ -228,7 +228,7 @@ contains
     if (use_cn) then
        ! For dry-deposition need to call CLMSP so that mlaidiff is obtained
        ! NOTE: This is also true of FATES below
-       if ( n_drydep > 0 .and. drydep_method == DD_XLND ) then
+       if ( n_drydep > 0 ) then
           call t_startf('interpMonthlyVeg')
           call interpMonthlyVeg(bounds_proc, canopystate_inst)
           call t_stopf('interpMonthlyVeg')
@@ -239,7 +239,7 @@ contains
        ! For FATES-Specified phenology mode interpolate the weights for
        ! time-interpolation of monthly vegetation data (as in SP mode below)
        ! Also for FATES with dry-deposition as above need to call CLMSP so that mlaidiff is obtained
-       !if ( use_fates_sp .or. (n_drydep > 0 .and. drydep_method == DD_XLND ) ) then    ! Replace with this when we have dry-deposition working
+       !if ( use_fates_sp .or. (n_drydep > 0 ) ) then    ! Replace with this when we have dry-deposition working
        ! For now don't allow for dry-deposition because of issues in #1044 EBK Jun/17/2022
        if ( use_fates_sp ) then
           call t_startf('interpMonthlyVeg')
@@ -256,7 +256,7 @@ contains
        ! weights obtained here are used in subroutine SatellitePhenology to obtain time
        ! interpolated values.
        ! This is also done for FATES-SP mode above
-       if ( doalb .or. ( n_drydep > 0 .and. drydep_method == DD_XLND ) )then
+       if ( doalb .or. ( n_drydep > 0 ) )then
           call t_startf('interpMonthlyVeg')
           call interpMonthlyVeg(bounds_proc, canopystate_inst)
           call t_stopf('interpMonthlyVeg')
@@ -311,7 +311,7 @@ contains
           call get_clump_bounds(nc, bounds_clump)
 
           call t_startf('cninit')
-           
+
           call bgc_vegetation_inst%InitEachTimeStep(bounds_clump, &
                filter(nc)%num_soilc, filter(nc)%soilc)
 
@@ -1107,7 +1107,7 @@ contains
           ! for leaf photosynthetic acclimation temperature. These
           ! moving averages are updated here
           call clm_fates%WrapUpdateFatesRmean(nc,temperature_inst)
-          
+
           call EDBGCDyn(bounds_clump,                                                              &
                filter(nc)%num_soilc, filter(nc)%soilc,                                             &
                filter(nc)%num_soilp, filter(nc)%soilp,                                             &
@@ -1132,11 +1132,11 @@ contains
                    soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst,     &
                    nc)
           end if
-          
+
           call clm_fates%wrap_update_hifrq_hist(bounds_clump, &
                soilbiogeochem_carbonflux_inst, &
                soilbiogeochem_carbonstate_inst)
-          
+
 
           if( is_beg_curr_day() ) then
 
@@ -1158,9 +1158,9 @@ contains
              call setFilters( bounds_clump, glc_behavior )
 
           end if
-          
-    
-          
+
+
+
        end if ! use_fates branch
 
        ! ============================================================================

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -145,7 +145,7 @@ contains
     use ch4varcon                     , only : ch4conrd
     use UrbanParamsType               , only : UrbanInput, IsSimpleBuildTemp
     use shr_orb_mod                   , only : shr_orb_decl
-    use seq_drydep_mod                , only : n_drydep, drydep_method, DD_XLND
+    use shr_drydep_mod                , only : n_drydep
     use accumulMod                    , only : print_accum_fields
     use clm_time_manager              , only : get_step_size_real, get_curr_calday
     use clm_time_manager              , only : get_curr_date, get_nstep, advance_timestep
@@ -201,9 +201,9 @@ contains
     logical            :: reset_dynbal_baselines_lake_columns
     integer            :: begg, endg
     integer            :: iun
-    integer            :: klen 
+    integer            :: klen
     integer            :: ioe
-    integer            :: ier 
+    integer            :: ier
     logical            :: lexists
     real(r8), pointer  :: data2dptr(:,:) ! temp. pointers for slicing larger arrays
     character(len=32)  :: subname = 'initialize2' ! subroutine name
@@ -234,7 +234,7 @@ contains
     allocate (haslake      (begg:endg                      ))
     allocate (pct_urban_max(begg:endg, numurbl             ))
     allocate (wt_nat_patch (begg:endg, surfpft_lb:surfpft_ub ))
-    
+
     ! Read list of Patches and their corresponding parameter values
     ! Independent of model resolution, Needs to stay before surfrd_get_data
     call pftcon%Init()
@@ -338,7 +338,7 @@ contains
 
     ! Pass model timestep info to FATES
     call CLMFatesTimesteps()
-    
+
     ! Initialize daylength from the previous time step (needed so prev_dayl can be set correctly)
     call t_startf('init_orbd')
     calday = get_curr_calday(reuse_day_365_for_day_366=.true.)
@@ -434,7 +434,7 @@ contains
 
        ! NOTE(wjs, 2016-02-23) Maybe the rest of the body of this conditional should also
        ! be moved into bgc_vegetation_inst%Init2
-       if (n_drydep > 0 .and. drydep_method == DD_XLND) then
+       if (n_drydep > 0) then
           ! Must do this also when drydeposition is used so that estimates of monthly
           ! differences in LAI can be computed
           ! Also do this for FATES see below
@@ -451,7 +451,7 @@ contains
 
        ! For SP FATES-SP Initialize SP
        ! Also for FATES with Dry-Deposition on as well (see above)
-       !if(use_fates_sp .or. (.not.use_cn) .or. (n_drydep > 0 .and.  drydep_method == DD_XLND) )then  !  Replace with this when we have dry-deposition working
+       !if(use_fates_sp .or. (.not.use_cn) .or. (n_drydep > 0) )then  !  Replace with this when we have dry-deposition working
        ! For now don't allow for dry-deposition because of issues in #1044 EBK Jun/17/2022
        if( use_fates_sp .or. .not. use_fates )then
           call SatellitePhenologyInit(bounds_proc)
@@ -660,7 +660,7 @@ contains
     ! Read monthly vegetation
     ! Even if CN or FATES is on, and dry-deposition is active, read CLMSP annual vegetation
     ! to get estimates of monthly LAI
-    if ( n_drydep > 0 .and. drydep_method == DD_XLND )then
+    if ( n_drydep > 0 ) then
        call readAnnualVegetation(bounds_proc, canopystate_inst)
        ! Call interpMonthlyVeg for dry-deposition so that mlaidiff will be calculated
        ! This needs to be done even if FATES, CN or CNDV is on!

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -21,8 +21,8 @@ module controlMod
   use clm_varcon                       , only: h2osno_max
   use clm_varpar                       , only: maxpatch_glc, numrad, nlevsno
   use fileutils                        , only: getavu, relavu, get_filename
-  use histFileMod                      , only: max_tapes, max_namlen 
-  use histFileMod                      , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape 
+  use histFileMod                      , only: max_tapes, max_namlen
+  use histFileMod                      , only: hist_empty_htapes, hist_dov2xy, hist_avgflag_pertape, hist_type1d_pertape
   use histFileMod                      , only: hist_nhtfrq, hist_ndens, hist_mfilt, hist_fincl1, hist_fincl2, hist_fincl3
   use histFileMod                      , only: hist_fincl4, hist_fincl5, hist_fincl6, hist_fincl7, hist_fincl8
   use histFileMod                      , only: hist_fincl9, hist_fincl10
@@ -43,12 +43,12 @@ module controlMod
   use CIsoAtmTimeseriesMod             , only: use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
   use SoilBiogeochemCompetitionMod     , only: suplnitro, suplnNon
   use SoilBiogeochemLittVertTranspMod  , only: som_adv_flux, max_depth_cryoturb
-  use SoilBiogeochemVerticalProfileMod , only: surfprof_exp 
+  use SoilBiogeochemVerticalProfileMod , only: surfprof_exp
   use SoilBiogeochemNitrifDenitrifMod  , only: no_frozen_nitrif_denitrif
   use SoilHydrologyMod                 , only: soilHydReadNML
   use CNFireFactoryMod                 , only: CNFireReadNML
   use CanopyFluxesMod                  , only: CanopyFluxesReadNML
-  use seq_drydep_mod                   , only: drydep_method, DD_XLND, n_drydep
+  use shr_drydep_mod                   , only: n_drydep
   use clm_varctl
   !
   ! !PUBLIC TYPES:
@@ -188,7 +188,7 @@ contains
     ! lake_melt_icealb is of dimension numrad
 
     ! Glacier_mec info
-    namelist /clm_inparm/ &    
+    namelist /clm_inparm/ &
          maxpatch_glc, glc_do_dynglacier, &
          glc_snow_persistence_max_days, &
          nlevsno, h2osno_max
@@ -210,7 +210,7 @@ contains
          som_adv_flux, max_depth_cryoturb
 
     ! C and N input vertical profiles
-    namelist /clm_inparm/  & 
+    namelist /clm_inparm/  &
           surfprof_exp
 
     namelist /clm_inparm/ no_frozen_nitrif_denitrif
@@ -231,8 +231,8 @@ contains
           fates_inventory_ctrl_filename,                &
           fates_parteh_mode,                            &
           use_fates_tree_damage
-    
-   ! Ozone vegetation stress method 
+
+   ! Ozone vegetation stress method
    namelist / clm_inparam / o3_veg_stress_method
 
     ! CLM 5.0 nitrogen flags
@@ -256,8 +256,8 @@ contains
 
     namelist /clm_inparm/  &
          use_c14_bombspike, atm_c14_filename, use_c13_timeseries, atm_c13_filename
-		 
-    ! All old cpp-ifdefs are below and have been converted to namelist variables 
+
+    ! All old cpp-ifdefs are below and have been converted to namelist variables
 
     ! Number of dominant pfts and landunits. Enhance ctsm performance by
     ! reducing the number of active pfts to n_dom_pfts and
@@ -309,7 +309,7 @@ contains
     if (masterproc) then
 
        ! ----------------------------------------------------------------------
-       ! Read namelist from standard input. 
+       ! Read namelist from standard input.
        ! ----------------------------------------------------------------------
 
        if ( len_trim(NLFilename) == 0  )then
@@ -422,22 +422,22 @@ contains
           call endrun(msg=' ERROR: prognostic crop Patches require create_crop_landunit=.true.'//&
             errMsg(sourcefile, __LINE__))
        end if
-       
-       if (use_lch4 ) then 
+
+       if (use_lch4 ) then
           anoxia = .true.
        else
           anoxia = .false.
        end if
 
        ! ----------------------------------------------------------------------
-       ! Check compatibility with the FATES model 
+       ! Check compatibility with the FATES model
        if ( use_fates ) then
 
           if ( use_cn) then
              call endrun(msg=' ERROR: use_cn and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
           end if
-          
+
           if ( use_hydrstress) then
              call endrun(msg=' ERROR: use_hydrstress and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
@@ -447,8 +447,8 @@ contains
              call endrun(msg=' ERROR: use_crop and use_fates cannot both be set to true.'//&
                    errMsg(sourcefile, __LINE__))
           end if
-          
-          if ( n_drydep > 0 .and. drydep_method /= DD_XLND ) then
+
+          if ( n_drydep > 0 ) then
              call endrun(msg=' ERROR: dry deposition via ML Welsey is not compatible with FATES.'//&
                    errMsg(sourcefile, __LINE__))
           end if
@@ -466,7 +466,7 @@ contains
        end if
 
        ! If nfix_timeconst is equal to the junk default value, then it was not specified
-       ! by the user namelist and we need to assign it the correct default value. If the 
+       ! by the user namelist and we need to assign it the correct default value. If the
        ! user specified it in the namelist, we leave it alone.
 
        if (nfix_timeconst == -1.2345_r8) then
@@ -521,7 +521,7 @@ contains
     ! ----------------------------------------------------------------------
 
     call control_spmd()
-    
+
     ! ----------------------------------------------------------------------
     ! Read in other namelists that are dependent on other namelist setttings
     ! ----------------------------------------------------------------------
@@ -560,7 +560,7 @@ contains
 
     ! Check on run type
     if (nsrest == iundef) then
-       call endrun(msg=' ERROR:: must set nsrest'//& 
+       call endrun(msg=' ERROR:: must set nsrest'//&
             errMsg(sourcefile, __LINE__))
     end if
     if (nsrest == nsrBranch .and. nrevsn == ' ') then
@@ -570,7 +570,7 @@ contains
 
     ! Consistency settings for co2_ppvm
     if ( (co2_ppmv <= 0.0_r8) .or. (co2_ppmv > 3000.0_r8) ) then
-       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//& 
+       call endrun(msg=' ERROR: co2_ppmv is out of a reasonable range'//&
             errMsg(sourcefile, __LINE__))
     end if
 
@@ -604,9 +604,9 @@ contains
   subroutine control_spmd()
     !
     ! !DESCRIPTION:
-    ! Distribute namelist data all processors. All program i/o is 
-    ! funnelled through the master processor. Processor 0 either 
-    ! reads restart/history data from the disk and distributes 
+    ! Distribute namelist data all processors. All program i/o is
+    ! funnelled through the master processor. Processor 0 either
+    ! reads restart/history data from the disk and distributes
     ! it to all processors, or collects data from
     ! all processors and writes it to disk.
     !
@@ -726,13 +726,13 @@ contains
     ! flexibleCN nitrogen model
     call mpi_bcast (use_flexibleCN, 1, MPI_LOGICAL, 0, mpicom, ier)
     ! TODO(bja, 2015-08) need to move some of these into a module with limited scope.
-    call mpi_bcast (MM_Nuptake_opt, 1, MPI_LOGICAL, 0, mpicom, ier)             
+    call mpi_bcast (MM_Nuptake_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (CNratio_floating, 1, MPI_LOGICAL, 0, mpicom, ier)
-    call mpi_bcast (lnc_opt, 1, MPI_LOGICAL, 0, mpicom, ier)                    
-    call mpi_bcast (reduce_dayl_factor, 1, MPI_LOGICAL, 0, mpicom, ier)         
-    call mpi_bcast (vcmax_opt, 1, MPI_INTEGER, 0, mpicom, ier)                  
+    call mpi_bcast (lnc_opt, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (reduce_dayl_factor, 1, MPI_LOGICAL, 0, mpicom, ier)
+    call mpi_bcast (vcmax_opt, 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (CN_evergreen_phenology_opt, 1, MPI_INTEGER, 0, mpicom, ier)
-    call mpi_bcast (carbon_resp_opt, 1, MPI_INTEGER, 0, mpicom, ier) 
+    call mpi_bcast (carbon_resp_opt, 1, MPI_INTEGER, 0, mpicom, ier)
 
     call mpi_bcast (use_luna, 1, MPI_LOGICAL, 0, mpicom, ier)
 
@@ -757,7 +757,7 @@ contains
        call mpi_bcast (surfprof_exp,            1, MPI_REAL8,  0, mpicom, ier)
     end if
 
-    if (use_cn .and. use_nitrif_denitrif) then 
+    if (use_cn .and. use_nitrif_denitrif) then
        call mpi_bcast (no_frozen_nitrif_denitrif,  1, MPI_LOGICAL, 0, mpicom, ier)
     end if
 
@@ -909,13 +909,13 @@ contains
           write(iulog,*) '   Supplemental Nitrogen mode is set to run over Patches: ', &
                trim(suplnitro)
        end if
-       
+
        if (nfix_timeconst /= 0._r8) then
           write(iulog,*) '   nfix_timeconst, timescale for smoothing npp in N fixation term: ', nfix_timeconst
        else
           write(iulog,*) '   nfix_timeconst == zero, use standard N fixation scheme. '
        end if
-       
+
        write(iulog,*) '   spinup_state, (0 = normal mode; 1 = AD spinup; 2 AAD)         : ', spinup_state
        if ( spinup_state .eq. 0 ) then
           write(iulog,*) '   model is currently NOT in AD spinup mode.'
@@ -931,7 +931,7 @@ contains
        if ( use_fun ) then
           write(iulog,*) '   Fixation and Uptake of Nitrogen Model Version 2 (FUN2) is turned on for Nitrogen Competition'
        end if
-       
+
        write(iulog,*) '   override_bgc_restart_mismatch_dump                     : ', override_bgc_restart_mismatch_dump
     end if
 
@@ -940,7 +940,7 @@ contains
        write(iulog, *) '   max_depth_cryoturb (m)                                : ', max_depth_cryoturb
        write(iulog, *) '   surfprof_exp                                          : ', surfprof_exp
     end if
-       
+
     if (use_cn .and. .not. use_nitrif_denitrif) then
        write(iulog, *) '   no_frozen_nitrif_denitrif                             : ', no_frozen_nitrif_denitrif
     end if
@@ -1034,13 +1034,13 @@ contains
                    'as compared with 0.60, 0.40 for cold frozen lakes with no snow.'
 
     write(iulog, *) 'plant nitrogen model namelists:'
-    write(iulog, *) '  use_flexibleCN = ', use_flexibleCN                       
+    write(iulog, *) '  use_flexibleCN = ', use_flexibleCN
     if (use_flexibleCN) then
-       write(iulog, *) '    MM_Nuptake_opt = ', MM_Nuptake_opt                       
+       write(iulog, *) '    MM_Nuptake_opt = ', MM_Nuptake_opt
        write(iulog, *) '    CNratio_floating = ', CNratio_floating
-       write(iulog, *) '    lnc_opt = ', lnc_opt                              
-       write(iulog, *) '    reduce_dayl_factor = ', reduce_dayl_factor          
-       write(iulog, *) '    vcmax_opt = ', vcmax_opt                            
+       write(iulog, *) '    lnc_opt = ', lnc_opt
+       write(iulog, *) '    reduce_dayl_factor = ', reduce_dayl_factor
+       write(iulog, *) '    vcmax_opt = ', vcmax_opt
        write(iulog, *) '    CN_evergreen_phenology_opt = ', CN_evergreen_phenology_opt
        write(iulog, *) '    carbon_resp_opt = ', carbon_resp_opt
     end if
@@ -1119,7 +1119,7 @@ contains
     inquire(file=trim(finidat_interp_dest), exist=lexists)
     if (lexists) then
        ! open the input file and check for the name of the input source file
-       status = nf90_open(trim(finidat_interp_dest), 0, ncid)  
+       status = nf90_open(trim(finidat_interp_dest), 0, ncid)
        if (status /= nf90_noerr) call handle_err(status)
        status = nf90_get_att(ncid, NF90_GLOBAL, 'initial_source_file', initial_source_file)
        if (status /= nf90_noerr) call handle_err(status)

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -448,10 +448,11 @@ contains
                    errMsg(sourcefile, __LINE__))
           end if
 
-          if ( n_drydep > 0 ) then
-             call endrun(msg=' ERROR: dry deposition via ML Welsey is not compatible with FATES.'//&
-                   errMsg(sourcefile, __LINE__))
-          end if
+! Remove this check ??? the conditional will alway be false when n_drydep>0
+!          if ( n_drydep > 0 .and. drydep_method /= DD_XLND ) then
+!             call endrun(msg=' ERROR: dry deposition via ML Welsey is not compatible with FATES.'//&
+!                   errMsg(sourcefile, __LINE__))
+!          end if
 
           if( use_luna ) then
              call endrun(msg=' ERROR: luna is not compatible with FATES.'//&

--- a/src/main/lnd2atmMod.F90
+++ b/src/main/lnd2atmMod.F90
@@ -13,7 +13,7 @@ module lnd2atmMod
   use clm_varpar           , only : numrad, ndst, nlevgrnd, nlevmaxurbgrnd !ndst = number of dust bins.
   use clm_varcon           , only : rair, grav, cpair, hfus, tfrz, spval
   use clm_varctl           , only : iulog, use_lch4
-  use seq_drydep_mod       , only : n_drydep, drydep_method, DD_XLND
+  use shr_drydep_mod       , only : n_drydep
   use decompMod            , only : bounds_type
   use subgridAveMod        , only : p2g, c2g
   use filterColMod         , only : filter_col_type, col_filter_from_logical_array
@@ -35,7 +35,7 @@ module lnd2atmMod
   use glc2lndMod           , only : glc2lnd_type
   use ColumnType           , only : col
   use LandunitType         , only : lun
-  use GridcellType         , only : grc                
+  use GridcellType         , only : grc
   use landunit_varcon      , only : istice
   !
   ! !PUBLIC TYPES:
@@ -69,11 +69,11 @@ contains
     use clm_varcon, only : sb
     !
     ! !ARGUMENTS:
-    type(bounds_type)     , intent(in)    :: bounds  
+    type(bounds_type)     , intent(in)    :: bounds
     type(water_type)      , intent(inout) :: water_inst
     type(surfalb_type)    , intent(in)    :: surfalb_inst
     type(energyflux_type) , intent(in)    :: energyflux_inst
-    type(lnd2atm_type)    , intent(inout) :: lnd2atm_inst 
+    type(lnd2atm_type)    , intent(inout) :: lnd2atm_inst
     !
     ! !LOCAL VARIABLES:
     integer  :: i,g                                   ! index
@@ -152,7 +152,7 @@ contains
        energyflux_inst, solarabs_inst, drydepvel_inst,  &
        vocemis_inst, fireemis_inst, dust_inst, ch4_inst, glc_behavior, &
        lnd2atm_inst, &
-       net_carbon_exchange_grc) 
+       net_carbon_exchange_grc)
     !
     ! !DESCRIPTION:
     ! Compute lnd2atm_inst component of gridcell derived type
@@ -161,7 +161,7 @@ contains
     use ch4varcon  , only : ch4offline
     !
     ! !ARGUMENTS:
-    type(bounds_type)           , intent(in)    :: bounds  
+    type(bounds_type)           , intent(in)    :: bounds
     type(atm2lnd_type)          , intent(in)    :: atm2lnd_inst
     type(surfalb_type)          , intent(in)    :: surfalb_inst
     type(temperature_type)      , intent(in)    :: temperature_inst
@@ -175,7 +175,7 @@ contains
     type(dust_type)             , intent(in)    :: dust_inst
     type(ch4_type)              , intent(in)    :: ch4_inst
     type(glc_behavior_type)     , intent(in)    :: glc_behavior
-    type(lnd2atm_type)          , intent(inout) :: lnd2atm_inst 
+    type(lnd2atm_type)          , intent(inout) :: lnd2atm_inst
     real(r8)                    , intent(in)    :: net_carbon_exchange_grc( bounds%begg: )  ! net carbon exchange between land and atmosphere, positive for source (gC/m2/s)
     !
     ! !LOCAL VARIABLES:
@@ -199,7 +199,7 @@ contains
     !----------------------------------------------------
     ! lnd -> atm
     !----------------------------------------------------
-    
+
     ! First, compute the "minimal" set of fields.
     call lnd2atm_minimal(bounds, &
          water_inst, surfalb_inst, energyflux_inst, lnd2atm_inst)
@@ -270,7 +270,7 @@ contains
        lnd2atm_inst%eflx_sh_tot_grc(g) =  lnd2atm_inst%eflx_sh_tot_grc(g) + &
             lnd2atm_inst%eflx_sh_precip_conversion_grc(g) + &
             eflx_sh_ice_to_liq_grc(g) - &
-            energyflux_inst%eflx_dynbal_grc(g) 
+            energyflux_inst%eflx_dynbal_grc(g)
     enddo
 
     call p2g(bounds, &
@@ -299,7 +299,7 @@ contains
     end do
 
     ! drydepvel
-    if ( n_drydep > 0 .and. drydep_method == DD_XLND ) then
+    if ( n_drydep > 0 ) then
        call p2g(bounds, n_drydep, &
             drydepvel_inst%velocity_patch (bounds%begp:bounds%endp, :), &
             lnd2atm_inst%ddvel_grc        (bounds%begg:bounds%endg, :), &
@@ -396,7 +396,7 @@ contains
 
     call c2g( bounds, &
          water_inst%waterlnd2atmbulk_inst%qflx_ice_runoff_col(bounds%begc:bounds%endc),  &
-         water_inst%waterlnd2atmbulk_inst%qflx_rofice_grc(bounds%begg:bounds%endg),  & 
+         water_inst%waterlnd2atmbulk_inst%qflx_rofice_grc(bounds%begg:bounds%endg),  &
          c2l_scale_type= 'urbanf', l2g_scale_type='unity' )
     do g = bounds%begg, bounds%endg
        water_inst%waterlnd2atmbulk_inst%qflx_rofice_grc(g) = &

--- a/src/main/lnd2atmType.F90
+++ b/src/main/lnd2atmType.F90
@@ -15,7 +15,7 @@ module lnd2atmType
   use clm_varctl    , only : iulog, use_lch4
   use shr_megan_mod , only : shr_megan_mechcomps_n
   use shr_fire_emis_mod,only : shr_fire_emis_mechcomps_n
-  use seq_drydep_mod, only : n_drydep, drydep_method, DD_XLND
+  use shr_drydep_mod, only : n_drydep
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -64,8 +64,8 @@ module lnd2atmType
 
      procedure, public  :: Init
      procedure, private :: ReadNamelist
-     procedure, private :: InitAllocate 
-     procedure, private :: InitHistory  
+     procedure, private :: InitAllocate
+     procedure, private :: InitHistory
 
   end type lnd2atm_type
   !------------------------------------------------------------------------
@@ -105,13 +105,13 @@ contains
   subroutine Init(this, bounds, NLFilename)
 
     class(lnd2atm_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     character(len=*), intent(in) :: NLFilename ! Namelist filename
 
     call this%InitAllocate(bounds)
     call this%ReadNamelist(NLFilename)
     call this%InitHistory(bounds)
-    
+
   end subroutine Init
 
   !------------------------------------------------------------------------
@@ -122,7 +122,7 @@ contains
     !
     ! !ARGUMENTS:
     class (lnd2atm_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     real(r8) :: ival  = 0.0_r8  ! initial value
@@ -163,7 +163,7 @@ contains
        allocate(this%fireztop_grc(begg:endg))
        this%fireztop_grc = ival
     endif
-    if ( n_drydep > 0 .and. drydep_method == DD_XLND )then
+    if ( n_drydep > 0 )then
        allocate(this%ddvel_grc(begg:endg,1:n_drydep)); this%ddvel_grc(:,:)=ival
     end if
 
@@ -240,7 +240,7 @@ contains
     !
     ! !ARGUMENTS:
     class(lnd2atm_type) :: this
-    type(bounds_type), intent(in) :: bounds  
+    type(bounds_type), intent(in) :: bounds
     !
     ! !LOCAL VARIABLES:
     integer  :: begc, endc


### PR DESCRIPTION
### Description of changes
 Use `shr_drydep_mod` rather than the `seq_drydep_mod` module (which is merely a wrapper to shr_drydep_mod).

### Specific notes

 Namelist option `drydep_method` is removed.  The other dry deposition options were obsolete and were removed from the code base.  The only method available now is the "land" method.  We are dependent on the land model to provide deposition velocities of chemical constituents over land in all configurations.

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #): #1822

Are answers expected to change (and if so in what way)? No
 Expect bit-for-bit unchanged

Any User Interface Changes (namelist or namelist defaults changes)?
 Namelist option `drydep_method` is removed

Testing performed, if any:
 Only tested a few F compsets with chemistry

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
