### PR TITLE
Rework handling of evaporation constraint in SoilFluxes

### DIFF
--- a/src/biogeophys/SoilFluxesMod.F90
+++ b/src/biogeophys/SoilFluxesMod.F90
@@ -289,8 +289,8 @@ contains
                evaporation_demand = qflx_ev_snow(p)
                qflx_ev_snow(p)    = evaporation_limit
                qflx_evap_soi(p)   = qflx_evap_soi(p) - frac_sno_eff(c)*(evaporation_demand - evaporation_limit)
-               qflx_liqevap_from_top_layer(p)   = h2osoi_liq(c,j)/(frac_sno_eff(c)*dtime)
-               qflx_solidevap_from_top_layer(p) = h2osoi_ice(c,j)/(frac_sno_eff(c)*dtime)
+               qflx_liqevap_from_top_layer(p)   = max(h2osoi_liq(c,j)/(frac_sno_eff(c)*dtime), 0._r8)
+               qflx_solidevap_from_top_layer(p) = max(h2osoi_ice(c,j)/(frac_sno_eff(c)*dtime), 0._r8)
                ! conserve total energy flux
                eflx_sh_grnd(p) = eflx_sh_grnd(p) + frac_sno_eff(c)*(evaporation_demand - evaporation_limit)*htvp(c)
             endif
@@ -305,8 +305,8 @@ contains
                evaporation_demand = qflx_evap_soi(p)
                qflx_evap_soi(p)   = evaporation_limit
                qflx_ev_snow(p)    = qflx_evap_soi(p)
-               qflx_liqevap_from_top_layer(p)   = h2osoi_liq(c,j)/dtime
-               qflx_solidevap_from_top_layer(p) = h2osoi_ice(c,j)/dtime
+               qflx_liqevap_from_top_layer(p)   = max(h2osoi_liq(c,j)/dtime, 0._r8)
+               qflx_solidevap_from_top_layer(p) = max(h2osoi_ice(c,j)/dtime, 0._r8)
                ! conserve total energy flux
                eflx_sh_grnd(p) = eflx_sh_grnd(p) +(evaporation_demand -evaporation_limit)*htvp(c)
             endif


### PR DESCRIPTION
### Description of changes

Occasionally, h2osoi_ice was going significantly negative in UpdateState_TopLayerFluxes - see
https://github.com/ESCOMP/CTSM/issues/1979. As noted in that issue, this seems to be due to h2osoi_ice having a very different magnitude from h2osoi_liq, leading to greater-than-roundoff-level differences from zero final state in a relative sense (i.e., relative to the magnitude of h2osoi_ice) - I think because of the appearance of the sum (h2osoi_ice + h2osoi_liq) in the equations that limit fluxes.

To try to deal with this, I have reworked the handling of the evaporation constraint to directly limit both the liqevap and solidevap, so that both of them should result in the equivalent liq or ice states going to 0 within roundoff.

To do that, I needed to move the partitioning of the total flux into liquid and solid to earlier in the subroutine and then recalculate those partitioning fluxes in conditions where we're applying an evaporation constraint.

Note that the deleted lines in this commit have just been moved as-is to earlier in this subroutine.

### Specific notes

Contributors other than yourself, if any: Discussions with @olyson and @swensosc 

CTSM Issues Fixed (include github issue)
- Resolves #1979 

Are answers expected to change (and if so in what way)? YES - occasional roundoff-level changes

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
Ran full aux_clm test suite. Most tests were bit-for-bit; a few had roundoff-level changes. One (SMS_D_Ln9_P36x3.f19_g17.IHistClm50Sp.cheyenne_intel.clm-waccmx_offline) had greater-than-roundoff-level changes; I am going to investigate that further to confirm that the fundamental changes are just roundoff-level and we're just seeing error growth.
