### PR TITLE
Rearrange calculation of leaf/livestem C and N to biofuels/litter

### DIFF
--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -3136,6 +3136,10 @@ contains
                   leafc_to_litter(p)  = t1 * leafc_remaining  + cpool_to_leafc(p)
                   livestemc_to_litter(p)   = t1 * livestemc_remaining  + cpool_to_livestemc(p)
                   livestemn_to_litter(p)   = t1 * livestemn_remaining
+                  ! Sam Rabin 2023-09-11:
+                  ! leafn_to_litter is calculated below based on leafc_to_litter (updated above)
+                  ! as well as leaf C:N ratio (unaffected by biofuel harvest). It thus does not
+                  ! need to be updated here.
 
                   ! Matrix for grain, livestem to litter and biofuel
                   if(use_matrixcn)then

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2980,6 +2980,7 @@ contains
     real(r8) :: cropseedn_deficit_to_restore ! amount of crop seed N deficit that will be restored from this grain pool (gN/m2)
     real(r8) :: repr_grainc_to_food_thispool ! amount added to / subtracted from repr_grainc_to_food for the pool in question (gC/m2/s)
     real(r8) :: leafc_remaining, livestemc_remaining
+    real(r8) :: leafn_remaining, livestemn_remaining
     !-----------------------------------------------------------------------
 
     associate(                                                                           & 
@@ -3123,15 +3124,18 @@ contains
                   leafc_to_biofuelc(p) = t1 * leafc(p) * biofuel_harvfrac(ivt(p))
                   leafc_remaining = leafc(p)*(1._r8-biofuel_harvfrac(ivt(p)))
                   leafn_to_biofueln(p) = t1 * leafn(p) * biofuel_harvfrac(ivt(p))
+                  leafn_remaining = leafn(p)*(1._r8-biofuel_harvfrac(ivt(p)))
 
                   ! Cut a certain fraction (i.e., biofuel_harvfrac(ivt(p))) (e.g., biofuel_harvfrac(ivt(p)=70% for bioenergy crops) of livestem C
                   ! and move this fration of leaf C to biofuel C, rather than move it to litter
                   livestemc_to_biofuelc(p) = t1 * livestemc(p) * biofuel_harvfrac(ivt(p))
                   livestemn_to_biofueln(p) = t1 * livestemn(p) * biofuel_harvfrac(ivt(p))
                   livestemc_remaining = livestemc(p)*(1._r8-biofuel_harvfrac(ivt(p)))
+                  livestemn_remaining = livestemn(p)*(1._r8-biofuel_harvfrac(ivt(p)))
 
                   leafc_to_litter(p)  = t1 * leafc_remaining  + cpool_to_leafc(p)
                   livestemc_to_litter(p)   = t1 * livestemc_remaining  + cpool_to_livestemc(p)
+                  livestemn_to_litter(p)   = t1 * livestemn_remaining
 
                   ! Matrix for grain, livestem to litter and biofuel
                   if(use_matrixcn)then
@@ -3267,18 +3271,6 @@ contains
                      ! Matrix update for frootn to litter
                   end if
                endif    
-            end if
-
-            if (ivt(p) >= npcropmin) then
-               ! NOTE(slevis, 2014-12) results in -ve livestemn and -ve totpftn
-               !X! livestemn_to_litter(p) = livestemc_to_litter(p) / livewdcn(ivt(p))
-               ! NOTE(slevis, 2014-12) Beth Drewniak suggested this instead
-               livestemn_to_litter(p) = livestemn(p) / dt * (1._r8 - biofuel_harvfrac(ivt(p)))
-
-               ! Matrix update for livestemn to litter
-               if(use_matrixcn)then
-               else
-               end if
             end if
 
             ! save the current litterfall fluxes

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2979,6 +2979,7 @@ contains
     real(r8) :: cropseedc_deficit_to_restore ! amount of crop seed C deficit that will be restored from this grain pool (gC/m2)
     real(r8) :: cropseedn_deficit_to_restore ! amount of crop seed N deficit that will be restored from this grain pool (gN/m2)
     real(r8) :: repr_grainc_to_food_thispool ! amount added to / subtracted from repr_grainc_to_food for the pool in question (gC/m2/s)
+    real(r8) :: leafc_remaining, livestemc_remaining
     !-----------------------------------------------------------------------
 
     associate(                                                                           & 
@@ -3120,15 +3121,17 @@ contains
                   ! Cut a certain fraction (i.e., biofuel_harvfrac(ivt(p))) (e.g., biofuel_harvfrac(ivt(p)=70% for bioenergy crops) of leaf C
                   ! and move this fration of leaf C to biofuel C, rather than move it to litter
                   leafc_to_biofuelc(p) = t1 * leafc(p) * biofuel_harvfrac(ivt(p))
+                  leafc_remaining = leafc(p)*(1._r8-biofuel_harvfrac(ivt(p)))
                   leafn_to_biofueln(p) = t1 * leafn(p) * biofuel_harvfrac(ivt(p))
 
                   ! Cut a certain fraction (i.e., biofuel_harvfrac(ivt(p))) (e.g., biofuel_harvfrac(ivt(p)=70% for bioenergy crops) of livestem C
                   ! and move this fration of leaf C to biofuel C, rather than move it to litter
-                  livestemc_to_litter(p)   = t1 * livestemc(p)*(1._r8-biofuel_harvfrac(ivt(p)))  + cpool_to_livestemc(p)
                   livestemc_to_biofuelc(p) = t1 * livestemc(p) * biofuel_harvfrac(ivt(p))
                   livestemn_to_biofueln(p) = t1 * livestemn(p) * biofuel_harvfrac(ivt(p))
+                  livestemc_remaining = livestemc(p)*(1._r8-biofuel_harvfrac(ivt(p)))
 
-                  leafc_to_litter(p)  = t1 * leafc(p)*(1._r8-biofuel_harvfrac(ivt(p)))  + cpool_to_leafc(p)
+                  leafc_to_litter(p)  = t1 * leafc_remaining  + cpool_to_leafc(p)
+                  livestemc_to_litter(p)   = t1 * livestemc_remaining  + cpool_to_livestemc(p)
 
                   ! Matrix for grain, livestem to litter and biofuel
                   if(use_matrixcn)then

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -3056,9 +3056,6 @@ contains
                t1 = 1.0_r8 / dt
                frootc_to_litter(p) = t1 * frootc(p) + cpool_to_frootc(p)
                
-               ! biofuel_harvfrac is only non-zero for prognostic crops.
-               leafc_to_litter(p)  = t1 * leafc(p)*(1._r8-biofuel_harvfrac(ivt(p)))  + cpool_to_leafc(p)
-
                ! leafc_litter and frootc_to_litter for matrix
                if (use_matrixcn) then
                else
@@ -3130,6 +3127,8 @@ contains
                   livestemc_to_litter(p)   = t1 * livestemc(p)*(1._r8-biofuel_harvfrac(ivt(p)))  + cpool_to_livestemc(p)
                   livestemc_to_biofuelc(p) = t1 * livestemc(p) * biofuel_harvfrac(ivt(p))
                   livestemn_to_biofueln(p) = t1 * livestemn(p) * biofuel_harvfrac(ivt(p))
+
+                  leafc_to_litter(p)  = t1 * leafc(p)*(1._r8-biofuel_harvfrac(ivt(p)))  + cpool_to_leafc(p)
 
                   ! Matrix for grain, livestem to litter and biofuel
                   if(use_matrixcn)then


### PR DESCRIPTION
### Description of changes

This PR rearranges the calculation of how much leaf and livestem C and N goes to biofuels vs. litter, in anticipation of me adding crop residue removal. This PR also makes the affected subroutine easier to read.

### Specific notes

Specifically, this PR introduces four new variables in `CNOffsetLitterfall()`:
- `leafc_remaining`
- `leafn_remaining`
- `livestemc_remaining`
- `livestemn_remaining`

Those variables are initialized with the pool remaining after biofuel harvest. When I introduce crop residue removal, it will be able to act on (and update) those variables directly.

**Contributors other than yourself, if any:** @billsacks, @ekluzek 

**CTSM Issues Fixed:** None

**Are answers expected to change (and if so in what way)?** Yes, but only roundoff-level due to order-of-operations changes.

**Any User Interface Changes (namelist or namelist defaults changes)?** No.

**Testing performed:** `aux_clm` showed diffs from `ctsm5.1.dev132`.
