### PR TITLE
mksurfdata: Rework mapping of landunits to handle coastal areas more rigorously

### DIFF
--- a/doc/design/surface_dataset_areas.rst
+++ b/doc/design/surface_dataset_areas.rst
@@ -1,0 +1,39 @@
+.. sectnum::
+
+.. contents::
+
+==================================
+ Overview of this design document
+==================================
+
+This document gives a high-level overview of the specification of sub-grid areas on surface datasets and the raw datasets used to create them.
+
+See also https://github.com/ESCOMP/CTSM/issues/1716 for related discussion.
+
+=================================================
+ Specification of landunit areas in raw datasets
+=================================================
+
+In the high-resolution raw datasets used as input to the mksurfdata tool, landunit areas should be specified as percent of the grid cell, **not** percent of the land area. For example, on the urban raw dataset, if there is a grid cell that is 50% land and 50% ocean, and 60% of the land area is urban, the urban area in that grid cell should be given as 30%.
+
+One reason for this is that it makes reconciling the different landunit areas more straightforward if different raw datasets disagree about the land mask. In addition, this convention makes it easier to map raw datasets to the model resolution. For example, consider averaging two grid cells into a destination grid cell: one with 2% land area, of which 50% is glacier; and one with 100% land area, of which none is glacier. If we encode these as percent of the land area, we would have 50% glacier and 0% glacier, and then the final glacier cover would be 25%, suggesting that 25% of the land area is glacier, but this is incorrect. If we instead encode these as percent of the total grid cell area, we would have 1% glacier and 0% glacier, and then the final glacier cover would be 0.5%, suggesting that 0.5% of the total grid cell is glacier, which is correct.
+
+=====================================================
+ Specification of landunit areas in surface datasets
+=====================================================
+
+In contrast to the raw datasets, landunit areas in surface datasets are specified as percent of the land area, **not** as percent of the total grid cell. This is because we don't know what the model's actual land fraction will be at the time when the surface datasets are created: instead, this land fraction is determined at runtime based on the ocean grid.
+
+===========================================================================================
+ Procedure for converting landunit areas from percent of grid cell to percent of land area
+===========================================================================================
+
+There are a few important aspects to how we determine final landunit areas in mksurfdata:
+
+When mapping landunit areas from the raw data resolution to the model resolution, we initially want to maintain areas as percent of the total grid cell area. To achieve this, we set ``norm_by_fracs=.false.`` in the call to ``create_routehandle``, resulting in the use of ``ESMF_NORMTYPE_DSTAREA`` rather than ``ESMF_NORMTYPE_FRACAREA`` as a ``normType`` when computing mapping weights. Using ``FRACAREA`` normalization is appropriate when you want to treat areas outside of the source mask as missing values that do not contribute in any way to the final destination value. Using ``DSTAREA`` normalization, in contrast, essentially treats areas outside of the source mask as zeroes. ``FRACAREA`` normalization is appropriate for many surface dataset fields, but ``DSTAREA`` is appropriate for areas specified as percent of the grid cell. For example, if a source grid cell is entirely ocean, then we want to treat glacier area in that source grid cell as 0%.
+
+The conversion from percent of the grid cell area to percent of the land area happens in the subroutine ``normalize_and_check_landuse``. An important piece of doing this conversion is to determine an estimate of the land fraction for each model grid cell. This is not straightforward given the disparate land masks used for each raw dataset. We start by using the land fraction from the vegetation (PFT) raw dataset, with the assumption that that is probably the most reliable land mask. However, there are areas where using that land fraction is problematic, particularly where the areas of other landunits extend beyond the PFT's land mask. This is especially an issue for glaciers, where floating ice shelves can extend beyond the land-ocean border. To deal with this problem, if the sum of the areas of special landunits and crops exceeds the land fraction from the PFT data, we instead use that sum as an estimate of the land fraction. Exactly which landunits to include in this sum is a bit arbitrary. Arguably, the natural vegetated landunit should also be included in this sum. However, we ideally want to avoid changes in this estimated land fraction through time in transient datasets, which means that we generally want to use the PFT data's land fraction, only falling back on this landunit sum in exceptional cases. By excluding the natural vegetated area from this sum, we are more likely to use the PFT's land fraction. An implication of this choice is that we are more likely to replace natural vegetated areas with special landunits in cases where there are disagreements between the different raw datasets in coastal grid cells. For more detailed explanation and rationale, see some comments in ``normalize_and_check_landuse``.
+
+In grid cells where the estimated land fraction is essentially zero, we set the land cover to wetland, as a rough parameterization of ocean. This situation will only arise if the areas of all landunits on the raw datasets are essentially zero for the given grid cell, so we would have no information to choose any particular land cover for the grid cell. (This wetland area may end up being changed to bare ground at runtime, depending on the value of the ``convert_ocean_to_land`` namelist flag.)
+
+In grid cells where the estimated land fraction is greater than zero, we fill any unclaimed land area with the natural vegetated landunit. We then normalize all landunit areas based on the estimated land fraction so that they now specify areas as percent of the land area rather than as percent of the grid cell.

--- a/doc/design/surface_dataset_areas.rst
+++ b/doc/design/surface_dataset_areas.rst
@@ -37,3 +37,33 @@ The conversion from percent of the grid cell area to percent of the land area ha
 In grid cells where the estimated land fraction is essentially zero, we set the land cover to wetland, as a rough parameterization of ocean. This situation will only arise if the areas of all landunits on the raw datasets are essentially zero for the given grid cell, so we would have no information to choose any particular land cover for the grid cell. (This wetland area may end up being changed to bare ground at runtime, depending on the value of the ``convert_ocean_to_land`` namelist flag.)
 
 In grid cells where the estimated land fraction is greater than zero, we fill any unclaimed land area with the natural vegetated landunit. We then normalize all landunit areas based on the estimated land fraction so that they now specify areas as percent of the land area rather than as percent of the grid cell.
+
+===================
+ Example scenarios
+===================
+
+The following example scenarios illustrate the operation of ``normalize_and_check_landuse``; in the following, any landunit not explicitly mentioned has 0% area:
+
+(a) With pctlnd_pft = 0% and all initial landunit areas 0%: wetland area = 100%
+
+(b) With pctlnd_pft = 0% and initial glacier area 1%: glacier area = 100%
+
+(c) With pctlnd_pft > 0% and all initial landunit areas 0%: natural vegetated area = 100%
+
+(d) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%: crop area = 50%, natural vegetated area = 50%
+
+(e) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 10%: crop area = 50%, natural vegetated area = 25%, glacier area = 25%
+
+(f) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 15%: crop area = 50%, natural vegetated area = 12.5%, glacier area = 37.5%
+
+(g) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 20%: crop area = 50%, glacier area = 50%
+
+(h) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 30%: crop area = 40%, glacier area = 60%
+
+(i) With pctlnd_pft = 40%, initial crop area 0%, natural vegetated area 40%, glacier area 40%: glacier area = 100%
+
+(j) With pctlnd_pft = 2%, initial natural vegetated area 1%, glacier area 1%: natural vegetated area = 50%, glacier area = 50%
+
+(k) With pctlnd_pft = 2%, initial natural vegetated area 0%, glacier area 1%: natural vegetated area = 50%, glacier area = 50%
+
+(l) With pctlnd_pft = 2%, initial natural vegetated area 2%, glacier area 1%: natural vegetated area = 50%, glacier area = 50%

--- a/tools/mksurfdata_esmf/src/mkVICparamsMod.F90
+++ b/tools/mksurfdata_esmf/src/mkVICparamsMod.F90
@@ -116,7 +116,8 @@ contains
 
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o))
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     do n = 1, ns_o

--- a/tools/mksurfdata_esmf/src/mkesmfMod.F90
+++ b/tools/mksurfdata_esmf/src/mkesmfMod.F90
@@ -27,11 +27,21 @@ module mkesmfMod
 contains
 !===============================================================
 
-  subroutine create_routehandle_r4(mesh_i, mesh_o, routehandle, frac_o, rc)
+  subroutine create_routehandle_r4(mesh_i, mesh_o, norm_by_fracs, routehandle, frac_o, rc)
 
     ! input/output variables
     type(ESMF_Mesh)        , intent(in)    :: mesh_i
     type(ESMF_Mesh)        , intent(in)    :: mesh_o
+    ! If norm_by_fracs is .true., then remapping is done using ESMF_NORMTYPE_FRACAREA;
+    ! otherwise, remapping is done using ESMF_NORMTYPE_DSTAREA. FRACAREA normalization
+    ! adds a normalization factor of the fraction of the unmasked source grid that
+    ! overlaps with a destination cell. FRACAREA normalization is appropriate when you
+    ! want to treat values outside the mask as missing values that shouldn't contribute
+    ! to the average (this is appropriate for most fields); DSTAREA normalization is
+    ! appropriate when you want to treat values outside the mask as 0 (this is
+    ! appropriate for PCT cover fields where we want the final value to be expressed as
+    ! percent of the entire gridcell area).
+    logical                , intent(in)    :: norm_by_fracs
     type(ESMF_RouteHandle) , intent(inout) :: routehandle
     real(r4), optional     , intent(inout) :: frac_o(:)
     integer                , intent(out)   :: rc
@@ -40,6 +50,7 @@ contains
     integer           :: srcMaskValue = 0          ! ignore source points where the mesh mask is 0
     integer           :: dstMaskValue = -987987    ! don't ingore any destination points
     integer           :: srcTermProcessing_Value = 0
+    type(ESMF_NormType_Flag) :: normtype
     type(ESMF_Field)  :: field_i
     type(ESMF_Field)  :: field_o
     type(ESMF_Field)  :: dstfracfield
@@ -56,9 +67,15 @@ contains
     dstfracfield = ESMF_FieldCreate(mesh_o, ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+    if (norm_by_fracs) then
+       normtype = ESMF_NORMTYPE_FRACAREA
+    else
+       normtype = ESMF_NORMTYPE_DSTAREA
+    end if
+
     ! Create route handle to map field_model to field_data
     call ESMF_FieldRegridStore(field_i, field_o, routehandle=routehandle, &
-         regridmethod=ESMF_REGRIDMETHOD_CONSERVE, normType=ESMF_NORMTYPE_FRACAREA, &
+         regridmethod=ESMF_REGRIDMETHOD_CONSERVE, normType=normtype, &
          srcMaskValues=(/srcMaskValue/), &
          dstMaskValues=(/dstMaskValue/), &
          srcTermProcessing=srcTermProcessing_Value, &
@@ -83,11 +100,21 @@ contains
   end subroutine create_routehandle_r4
 
   !===============================================================
-  subroutine create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o, rc)
+  subroutine create_routehandle_r8(mesh_i, mesh_o, norm_by_fracs, routehandle, frac_o, rc)
 
     ! input/output variables
     type(ESMF_Mesh)        , intent(in)    :: mesh_i
     type(ESMF_Mesh)        , intent(in)    :: mesh_o
+    ! If norm_by_fracs is .true., then remapping is done using ESMF_NORMTYPE_FRACAREA;
+    ! otherwise, remapping is done using ESMF_NORMTYPE_DSTAREA. FRACAREA normalization
+    ! adds a normalization factor of the fraction of the unmasked source grid that
+    ! overlaps with a destination cell. FRACAREA normalization is appropriate when you
+    ! want to treat values outside the mask as missing values that shouldn't contribute
+    ! to the average (this is appropriate for most fields); DSTAREA normalization is
+    ! appropriate when you want to treat values outside the mask as 0 (this is
+    ! appropriate for PCT cover fields where we want the final value to be expressed as
+    ! percent of the entire gridcell area).
+    logical                , intent(in)    :: norm_by_fracs
     type(ESMF_RouteHandle) , intent(inout) :: routehandle
     real(r8), optional     , intent(inout) :: frac_o(:)
     integer                , intent(out)   :: rc
@@ -96,6 +123,7 @@ contains
     integer           :: srcMaskValue = 0          ! ignore source points where the mesh mask is 0
     integer           :: dstMaskValue = -987987    ! don't ingore any destination points
     integer           :: srcTermProcessing_Value = 0
+    type(ESMF_NormType_Flag) :: normtype
     type(ESMF_Field)  :: field_i
     type(ESMF_Field)  :: field_o
     type(ESMF_Field)  :: dstfracfield
@@ -112,9 +140,15 @@ contains
     dstfracfield = ESMF_FieldCreate(mesh_o, ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
+    if (norm_by_fracs) then
+       normtype = ESMF_NORMTYPE_FRACAREA
+    else
+       normtype = ESMF_NORMTYPE_DSTAREA
+    end if
+
     ! Create route handle to map field_model to field_data
     call ESMF_FieldRegridStore(field_i, field_o, routehandle=routehandle, &
-         regridmethod=ESMF_REGRIDMETHOD_CONSERVE, normType=ESMF_NORMTYPE_FRACAREA, &
+         regridmethod=ESMF_REGRIDMETHOD_CONSERVE, normType=normtype, &
          srcMaskValues=(/srcMaskValue/), &
          dstMaskValues=(/dstMaskValue/), &
          srcTermProcessing=srcTermProcessing_Value, &

--- a/tools/mksurfdata_esmf/src/mkfileMod.F90
+++ b/tools/mksurfdata_esmf/src/mkfileMod.F90
@@ -607,6 +607,17 @@ contains
          long_name='land fraction from pft dataset (DIFF FROM landfrac USED IN SIMULATION, SHOWN IN HISTORY)', units='unitless')
 
     if (.not. dynlanduse) then
+       call mkpio_def_spatial_var(pioid=pioid, varname='LANDFRAC_MKSURFDATA', xtype=xtype, &
+            long_name='land fraction used for renormalization of areas in mksurfdata (DIFF FROM landfrac USED IN SIMULATION)', &
+            units='unitless')
+    else
+       call mkpio_def_spatial_var(pioid=pioid, varname='LANDFRAC_MKSURFDATA', xtype=xtype, &
+            lev1name='time', &
+            long_name='land fraction used for renormalization of areas in mksurfdata (DIFF FROM landfrac USED IN SIMULATION)', &
+            units='unitless')
+    end if
+
+    if (.not. dynlanduse) then
        call mkpio_def_spatial_var(pioid=pioid, varname='PCT_NATVEG', xtype=xtype, &
             long_name='total percent natural vegetation landunit', units='unitless')
     end  if

--- a/tools/mksurfdata_esmf/src/mkgdpMod.F90
+++ b/tools/mksurfdata_esmf/src/mkgdpMod.F90
@@ -111,7 +111,8 @@ contains
     ! Create a route handle between the input and output mesh and get frac_o
     allocate(frac_o(ns_o),stat=ier)
     if (ier/=0) call shr_sys_abort()
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mkglacierregionMod.F90
+++ b/tools/mksurfdata_esmf/src/mkglacierregionMod.F90
@@ -117,7 +117,8 @@ contains
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o))
     if (ier/=0) call abort()
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mkglcmecMod.F90
+++ b/tools/mksurfdata_esmf/src/mkglcmecMod.F90
@@ -284,7 +284,8 @@ contains
     ! Create a route handle between the input and output mesh and get frac_o
     allocate(frac_o(ns_o),stat=ier)
     if (ier/=0) call shr_sys_abort(subname//" error in allocating frac_o")
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 
@@ -580,7 +581,8 @@ contains
     ! Create a route handle between the input and output mesh and get frac_o
     allocate(frac_o(ns_o),stat=ier)
     if (ier/=0) call shr_sys_abort()
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mkharvestMod.F90
+++ b/tools/mksurfdata_esmf/src/mkharvestMod.F90
@@ -153,7 +153,8 @@ contains
     ! NOTE: this must be done after mask_i is set in mesh_i
     if (.not. ESMF_RouteHandleIsCreated(routehandle_r8)) then
        allocate(frac_o(ns_o))
-       call create_routehandle_r8(mesh_i, mesh_o, routehandle_r8, frac_o=frac_o, rc=rc)
+       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+            routehandle=routehandle_r8, frac_o=frac_o, rc=rc)
        call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     end if
 

--- a/tools/mksurfdata_esmf/src/mklaiMod.F90
+++ b/tools/mksurfdata_esmf/src/mklaiMod.F90
@@ -121,7 +121,8 @@ contains
 
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o))
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mklanwatMod.F90
+++ b/tools/mksurfdata_esmf/src/mklanwatMod.F90
@@ -116,7 +116,8 @@ contains
     ! Create a route handle between the input and output mesh
     if (.not. ESMF_RouteHandleIsCreated(routehandle_mklak)) then
        allocate(frac_o_mklak(ns_o))
-       call create_routehandle_r8(mesh_i, mesh_o, routehandle_mklak, frac_o=frac_o_mklak, rc=rc)
+       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+            routehandle=routehandle_mklak, frac_o=frac_o_mklak, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     end if
@@ -255,7 +256,8 @@ contains
     ! Create a route handle between the input and output mesh
     if (.not. ESMF_RouteHandleIsCreated(routehandle_mklak)) then
        allocate(frac_o_mklak(ns_o))
-       call create_routehandle_r8(mesh_i, mesh_o, routehandle_mklak, frac_o=frac_o_mklak, rc=rc)
+       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+            routehandle=routehandle_mklak, frac_o=frac_o_mklak, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     end if
@@ -402,7 +404,8 @@ contains
 
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o))
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mkpeatMod.F90
+++ b/tools/mksurfdata_esmf/src/mkpeatMod.F90
@@ -108,7 +108,8 @@ contains
     ! Create a route handle between the input and output mesh and get frac_o
     allocate(frac_o(ns_o),stat=ier)
     if (ier/=0) call shr_sys_abort()
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mkpftMod.F90
+++ b/tools/mksurfdata_esmf/src/mkpftMod.F90
@@ -380,16 +380,14 @@ contains
     call regrid_rawdata(mesh_i, mesh_o, routehandle_nonorm, pct_nat_pft_i, pct_nat_pft_o, 0, num_natpft, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Rescale pct_nat_pft_o
+    ! Rescale pct_nat_pft_o, and set tiny pctnatveg to 0
     do no = 1,ns_o
-       if (pctnatveg_o(no) > 0._r8) then
+       if (pctnatveg_o(no) >= 1.0e-6_r8) then
           do m = 0,num_natpft
              pct_nat_pft_o(m,no) = pct_nat_pft_o(m,no) / (pctnatveg_o(no) * 0.01_r8)
           end do
        else
-          pct_nat_pft_o(0:num_natpft,no) = 0._r8
-       end if
-       if (pctlnd_o(no) < 1.0e-6 .or. pctnatveg_o(no) < 1.0e-6) then
+          pctnatveg_o(no) = 0._r8
           pct_nat_pft_o(0,no) = 100._r8
           pct_nat_pft_o(1:num_natpft,no) = 0._r8
        end if
@@ -469,16 +467,14 @@ contains
     call regrid_rawdata(mesh_i, mesh_o, routehandle_nonorm, pct_cft_i, pct_cft_o, 1, num_cft, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! Rescale pct_nat_pft_o
+    ! Rescale pct_cft_o, and set tiny pctcrop to 0
     do no = 1,ns_o
-       if (pctcrop_o(no) > 0._r8) then
+       if (pctcrop_o(no) >= 1.0e-6_r8) then
           do m = 1,num_cft
              pct_cft_o(m,no) = pct_cft_o(m,no) / (pctcrop_o(no) * 0.01_r8)
           end do
        else
-          pct_cft_o(1:num_cft,no) = 0._r8
-       end if
-       if (pctlnd_o(no) < 1.0e-6 .or. pctcrop_o(no) < 1.0e-6) then
+          pctcrop_o(no) = 0._r8
           pct_cft_o(1,no) = 100._r8
           pct_cft_o(2:num_cft,no) = 0._r8
        end if

--- a/tools/mksurfdata_esmf/src/mkpftMod.F90
+++ b/tools/mksurfdata_esmf/src/mkpftMod.F90
@@ -331,7 +331,8 @@ contains
     if (.not. ESMF_RouteHandleIsCreated(routehandle)) then
        allocate(frac_o(ns_o),stat=ier)
        if (ier/=0) call shr_sys_abort()
-       call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+            routehandle=routehandle, frac_o=frac_o, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     end if

--- a/tools/mksurfdata_esmf/src/mksoildepthMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoildepthMod.F90
@@ -87,7 +87,8 @@ contains
     ! Get the landmask from the file and reset the mesh mask based on that
     allocate(frac_o(ns_o),stat=ier)
     if (ier/=0) call shr_sys_abort()
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     allocate(frac_i(ns_i), stat=ier)
     if (ier/=0) call shr_sys_abort()
@@ -106,7 +107,8 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Create a route handle between the input and output mesh and get frac_o
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     do no = 1, ns_o

--- a/tools/mksurfdata_esmf/src/mksoilfmaxMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoilfmaxMod.F90
@@ -102,7 +102,8 @@ contains
 
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o))
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     do n = 1, ns_o

--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -393,10 +393,6 @@ program mksurfdata
         call pctnatpft(n)%set_pct_l2g(0._r8)
         call pctcft(n)%set_pct_l2g(0._r8)
      end if
-     if (pctlnd_pft(n) < 1.e-6_r8) then
-        call pctnatpft(n)%set_pct_l2g(0._r8)
-        call pctcft(n)%set_pct_l2g(0._r8)
-     end if
      landfrac_pft(n) = pctlnd_pft(n)/100._r8
   end do
   if (fsurdat /= ' ') then
@@ -1240,15 +1236,6 @@ program mksurfdata
             call shr_sys_abort()
          end if
 
-      end do
-
-      ! Make sure that there is no vegetation outside the pft mask
-      do n = 1,ns_o
-         if (pctlnd_pft(n) < 1.e-6_r8 .and. (pctnatpft(n)%get_pct_l2g() > 0 .or. pctcft(n)%get_pct_l2g() > 0)) then
-            write (6,*)'vegetation found outside the pft mask at n=',n
-            write (6,*)'pctnatveg,pctcrop=', pctnatpft(n)%get_pct_l2g(), pctcft(n)%get_pct_l2g()
-            call shr_sys_abort()
-         end if
       end do
 
       ! Make sure that sums at the landunit level all add to 100%

--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -1110,19 +1110,23 @@ program mksurfdata
          ! Start by using the land fraction field from the PFT raw data set:
          pct_land = pctlnd_pft(n)
          !
-         ! But we don't want to overwrite special landunits or crop with ocean where these
-         ! special landunits extend beyond the PFT data's land fraction. In essence, this
-         ! is saying that we'll let special landunit area grow into the natveg area before
-         ! growing into ocean, but we'll have special landunit area grow into ocean before
-         ! growing into crop or any other special landunit area. (This check of special
-         ! landunit area is particularly important for glaciers, where we can have
-         ! floating ice shelves, so we can have a scenario where pctlnd_pft is 0 but we
-         ! have non-zero glacier cover and we want the final grid cell to be
-         ! glacier-covered.) (We could possibly do better by considering the land mask
-         ! from each special landunit raw dataset, and even better by mapping these
-         ! various notions of land mask onto each other, but that starts to get messy, and
-         ! relies on the trustworthiness of each raw dataset's land mask... this
-         ! formulation seems reasonable enough.)
+         ! Brief summary of the following: But we don't want to overwrite special
+         ! landunits or crop with ocean where these special landunits extend beyond the
+         ! PFT data's land fraction.
+         !
+         ! More details:
+         !
+         ! In essence, this is saying that we'll let special landunit area grow into the
+         ! natveg area before growing into ocean, but we'll have special landunit area
+         ! grow into ocean before growing into crop or any other special landunit area.
+         ! (This check of special landunit area is particularly important for glaciers,
+         ! where we can have floating ice shelves, so we can have a scenario where
+         ! pctlnd_pft is 0 but we have non-zero glacier cover and we want the final grid
+         ! cell to be glacier-covered.) (We could possibly do better by considering the
+         ! land mask from each special landunit raw dataset, and even better by mapping
+         ! these various notions of land mask onto each other, but that starts to get
+         ! messy, and relies on the trustworthiness of each raw dataset's land mask...
+         ! this formulation seems reasonable enough.)
          !
          ! Note that we include pct_crop in the following, but NOT pct_natveg. The
          ! assumption behind that is that pct_crop is more reliable and/or more important,

--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -878,26 +878,21 @@ program mksurfdata
         if (ChkErr(rc,__LINE__,u_FILE_u)) call shr_sys_abort('error in calling mkpft')
         call pio_syncfile(pioid)
 
-!       ! Consistency check on input land fraction
-!       ! pctlnd_pft was calculated ABOVE
-!       ! TODO This error check serves no purpose now that mkpft calls
-!       ! create_routehandle_r8 only once and, therefore, doesn't update
-!       ! frac_o and pctlnd_o. Delete? (slevis)
-!       do n = 1,lsize_o
-!          if (pctlnd_pft_dyn(n) /= pctlnd_pft(n)) then
-!             if (root_task) then
-!                write(ndiag,*) subname,' error: pctlnd_pft for dynamics data = ',&
-!                     pctlnd_pft_dyn(n), ' not equal to pctlnd_pft for surface data = ',&
-!                     pctlnd_pft(n),' at n= ',n
-!                if ( trim(fname) == ' ' )then
-!                   write(ndiag,*) ' PFT string = ',trim(string)
-!                else
-!                   write(ndiag,*) ' PFT file = ', fname
-!                end if
-!             end if
-!             call shr_sys_abort()
-!          end if
-!       end do
+        ! Consistency check on input land fraction
+        ! pctlnd_pft was calculated ABOVE
+        do n = 1,lsize_o
+           if (pctlnd_pft_dyn(n) /= pctlnd_pft(n)) then
+              write(ndiag,*) subname,' error: pctlnd_pft for dynamics data = ',&
+                   pctlnd_pft_dyn(n), ' not equal to pctlnd_pft for surface data = ',&
+                   pctlnd_pft(n),' at n= ',n
+              if ( trim(fname) == ' ' )then
+                 write(ndiag,*) ' PFT string = ',trim(string)
+              else
+                 write(ndiag,*) ' PFT file = ', fname
+              end if
+              call shr_sys_abort()
+           end if
+        end do
 
         ! Create harvesting data at model resolution
         ! Output data is written in mkharvest

--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -1189,8 +1189,10 @@ program mksurfdata
             ! If we have essentially 0 land area, set land area to exactly 0 and put all
             ! area in wetlands (to simulate ocean). Note that, based on the formulation
             ! for pct_land above, this should only arise if the non-natveg landunits
-            ! already have near-zero area, so the zeroing of these other landunits should
-            ! only result in changes near the roundoff level.
+            ! already have near-zero area (and the natveg landunit should also have
+            ! near-zero area in this case, because its area should be no greater than the
+            ! land fraction from the PFT raw dataset), so the zeroing of these other
+            ! landunits should only result in changes near the roundoff level.
             pct_land = 0._r8
             frac_land = 0._r8
             call pctnatpft(n)%set_pct_l2g(0._r8)

--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -1008,7 +1008,7 @@ program mksurfdata
      if (root_task)  write(ndiag, '(a,i8)') trim(subname)//" writing PCT_CROP_MAX"
      call get_pct_l2g_array(pctcft_max, pctcrop)
      call mkfile_output(pioid, mesh_model, 'PCT_CROP_MAX', pctcrop, rc=rc)
-     if (ChkErr(rc,__LINE__,u_FILE_u)) call shr_sys_abort('error in calling mkfile_output for PCT_CROP')
+     if (ChkErr(rc,__LINE__,u_FILE_u)) call shr_sys_abort('error in calling mkfile_output for PCT_CROP_MAX')
 
      if (root_task)  write(ndiag, '(a,i8)') trim(subname)//" writing PCT_URBAN_MAX"
      call mkfile_output(pioid, mesh_model, 'PCT_URBAN_MAX', pcturb_max, rc=rc)

--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -389,13 +389,7 @@ program mksurfdata
        pctlnd_o=pctlnd_pft, pctnatpft_o=pctnatpft, pctcft_o=pctcft, rc=rc)
   if (ChkErr(rc,__LINE__,u_FILE_u)) call shr_sys_abort('error in calling mkdomain')
 
-  ! If have pole points on grid - set south pole to glacier
-  ! north pole is assumed as non-land
   do n = 1,lsize_o
-     if (abs((lat(n) - 90._r8)) < 1.e-6_r8) then
-        call pctnatpft(n)%set_pct_l2g(0._r8)
-        call pctcft(n)%set_pct_l2g(0._r8)
-     end if
      landfrac_pft(n) = pctlnd_pft(n)/100._r8
   end do
   if (fsurdat /= ' ') then
@@ -573,22 +567,9 @@ program mksurfdata
   end if
 
   ! -----------------------------------
-  ! Adjust pctlak, pctwet, pcturb and pctgla
-  ! -----------------------------------
-  do n = 1,lsize_o
-
-     ! If have pole points on grid - set south pole to glacier
-     ! north pole is assumed as non-land
-     if (abs((lat(n) - 90._r8)) < 1.e-6_r8) then
-        pctlak(n) = 0._r8
-        pctwet(n) = 0._r8
-        pcturb(n) = 0._r8
-        pctgla(n) = 100._r8
-     end if
-
-  end do
-
   ! Save special land unit areas of surface dataset
+  ! -----------------------------------
+
   pctwet_orig(:) = pctwet(:)
   pctgla_orig(:) = pctgla(:)
 
@@ -928,22 +909,6 @@ program mksurfdata
         ! in preparation for redoing landunit area normalization
         pctwet(:) = pctwet_orig(:)
         pctgla(:) = pctgla_orig(:)
-
-        ! If have pole points on grid - set south pole to glacier
-        ! north pole is assumed as non-land
-        ! pctlak, pctwet, pcturb and pctgla were calculated ABOVE
-        ! pctnatpft and pctcft were calculated ABOVE
-        do n = 1,lsize_o
-           if (abs(lat(n) - 90._r8) < 1.e-6_r8) then
-              pctlak(n) = 0._r8
-              pctwet(n) = 0._r8
-              pcturb(n) = 0._r8
-              pctgla(n) = 100._r8
-              call pctnatpft(n)%set_pct_l2g(0._r8)
-              call pctcft(n)%set_pct_l2g(0._r8)
-           end if
-
-        end do
 
         ! Normalize land use and make sure things add up to 100% as well as
         ! checking that things are as they should be.

--- a/tools/mksurfdata_esmf/src/mkurbanparMod.F90
+++ b/tools/mksurfdata_esmf/src/mkurbanparMod.F90
@@ -184,7 +184,8 @@ contains
     ! Create a route handle between the input and output mesh
     if (.not. ESMF_RouteHandleIsCreated(routehandle_mkurban)) then
        allocate(frac_o_mkurban(ns_o))
-       call create_routehandle_r8(mesh_i, mesh_o, routehandle_mkurban, frac_o=frac_o_mkurban, rc=rc)
+       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+            routehandle=routehandle_mkurban, frac_o=frac_o_mkurban, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     end if
@@ -938,7 +939,8 @@ contains
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o), stat=ier)
     if (ier/=0) call shr_sys_abort()
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 

--- a/tools/mksurfdata_esmf/src/mkurbanparMod.F90
+++ b/tools/mksurfdata_esmf/src/mkurbanparMod.F90
@@ -42,8 +42,8 @@ module mkurbanparMod
   ! private data members:
   ! flag to indicate nodata for index variables in output file:
   integer         , parameter :: index_nodata = 0
-  real(r8)        , allocatable :: frac_o_mkurban(:)
-  type(ESMF_RouteHandle) :: routehandle_mkurban
+  real(r8)        , allocatable :: frac_o_mkurban_nonorm(:)
+  type(ESMF_RouteHandle) :: routehandle_mkurban_nonorm
   character(len=*), parameter :: modname = 'mkurbanparMod'
 
   private :: index_nodata
@@ -182,10 +182,10 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Create a route handle between the input and output mesh
-    if (.not. ESMF_RouteHandleIsCreated(routehandle_mkurban)) then
-       allocate(frac_o_mkurban(ns_o))
-       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
-            routehandle=routehandle_mkurban, frac_o=frac_o_mkurban, rc=rc)
+    if (.not. ESMF_RouteHandleIsCreated(routehandle_mkurban_nonorm)) then
+       allocate(frac_o_mkurban_nonorm(ns_o))
+       call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.false., &
+            routehandle=routehandle_mkurban_nonorm, frac_o=frac_o_mkurban_nonorm, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
     end if
@@ -203,7 +203,9 @@ contains
     call ESMF_VMLogMemInfo("After mkpio_getrawdata in "//trim(subname))
 
     ! Regrid input data to model resolution
-    call regrid_rawdata(mesh_i, mesh_o, routehandle_mkurban, data_i, data_o, 1, numurbl, rc)
+    !
+    ! Use a nonorm mapper because we're mapping a field expressed as % of the grid cell area
+    call regrid_rawdata(mesh_i, mesh_o, routehandle_mkurban_nonorm, data_i, data_o, 1, numurbl, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After regrid_data for in "//trim(subname))
 
@@ -301,7 +303,11 @@ contains
     if (allocated(data_o)) deallocate(data_o)
     allocate(data_o(max_regions, ns_o), stat=ier)
     if (ier/=0) call shr_sys_abort('error allocating data_i(max_regions, ns_o)')
-    call regrid_rawdata(mesh_i, mesh_o, routehandle_mkurban, data_i, data_o, 1, nregions, rc)
+    ! This regridding could be done either with or without fracarea normalization,
+    ! because we just use it to find a dominant value. We use nonorm because we already
+    ! have a nonorm mapper for the sake of PCTURB and this way we don't need to make a
+    ! separate mapper with fracarea normalization.
+    call regrid_rawdata(mesh_i, mesh_o, routehandle_mkurban_nonorm, data_i, data_o, 1, nregions, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Now find dominant region in each output gridcell - this is identical to the maximum index
@@ -319,7 +325,7 @@ contains
     end if
 
     ! Output diagnostics
-    call output_diagnostics_index(mesh_i, mesh_o, mask_i, frac_o_mkurban, &
+    call output_diagnostics_index(mesh_i, mesh_o, mask_i, frac_o_mkurban_nonorm, &
          1, max_regions, region_i, region_o, 'urban region', ndiag, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) call shr_sys_abort()
 
@@ -331,9 +337,9 @@ contains
     ! TODO: determine what to deallocate
     ! deallocate (urban_classes_gcell_i, urban_classes_gcell_o, region_i)
     if (mksrf_fdynuse == ' ') then  ! ...else we will reuse it
-       deallocate(frac_o_mkurban)
+       deallocate(frac_o_mkurban_nonorm)
        call ESMF_VMLogMemInfo("Before destroy operation in "//trim(subname))
-       call ESMF_RouteHandleDestroy(routehandle_mkurban, nogarbage = .true., rc=rc)
+       call ESMF_RouteHandleDestroy(routehandle_mkurban_nonorm, nogarbage = .true., rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) call shr_sys_abort()
     end if
     call ESMF_MeshDestroy(mesh_i, nogarbage = .true., rc=rc)

--- a/tools/mksurfdata_esmf/src/mkvocefMod.F90
+++ b/tools/mksurfdata_esmf/src/mkvocefMod.F90
@@ -122,7 +122,8 @@ contains
 
     ! Create a route handle between the input and output mesh
     allocate(frac_o(ns_o))
-    call create_routehandle_r8(mesh_i, mesh_o, routehandle, frac_o=frac_o, rc=rc)
+    call create_routehandle_r8(mesh_i=mesh_i, mesh_o=mesh_o, norm_by_fracs=.true., &
+         routehandle=routehandle, frac_o=frac_o, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMLogMemInfo("After create routehandle in "//trim(subname))
 


### PR DESCRIPTION
### Description of changes

This PR reworks the mapping of landunit areas and the determination of wetland areas according to the plan laid out in #1716. (Note that the final implementation differs from the initial comment in #1716, as discussed in follow-up comments in that issue.) See the discussion there as well as the design document in this PR for details.

### Specific notes

Contributors other than yourself, if any: Various discussions with others, especially @ekluzek and @slevisconsulting 

CTSM Issues Fixed (include github issue #):
- Resolves #1716 
- Resolves #1930 

Are answers expected to change (and if so in what way)? Areas will change on surface datasets

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:

(1) Compared 1850 f09 surface dataset before and after these changes (and after each individual change from the individual commits on this branch)

(2) By hard-coding landunit areas before the call to `normalize_and_check_landuse`, I performed various "manual unit tests" of the normalization code, using diffs like this:

``` diff
diff --git a/tools/mksurfdata_esmf/src/mksurfdata.F90 b/tools/mksurfdata_esmf/src/mksurfdata.F90
index eb91be30c..0f347f8c0 100644
--- a/tools/mksurfdata_esmf/src/mksurfdata.F90
+++ b/tools/mksurfdata_esmf/src/mksurfdata.F90
@@ -593,6 +593,17 @@ program mksurfdata
   ! Perform other normalizations
   ! -----------------------------------
 
+  do n = 1, lsize_o
+     pctlnd_pft(n) = 0._r8
+
+     call pctnatpft(n)%set_pct_l2g(0._r8)
+     call pctcft(n)%set_pct_l2g(0._r8)
+     pctlak(n) = 0._r8
+     pcturb(n) = 0._r8
+     pctgla(n) = 0._r8
+     pctwet(n) = 0._r8
+  end do
+
   ! Normalize land use and make sure things add up to 100% as well as
   ! checking that things are as they should be.
   call normalize_and_check_landuse(lsize_o)
```

In the following, any landunit not explicitly mentioned had 0% area:

(a) With pctlnd_pft = 0% and all initial landunit areas 0%: wetland area = 100%

(b) With pctlnd_pft = 0% and initial glacier area 1%: glacier area = 100%

(c) With pctlnd_pft > 0% and all initial landunit areas 0%: natural vegetated area = 100%

(d) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%: crop area = 50%, natural vegetated area = 50%

(e) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 10%: crop area = 50%, natural vegetated area = 25%, glacier area = 25%

(f) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 15%: crop area = 50%, natural vegetated area = 12.5%, glacier area = 37.5%

(g) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 20%: crop area = 50%, glacier area = 50%

(h) With pctlnd_pft = 40%, initial crop area 20%, natural vegetated area 10%, glacier area 30%: crop area = 40%, glacier area = 60%

(i) With pctlnd_pft = 40%, initial crop area 0%, natural vegetated area 40%, glacier area 40%: glacier area = 100%

(j) With pctlnd_pft = 2%, initial natural vegetated area 1%, glacier area 1%: natural vegetated area = 50%, glacier area = 50%

(k) With pctlnd_pft = 2%, initial natural vegetated area 0%, glacier area 1%: natural vegetated area = 50%, glacier area = 50%

(l) With pctlnd_pft = 2%, initial natural vegetated area 2%, glacier area 1%: natural vegetated area = 50%, glacier area = 50%
