### PR TITLE
Add is_doy_in_interval() function

### DIFF
--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1726,6 +1726,7 @@ contains
     use clm_time_manager , only : get_prev_calday, get_curr_days_per_year, is_beg_curr_year
     use clm_time_manager , only : get_average_days_per_year
     use clm_time_manager , only : get_prev_date
+    use clm_time_manager , only : is_doy_in_interval
     use pftconMod        , only : ntmp_corn, nswheat, nwwheat, ntmp_soybean
     use pftconMod        , only : nirrig_tmp_corn, nirrig_swheat, nirrig_wwheat, nirrig_tmp_soybean
     use pftconMod        , only : ntrp_corn, nsugarcane, ntrp_soybean, ncotton, nrice
@@ -1930,7 +1931,7 @@ contains
          end if
 
          ! This is outside the croplive check so that the "harvest if planting conditions were met today" conditional works.
-         is_in_sowing_window = jday >= minplantjday(ivt(p),h) .and. jday <= maxplantjday(ivt(p),h)
+         is_in_sowing_window = is_doy_in_interval(minplantjday(ivt(p),h), maxplantjday(ivt(p),h), jday)
          is_end_sowing_window = jday == maxplantjday(ivt(p),h)
          !
          ! Only allow sowing according to normal "window" rules if not using prescribed

--- a/src/utils/clm_time_manager.F90
+++ b/src/utils/clm_time_manager.F90
@@ -59,6 +59,7 @@ module clm_time_manager
         is_beg_curr_year,         &! return true on first timestep in current year
         is_end_curr_year,         &! return true on last timestep in current year
         is_perpetual,             &! return true if perpetual calendar is in use
+        is_doy_in_interval,       &! return true if day of year is in the provided interval
         is_near_local_noon,       &! return true if near local noon
         is_restart,               &! return true if this is a restart run
         update_rad_dtime,         &! track radiation interval via nstep
@@ -1756,6 +1757,44 @@ contains
     is_perpetual = tm_perp_calendar
 
   end function is_perpetual
+
+  !=========================================================================================
+
+  logical function is_doy_in_interval(start, end, doy_in)
+
+    ! Return true if day of year is in the provided interval.
+    ! Does not treat leap years differently from normal years.
+    ! Arguments
+    integer, intent(in) :: start ! start of interval (day of year)
+    integer, intent(in) :: end ! end of interval (day of year)
+    integer, optional, intent(in) :: doy_in ! day of year to query
+    
+    ! Local variables
+    integer :: doy
+    logical :: window_crosses_newyear
+
+    character(len=*), parameter :: sub = 'clm::is_doy_in_interval'
+
+    ! Get doy of beginning of current timestep if doy_in is not provided
+    if (present(doy_in)) then
+       doy = doy_in
+    else
+       doy = get_prev_calday()
+    end if
+
+    window_crosses_newyear = end < start
+
+    if (window_crosses_newyear .and. &
+        (doy >= start .or. doy <= end)) then
+       is_doy_in_interval = .true.
+    else if (.not. window_crosses_newyear .and. &
+        (doy >= start .and. doy <= end)) then
+       is_doy_in_interval = .true.
+    else
+       is_doy_in_interval = .false.
+    end if
+    
+  end function is_doy_in_interval
 
   !=========================================================================================
 

--- a/src/utils/clm_time_manager.F90
+++ b/src/utils/clm_time_manager.F90
@@ -60,6 +60,7 @@ module clm_time_manager
         is_end_curr_year,         &! return true on last timestep in current year
         is_perpetual,             &! return true if perpetual calendar is in use
         is_doy_in_interval,       &! return true if day of year is in the provided interval
+        is_today_in_doy_interval, &! return true if today's day of year is in the provided interval
         is_near_local_noon,       &! return true if near local noon
         is_restart,               &! return true if this is a restart run
         update_rad_dtime,         &! track radiation interval via nstep
@@ -1760,27 +1761,19 @@ contains
 
   !=========================================================================================
 
-  logical function is_doy_in_interval(start, end, doy_in)
+  logical function is_doy_in_interval(start, end, doy)
 
     ! Return true if day of year is in the provided interval.
     ! Does not treat leap years differently from normal years.
     ! Arguments
     integer, intent(in) :: start ! start of interval (day of year)
     integer, intent(in) :: end ! end of interval (day of year)
-    integer, optional, intent(in) :: doy_in ! day of year to query
+    integer, intent(in) :: doy ! day of year to query
     
     ! Local variables
-    integer :: doy
     logical :: window_crosses_newyear
 
     character(len=*), parameter :: sub = 'clm::is_doy_in_interval'
-
-    ! Get doy of beginning of current timestep if doy_in is not provided
-    if (present(doy_in)) then
-       doy = doy_in
-    else
-       doy = get_prev_calday()
-    end if
 
     window_crosses_newyear = end < start
 
@@ -1795,6 +1788,28 @@ contains
     end if
     
   end function is_doy_in_interval
+
+  !=========================================================================================
+
+  logical function is_today_in_doy_interval(start, end)
+
+    ! Return true if today's day of year is in the provided interval.
+    ! Does not treat leap years differently from normal years.
+    ! Arguments
+    integer, intent(in) :: start ! start of interval (day of year)
+    integer, intent(in) :: end ! end of interval (day of year)
+
+    ! Local variable(s)
+    integer :: doy_today
+
+    character(len=*), parameter :: sub = 'clm::is_today_in_doy_interval'
+
+    ! Get doy of beginning of current timestep
+    doy_today = get_prev_calday()
+
+    is_today_in_doy_interval = is_doy_in_interval(start, end, doy_today)
+
+  end function is_today_in_doy_interval
 
   !=========================================================================================
 

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -577,4 +577,35 @@ contains
 
   end subroutine bad_hilontolocal_time
 
+  @Test
+  subroutine check_is_doy_in_interval(this)
+    class(TestTimeManager), intent(inout) :: this
+
+    integer :: start, end
+
+    start = 100
+    end = 300
+    @assertTrue(is_doy_in_interval(start, end, start))
+    @assertTrue(is_doy_in_interval(start, end, end))
+    @assertTrue(is_doy_in_interval(start, end, 200))
+    @assertFalse(is_doy_in_interval(start, end, 35))
+    @assertFalse(is_doy_in_interval(start, end, 350))
+
+    start = 300
+    end = 100
+    @assertTrue(is_doy_in_interval(start, end, start))
+    @assertTrue(is_doy_in_interval(start, end, end))
+    @assertFalse(is_doy_in_interval(start, end, 200))
+    @assertTrue(is_doy_in_interval(start, end, 35))
+    @assertTrue(is_doy_in_interval(start, end, 350))
+
+    start = 300
+    end = 300
+    @assertTrue(is_doy_in_interval(start, end, start))
+    @assertTrue(is_doy_in_interval(start, end, end))
+    @assertFalse(is_doy_in_interval(start, end, 200))
+    @assertFalse(is_doy_in_interval(start, end, 350))
+
+  end subroutine check_is_doy_in_interval
+
 end module test_clm_time_manager

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -578,35 +578,48 @@ contains
   end subroutine bad_hilontolocal_time
 
   @Test
-  subroutine check_is_doy_in_interval(this)
+  subroutine check_is_doy_in_interval_startend(this)
     class(TestTimeManager), intent(inout) :: this
 
-    integer :: start, end
+    integer, parameter :: start = 100
+    integer, parameter :: end   = 300
 
-    start = 100
-    end = 300
     @assertTrue(is_doy_in_interval(start, end, start))
     @assertTrue(is_doy_in_interval(start, end, end))
     @assertTrue(is_doy_in_interval(start, end, 200))
     @assertFalse(is_doy_in_interval(start, end, 35))
     @assertFalse(is_doy_in_interval(start, end, 350))
 
-    start = 300
-    end = 100
+  end subroutine check_is_doy_in_interval_startend
+
+  @Test
+  subroutine check_is_doy_in_interval_endstart(this)
+    class(TestTimeManager), intent(inout) :: this
+
+    integer, parameter :: start = 300
+    integer, parameter :: end   = 100
+
     @assertTrue(is_doy_in_interval(start, end, start))
     @assertTrue(is_doy_in_interval(start, end, end))
     @assertFalse(is_doy_in_interval(start, end, 200))
     @assertTrue(is_doy_in_interval(start, end, 35))
     @assertTrue(is_doy_in_interval(start, end, 350))
 
-    start = 300
-    end = 300
+  end subroutine check_is_doy_in_interval_endstart
+
+  @Test
+  subroutine check_is_doy_in_interval_sameday(this)
+    class(TestTimeManager), intent(inout) :: this
+
+    integer, parameter :: start = 300
+    integer, parameter :: end   = 300
+
     @assertTrue(is_doy_in_interval(start, end, start))
     @assertTrue(is_doy_in_interval(start, end, end))
     @assertFalse(is_doy_in_interval(start, end, 200))
     @assertFalse(is_doy_in_interval(start, end, 350))
 
-  end subroutine check_is_doy_in_interval
+  end subroutine check_is_doy_in_interval_sameday
 
   @Test
   subroutine check_is_today_in_doy_interval(this)

--- a/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
+++ b/src/utils/test/clm_time_manager_test/test_clm_time_manager.pf
@@ -608,4 +608,41 @@ contains
 
   end subroutine check_is_doy_in_interval
 
+  @Test
+  subroutine check_is_today_in_doy_interval(this)
+    class(TestTimeManager), intent(inout) :: this
+
+    integer :: start, end
+
+    call unittest_timemgr_setup(dtime=dtime, use_gregorian_calendar=.true.)
+
+    start = 100 ! April 10
+    end   = 300 ! October 27
+
+    ! Test well before interval
+    call set_date(yr=2009, mon=3, day=25, tod=0)
+    @assertFalse(is_today_in_doy_interval(start, end))
+
+    ! Test last timestep before interval
+    call set_date(yr=2009, mon=4, day=10, tod=0)
+    @assertFalse(is_today_in_doy_interval(start, end))
+
+    ! Test first timestep of interval
+    call set_date(yr=2009, mon=4, day=10, tod=dtime)
+    @assertTrue(is_today_in_doy_interval(start, end))
+
+    ! Test well within interval
+    call set_date(yr=2009, mon=7, day=24, tod=0)
+    @assertTrue(is_today_in_doy_interval(start, end))
+
+    ! Test last timestep of interval
+    call set_date(yr=2009, mon=10, day=28, tod=0)
+    @assertTrue(is_today_in_doy_interval(start, end))
+
+    ! Test first timestep after interval
+    call set_date(yr=2009, mon=10, day=28, tod=dtime)
+    @assertFalse(is_today_in_doy_interval(start, end))
+
+  end subroutine check_is_today_in_doy_interval
+
 end module test_clm_time_manager


### PR DESCRIPTION
### Description of changes

This PR adds a function, `is_doy_in_interval()`, that checks whether a given date (in day-of-year, DOY, format) is inclusive-within an interval given by start and end dates (also DOY).

### Specific notes

This is in preparation for upcoming work on crop calendars.

I considered doing something fancier, using the ESMF date/time types, but eventually decided to just replicate the existing behavior of `CropPhenology()`. Specifically, there's no special consideration of leap days. This has two effects:
1. Intervals that include a leap day end, in leap years, on the calendar day before they end in non-leap years.
2. Intervals that occur entirely after a leap day are, in leap years, shifted one calendar day earlier than they occur in non-leap years.

I don't think this behavior is necessarily a bug, anyway.

Contributors other than yourself, if any: @ekluzek 

CTSM Issues Fixed: **None.**

Are answers expected to change (and if so in what way)? **No.**

Any User Interface Changes (namelist or namelist defaults changes)? **No.**

Testing performed: **`aux_clm` tests all pass bit-for-bit (except for expected failures).**