### PR TITLE
Revert some commits now that FUNITCTSM works again

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -51,13 +51,6 @@
     </phase>
   </test>
 
-  <test name="FUNITCTSM_P1x1.f10_f10_mg37.I2000Clm50Sp.cheyenne_intel">
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>#1972</issue>
-    </phase>
-  </test>
-
   <!-- fates test suite failures -->
 
   <test name="ERS_Lm12.1x1_brazil.I2000Clm50FatesCruRsGs.cheyenne_intel.clm-FatesFireLightningPopDens">

--- a/doc/.ChangeLog_template
+++ b/doc/.ChangeLog_template
@@ -121,15 +121,10 @@ infrastructure should be run when appropriate, as described below.
 
     clm_pymods test suite on cheyenne - 
 
-  regular tests:
-      - aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing
-      - Fortran unit tests on cheyenne (until https://github.com/ESCOMP/CTSM/issues/1972 is resolved): from src, run:
-          ../cime/scripts/fortran_unit_testing/run_tests.py --build-dir `mktemp -d --tmpdir=. unit_tests.XXXXXXXX`
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
 
-    aux_clm on cheyenne ------------
-    aux_clm on izumi ---------------
-    Fortran unit tests on cheyenne -
-
+    cheyenne ----
+    izumi -------
 
   fates tests: (give name of baseline if different from CTSM tagname, normally fates baselines are fates-<FATES TAG>-<CTSM TAG>)
     cheyenne ----


### PR DESCRIPTION
### Description of changes

- Revert "Add Fortran unit tests as a separate test to run". This reverts commit 2ee9024597cd21c1b755bd24e55e4b1d856d256d.

- Revert "Add FUNITCTSM test to expected fails list". This reverts commit 3cd1351964acd9e3fea7d8b3ced2f53de16bf13e.