### PR TITLE
Fix subset_data error "no attribute 'evenly_split_cropland'"

### DIFF
--- a/python/ctsm/subset_data.py
+++ b/python/ctsm/subset_data.py
@@ -150,6 +150,13 @@ def get_parser():
         required=False,
     )
     pt_parser.add_argument(
+        "--evenly_split_cropland",
+        help="Introduce equal areas of all crops",
+        action="store_true",
+        dest="evenly_split_cropland",
+        required=False,
+    )
+    pt_parser.add_argument(
         "--dompft",
         help="Dominant PFT(s): if we set the grid to 100%% one or multiple PFTs \
         [default: %(default)s].",


### PR DESCRIPTION
### Description of changes

Adding the following lines to subset_data.py fixes the error:
```
@@ -149,6 +149,13 @@ def get_parser():
         dest="cap_saturation",
         required=False,
     )
+    pt_parser.add_argument(
+        "--evenly_split_cropland",
+        help="???",
+        action="store_true",
+        dest="evenly_split_cropland",
+        required=False,
+    )
```
@ekluzek you plan to open an issue for resolving pylint suggestions that have appeared in recent tags and have been ignored. I could resolve these in this PR if you agree.

### Specific notes

Contributors other than yourself, if any:
@wwieder encountered the error

CTSM Issues Fixed (include github issue #):
No issue opened

Are answers expected to change (and if so in what way)?
No

Any User Interface Changes (namelist or namelist defaults changes)?
No

Testing performed, if any:
Python testing missed this and was passing and continues to pass