### PR TITLE
Update to documentation for Meier et al. (2022) roughness length parameterization

### DIFF
--- a/doc/source/tech_note/Fluxes/CLM50_Tech_Note_Fluxes.rst
+++ b/doc/source/tech_note/Fluxes/CLM50_Tech_Note_Fluxes.rst
@@ -785,26 +785,45 @@ The roughness lengths used to calculate :math:`r_{am}` ,
 :math:`r_{ah}` , and :math:`r_{aw}`  are :math:`z_{0m} =z_{0m,\, g}` ,
 :math:`z_{0h} =z_{0h,\, g}` , and :math:`z_{0w} =z_{0w,\, g}` . The
 displacement height :math:`d=0`. The momentum roughness length is
-:math:`z_{0m,\, g} =0.01` for soil, glaciers, and
-:math:`z_{0m,\, g} =0.0024` for snow-covered surfaces
-(:math:`f_{sno} >0`). In general, :math:`z_{0m}`  is different from
-:math:`z_{0h}`  because the transfer of momentum is affected by pressure
-fluctuations in the turbulent waves behind the roughness elements, while
-for heat and water vapor transfer no such dynamical mechanism exists.
-Rather, heat and water vapor must be transferred by molecular diffusion
-across the interfacial sublayer. The following relation from
-:ref:`Zilitinkevich (1970) <Zilitinkevich1970>` is adopted by 
-:ref:`Zeng and Dickinson 1998 <ZengDickinson1998>`
+:math:`z_{0m,\, g} =0.0023` for glaciers without snow (:math:`f_{sno} =0) {\rm }`, and
+:math:`z_{0m,\, g} =0.00085` for bare soil surfaces without snow (:math:`f_{sno} =0) {\rm }` 
+(:ref:`Meier et al. (2022) <Meieretal2022>`).
+
+For bare soil and glaciers with snow ( :math:`f_{sno} > 0` ),
+the momentum roughness length is evaluated based on accumulated snow melt :math:`M_{a} {\rm }` (:ref:`Meier et al. (2022) <Meieretal2022>`).
+For :math:`M_{a} >=1\times 10^{-5}`
+
+.. math::
+   :label: 5.81a
+
+   z_{0m,\, g} =\exp (b_{1} \tan ^{-1} \left[\frac{log_{10} (M_{a}) + 0.23)} {0.08}\right] + b_{4})\times 10^{-3}
+
+where :math:`M_{a}` is accumulated snow melt (meters water equivalent), :math:`b_{1} =1.4` and :math:`b_{4} =-0.31`.
+For :math:`M_{a} <1\times 10^{-5}`
+
+.. math::
+   :label: 5.81b
+
+   z_{0m,\, g} =\exp (-b_{1} 0.5 \pi + b_{4})\times 10^{-3}
+
+Accumulated snow melt :math:`M_{a}` at the current time step :math:`t` is defined as
+
+.. math::
+   :label: 5.81c
+
+   M ^{t}_{a} = M ^{t-1}_{a} - (q ^{t}_{sno} \Delta t + q ^{t}_{snowmelt} \Delta t)\times 10^{-3}
+
+where :math:`M ^{t}_{a}` and :math:`M ^{t-1}_{a}` are the accumulated snowmelt at the current time step and previous time step, respectively (m), :math:`q ^{t}_{sno} \Delta t` is the freshly fallen snow (mm), and :math:`q ^{t}_{snowmelt} \Delta t` is the melted snow (mm).
+
+The scalar roughness lengths (:math:`z_{0q,\, g}` for latent heat and :math:`z_{0h,\ g}` for sensible heat) are calculated
+as (:ref:`Meier et al. (2022) <Meieretal2022>`)
 
 .. math::
    :label: 5.82
 
-   z_{0h,\, g} =z_{0w,\, g} =z_{0m,\, g} e^{-a\left({u_{*} z_{0m,\, g} \mathord{\left/ {\vphantom {u_{*} z_{0m,\, g}  \upsilon }} \right. \kern-\nulldelimiterspace} \upsilon } \right)^{0.45} }
+   z_{0h,\, g}=z_{0q,\, g}=\frac{70 \nu}{u_{*}} \exp (-\beta {u_{*}} ^{0.5} |{\theta_{*}}| ^{0.25} )
 
-where the quantity
-:math:`{u_{\*} z_{0m,\, g} \mathord{\left/ {\vphantom {u_{*} z_{0m,\, g}  \upsilon }} \right. \kern-\nulldelimiterspace} \upsilon }` 
-is the roughness Reynolds number (and may be interpreted as the Reynolds number of the smallest turbulent eddy in the flow) with the kinematic
-viscosity of air :math:`\upsilon =1.5\times 10^{-5}`  m\ :sup:`2` s\ :sup:`-1` and :math:`a=0.13`.
+where :math:`\beta` = 7.2, and :math:`\theta_{*}` is the potential temperature scale.
 
 The numerical solution for the fluxes of momentum, sensible heat, and
 water vapor flux from non-vegetated surfaces proceeds as follows:
@@ -828,7 +847,7 @@ water vapor flux from non-vegetated surfaces proceeds as follows:
 #. Humidity scale :math:`q_{*}`  (:eq:`5.41`, :eq:`5.42`, :eq:`5.43`, :eq:`5.44`)
 
 #. Roughness lengths for sensible :math:`z_{0h,\, g}`  and latent heat
-   :math:`z_{0w,\, g}`  (:eq:`5.82` )
+   :math:`z_{0w,\, g}`  (:eq:`5.81a` , :eq:`5.81b` , :eq:`5.82`)
 
 #. Virtual potential temperature scale :math:`\theta _{v*}`  ( :eq:`5.17`)
 
@@ -1264,101 +1283,153 @@ determined analytically, are ignored for
 The roughness lengths used to calculate :math:`r_{am}` ,
 :math:`r_{ah}` , and :math:`r_{aw}`  from :eq:`5.55`, :eq:`5.56`, and :eq:`5.57` are
 :math:`z_{0m} =z_{0m,\, v}` , :math:`z_{0h} =z_{0h,\, v}` , and
-:math:`z_{0w} =z_{0w,\, v}` . The vegetation displacement height
-:math:`d` and the roughness lengths are a function of plant height and
-adjusted for canopy density following :ref:`Zeng and Wang (2007) <ZengWang2007>`
+:math:`z_{0w} =z_{0w,\, v}` . 
+
+The vegetation roughness lengths and displacement height :math:`d` 
+are from :ref:`Meier et al. (2022) <Meieretal2022>`
 
 .. math::
    :label: 5.125
 
-   z_{0m,\, v} = z_{0h,\, v} =z_{0w,\, v} =\exp \left[V\ln \left(z_{top} R_{z0m} \right)+\left(1-V\right)\ln \left(z_{0m,\, g} \right)\right]
-
-.. math::
-   :label: 5.126 
-
-   d = z_{top} R_{d} V
+   z_{0m,\, v} = z_{0h,\, v} =z_{0w,\, v} = z_{top} (1 - \frac{d} {z_{top} } ) \exp (\psi_{h} - \frac{k U_{h}} {u_{*} } )
 
 where :math:`z_{top}`  is canopy top height (m) 
-(:numref:`Table Plant functional type canopy top and bottom heights`),
-:math:`R_{z0m}`  and :math:`R_{d}`  are the ratio of momentum roughness
-length and displacement height to canopy top height, respectively 
-(:numref:`Table Plant functional type aerodynamic parameters`), and :math:`z_{0m,\, g}` 
-is the ground momentum roughness length (m) (section 
-:numref:`Sensible and Latent Heat Fluxes for Non-Vegetated Surfaces`). The 
-fractional weight :math:`V` is determined from
+(:numref:`Table Plant functional type canopy top and bottom heights`), 
+:math:`k` is the von Karman constant (:numref:`Table Physical constants`),
+and :math:`\psi_{h}` is the roughness sublayer influence function
 
 .. math::
-   :label: 5.127 
+   :label: 5.125a
 
-   V = \frac{1-\exp \left\{-\beta \min \left[L+S,\, \left(L+S\right)_{cr} \right]\right\}}{1-\exp \left[-\beta \left(L+S\right)_{cr} \right]}
+   \psi_{h} = \ln(c_{w}) - 1 + c_{w}^{-1}
 
-where :math:`\beta =1` and :math:`\left(L+S\right)_{cr} = 2` 
-(m\ :sup:`2` m\ :sup:`-2`) is a critical value of exposed leaf
-plus stem area for which :math:`z_{0m}`  reaches its maximum.
+where :math:`c_{w}` is a pft-dependent constant (:numref:`Table Plant functional type aerodynamic parameters`).
+
+The ratio of wind speed at canopy height to friction velocity, :math:`\frac{U_{h}} {u_{*}}` is derived from an
+implicit function of the roughness density :math:`\lambda`
+
+.. math::
+   :label: 5.125b
+
+   \frac{U_{h}} {u_{*} } =(C_{S} + \lambda C_{R})^{0.5} \exp(\frac{\min \left(\lambda, \lambda_{\max}\right) c U_{h}} {2 u_{*}})
+
+where :math:`C_{S}` represents the drag coefficient of the ground in the absence of vegetation,
+:math:`C_{R}` is the drag coefficient of an isolated roughness element (plant), and :math:`c` is an empirical constant.
+These three are pft-dependent parameters (:numref:`Table Plant functional type aerodynamic parameters`).
+:math:`\lambda_{max}` is the maximum :math:`\lambda` above which :math:`\frac{U_{h}} {u_{*}}` becomes constant.
+:math:`\lambda_{max}` is set to the value of :math:`\lambda` for which :eq:`5.125b`, in the absence of :math:`\lambda_{max}`, 
+would have its minimum. :math:`\lambda_{max}` is also a pft-dependent parameter (:numref:`Table Plant functional type aerodynamic parameters`).
+:eq:`5.125b` can be written as
+
+.. math::
+   :label: 5.125c
+
+   X \exp(-X) =(C_{S} + \lambda C_{R})^{0.5} c \frac{\lambda} {2 }
+
+where 
+
+.. math::
+   :label: 5.125d
+
+   X =\frac{c \lambda U_{h}} {2 u_{*} }.
+
+:math:`X` and therefore :math:`\frac{U_{h}} {u_{*}}` can be solved for iteratively where the initial value of :math:`X` is 
+
+.. math::
+   :label: 5.125e
+
+   X_{i=0} =(C_{S} + \lambda C_{R})^{0.5} c \frac{\lambda} {2 }
+
+and the next value of :math:`X` at :math:`i+1` is
+
+.. math::
+   :label: 5.125f
+
+   X_{i+1} =(C_{S} + \lambda C_{R})^{0.5} c \frac{\lambda} {2 } \exp(X_{i}).
+
+:math:`X` is updated until :math:`\frac{U_{h}} {u_{*}}` converges to within :math:`1 \times 10^{-4}` between iterations.
+
+:math:`\lambda` is set to half the total single-sided area of all canopy elements, 
+here defined as the vegetation area index (VAI) defined as the sum of leaf (:math:`L`) and stem area index (:math:`S`),
+subject to a maximum of :math:`\lambda_{max}` and a minimum limit applied for numerical stability
+
+.. math::
+   :label: 5.126
+   
+   \lambda = \frac{\min(\max(1 \times 10^{-5}, VAI), \lambda_{max})} {2 }
+
+The displacement height :math:`d` is
+
+.. math::
+   :label: 5.127
+
+   d = z_{top}\left[1- \frac{1-\exp(-(c_{d1} 2 \lambda)^{0.5}} {(c_{d1} 2 \lambda)^{0.5} }\right]
+
+where :math:`c_{d1} =7.5`.
 
 .. _Table Plant functional type aerodynamic parameters:
 
 .. table:: Plant functional type aerodynamic parameters
 
- +----------------------------------+--------------------+------------------+-------------------------+
- | Plant functional type            | :math:`R_{z0m}`    | :math:`R_{d}`    | :math:`d_{leaf}`  (m)   |
- +==================================+====================+==================+=========================+
- | NET Temperate                    | 0.055              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | NET Boreal                       | 0.055              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | NDT Boreal                       | 0.055              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BET Tropical                     | 0.075              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BET temperate                    | 0.075              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BDT tropical                     | 0.055              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BDT temperate                    | 0.055              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BDT boreal                       | 0.055              | 0.67             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BES temperate                    | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BDS temperate                    | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | BDS boreal                       | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | C\ :sub:`3` arctic grass         | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | C\ :sub:`3` grass                | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | C\ :sub:`4` grass                | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Crop R                           | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Crop I                           | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Corn R                           | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Corn I                           | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Temp Cereal R                    | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Temp Cereal I                    | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Winter Cereal R                  | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Winter Cereal I                  | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Soybean R                        | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Soybean I                        | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Miscanthus R                     | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Miscanthus I                     | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Switchgrass R                    | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
- | Switchgrass I                    | 0.120              | 0.68             | 0.04                    |
- +----------------------------------+--------------------+------------------+-------------------------+
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Plant functional type            | :math:`d_{leaf}`  (m) | :math:`c_{w}`           | :math:`C_{S}`           | :math:`C_{R}`           | :math:`c`               | :math:`\lambda_{max}`   |
+ +==================================+=======================+=========================+=========================+=========================+=========================+=========================+
+ | NET Temperate                    | 0.04                  | 9                       | 0.003                   | 0.05                    | 0.09                    | 4.55                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | NET Boreal                       | 0.04                  | 9                       | 0.003                   | 0.05                    | 0.09                    | 4.55                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | NDT Boreal                       | 0.04                  | 9                       | 0.003                   | 0.05                    | 0.09                    | 4.55                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BET Tropical                     | 0.04                  | 3                       | 0.01                    | 0.14                    | 0.01                    | 7.87                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BET temperate                    | 0.04                  | 3                       | 0.01                    | 0.14                    | 0.01                    | 7.87                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BDT tropical                     | 0.04                  | 1                       | 0.013                   | 0.13                    | 0.06                    | 8.88                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BDT temperate                    | 0.04                  | 1                       | 0.013                   | 0.13                    | 0.06                    | 8.88                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BDT boreal                       | 0.04                  | 1                       | 0.013                   | 0.13                    | 0.06                    | 8.88                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BES temperate                    | 0.04                  | 20                      | 0.001                   | 0.05                    | 0.12                    | 3.07                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BDS temperate                    | 0.04                  | 20                      | 0.001                   | 0.05                    | 0.12                    | 3.07                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | BDS boreal                       | 0.04                  | 20                      | 0.001                   | 0.05                    | 0.12                    | 3.07                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | C\ :sub:`3` arctic grass         | 0.04                  | 19                      | 0.001                   | 0.05                    | 0.08                    | 4.61                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | C\ :sub:`3` grass                | 0.04                  | 19                      | 0.001                   | 0.05                    | 0.08                    | 4.61                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | C\ :sub:`4` grass                | 0.04                  | 19                      | 0.001                   | 0.05                    | 0.08                    | 4.61                    |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Crop R                           | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Crop I                           | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Corn R                           | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Corn I                           | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Temp Cereal R                    | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Temp Cereal I                    | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Winter Cereal R                  | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Winter Cereal I                  | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Soybean R                        | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Soybean I                        | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Miscanthus R                     | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Miscanthus I                     | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Switchgrass R                    | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
+ | Switchgrass I                    | 0.04                  | 3.5                     | 0.001                   | 0.05                    | 0.04                    | 5.3                     |
+ +----------------------------------+-----------------------+-------------------------+-------------------------+-------------------------+-------------------------+-------------------------+
  
 .. _Numerical Implementation:
 

--- a/doc/source/tech_note/Lake/CLM50_Tech_Note_Lake.rst
+++ b/doc/source/tech_note/Lake/CLM50_Tech_Note_Lake.rst
@@ -144,41 +144,22 @@ fraction (1 :math:`{-}` :math:`\beta`) is absorbed in the lake
 body or soil as described in section :numref:`Radiation Penetration`.
 
 The surface roughnesses are functions of the lake state and atmospheric
-forcing. For frozen lakes ( :math:`T_{g} \le T_{f}` ) with resolved
-snow layers, the momentum roughness length
-:math:`z_{0m} =2.4 \times 10^{-3} {\rm m}` (as over non-vegetated
-surfaces; Chapter :numref:`rst_Momentum, Sensible Heat, and Latent Heat Fluxes`), and the scalar roughness lengths
-(*z*\ :sub:`0q` for latent heat; and *z*\ :sub:`0h`, for sensible heat) are given by
-(:ref:`Zilitinkevich 1970<Zilitinkevich1970>`)
+forcing. 
+
+For unfrozen lakes (:math:`T_{g} > T_{f}`), :math:`z_{0m}` is given by (:ref:`Subin et al. (2012a) <Subinetal2012a>`)
 
 .. math::
    :label: 12.3
-
-   \begin{array}{l} {R_{0} =\frac{z_{0m} u_{*} }{\nu } ,} \\ {z_{0h} =z_{0q} =z_{0m} \exp \left\{-0.13R_{0} ^{0.45} \right\}} \end{array}
-
-where :math:`R_{0}` is the near-surface atmospheric roughness
-Reynolds number, :math:`z_{0h}` is the roughness
-length for sensible heat,  :math:`z_{0q}` is the
-roughness length for latent heat, :math:`\nu` (m\ :sup:`2` s\ :sup:`-1`) is the kinematic viscosity of air, and
-:math:`u_{\*}`  (m s\ :sup:`-1`) is the friction velocity in the
-atmospheric surface layer. For frozen lakes without resolved snow
-layers, :math:`z_{0m} =1\times 10^{-3} {\rm m}` (:ref:`Subin et al. (2012a) <Subinetal2012a>`),
-and the scalar roughness lengths are given by .
-
-For unfrozen lakes, *z*\ :sub:`0m` is given by (:ref:`Subin et al. (2012a) <Subinetal2012a>`)
-
-.. math::
-   :label: 12.4
 
    z_{0m} =\max \left(\frac{\alpha \nu }{u_{*} } ,C\frac{u_{*} ^{2} }{g} \right)
 
 where :math:`\alpha` = 0.1, :math:`\nu` is the kinematic viscosity
 of air given below, *C* is the effective Charnock coefficient given
-below, and *g* is the acceleration of gravity (:numref:`Table Physical Constants`). The kinematic
+below, :math:`u_{*}` is the friction velocity (m/s), and *g* is the acceleration of gravity (:numref:`Table Physical Constants`). The kinematic
 viscosity is given by
 
 .. math::
-   :label: 12.5 
+   :label: 12.4 
 
    \nu =\nu _{0} \left(\frac{T_{g} }{T_{0} } \right)^{1.5} \frac{P_{0} }{P_{ref} }
 
@@ -192,7 +173,7 @@ height. The Charnock coefficient *C* is a function of the lake fetch *F*
 default:
 
 .. math::
-   :label: 12.6 
+   :label: 12.5 
 
    \begin{array}{l} {C=C_{\min } +(C_{\max } -C_{\min } )\exp \left\{-\min \left(A,B\right)\right\}} \\ {A={\left(\frac{Fg}{u_{\*} ^{2} } \right)^{{1\mathord{\left/ {\vphantom {1 3}} \right. \kern-\nulldelimiterspace} 3} } \mathord{\left/ {\vphantom {\left(\frac{Fg}{u_{\*} ^{2} } \right)^{{1\mathord{\left/ {\vphantom {1 3}} \right. \kern-\nulldelimiterspace} 3} }  f_{c} }} \right. \kern-\nulldelimiterspace} f_{c} } } \\ {B=\varepsilon \frac{\sqrt{dg} }{u} } \end{array}
 
@@ -200,6 +181,65 @@ where *A* and *B* define the fetch- and depth-limitation, respectively;
 :math:`C_{\min } =0.01` , :math:`C_{\max } =0.01`,
 :math:`\varepsilon =1` , :math:`f_{c} =100` , and *u* (m
 s\ :sup:`-1`) is the atmospheric forcing wind.
+
+The scalar roughness lengths
+(:math:`z_{0q}` for latent heat and :math:`z_{0h}` for sensible heat) are given by
+(:ref:`Subin  et al. 2012a<Subinetal2012a>`)
+
+.. math::
+   :label: 12.5a
+
+   \begin{array}{l} {R_{0} =(\frac{z_{0m} u_{*} }{\nu })^{0.5} ,} \\ {z_{0h} =z_{0m} \exp \left\{-\frac{k} {Pr} (4 R_{0} ^{0.5} -3.2) \right\},} \\ {z_{0q} =z_{0m} \exp \left\{-\frac{k} {Sc} (4 R_{0} ^{0.5} - 4.2) \right\}}\end{array}
+
+where :math:`R_{0}` is the near-surface atmospheric roughness Reynolds number, :math:`k` is the von Karman constant (:numref:`Table Physical Constants`), :math:`Pr = 0.713` is the molecular Prandt number for air at neutral stability, :math:`Sc = 0.66` is the Schmidt number for water in air at neutral stability.
+:math:`z_{0q}` and :math:`z_{0h}` are restricted to be no smaller than :math:`1 \times 10^{-10}`.
+
+For frozen lakes ( :math:`T_{g} \le T_{f}` ) without resolved snow
+layers ( :math:`snl = 0` ), :math:`z_{0m} =z_{0m_{ice}} =2.3\times 10^{-3} {\rm m}` (:ref:`Meier et al. (2022) <Meieretal2022>`).
+
+For frozen lakes with resolved
+snow layers ( :math:`snl > 0` ), the momentum roughness length is evaluated based on accumulated snow melt :math:`M_{a} {\rm }` (:ref:`Meier et al. (2022) <Meieretal2022>`). 
+For :math:`M_{a} >=1\times 10^{-5}`
+
+.. math::
+   :label: 12.5b
+
+   z_{0m} =\exp (b_{1} \tan ^{-1} \left[\frac{log_{10} (M_{a}) + 0.23)} {0.08}\right] + b_{4})\times 10^{-3}
+
+where :math:`M_{a}` is accumulated snow melt (meters water equivalent), :math:`b_{1} =1.4` and :math:`b_{4} =-0.31`.
+For :math:`M_{a} <1\times 10^{-5}`
+
+.. math::
+   :label: 12.5c
+
+   z_{0m} =\exp (-b_{1} 0.5 \pi + b_{4})\times 10^{-3}
+
+Accumulated snow melt :math:`M_{a}` at the current time step :math:`t` is defined as
+
+.. math::
+   :label: 12.5d   
+
+   M ^{t}_{a} = M ^{t-1}_{a} - (q ^{t}_{sno} \Delta t + q ^{t}_{snowmelt} \Delta t)\times 10^{-3}
+
+where :math:`M ^{t}_{a}` and :math:`M ^{t-1}_{a}` are the accumulated snowmelt at the current time step and previous time step, respectively (m), :math:`q ^{t}_{sno} \Delta t` is the freshly fallen snow (mm), and :math:`q ^{t}_{snowmelt} \Delta t` is the melted snow (mm).
+
+For frozen lakes without and with resolved snow layers, an initial guess for the scalar roughness lengths is derived by assuming :math:`\theta_{*} = 0 {\rm }` (:ref:`Meier et al. (2022) <Meieretal2022>`)
+
+.. math::
+   :label: 12.5e
+
+   z_{0h}=z_{0q}=\frac{70 \nu}{u_{*}}
+
+where :math:`\nu=1.5 \times 10^{-5}` is the kinematic viscosity of air (m\ :sup:`2`  s\ :sup:`-1`), and
+:math:`u_{*}` is the friction velocity in the atmospheric surface layer (m s\ :sup:`-1`).
+Thereafter, the scalar roughness lengths are updated within the stability iteration described in section :numref:`Surface Flux Solution Lake` as
+
+.. math::
+   :label: 12.6
+
+   z_{0h}=z_{0q}=\frac{70 \nu}{u_{*}} \exp (-\beta {u_{*}} ^{0.5} |{\theta_{*}}| ^{0.25} )
+
+where :math:`\beta` = 7.2, and :math:`\theta_{*}` is the potential temperature scale (section :numref:`Surface Flux Solution Lake`).
 
 .. _Surface Flux Solution Lake:
 
@@ -380,15 +420,9 @@ where the partial derivatives are
    \frac{\partial G}{\partial T_{g} } =\frac{2\lambda _{T} }{\Delta z_{T} } .
 
 The fluxes of momentum, sensible heat, and water vapor are solved for
-simultaneously with lake surface temperature as follows. The
-stability-related equations are the same as for non-vegetated surfaces
-(section :numref:`Sensible and Latent Heat Fluxes for Non-Vegetated Surfaces`), 
-except that the surface roughnesses are here (weakly varying) functions 
-of the friction velocity :math:`u_{\*}` . To begin, *z*\ :sub:`0m` is set 
-based on the value calculated for the last timestep (for 
-:math:`T_{g} >T_{f}` ) or based on the values in section 
-:numref:`Surface Properties Lake` (otherwise), and the scalar roughness
-lengths are set based on the relationships in section :numref:`Surface Properties Lake`.
+simultaneously with lake surface temperature as follows.
+To begin, :math:`z_{0m}` and the scalar roughness
+lengths are set as described in section :numref:`Surface Properties Lake`.
 
 #. An initial guess for the wind speed :math:`V_{a}`  including the
    convective velocity :math:`U_{c}`  is obtained from :eq:`5.24` assuming an
@@ -444,7 +478,7 @@ iterations.
 
 #. Monin-Obukhov length :math:`L` (:eq:`5.49`)
 
-#. Roughness lengths (:eq:`12.3`, :eq:`12.4`).
+#. Roughness lengths (section :numref:`Surface Properties Lake`).
 
 Once the four iterations for lake surface temperature have been yielded
 a tentative solution :math:`T_{g} ^{{'} }` , several restrictions

--- a/doc/source/tech_note/References/CLM50_Tech_Note_References.rst
+++ b/doc/source/tech_note/References/CLM50_Tech_Note_References.rst
@@ -1341,6 +1341,15 @@ Wingate, L., 2011. Reconciling the optimal and empirical approaches to
 modelling stomatal conductance. Global Change Biology, 17: 2134–2144.
 doi:10.1111/j.1365-2486.2010.02375.x
 
+.. _Meieretal2022:
+
+Meier, R., Davin, E. L., Bonan, G. B., Lawrence, D. M., Hu, X.,
+Duveiller, G., Prigent, C., and Seneviratne, S. I., 2022. Impacts of a
+revised surface roughness parameterization in the Community Land Model
+5.1, Geosci. Model Dev., 15, 2365–2393,
+https://doi.org/10.5194/gmd-15-2365-2022
+
+
 .. _MelzerOLeary1987:
 
 Melzer, E., and O’Leary, M.H. 1987. Anapleurotic CO2 Fixation by


### PR DESCRIPTION
### Description of changes

Update documentation for Meier et al. (2022) roughness length parameterization

### Specific notes

Fluxes, Lakes, and References chapters updated.
I believe I've fixed the CRLF problem created by my windows machine.  These are now line feeds (LF) as they are in unix systems and the repository.  I've built the documentation and pushed it to gh-pages and it looks fine.

Contributors other than yourself, if any:  @slevis-lmwg 

CTSM Issues Fixed (include github issue #):  Partial #2113

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:
Built new documentation on local machine.
Pushed new documentation to gh-pages.
