### PR TITLE
Add sowing window fields and per-harvest grainC_to_seed to restart

### DIFF
--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -3742,6 +3742,20 @@ contains
                    readvar=readvar, &
                    scale_by_thickness=.false., &
                    interpinic_flag='interp', data=data2dptr)
+               
+              ! e.g., grainc_to_seed_perharv
+              data2dptr => this%repr_grainc_to_seed_perharv_patch(:,:,k)
+              varname = get_repr_rest_fname(k)//'c_to_seed_perharv'
+              call restartvar(ncid=ncid, flag=flag,  varname=varname, &
+                   xtype=ncd_double,  &
+                   dim1name='pft', &
+                   dim2name='mxharvests', &
+                   switchdim=.true., &
+                   long_name=get_repr_longname(k)//' C to seed per harvest; should only be output annually', &
+                   units='gC/m2', &
+                   readvar=readvar, &
+                   scale_by_thickness=.false., &
+                   interpinic_flag='interp', data=data2dptr)
           end do
        end if
 

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -3729,8 +3729,8 @@ contains
        ! BACKWARDS_COMPATIBILITY(wjs/ssr, 2022-06-10) See note in CallRestartvarDimOK()
        if (CallRestartvarDimOK(ncid, flag, 'mxharvests')) then
           do k = repr_grain_min, repr_grain_max
-              data2dptr => this%repr_grainc_to_food_perharv_patch(:,:,k)
               ! e.g., grainc_to_food_perharv
+              data2dptr => this%repr_grainc_to_food_perharv_patch(:,:,k)
               varname = get_repr_rest_fname(k)//'c_to_food_perharv'
               call restartvar(ncid=ncid, flag=flag,  varname=varname, &
                    xtype=ncd_double,  &
@@ -3746,8 +3746,8 @@ contains
        end if
 
        do k = repr_grain_min, repr_grain_max
-          data1dptr => this%repr_grainc_to_food_thisyr_patch(:,k)
           ! e.g., grainc_to_food_thisyr
+          data1dptr => this%repr_grainc_to_food_thisyr_patch(:,k)
           varname = get_repr_rest_fname(k)//'c_to_food_thisyr'
           call restartvar(ncid=ncid, flag=flag,  varname=varname, &
                xtype=ncd_double,  &
@@ -3755,8 +3755,9 @@ contains
                long_name=get_repr_longname(k)//' C to food per calendar year; should only be output annually', &
                units='gC/m2', &
                interpinic_flag='interp', readvar=readvar, data=data1dptr)
-          data1dptr => this%repr_grainc_to_seed_thisyr_patch(:,k)
+
           ! e.g., grainc_to_seed_thisyr
+          data1dptr => this%repr_grainc_to_seed_thisyr_patch(:,k)
           varname = get_repr_rest_fname(k)//'c_to_seed_thisyr'
           call restartvar(ncid=ncid, flag=flag,  varname=varname, &
                xtype=ncd_double,  &

--- a/src/biogeochem/CropType.F90
+++ b/src/biogeochem/CropType.F90
@@ -655,6 +655,16 @@ contains
                 long_name='crop sowing dates for this patch this year', units='day of year', &
                 scale_by_thickness=.false., &
                 interpinic_flag='interp', readvar=readvar, data=this%sdates_thisyr_patch)
+           call restartvar(ncid=ncid, flag=flag, varname='swindow_starts_thisyr_patch', xtype=ncd_double,  &
+                dim1name='pft', dim2name='mxsowings', switchdim=.true., &
+                long_name='sowing window start dates for this patch this year', units='day of year', &
+                scale_by_thickness=.false., &
+                interpinic_flag='interp', readvar=readvar, data=this%swindow_starts_thisyr_patch)
+           call restartvar(ncid=ncid, flag=flag, varname='swindow_ends_thisyr_patch', xtype=ncd_double,  &
+                dim1name='pft', dim2name='mxsowings', switchdim=.true., &
+                long_name='sowing window end dates for this patch this year', units='day of year', &
+                scale_by_thickness=.false., &
+                interpinic_flag='interp', readvar=readvar, data=this%swindow_ends_thisyr_patch)
            ! Fill variable(s) derived from read-in variable(s)
            if (flag == 'read' .and. readvar) then
              do p = bounds%begp,bounds%endp


### PR DESCRIPTION
### Description of changes

Adds the following fields to restart files:
- `repr_grainc_to_seed_perharv_patch`
- `swindow_starts_thisyr_patch`
- `swindow_ends_thisyr_patch`

This resolves a failure in `COMPARE_base_rest` for one aux_clm test.

### Specific notes

**CTSM Issues Fixed (include github issue #):**
- Fixes #2236

**Are answers expected to change (and if so in what way)?** Yes, but seemingly just for Smallville "no initial" restarts. Specifically, aux_clm test `ERS_Lm20_Mmpi-serial.1x1_smallvilleIA.I2000Clm50BgcCropQianRs.izumi_gnu.clm-cropMonthlyNoinitial`.

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Testing performed, if any:**
- [x] `ERS_Lm20_Mmpi-serial.1x1_smallvilleIA.I2000Clm50BgcCropQianRs.izumi_gnu.clm-cropMonthlyNoinitial` now passes `COMPARE_base_rest` (although fails as expected in `BASELINE`).
- [ ] **(Waiting until ready to come in)** No other failures detected in aux_clm run