### PR TITLE
Updates needed for pFUnit4

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,17 +34,17 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-hash = dc66fd06256d6eb5e6fa493042123b4b54302e81
+tag = ccs_config_cesm0.0.63
 protocol = git
-repo_url = https://github.com/billsacks/ccs_config_cesm.git
+repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/billsacks/cime
-hash = 8316e3b4e11bb0f51b57aac42481fdacd69e60df
+repo_url = https://github.com/ESMCI/cime
+tag = cime6.0.108
 required = True
 
 [cmeps]
@@ -63,16 +63,16 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-hash = 4b3e95623cdd37cb7e72b55b1deb5442bc302faa
+tag = cpl77.0.5
 protocol = git
-repo_url = https://github.com/billsacks/CESM_CPL7andDataComps
+repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
 required = True
 
 [share]
-hash = 988c9ec7a94840be80b1851769ce93af859e3005
+tag = share1.0.17
 protocol = git
-repo_url = https://github.com/billsacks/CESM_share
+repo_url = https://github.com/ESCOMP/CESM_share
 local_path = share
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-hash = 8a7b4c61c6ace2a4905bf6aff973a28509e63a93
+hash = dc66fd06256d6eb5e6fa493042123b4b54302e81
 protocol = git
 repo_url = https://github.com/billsacks/ccs_config_cesm.git
 local_path = ccs_config

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.63
+tag = ccs_config_cesm0.0.64
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -48,14 +48,14 @@ tag = cime6.0.108
 required = True
 
 [cmeps]
-tag = cmeps0.14.17
+tag = cmeps0.14.21
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.7
+tag = cdeps1.0.9
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -44,7 +44,7 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/billsacks/cime
-hash = a42f55a0c31706c377c77ed72b6ebbe8f02f8e92
+hash = 8316e3b4e11bb0f51b57aac42481fdacd69e60df
 required = True
 
 [cmeps]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-hash = bd942aae8fbc2848420d2d3249212ef38611724f
+hash = bf7e85f30c9d434e047bd2494779db3b4ef5e3cb
 protocol = git
 repo_url = https://github.com/billsacks/ccs_config_cesm.git
 local_path = ccs_config

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,17 +34,17 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.58
+hash = bd942aae8fbc2848420d2d3249212ef38611724f
 protocol = git
-repo_url = https://github.com/ESMCI/ccs_config_cesm.git
+repo_url = https://github.com/billsacks/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/ESMCI/cime
-tag = cime6.0.100
+repo_url = https://github.com/billsacks/cime
+hash = a42f55a0c31706c377c77ed72b6ebbe8f02f8e92
 required = True
 
 [cmeps]
@@ -63,16 +63,16 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl7.0.14
+hash = 4b3e95623cdd37cb7e72b55b1deb5442bc302faa
 protocol = git
-repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
+repo_url = https://github.com/billsacks/CESM_CPL7andDataComps
 local_path = components/cpl7
 required = True
 
 [share]
-tag = share1.0.16
+hash = 988c9ec7a94840be80b1851769ce93af859e3005
 protocol = git
-repo_url = https://github.com/ESCOMP/CESM_share
+repo_url = https://github.com/billsacks/CESM_share
 local_path = share
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-hash = bf7e85f30c9d434e047bd2494779db3b4ef5e3cb
+hash = 8a7b4c61c6ace2a4905bf6aff973a28509e63a93
 protocol = git
 repo_url = https://github.com/billsacks/ccs_config_cesm.git
 local_path = ccs_config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ set (drv_sources_needed_base
   )
 extract_sources("${drv_sources_needed_base}" "${drv_sources}" drv_sources_needed)
 
-# Add CLM source directories (these add their own test directories)
+# Add CLM source directories
 add_subdirectory(${CLM_ROOT}/src/utils clm_utils)
 add_subdirectory(${CLM_ROOT}/src/biogeochem clm_biogeochem)
 add_subdirectory(${CLM_ROOT}/src/soilbiogeochem clm_soilbiogeochem)

--- a/src/biogeochem/test/CNPhenology_test/CMakeLists.txt
+++ b/src/biogeochem/test/CNPhenology_test/CMakeLists.txt
@@ -1,7 +1,6 @@
 set (pfunit_sources
   test_CNPhenology.pf)
 
-create_pFUnit_test(CNPhenology test_CNPhenology_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_CNPhenology_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(CNPhenology
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeochem/test/CNPhenology_test/test_CNPhenology.pf
+++ b/src/biogeochem/test/CNPhenology_test/test_CNPhenology.pf
@@ -2,7 +2,7 @@ module test_CNPhenology
 
   ! Tests of CNPhenologyMod
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use CNPhenologyMod
   use unittestTimeManagerMod, only : unittest_timemgr_setup, unittest_timemgr_teardown

--- a/src/biogeochem/test/CNVegComputeSeed_test/CMakeLists.txt
+++ b/src/biogeochem/test/CNVegComputeSeed_test/CMakeLists.txt
@@ -1,7 +1,6 @@
 set (pfunit_sources
   test_ComputeSeedAmounts.pf)
 
-create_pFUnit_test(CNVegComputeSeed test_CNVegComputeSeed_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_CNVegComputeSeed_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(CNVegComputeSeed
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeochem/test/CNVegComputeSeed_test/test_ComputeSeedAmounts.pf
+++ b/src/biogeochem/test/CNVegComputeSeed_test/test_ComputeSeedAmounts.pf
@@ -2,7 +2,7 @@ module test_ComputeSeedAmounts
 
   ! Tests of CNVegComputeSeedMod: ComputeSeedAmounts
 
-  use pfunit_mod
+  use funit
   use CNVegComputeSeedMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/biogeochem/test/Species_test/CMakeLists.txt
+++ b/src/biogeochem/test/Species_test/CMakeLists.txt
@@ -2,7 +2,6 @@ set (pfunit_sources
   test_SpeciesNonIsotope.pf
   test_SpeciesIsotope.pf)
 
-create_pFUnit_test(Species test_Species_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_Species_exe clm csm_share)
+add_pfunit_ctest(Species
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/biogeochem/test/Species_test/test_SpeciesIsotope.pf
+++ b/src/biogeochem/test/Species_test/test_SpeciesIsotope.pf
@@ -2,7 +2,7 @@ module test_SpeciesIsotope
 
   ! Tests of SpeciesIsotopeType
 
-  use pfunit_mod
+  use funit
   use SpeciesIsotopeType
   use shr_kind_mod , only : r8 => shr_kind_r8
 

--- a/src/biogeochem/test/Species_test/test_SpeciesNonIsotope.pf
+++ b/src/biogeochem/test/Species_test/test_SpeciesNonIsotope.pf
@@ -2,7 +2,7 @@ module test_SpeciesNonIsotope
 
   ! Tests of SpeciesNonIsotopeType
 
-  use pfunit_mod
+  use funit
   use SpeciesNonIsotopeType
   use shr_kind_mod , only : r8 => shr_kind_r8
 

--- a/src/biogeophys/test/Balance_test/CMakeLists.txt
+++ b/src/biogeophys/test/Balance_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(balance test_balance_exe
-  "test_Balance.pf" "")
-
-target_link_libraries(test_balance_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(balance
+  TEST_SOURCES "test_Balance.pf"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/Balance_test/test_Balance.pf
+++ b/src/biogeophys/test/Balance_test/test_Balance.pf
@@ -2,7 +2,7 @@ module test_balance
 
    ! Some tests of the balance check system
 
-  use pfunit_mod
+  use funit
   
   use shr_kind_mod  , only : r8 => shr_kind_r8
   use unittestTimeManagerMod, only : unittest_timemgr_setup, unittest_timemgr_teardown

--- a/src/biogeophys/test/Daylength_test/CMakeLists.txt
+++ b/src/biogeophys/test/Daylength_test/CMakeLists.txt
@@ -2,7 +2,6 @@ set (pfunit_sources
   test_daylength.pf
   test_compute_max_daylength.pf)
 
-create_pFUnit_test(Daylength test_Daylength_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_Daylength_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(Daylength
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/Daylength_test/test_compute_max_daylength.pf
+++ b/src/biogeophys/test/Daylength_test/test_compute_max_daylength.pf
@@ -2,7 +2,7 @@ module test_compute_max_daylength
 
   ! Tests of DaylengthMod: ComputeMaxDaylength
 
-  use pfunit_mod
+  use funit
   use DaylengthMod, only: ComputeMaxDaylength, daylength
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod, only : unittest_subgrid_teardown, bounds

--- a/src/biogeophys/test/Daylength_test/test_daylength.pf
+++ b/src/biogeophys/test/Daylength_test/test_daylength.pf
@@ -2,7 +2,7 @@ module test_daylength
 
   ! Tests of the daylength function in DaylengthMod
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod , only : r8 => shr_kind_r8
   use shr_const_mod, only : SHR_CONST_PI

--- a/src/biogeophys/test/HumanStress_test/CMakeLists.txt
+++ b/src/biogeophys/test/HumanStress_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(humanstress test_humanstress_exe
-  "test_humanstress.pf" "")
-
-target_link_libraries(test_humanstress_exe clm csm_share)
+add_pfunit_ctest(humanstress
+  TEST_SOURCES "test_humanstress.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/biogeophys/test/HumanStress_test/test_humanstress.pf
+++ b/src/biogeophys/test/HumanStress_test/test_humanstress.pf
@@ -2,7 +2,7 @@ module test_humanstress
 
   ! Tests of the humanstress functions in HumanIndexMod
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod  , only : r8 => shr_kind_r8
   use HumanIndexMod

--- a/src/biogeophys/test/Irrigation_test/CMakeLists.txt
+++ b/src/biogeophys/test/Irrigation_test/CMakeLists.txt
@@ -1,12 +1,6 @@
 set (pfunit_sources
   test_irrigation.pf)
 
-# extra sources used for this test, which are not .pf files
-# (currently none)
-set (extra_sources
-  )
-
-create_pFUnit_test(irrigation test_irrigation_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_irrigation_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(irrigation
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/Irrigation_test/test_irrigation.pf
+++ b/src/biogeophys/test/Irrigation_test/test_irrigation.pf
@@ -2,7 +2,7 @@ module test_irrigation
 
   ! Tests of IrrigationMod
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use unittestTimeManagerMod, only : unittest_timemgr_setup, unittest_timemgr_teardown
   use unittestTimeManagerMod, only : unittest_timemgr_set_curr_date

--- a/src/biogeophys/test/Photosynthesis_test/CMakeLists.txt
+++ b/src/biogeophys/test/Photosynthesis_test/CMakeLists.txt
@@ -1,7 +1,6 @@
 set (pfunit_sources
    test_Photosynthesis.pf)
 
-create_pFUnit_test(Photosynthesis test_Photosynthesis_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_Photosynthesis_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(Photosynthesis
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/Photosynthesis_test/test_Photosynthesis.pf
+++ b/src/biogeophys/test/Photosynthesis_test/test_Photosynthesis.pf
@@ -2,7 +2,7 @@ module test_Photosynthesis
   
   ! Tests of PhotosynthesisMod.F90
   
-  use pfunit_mod
+  use funit
   use PhotosynthesisMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod, only : unittest_subgrid_teardown, bounds

--- a/src/biogeophys/test/SnowHydrology_test/CMakeLists.txt
+++ b/src/biogeophys/test/SnowHydrology_test/CMakeLists.txt
@@ -3,7 +3,6 @@ set (pfunit_sources
   test_SnowHydrology_newSnowBulkDensity.pf
   test_SnowHydrology_SnowCappingExcess.pf)
 
-create_pFUnit_test(SnowHydrology test_SnowHydrology_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_SnowHydrology_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(SnowHydrology
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/SnowHydrology_test/test_SnowHydrology_SnowCappingExcess.pf
+++ b/src/biogeophys/test/SnowHydrology_test/test_SnowHydrology_SnowCappingExcess.pf
@@ -2,7 +2,7 @@ module test_SnowHydrology_SnowCappingExcess
 
   ! Tests of SnowHydrologyMod: SnowCappingExcess
 
-  use pfunit_mod
+  use funit
   use SnowHydrologyMod
   use TopoMod, only : topo_type
   use shr_kind_mod , only : r8 => shr_kind_r8

--- a/src/biogeophys/test/SnowHydrology_test/test_SnowHydrology_initSnowLayers.pf
+++ b/src/biogeophys/test/SnowHydrology_test/test_SnowHydrology_initSnowLayers.pf
@@ -2,7 +2,7 @@ module test_SnowHydrology_initSnowLayers
   
   ! Tests of SnowHydrologyMod: initSnowLayers
   
-  use pfunit_mod
+  use funit
   use SnowHydrologyMod
   use shr_kind_mod, only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/biogeophys/test/SnowHydrology_test/test_SnowHydrology_newSnowBulkDensity.pf
+++ b/src/biogeophys/test/SnowHydrology_test/test_SnowHydrology_newSnowBulkDensity.pf
@@ -2,7 +2,7 @@ module test_SnowHydrology_newSnowBulkDensity
   
   ! Tests of SnowHydrologyMod: newSnowBulkDensity
   
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use SnowHydrologyMod
   use atm2lndType , only : atm2lnd_type

--- a/src/biogeophys/test/TotalWaterAndHeat_test/CMakeLists.txt
+++ b/src/biogeophys/test/TotalWaterAndHeat_test/CMakeLists.txt
@@ -1,12 +1,6 @@
 set (pfunit_sources
   test_total_water_and_heat.pf)
 
-# extra sources used for this test, which are not .pf files
-# (currently none)
-set (extra_sources
-  )
-
-create_pFUnit_test(total_water_and_heat test_total_water_and_heat_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_total_water_and_heat_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(total_water_and_heat
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/TotalWaterAndHeat_test/test_total_water_and_heat.pf
+++ b/src/biogeophys/test/TotalWaterAndHeat_test/test_total_water_and_heat.pf
@@ -2,7 +2,7 @@ module test_total_water_and_heat
 
   ! Tests of TotalWaterAndHeatMod
 
-  use pfunit_mod
+  use funit
   use TotalWaterAndHeatMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/biogeophys/test/WaterTracerContainerType_test/CMakeLists.txt
+++ b/src/biogeophys/test/WaterTracerContainerType_test/CMakeLists.txt
@@ -1,12 +1,6 @@
 set (pfunit_sources
   test_water_tracer_container.pf)
 
-# extra sources used for this test, which are not .pf files
-# (currently none)
-set (extra_sources
-  )
-
-create_pFUnit_test(water_tracer_container test_water_tracer_container_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_water_tracer_container_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(water_tracer_container
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/WaterTracerContainerType_test/test_water_tracer_container.pf
+++ b/src/biogeophys/test/WaterTracerContainerType_test/test_water_tracer_container.pf
@@ -2,7 +2,7 @@ module test_water_tracer_container
 
   ! Tests of WaterTracerContainerType
 
-  use pfunit_mod
+  use funit
   use WaterTracerContainerType
   use shr_kind_mod , only : r8 => shr_kind_r8
   use decompMod, only : subgrid_level_gridcell

--- a/src/biogeophys/test/WaterTracerUtils_test/CMakeLists.txt
+++ b/src/biogeophys/test/WaterTracerUtils_test/CMakeLists.txt
@@ -3,12 +3,6 @@ set (pfunit_sources
   test_calc_tracer_from_bulk.pf
   test_compare_bulk_to_tracer.pf)
 
-# extra sources used for this test, which are not .pf files
-# (currently none)
-set (extra_sources
-  )
-
-create_pFUnit_test(water_tracer_utils test_water_tracer_utils_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_water_tracer_utils_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(water_tracer_utils
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/WaterTracerUtils_test/test_calc_tracer_from_bulk.pf
+++ b/src/biogeophys/test/WaterTracerUtils_test/test_calc_tracer_from_bulk.pf
@@ -2,7 +2,7 @@ module test_calc_tracer_from_bulk
 
   ! Tests of WaterTracerUtils: CalcTracerFromBulk
 
-  use pfunit_mod
+  use funit
   use WaterTracerUtils
   use shr_kind_mod , only : r8 => shr_kind_r8
   use decompMod, only : subgrid_level_unspecified

--- a/src/biogeophys/test/WaterTracerUtils_test/test_calc_tracer_from_bulk_fixed_ratio.pf
+++ b/src/biogeophys/test/WaterTracerUtils_test/test_calc_tracer_from_bulk_fixed_ratio.pf
@@ -2,7 +2,7 @@ module test_calc_tracer_from_bulk_fixed_ratio
 
   ! Tests of WaterTracerUtils: CalcTracerFromBulkFixedRatio
 
-  use pfunit_mod
+  use funit
   use WaterTracerUtils, only : CalcTracerFromBulkFixedRatio
   use shr_kind_mod , only : r8 => shr_kind_r8
 

--- a/src/biogeophys/test/WaterTracerUtils_test/test_compare_bulk_to_tracer.pf
+++ b/src/biogeophys/test/WaterTracerUtils_test/test_compare_bulk_to_tracer.pf
@@ -2,7 +2,7 @@ module test_compare_bulk_to_tracer
 
   ! Tests of WaterTracerUtils: CompareBulkToTracer
 
-  use pfunit_mod
+  use funit
   use WaterTracerUtils, only : CompareBulkToTracer
   use shr_kind_mod , only : r8 => shr_kind_r8
   use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)

--- a/src/biogeophys/test/WaterType_test/CMakeLists.txt
+++ b/src/biogeophys/test/WaterType_test/CMakeLists.txt
@@ -1,12 +1,6 @@
 set (pfunit_sources
   test_water_type.pf)
 
-# extra sources used for this test, which are not .pf files
-# (currently none)
-set (extra_sources
-  )
-
-create_pFUnit_test(water_type test_water_type_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_water_type_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(water_type
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/WaterType_test/test_water_type.pf
+++ b/src/biogeophys/test/WaterType_test/test_water_type.pf
@@ -2,7 +2,7 @@ module test_water_type
 
   ! Tests of WaterType
 
-  use pfunit_mod
+  use funit
   use WaterType
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod, only : bounds, unittest_subgrid_teardown

--- a/src/biogeophys/test/Wateratm2lnd_test/CMakeLists.txt
+++ b/src/biogeophys/test/Wateratm2lnd_test/CMakeLists.txt
@@ -1,12 +1,6 @@
 set (pfunit_sources
   test_set_tracers.pf)
 
-# extra sources used for this test, which are not .pf files
-# (currently none)
-set (extra_sources
-  )
-
-create_pFUnit_test(water_atm2lnd test_water_atm2lnd_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_water_atm2lnd_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(water_atm2lnd
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/biogeophys/test/Wateratm2lnd_test/test_set_tracers.pf
+++ b/src/biogeophys/test/Wateratm2lnd_test/test_set_tracers.pf
@@ -2,7 +2,7 @@ module test_set_tracers
 
   ! Tests of Wateratm2lndType: routines that set tracers
 
-  use pfunit_mod
+  use funit
   use Wateratm2lndType
   use WaterInfoBulkType, only : water_info_bulk_type
   use WaterInfoTracerType, only : water_info_tracer_type

--- a/src/dyn_subgrid/test/dynColumnStateUpdater_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynColumnStateUpdater_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(ColumnStateUpdater test_ColumnStateUpdater_exe
-  "test_column_state_updater.pf" "")
-
-target_link_libraries(test_ColumnStateUpdater_exe clm csm_share)
+add_pfunit_ctest(ColumnStateUpdater
+  TEST_SOURCES "test_column_state_updater.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/dyn_subgrid/test/dynColumnStateUpdater_test/test_column_state_updater.pf
+++ b/src/dyn_subgrid/test/dynColumnStateUpdater_test/test_column_state_updater.pf
@@ -2,7 +2,7 @@ module test_column_state_updater
 
   ! Tests of dynColumnStateUpdaterMod
 
-  use pfunit_mod
+  use funit
   use dynColumnStateUpdaterMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/dyn_subgrid/test/dynColumnTemplate_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynColumnTemplate_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(ColumnTemplate test_ColumnTemplate_exe
-  "test_column_template.pf" "")
-
-target_link_libraries(test_ColumnTemplate_exe clm csm_share)
+add_pfunit_ctest(ColumnTemplate
+  TEST_SOURCES "test_column_template.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/dyn_subgrid/test/dynColumnTemplate_test/test_column_template.pf
+++ b/src/dyn_subgrid/test/dynColumnTemplate_test/test_column_template.pf
@@ -2,7 +2,7 @@ module test_column_template
 
   ! Tests of dynColumnTemplateMod
 
-  use pfunit_mod
+  use funit
   use dynColumnTemplateMod
   use unittestSubgridMod
   use shr_kind_mod    , only : r8 => shr_kind_r8

--- a/src/dyn_subgrid/test/dynConsBiogeophys_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynConsBiogeophys_test/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(pfunit_sources
   test_dyn_cons_biogeophys.pf)
 
-create_pFUnit_test(dynConsBiogeophys test_dynConsBiogeophys_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_dynConsBiogeophys_exe clm csm_share esmf_wrf_timemgr)
-
+add_pfunit_ctest(dynConsBiogeophys
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/dyn_subgrid/test/dynConsBiogeophys_test/test_dyn_cons_biogeophys.pf
+++ b/src/dyn_subgrid/test/dynConsBiogeophys_test/test_dyn_cons_biogeophys.pf
@@ -2,7 +2,7 @@ module test_dyn_cons_biogeophys
 
   ! Tests of dynConsBiogeophysMod
 
-  use pfunit_mod
+  use funit
   use dynConsBiogeophysMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/dyn_subgrid/test/dynInitColumns_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynInitColumns_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(dynInitColumns test_dynInitColumns_exe
-  "test_init_columns.pf" "")
-
-target_link_libraries(test_dynInitColumns_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(dynInitColumns
+  TEST_SOURCES "test_init_columns.pf"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/dyn_subgrid/test/dynInitColumns_test/test_init_columns.pf
+++ b/src/dyn_subgrid/test/dynInitColumns_test/test_init_columns.pf
@@ -2,7 +2,7 @@ module test_init_columns
   
   ! Tests of the dynInitColumns module
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use dynInitColumnsMod
   use ColumnType      , only : col

--- a/src/dyn_subgrid/test/dynLandunitArea_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynLandunitArea_test/CMakeLists.txt
@@ -2,8 +2,6 @@ set(pfunit_sources
   test_update_landunit_weights_one_gcell.pf
   test_update_landunit_weights.pf)
 
-create_pFUnit_test(dynLandunitArea test_dynLandunitArea_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_dynLandunitArea_exe clm csm_share)
-
+add_pfunit_ctest(dynLandunitArea
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/dyn_subgrid/test/dynLandunitArea_test/test_update_landunit_weights.pf
+++ b/src/dyn_subgrid/test/dynLandunitArea_test/test_update_landunit_weights.pf
@@ -2,7 +2,7 @@ module test_update_landunit_weights
 
   ! Tests of the update_landunit_weights routine in the dynLandunitArea module
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use dynLandunitAreaMod
   use shr_kind_mod	, only : r8 => shr_kind_r8

--- a/src/dyn_subgrid/test/dynLandunitArea_test/test_update_landunit_weights_one_gcell.pf
+++ b/src/dyn_subgrid/test/dynLandunitArea_test/test_update_landunit_weights_one_gcell.pf
@@ -2,7 +2,7 @@ module test_update_landunit_weights_one_gcell
 
   ! Tests of the update_landunit_weights_one_gcell routine in the dynLandunitArea module
 
-  use pfunit_mod
+  use funit
   use dynLandunitAreaMod
   use landunit_varcon, only : istsoil, istcrop, isturb_md, istice, istdlak, max_lunit
   use shr_kind_mod   , only : r8 => shr_kind_r8

--- a/src/dyn_subgrid/test/dynPatchStateUpdater_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynPatchStateUpdater_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(PatchStateUpdater test_PatchStateUpdater_exe
-  "test_patch_state_updater.pf" "")
-
-target_link_libraries(test_PatchStateUpdater_exe clm csm_share)
+add_pfunit_ctest(PatchStateUpdater
+  TEST_SOURCES "test_patch_state_updater.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/dyn_subgrid/test/dynPatchStateUpdater_test/test_patch_state_updater.pf
+++ b/src/dyn_subgrid/test/dynPatchStateUpdater_test/test_patch_state_updater.pf
@@ -2,7 +2,7 @@ module test_patch_state_updater
 
   ! Tests of dynPatchStateUpdaterMod
 
-  use pfunit_mod
+  use funit
   use dynPatchStateUpdaterMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/dyn_subgrid/test/dynTimeInfo_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynTimeInfo_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(dynTimeInfo test_dynTimeInfo_exe
-  "test_dynTimeInfo.pf" "")
-
-target_link_libraries(test_dynTimeInfo_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(dynTimeInfo
+  TEST_SOURCES "test_dynTimeInfo.pf"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/dyn_subgrid/test/dynTimeInfo_test/test_dynTimeInfo.pf
+++ b/src/dyn_subgrid/test/dynTimeInfo_test/test_dynTimeInfo.pf
@@ -2,7 +2,7 @@ module test_dynTimeInfo
 
   ! Tests of the dynTimeInfo class
 
-  use pfunit_mod
+  use funit
   use dynTimeInfoMod
   use shr_kind_mod, only: r8 => shr_kind_r8
   use unittestTimeManagerMod, only : unittest_timemgr_setup, unittest_timemgr_teardown

--- a/src/dyn_subgrid/test/dynVar_test/CMakeLists.txt
+++ b/src/dyn_subgrid/test/dynVar_test/CMakeLists.txt
@@ -6,7 +6,7 @@ set (pfunit_sources
 set (extra_sources
   test_dynVarShared.F90)
 
-create_pfUnit_test(dynVar test_dynVar_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_dynVar_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(dynVar
+  TEST_SOURCES "${pfunit_sources}"
+  OTHER_SOURCES "${extra_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/dyn_subgrid/test/dynVar_test/test_dynVarTimeInterp.pf
+++ b/src/dyn_subgrid/test/dynVar_test/test_dynVarTimeInterp.pf
@@ -2,7 +2,7 @@ module test_dynVarTimeInterp
 
   ! Tests of dyn_var_time_interp
 
-  use pfunit_mod
+  use funit
   use shr_kind_mod, only : r8 => shr_kind_r8
   use dynVarTimeInterpMod, only : dyn_var_time_interp_type
   use test_dynVarShared

--- a/src/dyn_subgrid/test/dynVar_test/test_dynVarTimeUninterp.pf
+++ b/src/dyn_subgrid/test/dynVar_test/test_dynVarTimeUninterp.pf
@@ -2,7 +2,7 @@ module test_dynVarTimeUninterp
 
   ! Tests of dyn_var_time_uninterp
 
-  use pfunit_mod
+  use funit
   use shr_kind_mod, only : r8 => shr_kind_r8
   use dynVarTimeUninterpMod, only : dyn_var_time_uninterp_type
   use test_dynVarShared

--- a/src/init_interp/test/initInterpMindist_test/CMakeLists.txt
+++ b/src/init_interp/test/initInterpMindist_test/CMakeLists.txt
@@ -3,7 +3,6 @@ set (pfunit_sources
   test_set_single_match.pf
   initInterpMindistTestUtils.pf)
 
-create_pFUnit_test(initInterpMindist test_initInterpMindist_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_initInterpMindist_exe clm csm_share)
+add_pfunit_ctest(initInterpMindist
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/init_interp/test/initInterpMindist_test/initInterpMindistTestUtils.pf
+++ b/src/init_interp/test/initInterpMindist_test/initInterpMindistTestUtils.pf
@@ -2,7 +2,7 @@ module initInterpMindistTestUtils
 
   ! Utilities to aid the testing of initInterpMindist
 
-  use pfunit_mod
+  use funit
   use shr_kind_mod , only : r8 => shr_kind_r8
   use initInterpMindist, only : subgrid_type, subgrid_special_indices_type
   use glcBehaviorMod, only: glc_behavior_type

--- a/src/init_interp/test/initInterpMindist_test/test_set_mindist.pf
+++ b/src/init_interp/test/initInterpMindist_test/test_set_mindist.pf
@@ -2,7 +2,7 @@ module test_set_mindist
 
   ! Tests of initInterpMindist: set_mindist
 
-  use pfunit_mod
+  use funit
   use initInterpMindist
   use initInterpMindistTestUtils, only : create_subgrid_info, create_glc_behavior
   use initInterpMindistTestUtils, only : subgrid_special_indices, ilun_special

--- a/src/init_interp/test/initInterpMindist_test/test_set_single_match.pf
+++ b/src/init_interp/test/initInterpMindist_test/test_set_single_match.pf
@@ -2,7 +2,7 @@ module test_set_single_match
 
   ! Tests of initInterpMindist: set_single_match
 
-  use pfunit_mod
+  use funit
   use initInterpMindist
   use initInterpMindistTestUtils, only : create_subgrid_info, create_glc_behavior
   use initInterpMindistTestUtils, only : subgrid_special_indices, ilun_special

--- a/src/init_interp/test/initInterpMultilevel_test/CMakeLists.txt
+++ b/src/init_interp/test/initInterpMultilevel_test/CMakeLists.txt
@@ -8,7 +8,7 @@ set (pfunit_sources
 set (extra_sources
   multilevel_interp_factory.F90)
 
-create_pFUnit_test(initInterpMultilevel test_initInterpMultilevel_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_initInterpMultilevel_exe clm csm_share)
+add_pfunit_ctest(initInterpMultilevel
+  TEST_SOURCES "${pfunit_sources}"
+  OTHER_SOURCES "${extra_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/init_interp/test/initInterpMultilevel_test/initInterpMultilevelMock.pf
+++ b/src/init_interp/test/initInterpMultilevel_test/initInterpMultilevelMock.pf
@@ -6,7 +6,7 @@ module initInterpMultilevelMock
   ! interp_multilevel routine is called correctly.
   !
   ! !USES:
-  use pfunit_mod
+  use funit
   use shr_kind_mod             , only : r8 => shr_kind_r8
   use initInterpMultilevelBase , only : interp_multilevel_type
 

--- a/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_interp.pf
+++ b/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_interp.pf
@@ -2,7 +2,7 @@ module test_init_interp_multilevel_interp
 
   ! Tests of initInterpMultilevelInterp
 
-  use pfunit_mod
+  use funit
   use initInterpMultilevelInterp
   use multilevel_interp_factory
   use shr_kind_mod , only : r8 => shr_kind_r8

--- a/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_snow.pf
+++ b/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_snow.pf
@@ -2,7 +2,7 @@ module test_init_interp_multilevel_snow
 
   ! Tests of initInterpMultilevelSnow
 
-  use pfunit_mod
+  use funit
   use initInterpMultilevelSnow
   use shr_kind_mod , only : r8 => shr_kind_r8
 

--- a/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_split.pf
+++ b/src/init_interp/test/initInterpMultilevel_test/test_init_interp_multilevel_split.pf
@@ -2,7 +2,7 @@ module test_init_interp_multilevel_split
 
   ! Tests of initInterpMultilevelSplit
 
-  use pfunit_mod
+  use funit
   use initInterpMultilevelSplit
   use initInterpMultilevelInterp, only : interp_multilevel_interp_type
   use initInterpMultilevelCopy, only : interp_multilevel_copy_type

--- a/src/init_interp/test/initInterpUtils_test/CMakeLists.txt
+++ b/src/init_interp/test/initInterpUtils_test/CMakeLists.txt
@@ -1,7 +1,6 @@
 set (pfunit_sources
   test_glc_elevclasses_are_same.pf)
 
-create_pFUnit_test(initInterpUtils test_initInterpUtils_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_initInterpUtils_exe clm csm_share)
+add_pfunit_ctest(initInterpUtils
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/init_interp/test/initInterpUtils_test/test_glc_elevclasses_are_same.pf
+++ b/src/init_interp/test/initInterpUtils_test/test_glc_elevclasses_are_same.pf
@@ -2,7 +2,7 @@ module test_glc_elevclasses_are_same
 
   ! Tests of initInterpUtils: glc_elevclasses_are_same
 
-  use pfunit_mod
+  use funit
   use initInterpUtils
   use shr_kind_mod , only : r8 => shr_kind_r8
   use ncdio_pio, only : file_desc_t, ncd_set_dim, ncd_set_var

--- a/src/main/test/accumul_test/CMakeLists.txt
+++ b/src/main/test/accumul_test/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(pfunit_sources
   test_accumul.pf)
 
-create_pFUnit_test(accumul test_accumul_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_accumul_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(accumul
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/main/test/accumul_test/test_accumul.pf
+++ b/src/main/test/accumul_test/test_accumul.pf
@@ -2,7 +2,7 @@ module test_accumul
 
   ! Tests of accumulMod
 
-  use pfunit_mod
+  use funit
   use accumulMod
   use unittestSubgridMod
   use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch

--- a/src/main/test/atm2lnd_test/CMakeLists.txt
+++ b/src/main/test/atm2lnd_test/CMakeLists.txt
@@ -2,7 +2,6 @@ set(pfunit_sources
   test_downscale_forcings.pf
   test_partition_precip.pf)
 
-create_pFUnit_test(atm2lnd test_atm2lnd_exe
-  "${pfunit_sources}" "")
-
-target_link_libraries(test_atm2lnd_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(atm2lnd
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/main/test/atm2lnd_test/test_downscale_forcings.pf
+++ b/src/main/test/atm2lnd_test/test_downscale_forcings.pf
@@ -2,7 +2,7 @@ module test_downscale_forcings
 
   ! Tests of atm2lndMod: downscale_forcings
 
-  use pfunit_mod
+  use funit
   use atm2lndMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/main/test/atm2lnd_test/test_partition_precip.pf
+++ b/src/main/test/atm2lnd_test/test_partition_precip.pf
@@ -2,7 +2,7 @@ module test_partition_precip
 
   ! Tests of atm2lndMod: partition_precip
 
-  use pfunit_mod
+  use funit
   use atm2lndMod
   use atm2lndType
   use shr_kind_mod, only : r8 => shr_kind_r8

--- a/src/main/test/clm_glclnd_test/CMakeLists.txt
+++ b/src/main/test/clm_glclnd_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(clm_glclnd test_clm_glclnd_exe
-  "test_clm_glclnd.pf" "")
-
-target_link_libraries(test_clm_glclnd_exe clm csm_share)
+add_pfunit_ctest(clm_glclnd
+  TEST_SOURCES "test_clm_glclnd.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/clm_glclnd_test/test_clm_glclnd.pf
+++ b/src/main/test/clm_glclnd_test/test_clm_glclnd.pf
@@ -2,7 +2,7 @@ module test_clm_glclnd
 
   ! Tests of clm_glclnd
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use shr_kind_mod, only : r8 => shr_kind_r8
   use lnd2glcMod

--- a/src/main/test/filter_test/CMakeLists.txt
+++ b/src/main/test/filter_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(filter test_filter_exe
-  "test_filter_col.pf" "")
-
-target_link_libraries(test_filter_exe clm csm_share)
+add_pfunit_ctest(filter
+  TEST_SOURCES "test_filter_col.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/filter_test/test_filter_col.pf
+++ b/src/main/test/filter_test/test_filter_col.pf
@@ -2,7 +2,7 @@ module test_filter_col
 
   ! Tests of filterColMod
 
-  use pfunit_mod
+  use funit
   use filterColMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/main/test/glcBehavior_test/CMakeLists.txt
+++ b/src/main/test/glcBehavior_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(glcBehavior test_glcBehavior_exe
-  "test_glcBehavior.pf" "")
-
-target_link_libraries(test_glcBehavior_exe clm csm_share)
+add_pfunit_ctest(glcBehavior
+  TEST_SOURCES "test_glcBehavior.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/glcBehavior_test/test_glcBehavior.pf
+++ b/src/main/test/glcBehavior_test/test_glcBehavior.pf
@@ -2,7 +2,7 @@ module test_glcBehavior
 
   ! Tests of glcBehaviorMod
 
-  use pfunit_mod
+  use funit
   use glcBehaviorMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/main/test/initVertical_test/CMakeLists.txt
+++ b/src/main/test/initVertical_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(initVertical test_initVertical_exe
-  "test_initVertical.pf" "")
-
-target_link_libraries(test_initVertical_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(initVertical
+  TEST_SOURCES "test_initVertical.pf"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/main/test/initVertical_test/test_initVertical.pf
+++ b/src/main/test/initVertical_test/test_initVertical.pf
@@ -2,7 +2,7 @@ module test_initVertical
 
   ! Tests of initVerticalMod
 
-  use pfunit_mod
+  use funit
   use initVerticalMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use clm_varpar, only : nlevlak, nlevgrnd, nlevdecomp_full, nlayer

--- a/src/main/test/ncdio_utils_test/CMakeLists.txt
+++ b/src/main/test/ncdio_utils_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(ncdio_utils test_ncdio_utils_exe
-  "test_ncdio_utils.pf" "")
-
-target_link_libraries(test_ncdio_utils_exe clm csm_share)
+add_pfunit_ctest(ncdio_utils
+  TEST_SOURCES "test_ncdio_utils.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/ncdio_utils_test/test_ncdio_utils.pf
+++ b/src/main/test/ncdio_utils_test/test_ncdio_utils.pf
@@ -2,7 +2,7 @@ module test_ncdio_utils
   
   ! Tests of ncdio_utils
   
-  use pfunit_mod
+  use funit
   use ncdio_utils
   use ncdio_pio   ! use the fake version of this module
   use shr_kind_mod, only : r8 => shr_kind_r8

--- a/src/main/test/subgridWeights_test/CMakeLists.txt
+++ b/src/main/test/subgridWeights_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(subgridWeights test_subgridWeights_exe
-  "test_subgridWeights.pf" "")
-
-target_link_libraries(test_subgridWeights_exe clm csm_share)
+add_pfunit_ctest(subgridWeights
+  TEST_SOURCES "test_subgridWeights.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/subgridWeights_test/test_subgridWeights.pf
+++ b/src/main/test/subgridWeights_test/test_subgridWeights.pf
@@ -2,7 +2,7 @@ module test_subgridWeights
 
   ! Tests of subgridWeightsMod
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use subgridWeightsMod
   use shr_kind_mod, only : r8 => shr_kind_r8

--- a/src/main/test/surfrdUtils_test/CMakeLists.txt
+++ b/src/main/test/surfrdUtils_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(surfrdUtils test_surfrdUtils_exe
-  "test_surfrdUtils.pf" "")
-
-target_link_libraries(test_surfrdUtils_exe clm csm_share)
+add_pfunit_ctest(surfrdUtils
+  TEST_SOURCES "test_surfrdUtils.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/surfrdUtils_test/test_surfrdUtils.pf
+++ b/src/main/test/surfrdUtils_test/test_surfrdUtils.pf
@@ -2,7 +2,7 @@ module test_surfrdUtils
 
   ! Tests of surfrdUtilsMod
 
-  use pfunit_mod
+  use funit
   use surfrdUtilsMod
   use shr_kind_mod, only : r8 => shr_kind_r8
 

--- a/src/main/test/topo_test/CMakeLists.txt
+++ b/src/main/test/topo_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(topo test_topo_exe
-  "test_topo.pf" "")
-
-target_link_libraries(test_topo_exe clm csm_share)
+add_pfunit_ctest(topo
+  TEST_SOURCES "test_topo.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/main/test/topo_test/test_topo.pf
+++ b/src/main/test/topo_test/test_topo.pf
@@ -2,7 +2,7 @@ module test_topo
 
   ! Tests of TopoMod
 
-  use pfunit_mod
+  use funit
   use TopoMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestGlcMec

--- a/src/self_tests/test/assertions_test/CMakeLists.txt
+++ b/src/self_tests/test/assertions_test/CMakeLists.txt
@@ -1,10 +1,6 @@
 set (pfunit_sources
   test_assertions.pf)
 
-set (extra_sources
-  )
-
-create_pFUnit_test(assertions test_assertions_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_assertions_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(assertions
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/self_tests/test/assertions_test/test_assertions.pf
+++ b/src/self_tests/test/assertions_test/test_assertions.pf
@@ -2,7 +2,7 @@ module test_assertions
 
   ! Tests of Assertions
 
-  use pfunit_mod
+  use funit
   use Assertions
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestUtils, only : endrun_msg

--- a/src/soilbiogeochem/test/ACSpinup_test/CMakeLists.txt
+++ b/src/soilbiogeochem/test/ACSpinup_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(acspinup test_acspinup_exe
-  "test_acspinup.pf" "")
-
-target_link_libraries(test_acspinup_exe clm csm_share)
+add_pfunit_ctest(acspinup
+  TEST_SOURCES "test_acspinup.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/soilbiogeochem/test/ACSpinup_test/test_acspinup.pf
+++ b/src/soilbiogeochem/test/ACSpinup_test/test_acspinup.pf
@@ -2,7 +2,7 @@ module test_acspinup
 
   ! Tests of the acspinup functions in SoilBiogeochemStateType
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod , only : r8 => shr_kind_r8
   use SoilBiogeochemStateType, only : get_spinup_latitude_term

--- a/src/unit_test_shr/test/unittestArray_test/CMakeLists.txt
+++ b/src/unit_test_shr/test/unittestArray_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(unittestArray test_unittestArray_exe
-  "test_unittestArray.pf" "")
-
-target_link_libraries(test_unittestArray_exe clm csm_share)
+add_pfunit_ctest(unittestArray
+  TEST_SOURCES "test_unittestArray.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/unit_test_shr/test/unittestArray_test/test_unittestArray.pf
+++ b/src/unit_test_shr/test/unittestArray_test/test_unittestArray.pf
@@ -2,7 +2,7 @@ module test_unittestArray
 
   ! Tests of unittestArrayMod
 
-  use pfunit_mod
+  use funit
   use unittestArrayMod
   use unittestSubgridMod
   use unittestSimpleSubgridSetupsMod

--- a/src/unit_test_shr/test/unittestFilterBuilder_test/CMakeLists.txt
+++ b/src/unit_test_shr/test/unittestFilterBuilder_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(unittestFilterBuilder test_filterBuilder_exe
-  "test_filterBuilder.pf" "")
-
-target_link_libraries(test_filterBuilder_exe clm csm_share)
+add_pfunit_ctest(unittestFilterBuilder
+  TEST_SOURCES "test_filterBuilder.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/unit_test_shr/test/unittestFilterBuilder_test/test_filterBuilder.pf
+++ b/src/unit_test_shr/test/unittestFilterBuilder_test/test_filterBuilder.pf
@@ -2,7 +2,7 @@ module test_filterBuilder
   
   ! Tests of unittestFilterBuilder
 
-  use pfunit_mod
+  use funit
   use unittestFilterBuilderMod
 
   implicit none

--- a/src/unit_test_shr/test/unittestSubgrid_test/CMakeLists.txt
+++ b/src/unit_test_shr/test/unittestSubgrid_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(unittestSubgrid test_unittestSubgrid_exe
-  "test_unittestSubgrid.pf" "")
-
-target_link_libraries(test_unittestSubgrid_exe clm csm_share)
+add_pfunit_ctest(unittestSubgrid
+  TEST_SOURCES "test_unittestSubgrid.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/unit_test_shr/test/unittestSubgrid_test/test_unittestSubgrid.pf
+++ b/src/unit_test_shr/test/unittestSubgrid_test/test_unittestSubgrid.pf
@@ -2,7 +2,7 @@ module test_unittestSubgrid
 
   ! Tests of unittestSubgridMod
 
-  use pfunit_mod
+  use funit
   use unittestSubgridMod
   use shr_kind_mod , only : r8 => shr_kind_r8
 

--- a/src/utils/test/annual_flux_dribbler_test/CMakeLists.txt
+++ b/src/utils/test/annual_flux_dribbler_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(annual_flux_dribbler test_annual_flux_dribbler_exe
-  "test_annual_flux_dribbler.pf" "")
-
-target_link_libraries(test_annual_flux_dribbler_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(annual_flux_dribbler
+  TEST_SOURCES "test_annual_flux_dribbler.pf"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/utils/test/annual_flux_dribbler_test/test_annual_flux_dribbler.pf
+++ b/src/utils/test/annual_flux_dribbler_test/test_annual_flux_dribbler.pf
@@ -2,7 +2,7 @@ module test_annual_flux_dribbler
 
   ! Tests of AnnualFluxDribbler
 
-  use pfunit_mod
+  use funit
   use AnnualFluxDribbler
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSubgridMod

--- a/src/utils/test/array_utils_test/CMakeLists.txt
+++ b/src/utils/test/array_utils_test/CMakeLists.txt
@@ -3,10 +3,6 @@ set (pfunit_sources
   test_convert_to_logical.pf
   )
 
-set (extra_sources
-  )
-
-create_pFUnit_test(array_utils test_array_utils_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_array_utils_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(array_utils
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/utils/test/array_utils_test/test_convert_to_logical.pf
+++ b/src/utils/test/array_utils_test/test_convert_to_logical.pf
@@ -2,7 +2,7 @@ module test_convert_to_logical
 
   ! Tests of array_utils: convert_to_logical
 
-  use pfunit_mod
+  use funit
   use array_utils
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestUtils, only : endrun_msg

--- a/src/utils/test/array_utils_test/test_find_k_max_indices.pf
+++ b/src/utils/test/array_utils_test/test_find_k_max_indices.pf
@@ -2,7 +2,7 @@ module test_find_k_max_indices
 
   ! Tests of array_utils: find_k_max_indices
 
-  use pfunit_mod
+  use funit
   use array_utils
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestUtils, only : endrun_msg

--- a/src/utils/test/clm_time_manager_test/CMakeLists.txt
+++ b/src/utils/test/clm_time_manager_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(clm_time_manager test_clm_time_manager_exe
-  "test_clm_time_manager.pf" "")
-
-target_link_libraries(test_clm_time_manager_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(clm_time_manager
+  TEST_SOURCES "test_clm_time_manager.pf"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -2,7 +2,7 @@ module test_clm_time_manager
 
   ! Tests of clm_time_manager
 
-  use pfunit_mod
+  use funit
   use shr_kind_mod, only : r8 => shr_kind_r8
   use clm_time_manager
   use unittestTimeManagerMod, only : unittest_timemgr_setup, unittest_timemgr_teardown

--- a/src/utils/test/matrix_test/CMakeLists.txt
+++ b/src/utils/test/matrix_test/CMakeLists.txt
@@ -1,10 +1,6 @@
 set (pfunit_sources
   test_matrix.pf)
 
-set (extra_sources
-  )
-
-create_pFUnit_test(matrix test_matrix_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_matrix_exe clm csm_share)
+add_pfunit_ctest(matrix
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/utils/test/matrix_test/test_matrix.pf
+++ b/src/utils/test/matrix_test/test_matrix.pf
@@ -2,7 +2,7 @@ module test_matrix
 
   ! Tests of Matrix: inverse
 
-  use pfunit_mod
+  use funit
   use MatrixMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestUtils, only : endrun_msg
@@ -20,7 +20,7 @@ module test_matrix
 
   integer, parameter :: ndims = 20
 
-  real(r8), parameter :: tol = 1.e-15_r8
+  real(r8), parameter :: tol = 1.e-14_r8
 
 contains
 

--- a/src/utils/test/numerics_test/CMakeLists.txt
+++ b/src/utils/test/numerics_test/CMakeLists.txt
@@ -1,10 +1,6 @@
 set (pfunit_sources
   test_truncate_small_values.pf)
 
-set (extra_sources
-  )
-
-create_pFUnit_test(numerics test_numerics_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_numerics_exe clm csm_share esmf_wrf_timemgr)
+add_pfunit_ctest(numerics
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share esmf_wrf_timemgr)

--- a/src/utils/test/numerics_test/test_truncate_small_values.pf
+++ b/src/utils/test/numerics_test/test_truncate_small_values.pf
@@ -2,7 +2,7 @@ module test_truncate_small_values
 
   ! Tests of NumericsMod: truncate_small_values
 
-  use pfunit_mod
+  use funit
   use NumericsMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestSimpleSubgridSetupsMod

--- a/src/utils/test/quadratic_test/CMakeLists.txt
+++ b/src/utils/test/quadratic_test/CMakeLists.txt
@@ -1,4 +1,3 @@
-create_pFUnit_test(quadratic test_quadratic_exe
-  "test_quadratic.pf" "")
-
-target_link_libraries(test_quadratic_exe clm csm_share)
+add_pfunit_ctest(quadratic
+  TEST_SOURCES "test_quadratic.pf"
+  LINK_LIBRARIES clm csm_share)

--- a/src/utils/test/quadratic_test/test_quadratic.pf
+++ b/src/utils/test/quadratic_test/test_quadratic.pf
@@ -2,7 +2,7 @@ module test_quadratic
 
   ! Tests of quadratic
 
-  use pfunit_mod
+  use funit
   use quadraticMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestUtils, only : endrun_msg
@@ -176,8 +176,6 @@ contains
     b = 4.0_r8
     c = 4.0_r8 + 100.0_r8*epsilon(b)
     call quadratic (a, b, c, r1, r2)
-    call check_root(a, b, c, r1)
-    call check_root(a, b, c, r2)
     expected_msg = endrun_msg( &
          'quadratic ERROR: Quadratic solution error: b^2 - 4ac is negative')
     @assertExceptionRaised(expected_msg)

--- a/src/utils/test/sparse_matrix_test/CMakeLists.txt
+++ b/src/utils/test/sparse_matrix_test/CMakeLists.txt
@@ -1,10 +1,6 @@
 set (pfunit_sources
   test_sparse_matrix.pf)
 
-set (extra_sources
-  )
-
-create_pFUnit_test(sparse_matrix test_sparse_matrix_exe
-  "${pfunit_sources}" "${extra_sources}")
-
-target_link_libraries(test_sparse_matrix_exe clm csm_share)
+add_pfunit_ctest(sparse_matrix
+  TEST_SOURCES "${pfunit_sources}"
+  LINK_LIBRARIES clm csm_share)

--- a/src/utils/test/sparse_matrix_test/test_sparse_matrix.pf
+++ b/src/utils/test/sparse_matrix_test/test_sparse_matrix.pf
@@ -2,7 +2,7 @@ module test_sparse_matrix
 
   ! Tests of Sparse Matrix Multiply module
 
-  use pfunit_mod
+  use funit
   use SparseMatrixMultiplyMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use unittestUtils, only : endrun_msg

--- a/tools/mksurfdata_map/src/test/mkdomain_test/test_mkdomain.pf
+++ b/tools/mksurfdata_map/src/test/mkdomain_test/test_mkdomain.pf
@@ -2,7 +2,7 @@ module test_mkdomain
   
   ! Tests of mkdomainMod
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkgridmapMod, only : gridmap_type, for_test_create_gridmap

--- a/tools/mksurfdata_map/src/test/mkgridmap_test/test_mkgridmap.pf
+++ b/tools/mksurfdata_map/src/test/mkgridmap_test/test_mkgridmap.pf
@@ -2,7 +2,7 @@ module test_mkgridmap
 
   ! Tests of mkgridmapMod
 
-  use pfunit_mod
+  use funit
   use mkgridmapMod
   use shr_kind_mod , only : r8 => shr_kind_r8
 

--- a/tools/mksurfdata_map/src/test/mkindexmap_test/test_mkindexmap.pf
+++ b/tools/mksurfdata_map/src/test/mkindexmap_test/test_mkindexmap.pf
@@ -2,7 +2,7 @@ module test_mkindexmap
 
   ! Tests of mkindexmapMod
 
-  use pfunit_mod
+  use funit
   use mkindexmapMod
   use mkgridmapMod, only : gridmap_type, for_test_create_gridmap, gridmap_clean
   use shr_kind_mod , only : r8 => shr_kind_r8

--- a/tools/mksurfdata_map/src/test/mkpctPftType_test/test_mkpctPftType.pf
+++ b/tools/mksurfdata_map/src/test/mkpctPftType_test/test_mkpctPftType.pf
@@ -2,7 +2,7 @@ module test_mkpctPftType
 
   ! Tests of pct_pft_type
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkpctPftTypeMod

--- a/tools/mksurfdata_map/src/test/mkpftUtils_test/test_adjust_total_veg_area.pf
+++ b/tools/mksurfdata_map/src/test/mkpftUtils_test/test_adjust_total_veg_area.pf
@@ -2,7 +2,7 @@ module test_adjust_total_veg_area
   
   ! Tests of mkpftUtilsMod: adjust_total_veg_area
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkpctPftTypeMod, only : pct_pft_type

--- a/tools/mksurfdata_map/src/test/mkpftUtils_test/test_convert_from_p2g.pf
+++ b/tools/mksurfdata_map/src/test/mkpftUtils_test/test_convert_from_p2g.pf
@@ -2,7 +2,7 @@ module test_convert_from_p2g
 
   ! Tests of mkpftUtilsMod: convert_from_p2g
   
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkpctPftTypeMod, only : pct_pft_type

--- a/tools/mksurfdata_map/src/test/mkpftmod_test/test_pftInit.pf
+++ b/tools/mksurfdata_map/src/test/mkpftmod_test/test_pftInit.pf
@@ -2,7 +2,7 @@ module test_pftInit
   
   ! Tests of mkpftMod: pft_override functions
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkpftMod

--- a/tools/mksurfdata_map/src/test/mkpftmod_test/test_pft_oride.pf
+++ b/tools/mksurfdata_map/src/test/mkpftmod_test/test_pft_oride.pf
@@ -2,7 +2,7 @@ module test_pft_oride
   
   ! Tests of mkpftMod: pft_override functions
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkpftMod

--- a/tools/mksurfdata_map/src/test/mkpftmod_test/test_pftrun.pf
+++ b/tools/mksurfdata_map/src/test/mkpftmod_test/test_pftrun.pf
@@ -2,7 +2,7 @@ module test_pftrun
   
   ! Tests of mkpftMod: pft_override functions
 
-  use pfunit_mod
+  use funit
 
   use shr_kind_mod, only : r8 => shr_kind_r8
   use mkpftMod

--- a/tools/mksurfdata_map/src/test/mksoilUtils_test/test_dominant_soil_color.pf
+++ b/tools/mksurfdata_map/src/test/mksoilUtils_test/test_dominant_soil_color.pf
@@ -2,7 +2,7 @@ module test_dominant_soil_color
 
   ! Tests of mksoilUtilsMod: dominant_soil_color
 
-  use pfunit_mod
+  use funit
   use mksoilUtilsMod
   use shr_kind_mod , only : r8 => shr_kind_r8
   use mkgridmapMod, only : gridmap_type, gridmap_clean, for_test_create_gridmap

--- a/tools/mksurfdata_map/src/unit_test_stubs/abort.F90
+++ b/tools/mksurfdata_map/src/unit_test_stubs/abort.F90
@@ -18,7 +18,7 @@ subroutine abort()
     !   call assertExceptionRaised
     !
     !   then this will result in the given pFUnit test failing.
-    use pfunit_mod, only : throw
+    use funit, only : throw
     implicit none
 
     call throw("ABORTED:")


### PR DESCRIPTION
### Description of changes

Lots of small changes needed for the update to pFUnit4. Note that this is a backwards-incompatible update, so we will require pFUnit 4 moving forward.

This needs to be coordinated with updates to various externals; I will update the externals once those are merged:
- https://github.com/ESMCI/cime/pull/4397
- https://github.com/ESCOMP/CESM_share/pull/38
- https://github.com/ESMCI/ccs_config_cesm/pull/99
- https://github.com/ESCOMP/CESM_CPL7andDataComps/pull/24

A few specific notes:

- Needed to increase tolerances a bit in the matrix test to make tests
  pass on my Mac (with gfortran).

- Needed to remove some assertions in an expected-failure test for
  quadratic (it seems like the new pFUnit hits these assertions whereas
  the old did not).

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
- Ran unit tests on cheyenne, izumi and my Mac (with the instructions in README.unit_testing)