### PR TITLE
Document side effects of htapes_fieldlist() method

### DIFF
--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -774,8 +774,11 @@ contains
     ! !DESCRIPTION:
     ! Define the contents of each history file based on namelist
     ! input for initial or branch run, and restart data if a restart run.
-    ! Use arrays fincl and fexcl to modify default history tape contents.
+    ! Fill and use arrays fincl and fexcl to modify default history tape contents.
     ! Then sort the result alphanumerically.
+    !
+    ! Sets history_tape_in_use and htapes_defined. Fills fields in 'tape' array.
+    ! Optionally updates masterlist avgflag.
     !
     ! !ARGUMENTS:
     !


### PR DESCRIPTION
List which variables are set.

### Description of changes

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Testing performed, if any: none
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
