### PR TITLE
Automatically assign high priority items to project 25.

### DIFF
--- a/.github/workflows/assign-to-project.yml
+++ b/.github/workflows/assign-to-project.yml
@@ -1,0 +1,23 @@
+name: Auto Assign to Project(s)
+
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign_high_priority:
+    runs-on: ubuntu-latest
+    name: Assign to High Priority project
+    steps:
+    - name: Assign issues and pull requests with `priority:high` label to project 25
+      uses: srggrs/assign-one-project-github-action@1.3.1
+      if: |
+        contains(github.event.issue.labels.*.name, 'priority:high') ||
+        contains(github.event.pull_request.labels.*.name, 'priority:high')
+      with:
+        project: 'https://github.com/ESCOMP/CTSM/projects/25'
+        column_name: 'Needs triage'

--- a/.github/workflows/assign-to-project.yml
+++ b/.github/workflows/assign-to-project.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign to High Priority project
     steps:
-    - name: Assign issues and pull requests with `priority:high` label to project 25
+    - name: Assign issues and pull requests with `priority: high` label to project 25
       uses: srggrs/assign-one-project-github-action@1.3.1
       if: |
-        contains(github.event.issue.labels.*.name, 'priority:high') ||
-        contains(github.event.pull_request.labels.*.name, 'priority:high')
+        contains(github.event.issue.labels.*.name, 'priority: high') ||
+        contains(github.event.pull_request.labels.*.name, 'priority: high')
       with:
         project: 'https://github.com/ESCOMP/CTSM/projects/25'
         column_name: 'Needs triage'


### PR DESCRIPTION
### Description of changes
Adds a Github action to automatically assign high-priority items to [Project 25: High priority](https://github.com/ESCOMP/CTSM/projects/25).

### Specific notes

Contributors other than yourself, if any: None

CTSM Issues Fixed (include github issue #): None

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any: Doesn't seem to be working at the moment, but maybe that's just because it needs to be merged to the master branch.
