### PR TITLE
small changes to fix warnings; add print statements for clarity to users

### DIFF
--- a/tools/site_and_regional/run_neon.py
+++ b/tools/site_and_regional/run_neon.py
@@ -5,17 +5,17 @@
 |---------------------  Instructions  -----------------------------|
 |------------------------------------------------------------------|
 This is a wrapper script for running CTSM simulation for one or more
-neon sites. 
+neon sites.
 
 This script is only for neon site and we will develop a more general
 code later.
 
-This script first creates and builds a generic base case. 
+This script first creates and builds a generic base case.
 Next, it will clone the base_case for different neon sites and run
-types to reduce the need to build ctsm everytime. 
+types to reduce the need to build ctsm everytime.
 
 This script will do the following:
-    1) Create a generic base case for cloning. 
+    1) Create a generic base case for cloning.
     2) Make the case for the specific neon site(s).
     3) Make changes to the case, for:
         a. AD spinup
@@ -24,13 +24,13 @@ This script will do the following:
     	#---------------
     	d. SASU or Matrix spinup
     4) Build and submit the case.
- 
+
 -------------------------------------------------------------------
 Instructions for running using conda python environments:
 
 ../../py_env_create
 conda activate ctsm_py
- 
+
 -------------------------------------------------------------------
 To see the available options:
     ./run_neon.py --help
@@ -113,7 +113,7 @@ def get_parser(args, description, valid_neon_sites):
         "--base-case",
         help="""
                 Root Directory of base case build
-                [default: %(default)s] 
+                [default: %(default)s]
                 """,
         action="store",
         dest="base_case_root",
@@ -126,7 +126,7 @@ def get_parser(args, description, valid_neon_sites):
         "--output-root",
         help="""
                 Root output directory of cases
-                [default: %(default)s] 
+                [default: %(default)s]
                 """,
         action="store",
         dest="output_root",
@@ -162,7 +162,7 @@ def get_parser(args, description, valid_neon_sites):
     parser.add_argument(
         "--rerun",
         help="""
-                If the case exists but does not appear to be complete, restart it. 
+                If the case exists but does not appear to be complete, restart it.
                 [default: %(default)s]
                 """,
         action="store_true",
@@ -209,7 +209,7 @@ def get_parser(args, description, valid_neon_sites):
     parser.add_argument(
        "--experiment",
         help="""
-                Appends the case name with string for model experiment 
+                Appends the case name with string for model experiment
                 """,
         action="store",
         dest="experiment",
@@ -231,7 +231,7 @@ def get_parser(args, description, valid_neon_sites):
 
     parser.add_argument(
         "--start-date",
-        help="""           
+        help="""
                 Start date for running CTSM simulation in ISO format.
                 [default: %(default)s]
                 (currently non-functional)
@@ -355,6 +355,22 @@ def parse_isoduration(s):
     # Convert all to timedelta
     dt = datetime.timedelta(days=int(days) + 365 * int(years) + 30 * int(months))
     return int(dt.total_seconds() / 86400)
+
+def get_queue_command(batch_system):
+    match batch_system.lower():
+        'pbs':
+            queue_command = 'qstat -u <user_name>'
+        'slurm':
+            queue_command = 'squeue -u <user_name>'
+        'cobalt':
+            queue_command = 'qstat -u <user_name>'
+        'lsf':
+            queue_command = 'bqueues -u <user_name>'
+        case _:
+        queue_command = ''
+
+    return queue_command
+
 
 
 class NeonSite:
@@ -506,7 +522,7 @@ class NeonSite:
         print ("using this version:", version)
 
         if experiment != None:
-            self.name = self.name + "." + experiment 
+            self.name = self.name + "." + experiment
         case_root = os.path.abspath(
                 os.path.join(base_case_root, "..", self.name + "." + run_type)
             )
@@ -604,7 +620,7 @@ class NeonSite:
                 case.set_value("CALENDAR", "GREGORIAN")
                 case.set_value("RESUBMIT", 0)
                 case.set_value("STOP_OPTION", "nmonths")
-            
+
             if not rundir:
                 rundir = case.get_value("RUNDIR")
 
@@ -856,7 +872,7 @@ def main(description):
                 rerun,
                 experiment,
             )
-            
+
 
 
 if __name__ == "__main__":

--- a/tools/site_and_regional/run_neon.py
+++ b/tools/site_and_regional/run_neon.py
@@ -550,11 +550,11 @@ class NeonSite:
                     elif not setup_only:
                         print("Resubmitting case {}".format(case_root))
                         case.submit(no_batch=no_batch)
-                        logger.info("-----------------------------------")
-                        logger.info("Successfully submitted case!")
+                        print("-----------------------------------")
+                        print("Successfully submitted case!")
                         batch_query = self.get_batch_query(case)
                         if batch_query != "none":
-                            logger.info(f"Use {batch_query} to check its run status")
+                            print(f"Use {batch_query} to check its run status")
                     return
             else:
                 logger.warning(
@@ -632,11 +632,11 @@ class NeonSite:
             case.check_all_input_data()
             if not setup_only:
                 case.submit(no_batch=no_batch)
-                logger.info("-----------------------------------")
-                logger.info("Successfully submitted case!")
+                print("-----------------------------------")
+                print("Successfully submitted case!")
                 batch_query = self.get_batch_query(case)
                 if batch_query != "none":
-                    logger.info(f"Use {batch_query} to check its run status")
+                    print(f"Use {batch_query} to check its run status")
 
     def set_ref_case(self, case):
         rundir = case.get_value("RUNDIR")

--- a/tools/site_and_regional/run_neon.py
+++ b/tools/site_and_regional/run_neon.py
@@ -478,7 +478,7 @@ class NeonSite:
     def get_batch_query(self, case):
         """
         Function for querying the batch queue query command for a case, depending on the 
-        user's batch system. If no batch system, empty string is returned
+        user's batch system. 
 
         Args:
         case:
@@ -486,7 +486,7 @@ class NeonSite:
         """
         
         if case.get_value("BATCH_SYSTEM") == "none":
-          return ""
+          return "none"
         else:
           return case.get_value("batch_query")
           
@@ -552,7 +552,9 @@ class NeonSite:
                         case.submit(no_batch=no_batch)
                         logger.info("-----------------------------------")
                         logger.info("Successfully submitted case!")
-                        logger.info(f"Use {self.get_batch_query(case)} to check its run status")
+                        batch_query = self.get_batch_query(case)
+                        if batch_query != "none":
+                            logger.info(f"Use {batch_query} to check its run status")
                     return
             else:
                 logger.warning(
@@ -632,7 +634,9 @@ class NeonSite:
                 case.submit(no_batch=no_batch)
                 logger.info("-----------------------------------")
                 logger.info("Successfully submitted case!")
-                logger.info(f"Use {self.get_batch_query(case)} to check its run status")
+                batch_query = self.get_batch_query(case)
+                if batch_query != "none":
+                    logger.info(f"Use {batch_query} to check its run status")
 
     def set_ref_case(self, case):
         rundir = case.get_value("RUNDIR")

--- a/tools/site_and_regional/run_neon.py
+++ b/tools/site_and_regional/run_neon.py
@@ -460,6 +460,7 @@ class NeonSite:
                 return case_path
 
             print("---- base case build ------")
+            print("--- This may take a while and you may see WARNING messages ---")
             # always walk through the build process to make sure it's up to date.
             t0 = time.time()
             build.case_build(case_path, case=case)
@@ -534,6 +535,9 @@ class NeonSite:
                     elif not setup_only:
                         print("Resubmitting case {}".format(case_root))
                         case.submit(no_batch=no_batch)
+                        logger.info("-----------------------------------")
+                        logger.info("Successfully submitted case!")
+                        logger.info("Use 'qstat -u <user-name>' to check its run status")
                     return
             else:
                 logger.warning(
@@ -564,7 +568,7 @@ class NeonSite:
                 )
 
         with Case(case_root, read_only=False) as case:
-            if run_type is not "transient":
+            if run_type != "transient":
                  # in order to avoid the complication of leap years we always set the run_length in units of days.
                  case.set_value("STOP_OPTION", "ndays")
                  case.set_value("REST_OPTION", "end")
@@ -611,6 +615,9 @@ class NeonSite:
             case.check_all_input_data()
             if not setup_only:
                 case.submit(no_batch=no_batch)
+                logger.info("-----------------------------------")
+                logger.info("Successfully submitted case!")
+                logger.info("Use 'qstat -u <user-name>' to check its run status")
 
     def set_ref_case(self, case):
         rundir = case.get_value("RUNDIR")
@@ -747,7 +754,7 @@ def parse_neon_listing(listing_file, valid_neon_sites):
 
             tmp_df = tmp_df[tmp_df[7].str.contains(latest_version)]
             # -- remove .nc from the file names
-            tmp_df[9] = tmp_df[9].str.replace(".nc", "")
+            tmp_df[9] = tmp_df[9].str.replace(".nc", "", regex=False)
 
 
             tmp_df2 = tmp_df[9].str.split("-", expand=True)
@@ -849,6 +856,7 @@ def main(description):
                 rerun,
                 experiment,
             )
+            
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of changes

Some small changes for quality of life improvements for the `run_neon` script.

### Specific notes

1. fixed a couple lines so that python will stop complaining about deprecated things
2. added print statements about warning messages being not an issue, and that building/running may take a while
3. added a "success" print statement - **I'm not sure this will actually only print if "successful"**

@ekluzek is there a way to get a return value from case.submit that tells you if it actually submitted?

Contributors other than yourself, if any:

@ekluzek @TeaganKing @wwieder 

CTSM Issues Fixed (include github issue #): 

Are answers expected to change (and if so in what way)? No changes

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
only affects `run_neon` 
