### PR TITLE
Add RXCROPMATURITY test to clm_pymods

### DIFF
--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -2541,6 +2541,12 @@
           <option name="comment">This test is designed to test the ability to prescribe crop sowing dates and maturity requirements. It first performs a GDD-generating run, then calls Python code to generate the maturity requirement file. This is then used in a sowing+maturity forced run, which finally is tested to ensure correct behavior.</option>
         </options>
       </machine>
+      <machine name="cheyenne" compiler="intel" category="clm_pymods">
+        <options>
+          <option name="wallclock">12:00:00</option>
+          <option name="comment">This test invokes python code, so it should be run whenever changing python code (in addition to being run as part of ctsm_sci).</option>
+        </options>
+      </machine>
     </machines>
   </test>
 </testlist>


### PR DESCRIPTION
### Description of changes
Adds `RXCROPMATURITY` test to clm_pymods suite, in addition to being run as part of ctsm_sci suite.

### Specific notes

Contributors other than yourself, if any: None

CTSM Issues Fixed: None

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None
