### PR TITLE
Implement GaoOneill raw urban datasets and OlesonFeddema urban properties into mksurfdata_esmf.

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1725,7 +1725,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_1"  hgrid="0.9x1.25"
->/glade/p/cgd/tss/people/oleson/urban_sfcdata/Feddema_urban_data_080410/HIGH_RES_VERSION2/URBAN_PROPERTIES_THESIS_TOOL/JUN_22_2018/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c200605.nc</stream_fldfilename_urbantv>
+>/glade/p/cgd/tss/people/oleson/urban_sfcdata/Feddema_urban_data_080410/HIGH_RES_VERSION2/URBAN_PROPERTIES_THESIS_TOOL/JUN_22_2018/CTSM52_tbuildmax_OlesonFeddema_2020_0.9x1.25_simyr1849-2106_c200605.nc</stream_fldfilename_urbantv>
 <stream_meshfile_urbantv    phys="clm5_1"  hgrid="0.9x1.25"
 >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1_ESMFmesh_cdf5_100621.nc</stream_meshfile_urbantv>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1725,7 +1725,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_1"  hgrid="0.9x1.25"
->lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c160923.nc</stream_fldfilename_urbantv>
+>/glade/p/cgd/tss/people/oleson/urban_sfcdata/Feddema_urban_data_080410/HIGH_RES_VERSION2/URBAN_PROPERTIES_THESIS_TOOL/JUN_22_2018/CLM50_tbuildmax_Oleson_2016_0.9x1.25_simyr1849-2106_c200605.nc</stream_fldfilename_urbantv>
 <stream_meshfile_urbantv    phys="clm5_1"  hgrid="0.9x1.25"
 >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1_ESMFmesh_cdf5_100621.nc</stream_meshfile_urbantv>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1725,7 +1725,7 @@ lnd/clm2/surfdata_map/release-clm5.0.30/surfdata_ne0np4.CONUS.ne30x8_hist_78pfts
 <stream_year_last_urbantv  sim_year="constant" sim_year_range="1850-2000" >2106</stream_year_last_urbantv>
 
 <stream_fldfilename_urbantv phys="clm5_1"  hgrid="0.9x1.25"
->/glade/p/cgd/tss/people/oleson/urban_sfcdata/Feddema_urban_data_080410/HIGH_RES_VERSION2/URBAN_PROPERTIES_THESIS_TOOL/JUN_22_2018/CTSM52_tbuildmax_OlesonFeddema_2020_0.9x1.25_simyr1849-2106_c200605.nc</stream_fldfilename_urbantv>
+>/glade/p/cesmdata/inputdata/lnd/clm2/urbandata/CTSM52_tbuildmax_OlesonFeddema_2020_0.9x1.25_simyr1849-2106_c200605.nc</stream_fldfilename_urbantv>
 <stream_meshfile_urbantv    phys="clm5_1"  hgrid="0.9x1.25"
 >lnd/clm2/urbandata/CLM50_tbuildmax_Oleson_2016_0.9x1_ESMFmesh_cdf5_100621.nc</stream_meshfile_urbantv>
 

--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -254,8 +254,23 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/rawdata/mksrf_vocef_0.5x0.5_simyr2000.c110531.nc</mksrf_fvocef>
 
 <!-- urban -->
-<mksrf_furban   hgrid="3x3min"   lmask="nomask"
->lnd/clm2/rawdata/mksrf_urban_0.05x0.05_simyr2000.c120621.nc</mksrf_furban>
+<mksrf_furban   hgrid="3x3min"   ssp_rcp="hist" lmask="nomask"
+>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2000_c20220910.nc</mksrf_furban>
+ 
+<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP1-2.6" lmask="nomask"
+>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_2000_c20220910.nc</mksrf_furban>
+ 
+<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP2-4.5" lmask="nomask"
+>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp2_2000_c20220910.nc</mksrf_furban>
+ 
+<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP3-7.0" lmask="nomask"
+>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp3_2000_c20220910.nc</mksrf_furban>
+ 
+<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP4-3.4" lmask="nomask"
+>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_2000_c20220910.nc</mksrf_furban>
+ 
+<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP5-8.5" lmask="nomask"
+>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_2000_c20220910.nc</mksrf_furban>
 
 <mksrf_furban   hgrid="3x3min"   lmask="nomask" sim_year="PtVg"
 >lnd/clm2/rawdata/mksrf_urban_0.05x0.05_zerourbanpct.c181014.nc</mksrf_furban>

--- a/bld/namelist_files/namelist_defaults_ctsm_tools.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm_tools.xml
@@ -254,23 +254,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/rawdata/mksrf_vocef_0.5x0.5_simyr2000.c110531.nc</mksrf_fvocef>
 
 <!-- urban -->
-<mksrf_furban   hgrid="3x3min"   ssp_rcp="hist" lmask="nomask"
->/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2000_c20220910.nc</mksrf_furban>
- 
-<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP1-2.6" lmask="nomask"
->/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_2000_c20220910.nc</mksrf_furban>
- 
-<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP2-4.5" lmask="nomask"
->/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp2_2000_c20220910.nc</mksrf_furban>
- 
-<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP3-7.0" lmask="nomask"
->/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp3_2000_c20220910.nc</mksrf_furban>
- 
-<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP4-3.4" lmask="nomask"
->/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_2000_c20220910.nc</mksrf_furban>
- 
-<mksrf_furban   hgrid="3x3min"   ssp_rcp="SSP5-8.5" lmask="nomask"
->/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/HistoricalPlusSSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_2000_c20220910.nc</mksrf_furban>
+<mksrf_furban   hgrid="3x3min"   lmask="nomask"
+>lnd/clm2/rawdata/mksrf_urban_0.05x0.05_simyr2000.c120621.nc</mksrf_furban>
 
 <mksrf_furban   hgrid="3x3min"   lmask="nomask" sim_year="PtVg"
 >lnd/clm2/rawdata/mksrf_urban_0.05x0.05_zerourbanpct.c181014.nc</mksrf_furban>

--- a/src/biogeophys/test/Photosynthesis_test/test_Photosynthesis.pf
+++ b/src/biogeophys/test/Photosynthesis_test/test_Photosynthesis.pf
@@ -38,7 +38,7 @@ contains
     soil_layerstruct_predefined = '20SL_8.5m'
     
     call setup_ncells_single_veg_patch(ncells=1, pft_type=1)
-    call clm_varpar_init( actual_maxsoil_patches=17, actual_numcft=2 )
+    call clm_varpar_init( actual_maxsoil_patches=17, actual_numcft=2, actual_nlevurb=5 )
     call this%photo%Init( bounds )
     call this%photo%setParamsForTesting( )
 

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -40,6 +40,7 @@ module clm_initializeMod
   public :: initialize2  ! Phase two initialization
 
   integer :: actual_numcft  ! numcft from sfc dataset
+  integer :: actual_nlevurb ! nlevurb from sfc dataset
 
 !-----------------------------------------------------------------------
 contains
@@ -55,7 +56,7 @@ contains
     use clm_varcon           , only: clm_varcon_init
     use landunit_varcon      , only: landunit_varcon_init
     use clm_varctl           , only: fsurdat, version
-    use surfrdMod            , only: surfrd_get_num_patches
+    use surfrdMod            , only: surfrd_get_num_patches, surfrd_get_nlevurb
     use controlMod           , only: control_init, control_print, NLFilename
     use ncdio_pio            , only: ncd_pio_init
     use initGridCellsMod     , only: initGridCells
@@ -97,7 +98,8 @@ contains
     call control_init(dtime)
     call ncd_pio_init()
     call surfrd_get_num_patches(fsurdat, actual_maxsoil_patches, actual_numcft)
-    call clm_varpar_init(actual_maxsoil_patches, actual_numcft)
+    call surfrd_get_nlevurb(fsurdat, actual_nlevurb)
+    call clm_varpar_init(actual_maxsoil_patches, actual_numcft, actual_nlevurb)
     call decomp_cascade_par_init( NLFilename )
     call clm_varcon_init( IsSimpleBuildTemp() )
     call landunit_varcon_init()

--- a/src/main/clm_varpar.F90
+++ b/src/main/clm_varpar.F90
@@ -110,7 +110,7 @@ module clm_varpar
 contains
 
   !------------------------------------------------------------------------------
-  subroutine clm_varpar_init(actual_maxsoil_patches, actual_numcft)
+  subroutine clm_varpar_init(actual_maxsoil_patches, actual_numcft, actual_nlevurb)
     !
     ! !DESCRIPTION:
     ! Initialize module variables 
@@ -119,6 +119,7 @@ contains
     implicit none
     integer, intent(in) :: actual_maxsoil_patches  ! value from surface dataset
     integer, intent(in) :: actual_numcft  ! Actual number of crops
+    integer, intent(in) :: actual_nlevurb ! nlevurb from surface dataset
     !
     ! !LOCAL VARIABLES:
     !
@@ -159,7 +160,7 @@ contains
     max_patch_per_col= max(maxsoil_patches, actual_numcft, maxpatch_urb)
 
     nlevsoifl   =  10
-    nlevurb     =  5
+    nlevurb     =  actual_nlevurb
 
     if ( masterproc ) write(iulog, *) 'soil_layerstruct_predefined varpar ', soil_layerstruct_predefined
     if ( masterproc ) write(iulog, *) 'soil_layerstruct_userdefined varpar ', soil_layerstruct_userdefined

--- a/src/main/initVerticalMod.F90
+++ b/src/main/initVerticalMod.F90
@@ -283,6 +283,11 @@ contains
        write(iulog, *) 'dzsoi_decomp: ',dzsoi_decomp
     end if
 
+    if (nlevurb == ispval) then
+       call shr_sys_abort(' ERROR nlevurb has not been defined '//&
+            errMsg(sourcefile, __LINE__))
+    end if
+
     if (nlevurb > 0) then
        allocate(zurb_wall(bounds%begl:bounds%endl,nlevurb),    &
             zurb_roof(bounds%begl:bounds%endl,nlevurb),    &

--- a/src/main/surfrdMod.F90
+++ b/src/main/surfrdMod.F90
@@ -29,6 +29,7 @@ module surfrdMod
   ! !PUBLIC MEMBER FUNCTIONS:
   public :: surfrd_get_data         ! Read surface dataset and determine subgrid weights
   public :: surfrd_get_num_patches  ! Read surface dataset to determine maxsoil_patches and numcft
+  public :: surfrd_get_nlevurb      ! Read surface dataset to determine nlevurb
 
   ! !PRIVATE MEMBER FUNCTIONS:
   private :: surfrd_special   ! Read the special landunits
@@ -299,6 +300,48 @@ contains
     end if
 
   end subroutine surfrd_get_num_patches
+
+!-----------------------------------------------------------------------
+  subroutine surfrd_get_nlevurb (lfsurdat, actual_nlevurb)
+    !
+    ! !DESCRIPTION:
+    ! Read nlevurb from the surface dataset
+    !
+    ! !USES:
+    use fileutils   , only : getfil
+    !
+    ! !ARGUMENTS:
+    character(len=*), intent(in) :: lfsurdat  ! surface dataset filename
+    integer, intent(out) :: actual_nlevurb    ! nlevurb from surface dataset
+    !
+    ! !LOCAL VARIABLES:
+    character(len=256):: locfn                ! local file name
+    type(file_desc_t) :: ncid                 ! netcdf file id
+    integer :: dimid                          ! netCDF dimension id
+    character(len=32) :: subname = 'surfrd_get_nlevurb'  ! subroutine name
+    !-----------------------------------------------------------------------
+
+    if (masterproc) then
+       write(iulog,*) 'Attempting to read nlevurb from the surface data .....'
+       if (lfsurdat == ' ') then
+          write(iulog,*)'lfsurdat must be specified'
+          call endrun(msg=errMsg(sourcefile, __LINE__))
+       endif
+    endif
+
+    ! Open surface dataset
+    call getfil( lfsurdat, locfn, 0 )
+    call ncd_pio_openfile (ncid, trim(locfn), 0)
+
+    ! Read nlevurb
+    call ncd_inqdlen(ncid, dimid, actual_nlevurb, 'nlevurb')
+
+    if ( masterproc )then
+       write(iulog,*) 'Successfully read nlevurb from the surface data'
+       write(iulog,*)
+    end if
+
+  end subroutine surfrd_get_nlevurb
 
 !-----------------------------------------------------------------------
   subroutine surfrd_special(begg, endg, ncid, ns)

--- a/tools/mksurfdata_esmf/README
+++ b/tools/mksurfdata_esmf/README
@@ -1,3 +1,13 @@
+=======
+Purpose
+=======
+This tool is intended to generate fsurdat files (surface datasets) for the
+CTSM. It can generate global, regional, and single-point fsurdat files, as long
+as a mesh file is available for the grid.
+
+The subset_data tool allows users to make fsurdat files from existing fsurdat
+files when a mesh file is unavailable. Generally, users should consider the
+subset_data tool for generating regional and single-point fsurdat files.
 ===================
 Build Requirements:
 ===================
@@ -70,13 +80,17 @@ running for a single submission:
 # to generate your target jobscript (again --help for instructions):
 > ./gen_mksurfdata_jobscript_single.py --number-of-nodes 24 --tasks-per-node 12 --namelist-file target.namelist
 > qsub mksurfdata_jobscript_single
+# Read note about regional grids below.
 
 =======================
 running for the generation of multiple datasets
 =======================
-# Note that gen_mksurfdata_jobscript_multi.py runs ./gen_mksurfdata_namelist.py
+# Notes:
+# - gen_mksurfdata_jobscript_multi.py runs ./gen_mksurfdata_namelist.py for you
+# - The regional grid 5x5_amazon may fail with 24 nodes.
+#   Task geometry that worked: #PBS -l select=4:ncpus=36:mpiprocs=4
 > ./gen_mksurfdata_jobscript_multi.py --help
-> ./gen_mksurfdata_jobscript_multi.py --number-of-nodes 24 --tasks-per-node 12 --scenario all
+> ./gen_mksurfdata_jobscript_multi.py --number-of-nodes 24 --scenario all
 > qsub mksurfdata_jobscript_multi
 
 ================

--- a/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_multi.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_multi.py
@@ -201,6 +201,11 @@ def main ():
                   }
 
     # --------------------------
+    # TODO Here, reuse code from gen_mksurfdata_jobscript_single.py
+    # that's found in the section titled "Obtain mpirun command ..."
+    # --------------------------
+
+    # --------------------------
     # Write run script
     # --------------------------
     with open(jobscript_file, "w",encoding='utf-8') as runfile:
@@ -210,7 +215,7 @@ def main ():
         runfile.write('#PBS -N mksurfdata \n')
         runfile.write('#PBS -j oe \n')
         runfile.write('#PBS -q regular \n')
-        runfile.write('#PBS -l walltime=30:00 \n')
+        runfile.write('#PBS -l walltime=12:00:00 \n')
         runfile.write(f"#PBS -l select={number_of_nodes}:ncpus=36:mpiprocs={tasks_per_node} \n")
         runfile.write("\n")
 
@@ -219,7 +224,7 @@ def main ():
         # Run env_mach_specific.sh to control the machine dependent
         # environment including the paths to compilers and libraries
         # external to cime such as netcdf
-        runfile.write('. ./.env_mach_specific.sh \n')
+        runfile.write('. ./tool_bld/.env_mach_specific.sh \n')
         for target in target_list:
             res_set = dataset_dict[target][1]
             for res in resolution_dict[res_set]:
@@ -236,7 +241,7 @@ def main ():
                 output = run_cmd.stdout.decode('utf-8').strip()
                 namelist = output.split(' ')[-1]
                 print (f"generated namelist {namelist}")
-                output = f"mpiexec_mpt -p \"%g:\" -np {n_p} ./tool_bld/mksurfdata < {namelist}"
+                output = f"mpiexec_mpt -p \"%g:\" -np {n_p} omplace -tm open64 ./tool_bld/mksurfdata < {namelist}"
                 runfile.write(f"{output} \n")
 
     print (f"Successfully created jobscript {jobscript_file}")

--- a/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_multi.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_multi.py
@@ -196,7 +196,7 @@ def main ():
                   "crop-global-SSP3-7.0"            : ("--start-year 1850 --end-year 2100 --nosurfdata --ssp-rcp SSP3-7.0 --res", "future_res"),
                   "crop-global-SSP4-3.4"            : ("--start-year 1850 --end-year 2100 --nosurfdata --ssp-rcp SSP4-3.4 --res", "future_res"),
                   "crop-global-SSP4-6.0"            : ("--start-year 1850 --end-year 2100 --nosurfdata --ssp-rcp SSP4-6.0 --res", "future_res"),
-                  "crop-global-SSP5-3.4"            : ("--start-year 1850 --end-year 2100 --nosurfdata --ssp-rcp SSP4-3.4 --res", "future_res"),
+                  "crop-global-SSP5-3.4"            : ("--start-year 1850 --end-year 2100 --nosurfdata --ssp-rcp SSP5-3.4 --res", "future_res"),
                   "crop-global-SSP5-8.5"            : ("--start-year 1850 --end-year 2100 --nosurfdata --ssp-rcp SSP5-8.5 --res", "future_res")
                   }
 

--- a/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_multi.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_jobscript_multi.py
@@ -171,7 +171,7 @@ def main ():
         "T42_res"              : ['T42'],
         "nldas_res"            : ['0.125nldas2'],
         "5x5_amazon_res"       : ['5x5_amazon'],
-        "ne16np4_res"          : ['ne120np4'],
+        "ne16np4_res"          : ['ne16np4'],
         "ne120np4_res"         : ['ne120np4'],
     }
 

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -431,6 +431,9 @@ def main ():
                         print('WARNING: run ./download_input_data to try TO ' \
                               'OBTAIN MISSING FILES')
                         _must_run_download_input_data = True
+                else:
+                   rawdata_files[child1.tag] = rawdata_files[child1.tag]. \
+                                               replace("%y",str(start_year))
 
             if item.tag == 'mesh_filename':
                 new_key = f"{child1.tag}_mesh"

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.py
@@ -431,7 +431,9 @@ def main ():
                         print('WARNING: run ./download_input_data to try TO ' \
                               'OBTAIN MISSING FILES')
                         _must_run_download_input_data = True
-                else:
+                elif 'urban_properties' in rawdata_files[child1.tag]:
+                   # Time-slice cases pull urban_properties from the transient
+                   # urban_properties data files
                    rawdata_files[child1.tag] = rawdata_files[child1.tag]. \
                                                replace("%y",str(start_year))
 

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
@@ -97,7 +97,19 @@
 
   <mksrf_furban>
     <entry>
-      <data_filename>lnd/clm2/rawdata/mksrf_urban_0.05x0.05_simyr2000.c220127.nc</data_filename>
+      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2000_c20220910.nc</data_filename>
+      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
+    </entry>
+    <entry pft_years="1850">
+      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_1850_c20220910.nc</data_filename>
+      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
+    </entry>
+    <entry pft_years="2000">
+      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2000_c20220910.nc</data_filename>
+      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
+    </entry>
+    <entry pft_years="2005">
+      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2005_c20220910.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
     </entry>
     <entry pft_years="PtVg">
@@ -252,7 +264,7 @@ version of the raw dataset will probably go away.
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.LUH2.histsimyr1850-2015.c20220305/mksrf_landuse_ctsm52_histLUH2_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_%y_c20220910.nc</urban_filename>
     </entry>
 
   </mksrf_fvegtyp>
@@ -266,49 +278,49 @@ version of the raw dataset will probably go away.
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP1RCP26_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP1/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP1-RCP 1.9 -->
     <entry  ssp_rcp="SSP1-1.9" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP1RCP19_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP1/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP2-RCP 4.5 -->
     <entry  ssp_rcp="SSP2-4.5" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP2RCP45_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP2/urban_properties_GaoOneil_05deg_ThreeClass_ssp2_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP3-RCP 7.0 -->
     <entry  ssp_rcp="SSP3-7.0" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP3RCP70_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP3/urban_properties_GaoOneil_05deg_ThreeClass_ssp3_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP4-RCP 3.4 -->
     <entry  ssp_rcp="SSP4-3.4" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP4RCP34_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP4/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP4-RCP 6.0 -->
     <entry  ssp_rcp="SSP4-6.0" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP4RCP60_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP4/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP5-RCP 8.5 -->
     <entry  ssp_rcp="SSP5-8.5" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-8.5.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP5RCP85_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/slevis/transient_urban_data/05deg_%y_NoAdjust.cdf5.c20220325.nc</urban_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
     </entry>
 
   </mksrf_fvegtyp_ssp>

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
@@ -104,10 +104,6 @@
       <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_1850_c20220910.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
     </entry>
-    <entry pft_years="2000">
-      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2000_c20220910.nc</data_filename>
-      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
-    </entry>
     <entry pft_years="2005">
       <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2005_c20220910.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
@@ -97,7 +97,7 @@
 
   <mksrf_furban>
     <entry>
-      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_%y_c20220910.nc</data_filename>
+      <data_filename>lnd/clm2/rawdata/gao_oneill_urban/historical/urban_properties_GaoOneil_05deg_ThreeClass_%y_c20220910.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
     </entry>
     <entry pft_years="PtVg">
@@ -252,7 +252,7 @@ version of the raw dataset will probably go away.
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.LUH2.histsimyr1850-2015.c20220305/mksrf_landuse_ctsm52_histLUH2_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/historical/urban_properties_GaoOneil_05deg_ThreeClass_%y_c20220910.nc</urban_filename>
     </entry>
 
   </mksrf_fvegtyp>
@@ -266,56 +266,56 @@ version of the raw dataset will probably go away.
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-2.6.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP1RCP26_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP1/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp1/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP1-RCP 1.9 -->
     <entry  ssp_rcp="SSP1-1.9" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP1-1.9.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP1RCP19_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP1/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp1/urban_properties_GaoOneil_05deg_ThreeClass_ssp1_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP2-RCP 4.5 -->
     <entry  ssp_rcp="SSP2-4.5" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP2-4.5.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP2RCP45_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP2/urban_properties_GaoOneil_05deg_ThreeClass_ssp2_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp2/urban_properties_GaoOneil_05deg_ThreeClass_ssp2_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP3-RCP 7.0 -->
     <entry  ssp_rcp="SSP3-7.0" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP3-7.0.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP3RCP70_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP3/urban_properties_GaoOneil_05deg_ThreeClass_ssp3_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp3/urban_properties_GaoOneil_05deg_ThreeClass_ssp3_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP4-RCP 3.4 -->
     <entry  ssp_rcp="SSP4-3.4" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-3.4.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP4RCP34_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP4/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp4/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP4-RCP 6.0 -->
     <entry  ssp_rcp="SSP4-6.0" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP4-6.0.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP4RCP60_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP4/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp4/urban_properties_GaoOneil_05deg_ThreeClass_ssp4_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP5-RCP 8.5 -->
     <entry  ssp_rcp="SSP5-8.5" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-8.5.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP5RCP85_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
     </entry>
     <!-- SSP5-RCP 3.4 -->
     <entry  ssp_rcp="SSP5-3.4" pft_years_ssp="2016-2100" >
       <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP5RCP34_%y.c220305.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
-      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
+      <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/ssp5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
     </entry>
 
   </mksrf_fvegtyp_ssp>

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
@@ -97,15 +97,7 @@
 
   <mksrf_furban>
     <entry>
-      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2000_c20220910.nc</data_filename>
-      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
-    </entry>
-    <entry pft_years="1850">
-      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_1850_c20220910.nc</data_filename>
-      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
-    </entry>
-    <entry pft_years="2005">
-      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_2005_c20220910.nc</data_filename>
+      <data_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/Historical/urban_properties_GaoOneil_05deg_ThreeClass_%y_c20220910.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_3x3min_nomask_cdf5_c200129.nc</mesh_filename>
     </entry>
     <entry pft_years="PtVg">

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
@@ -310,6 +310,13 @@ version of the raw dataset will probably go away.
       <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
       <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
     </entry>
+    <!-- SSP5-RCP 3.4 -->
+    <entry  ssp_rcp="SSP5-3.4" pft_years_ssp="2016-2100" >
+      <data_filename>lnd/clm2/rawdata/pftcftdynharv.0.25x0.25.SSP5-3.4.simyr2015-2100.c20220305/mksrf_landuse_ctsm52_SSP5RCP34_%y.c220305.nc</data_filename>
+      <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
+      <lake_filename>/glade/p/cgd/tss/people/slevis/transient_lake_data/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
+      <urban_filename>/glade/p/cgd/tss/people/oleson/Dynamic_Urban_Data/GaoOneil/PCTURB_GRID/SSP5/urban_properties_GaoOneil_05deg_ThreeClass_ssp5_%y_c20220910.nc</urban_filename>
+    </entry>
 
   </mksrf_fvegtyp_ssp>
 


### PR DESCRIPTION
### Description of changes
Implementation of GaoOneill raw urban datasets and OlesonFeddema urban properties into mksurfdata_esmf.

### Specific notes
1a. Incorporate new raw urban surface datasets for 1850, present day (2000, 2005), historical, and five SSPs (SSP1, SSP2, SSP3, SSP4, SSP5) developed primarily by @keerzhang1 from Gao and O'Neill (2021) and Gao and Pesaresi (2022). The urban properties (morphological, radiative, and thermal) in these datasets are described in Oleson and Feddema (2020). These datasets have PCT_URBAN calculated with respect to the total area of the gridcell (as discussed in #1716 ).  Note that the SSP1 datasets have been assigned to SSP1-1.9 and SSP1-2.6 and SSP4 datasets have been assigned to SSP4-3.4 and SSP4-6.0.

1b. A new building temperature stream file is implemented. The values of maximum interior building temperature in this file are  documented in Oleson and Feddema (2020).

1c. Code changes in CTSM and mksurfdata_esmf to read in nlevurb from the surface dataset instead of being hardcoded in clm_varpar.F90. This will ensure backward compatibility with older urban datasets (which have nlevurb=5 as opposed to the new datasets which have nlevurb=10).

Note that the paths to these files have been hard-coded to my directories because I don't have inputdata permissions.

Contributors other than yourself, if any: @keerzhang1 (Keer Zhang), @fang-bowen (Bowen Fang), @Face2sea (Lei Zhao), @billsacks (Bill Sacks)

CTSM Issues Fixed (include github issue #): #1445 #591 

Are answers expected to change (and if so in what way)?  Yes, urban quantities will change due to changes in urban fraction and urban properties and thus grid cell averages will be different for grid cells that have non-zero urban fraction.

Any User Interface Changes (namelist or namelist defaults changes)? Yes, changes to namelist_defaults_ctsm.xml (new building temperature stream file), namelist_defaults_ctsm_tools.xml (new year 2000 raw urban dataset), gen_mksurfdata_namelist.xml (new raw urban datasets).

Testing performed, if any:
Created 0.9x1.25 surface datasets and landuse timeseries for 1850, 1850-2015, 2000, 2005, 2015-2100 (SSP1-1.9, SSP1-2.6, SSP2-4.5, SSP3-7.0, SSP4-3.4, SSP4-6.0, SSP5-8.5) using mksurfdata_esmf.

