### PR TITLE
cropcalStreamMod compiler error bug fix

### DIFF
--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -55,7 +55,7 @@ contains
     !
     ! Initialize data stream information for crop calendars.
     !
-    !USES:
+    ! !USES:
     use shr_mpi_mod      , only : shr_mpi_bcast
     use clm_nlUtilsMod   , only : find_nlgroup_name
     use lnd_comp_shr     , only : mesh, model_clock
@@ -63,7 +63,7 @@ contains
     use controlMod       , only : NLFilename
     !
     ! !ARGUMENTS:
-     type(bounds_type), intent(in) :: bounds          ! bounds
+    type(bounds_type), intent(in) :: bounds          ! bounds
     !
     ! !LOCAL VARIABLES:
     integer                 :: i,n,ivt                    ! index
@@ -249,12 +249,12 @@ contains
     !
     ! Advance crop calendar streams
     !
-    !USES:
+    ! !USES:
     use clm_time_manager , only : get_curr_date
     use dshr_strdata_mod , only : shr_strdata_advance
     !
     ! !ARGUMENTS:
-     type(bounds_type), intent(in)    :: bounds
+    type(bounds_type), intent(in)    :: bounds
     !
     ! !LOCAL VARIABLES:
     integer :: g, ig   ! Indices
@@ -299,22 +299,22 @@ contains
   !================================================================
 
   subroutine cropcal_interp(bounds, num_pcropp, filter_pcropp, crop_inst)
-     !
-     ! Interpolate data stream information for crop calendars.
-     !
-     ! !USES:
-     use CropType        , only : crop_type
-     use PatchType       , only : patch
-     use clm_time_manager, only : get_curr_days_per_year
-     use pftconMod       , only : pftname
-     use dshr_methods_mod , only : dshr_fldbun_getfldptr
-     !
-     ! !ARGUMENTS:
-     implicit none
-     type(bounds_type)      , intent(in)    :: bounds
-     integer                , intent(in)    :: num_pcropp        ! number of prog. crop patches in filter
-     integer                , intent(in)    :: filter_pcropp(:)  ! filter for prognostic crop patches
-     type(crop_type)        , intent(inout) :: crop_inst
+    !
+    ! Interpolate data stream information for crop calendars.
+    !
+    ! !USES:
+    use CropType        , only : crop_type
+    use PatchType       , only : patch
+    use clm_time_manager, only : get_curr_days_per_year
+    use pftconMod       , only : pftname
+    use dshr_methods_mod , only : dshr_fldbun_getfldptr
+    !
+    ! !ARGUMENTS:
+    implicit none
+    type(bounds_type)      , intent(in)    :: bounds
+    integer                , intent(in)    :: num_pcropp        ! number of prog. crop patches in filter
+    integer                , intent(in)    :: filter_pcropp(:)  ! filter for prognostic crop patches
+    type(crop_type)        , intent(inout) :: crop_inst
     !
     ! !LOCAL VARIABLES:
     integer :: ivt, p, ip, ig
@@ -410,7 +410,7 @@ contains
        end if
 
        ! Handle invalid sowing window values
-        if (any(starts(begp:endp,:) < 1 .or. ends(begp:endp,:) < 1)) then 
+       if (any(starts(begp:endp,:) < 1 .or. ends(begp:endp,:) < 1)) then 
            ! Fail if not allowing fallback to paramfile sowing windows
            if ((.not. allow_invalid_swindow_inputs) .and. any(all(starts(begp:endp,:) < 1, dim=2) .and. patch%wtgcell > 0._r8 .and. patch%itype >= npcropmin)) then
                write(iulog, *) 'At least one crop in one gridcell has invalid prescribed sowing window start date(s). To ignore and fall back to paramfile sowing windows, set allow_invalid_swindow_inputs to .true.'
@@ -431,7 +431,7 @@ contains
                write(iulog, *) 'Every prescribed sowing window start date must have a corresponding end date.'
                call ESMF_Finalize(endflag=ESMF_END_ABORT)
            end if
-        end if
+       end if
 
     end if ! use_cropcal_rx_swindows
     deallocate(dataptr2d_swindow_start)


### PR DESCRIPTION
### Description of changes

Fixes a compiler error (for GNU 13.2) within cropcalStreamMod

### Specific notes

Simple fix was to change whole-array assignments/references for the `starts` and `ends` arrays to specifically reference bounds (`begp` and `endp`).

Contributors other than yourself, if any: @billsacks 

CTSM Issues Fixed (include github issue #): Closes #2232

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Testing performed, if any:

Successfully compiles with GNU 13.2
