### PR TITLE
Improve robustness of run_python_script()

### DIFF
--- a/cime_config/SystemTests/systemtest_utils.py
+++ b/cime_config/SystemTests/systemtest_utils.py
@@ -5,7 +5,7 @@ Reduce code duplication by putting reused functions here.
 import os, subprocess
 
 
-def cmds_to_setup_conda(caseroot):
+def cmds_to_setup_conda(caseroot, test_conda_retry=True):
     # Add specific commands needed on different machines to get conda available
     # Use semicolon here since it's OK to fail
     #
@@ -19,7 +19,12 @@ def cmds_to_setup_conda(caseroot):
         subprocess.run("which conda", shell=True, check=True)
     except subprocess.CalledProcessError:
         # Remove python and add conda to environment for cheyennne
-        conda_setup_commands += " module unload python; module load conda;"
+        unload_python_load_conda = "module unload python; module load conda;"
+        # Make sure that adding this actually loads conda
+        if test_conda_retry:
+            subprocess.run(unload_python_load_conda + "which conda", shell=True, check=True)
+        # Save
+        conda_setup_commands += " " + unload_python_load_conda
 
     return conda_setup_commands
 

--- a/cime_config/SystemTests/systemtest_utils.py
+++ b/cime_config/SystemTests/systemtest_utils.py
@@ -10,6 +10,9 @@ def cmds_to_setup_conda(caseroot):
     # Use semicolon here since it's OK to fail
     #
     conda_setup_commands = ". " + caseroot + "/.env_mach_specific.sh; "
+    # Setting CONDA_PREFIX to empty ensures that this works even if called from
+    # a shell with a conda environment activated
+    conda_setup_commands += "CONDA_PREFIX=; "
     # Execute the module unload/load when "which conda" fails
     # eg on cheyenne
     try:


### PR DESCRIPTION
Issue #2109: For tests that invoke `cmds_to_setup_conda()`, manually calling the script invoking that function (e.g., `case.build` for `FSURDATMODIFYCTSM`) could fail if doing so with a conda environment already activated. The problem is that
```bash
conda run -n ctsm_pylib ...
```
seems to not actually use ctsm_pylib if, for instance the conda base environment is active. 

Issue #2111: For some users, FSURDATMODIFYCTSM is failing because conda doesn't load.

### Description of changes

Putting `CONDA_PREFIX=;` before the `conda run` command fixes #2109.

### Specific notes

Remaining tasks:
- [ ] Figure out #2111. This may be an environment issue; @ekluzek will work with CISL to investigate.
- [ ] Split up the long list of commands into chunks for better error tracing.
- [ ] Use `subprocess.run(..., shell=False)` instead of `True`

Contributors other than yourself, if any: @adrifoster, @ekluzek 

CTSM Issues Fixed:
- Fixes #2109

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: None so far; will do tests from `aux_clm` that exercise this code (`FSURDATMODIFYCTSM` and `RXCROPMATURITY`). I will ask @adrifoster, @ekluzek, and @rgknox to try `FSURDATMODIFYCTSM` as well, once I have fixes in place.