### PR TITLE
Update Externals.cfg to work on Derecho

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -8,7 +8,7 @@ required = True
 local_path = components/cism
 protocol = git
 repo_url = https://github.com/ESCOMP/CISM-wrapper
-tag = cismwrap_2_1_95
+tag = cismwrap_2_1_96
 externals = Externals_CISM.cfg
 required = True
 
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.65
+tag = ccs_config_cesm0.0.82
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config
@@ -44,18 +44,18 @@ required = True
 local_path = cime
 protocol = git
 repo_url = https://github.com/ESMCI/cime
-tag = cime6.0.125
+tag = cime6.0.175
 required = True
 
 [cmeps]
-tag = cmeps0.14.21
+tag = cmeps0.14.43
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.13
+tag = cdeps1.0.23
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -63,7 +63,7 @@ externals =  Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl77.0.5
+tag = cpl77.0.7
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
@@ -84,7 +84,7 @@ local_path = libraries/mct
 required = True
 
 [parallelio]
-tag = pio2_5_10
+tag = pio2_6_2
 protocol = git
 repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -34,7 +34,7 @@ hash = 34723c2
 required = True
 
 [ccs_config]
-tag = ccs_config_cesm0.0.82
+tag = ccs_config_cesm0.0.84
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm.git
 local_path = ccs_config

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,76 @@
 ===============================================================
+Tag name: ctsm5.1.dev157
+Originator(s): samrabin (Sam Rabin, UCAR/TSS, samrabin@ucar.edu)
+Date: Tue Dec  5 09:48:26 MST 2023
+One-line Summary: Update Externals to work on Derecho
+
+Purpose and description of changes
+----------------------------------
+
+Updates Externals.cfg to work on Derecho.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed or introduced
+------------------------
+
+CTSM issues fixed (include CTSM Issue #):
+* Resolves #2217 ("Tags for building CTSM library on Derecho [WRF-CTSM]", https://github.com/ESCOMP/CTSM/issues/2217)
+* Resolves #2090 ("Update to cesm2_3_beta16 externals.", https://github.com/ESCOMP/CTSM/issues/2090)
+
+Known bugs introduced in this tag (include issue #):
+* #2280: Updating Externals for Derecho causes Izumi nag tests to fail (https://github.com/ESCOMP/CTSM/issues/2280)
+
+
+Notes of particular relevance for developers:
+---------------------------------------------
+
+Changes to tests or testing:
+* All Izumi nag tests fail early in the run phase. This should be fixed in the next tag, which will be a more comprehensive Derecho-focused update.
+
+
+Testing summary:
+----------------
+
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    cheyenne ---- OK
+    izumi ------- PASS (except nag)
+
+
+Other details
+-------------
+
+List any externals directories updated (cime, rtm, mosart, cism, fates, etc.):
+* cime: cime6.0.125 -> cime6.0.175
+* cmeps: cmeps0.14.21 -> cmeps0.14.43
+* cdeps: cdeps1.0.13 -> cdeps1.0.23
+* cpl7: cpl77.0.5 -> cpl77.0.7
+* parallelio: pio2_5_10 -> pio2_6_2
+
+Pull Requests that document the changes (include PR ids):
+* #2270: Update Externals.cfg to work on Derecho (https://github.com/ESCOMP/CTSM/pull/2270)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev156
 Originator(s): samrabin (Sam Rabin, UCAR/TSS, samrabin@ucar.edu)
 Date: Thu Nov 30 15:27:18 MST 2023

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev157 samrabin 12/05/2023 Update Externals to work on Derecho
     ctsm5.1.dev156 samrabin 11/30/2023 Do not use Meier roughness by default.
     ctsm5.1.dev155 samrabin 11/27/2023 Use baset_latvary parameters
     ctsm5.1.dev154   slevis 11/22/2023 New params files with changes for Meier roughness, MIMICS, and SNICAR, and changes to leafcn and k*_nonmyc


### PR DESCRIPTION
### Description of changes

Update Externals.cfg to version from CESM3_dev aba49b6.

### Specific notes

Contributors other than yourself, if any: @ekluzek 

CTSM Issues Fixed (include github issue #):
- Resolves #2217

Are answers expected to change (and if so in what way)? No.

Any User Interface Changes (namelist or namelist defaults changes)? No.

Testing performed, if any: With this change, my tillage & residue branch works on Derecho.
