### PR TITLE
Update fates history tests to use double precision

### DIFF
--- a/cime_config/testdefs/testmods_dirs/clm/Fates/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Fates/user_nl_clm
@@ -2,6 +2,7 @@
 hist_mfilt        = 365
 hist_nhtfrq       = -24
 hist_empty_htapes = .true.
+hist_ndens = 1
 fates_spitfire_mode = 1
 hist_fincl1       = 'FATES_NCOHORTS', 'FATES_TRIMMING', 'FATES_AREA_PLANTS',
 'FATES_AREA_TREES', 'FATES_COLD_STATUS', 'FATES_DROUGHT_STATUS', 'FATES_GDD',

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdAllVars/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdAllVars/user_nl_clm
@@ -3,6 +3,7 @@ hist_mfilt        = 365
 hist_nhtfrq       = -24
 hist_empty_htapes = .false.
 fates_spitfire_mode = 1
+hist_ndens = 1
 hist_fincl1       = 'FATES_CROWNAREA_PF', 'FATES_CANOPYCROWNAREA_PF',
 'FATES_NCL_AP', 'FATES_NPATCH_AP', 'FATES_VEGC_AP',
 'FATES_SECONDARY_FOREST_FRACTION', 'FATES_WOOD_PRODUCT',

--- a/cime_config/usermods_dirs/fates_sp/user_nl_clm
+++ b/cime_config/usermods_dirs/fates_sp/user_nl_clm
@@ -6,6 +6,7 @@ use_lch4 = .false.
 fates_spitfire_mode = 0
 use_fates_fixed_biogeog = .true.
 use_fates_nocomp = .true.
+hist_ndens = 1
 ! Turn off a list of fields that are not needed for FATES-SP mode
 hist_fexcl1 = 'FATES_TRIMMING', 'FATES_COLD_STATUS', 'FATES_DROUGHT_STATUS', 'FATES_GDD', 'FATES_NCHILLDAYS',
               'FATES_NCOLDDAYS', 'FATES_DAYSINCE_COLDLEAFOFF', 'FATES_DAYSINCE_COLDLEAFON', 'FATES_DAYSINCE_DROUGHTLEAFOFF',

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name: ctsm5.1.dev128
 Originator(s): glemieux (Gregory Lemieux,LBL/NGEET,510-486-5049)
-Date: Fri May 26 15:45:00 MDT 2023
+Date: Thu Jun  1 15:31:52 MDT 2023
 One-line Summary: Update FATES tests to double precision
 
 Purpose and description of changes

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,72 @@
 ===============================================================
+Tag name: ctsm5.1.dev128
+Originator(s): glemieux (Gregory Lemieux,LBL/NGEET,510-486-5049)
+Date: Fri May 26 15:45:00 MDT 2023
+One-line Summary: Update FATES tests to double precision
+
+Purpose and description of changes
+----------------------------------
+
+This pull request updates the fates tests to set the output
+precision to double precision.  The usermod fates_sp is similarly
+updated.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed or introduced
+------------------------
+
+CTSM issues fixed (include CTSM Issue #):
+- Resolves https://github.com/ESCOMP/CTSM/issues/1986
+
+Testing summary:
+----------------
+
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    cheyenne ---- OK
+    izumi ------- OK
+
+  fates tests: (give name of baseline if different from CTSM tagname, normally fates baselines are fates-<FATES TAG>-<CTSM TAG>)
+    cheyenne ---- OK
+    izumi ------- OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+
+  FATES tests run against fates-sci.1.65.6_api.25.4.0-ctsm5.1.dev127 baseline
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes, but only for fates tests and compsets
+
+  Summarize any changes to answers, i.e.,
+    - Differences are due to changing hist_ndens to 1 (double precision)
+
+Other details
+-------------
+
+Pull Requests that document the changes (include PR ids):
+https://github.com/ESCOMP/CTSM/pull/2010
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev127
 Originator(s): sacks (Bill Sacks)
 Date: Fri May 19 04:48:30 MDT 2023

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev128 glemieux 05/26/2023 Update FATES tests to double precision
     ctsm5.1.dev127    sacks 05/19/2023 Fix nuopc cplhist test
     ctsm5.1.dev126   jpalex 05/18/2023 Clean up some loops in UrbanTimeVarType
     ctsm5.1.dev125   jpalex 05/17/2023 Added cache for clock step_size in clm_time_manager.F90

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-    ctsm5.1.dev128 glemieux 05/26/2023 Update FATES tests to double precision
+    ctsm5.1.dev128 glemieux 06/01/2023 Update FATES tests to double precision
     ctsm5.1.dev127    sacks 05/19/2023 Fix nuopc cplhist test
     ctsm5.1.dev126   jpalex 05/18/2023 Clean up some loops in UrbanTimeVarType
     ctsm5.1.dev125   jpalex 05/17/2023 Added cache for clock step_size in clm_time_manager.F90


### PR DESCRIPTION
### Description of changes
The current fates regression tests default to single precision.  This PR updates to double precision

The PR resolves #1986 

### Specific notes

Contributors other than yourself, if any:
@ekluzek 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Yes

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
