### PR TITLE
Get rid of tiny snocan (tracer and bulk) that causes test failure

### DIFF
--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1373,9 +1373,6 @@ bioms:   do f = 1, fn
       fn = fnorig
       filterp(1:fn) = fporig(1:fn)
 
-      ! save before updating
-      snocan_baseline(begp:endp) = snocan(begp:endp)
-
       do f = 1, fn
          p = filterp(f)
          c = patch%column(p)
@@ -1524,6 +1521,9 @@ bioms:   do f = 1, fn
          cgrnds(p) = cgrnds(p) + cpair*forc_rho(c)*wtg(p)*wtal(p)
          cgrndl(p) = cgrndl(p) + forc_rho(c)*wtgq(p)*wtalq(p)*dqgdT(c)
          cgrnd(p)  = cgrnds(p) + cgrndl(p)*htvp(c)
+
+         ! save before updating
+         snocan_baseline(p) = snocan(p)
 
          ! Update dew accumulation (kg/m2)
          if (t_veg(p) > tfrz ) then ! above freezing, update accumulation in liqcan

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -47,6 +47,7 @@ module CanopyFluxesMod
   use EDTypesMod            , only : ed_site_type
   use SoilWaterRetentionCurveMod, only : soil_water_retention_curve_type
   use LunaMod               , only : Update_Photosynthesis_Capacity, Acc24_Climate_LUNA,Acc240_Climate_LUNA,Clear24_Climate_LUNA
+  use NumericsMod           , only : truncate_small_values
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -416,6 +417,7 @@ contains
     real(r8) :: uuc(bounds%begp:bounds%endp)             ! undercanopy windspeed
     real(r8) :: carea_stem                               ! cross-sectional area of stem
     real(r8) :: dlrad_leaf                               ! Downward longwave radition from leaf
+    real(r8) :: snocan_baseline(bounds%begp:bounds%endp)  ! baseline of snocan for use in truncate_small_values
 
     ! Indices for raw and rah
     integer, parameter :: above_canopy = 1         ! Above canopy
@@ -1371,6 +1373,9 @@ bioms:   do f = 1, fn
       fn = fnorig
       filterp(1:fn) = fporig(1:fn)
 
+      ! save before updating
+      snocan_baseline(begp:endp) = snocan(begp:endp)
+
       do f = 1, fn
          p = filterp(f)
          c = patch%column(p)
@@ -1537,6 +1542,12 @@ bioms:   do f = 1, fn
          end if
 
       end do
+
+      ! Remove snocan that got reduced by more than a factor of rel_epsilon
+      ! snocan < rel_epsilon * snocan_baseline will be set to zero
+      ! See NumericsMod for rel_epsilon value
+      call truncate_small_values(fn, filterp, begp, endp, &
+         snocan_baseline(begp:endp), snocan(begp:endp))
       
       if ( use_fates ) then
          

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -200,7 +200,6 @@ contains
      integer  :: i     ! index of water tracer or bulk
      real(r8) :: dtime ! land model time step (sec)
 
-     real(r8) :: snocan_baseline(bounds%begp:bounds%endp)                    ! baseline of snocan variable for use in truncate_small_values function
      real(r8) :: qflx_liq_above_canopy_patch(bounds%begp:bounds%endp)        ! liquid water input above canopy (rain plus irrigation) [mm/s]
      real(r8) :: tracer_qflx_liq_above_canopy_patch(bounds%begp:bounds%endp) ! For one tracer: liquid water input above canopy (rain plus irrigation) [mm/s]
      real(r8) :: forc_snow_patch(bounds%begp:bounds%endp)                    ! atm snow, patch-level [mm/s]

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -33,6 +33,7 @@ module CanopyHydrologyMod
   use WaterTracerUtils        , only : CalcTracerFromBulk
   use ColumnType      , only : col, column_type
   use PatchType       , only : patch, patch_type
+  use NumericsMod     , only : truncate_small_values, rel_epsilon
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -197,9 +198,10 @@ contains
      type(water_type)       , intent(inout) :: water_inst
      !
      ! !LOCAL VARIABLES:
-     integer  :: i     ! index of water tracer or bulk
+     integer  :: i, p  ! index of water tracer or bulk, index of patch-level
      real(r8) :: dtime ! land model time step (sec)
 
+     real(r8) :: snocan_baseline(bounds%begp:bounds%endp)                    ! baseline of snocan variable for use in truncate_small_values function
      real(r8) :: qflx_liq_above_canopy_patch(bounds%begp:bounds%endp)        ! liquid water input above canopy (rain plus irrigation) [mm/s]
      real(r8) :: tracer_qflx_liq_above_canopy_patch(bounds%begp:bounds%endp) ! For one tracer: liquid water input above canopy (rain plus irrigation) [mm/s]
      real(r8) :: forc_snow_patch(bounds%begp:bounds%endp)                    ! atm snow, patch-level [mm/s]
@@ -301,6 +303,23 @@ contains
      ! Update snocan and liqcan based on interception, for bulk water and each tracer
      do i = water_inst%bulk_and_tracers_beg, water_inst%bulk_and_tracers_end
         associate(w => water_inst%bulk_and_tracers(i))
+        ! Get rid of tiny snocan (tracer and bulk)
+        ! Very small snocan (< rel_epsilon**2) will be set to zero
+        ! See NumericsMod for rel_epsilon value
+        snocan_baseline(bounds%begp:bounds%endp) = rel_epsilon  ! this gets multiplied by rel_epsilon in truncate_small_values
+        call truncate_small_values(num_soilp, filter_soilp, begp, endp, &
+           snocan_baseline(begp:endp), b_waterstate_inst%snocan_patch(begp:endp))
+        ! Explanation for why we use this do-loop instead of call
+        ! truncate_small_values for w%waterstate_inst%snocan_patch:
+        ! call truncate_small_values would set w%waterstate_inst%snocan_patch
+        ! to zero only when w%waterstate_inst%snocan_patch < rel_epsilon**2
+        ! while it needs to be zero every time that
+        ! b_waterstate_inst%snocan_patch is zero
+        do p = begp, endp
+           if (b_waterstate_inst%snocan_patch(p) == 0._r8) then
+              w%waterstate_inst%snocan_patch(p) = b_waterstate_inst%snocan_patch(p)
+           end if
+        end do
         call UpdateState_AddInterceptionToCanopy(bounds, num_soilp, filter_soilp, &
              ! Inputs
              dtime                 = dtime, &


### PR DESCRIPTION
### Description of changes

Test failure described in issue #2041 goes away when we reset tiny snocan (tracer and bulk) to zero.

### Specific notes

Contributors other than yourself, if any:
@billsacks @ekluzek 

CTSM Issues Fixed (include github issue #): #2041 

Are answers expected to change (and if so in what way)? Yes, larger than roundoff

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
1) From my ctsm5.2 branch this test now passes and diffs from baseline are expected due to new ctsm5.2 fsurdat relative to baseline ctsm5.1 fsurdat...
`./create_test LWISO_Ld10.f10_f10_mg37.I2000Clm50BgcCrop.cheyenne_gnu.clm-coldStart -c /glade/p/cgd/tss/ctsm_baselines/ctsm5.1.dev123`
2) From ctsm5.1 main plus the same changes that I pushed to this PR, I get diffs from baseline...
`./create_test LWISO_Ld10.f10_f10_mg37.I2000Clm50BgcCrop.cheyenne_gnu.clm-coldStart -c /glade/p/cgd/tss/ctsm_baselines/ctsm5.1.dev129`
Largest NORMALIZED RMS diffs are of order 10-1 for variables ERRH2O*, ERRSEB, ERRSOL