### PR TITLE
Remove endrun for Meier2022 case to work

### DIFF
--- a/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
+++ b/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
@@ -147,7 +147,7 @@ contains
     !-----------------------------------------------------------------------
 
     associate( &
-         z0mg             =>    frictionvel_inst%z0mg_col             , & ! Input:  [real(r8) (:)   ]  roughness length of ground, momentum [m]
+         z0mg             =>    frictionvel_inst%z0mg_col             , & ! Input:  [real(r8) (:)   ] roughness length of ground, momentum [m]
          htop             =>    canopystate_inst%htop_patch           , & ! Input:  [real(r8) (:)   ] canopy top (m)                           
          z0m              =>    canopystate_inst%z0m_patch            , & ! Output: [real(r8) (:)   ] momentum roughness length (m)
          displa           =>    canopystate_inst%displa_patch           & ! Output: [real(r8) (:)   ] displacement height (m)

--- a/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
+++ b/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
@@ -200,16 +200,11 @@ contains
                          / 2._r8)**(-0.5_r8) /  (pftcon%z0v_LAImax(patch%itype(p))) / pftcon%z0v_c(patch%itype(p))
 
                if ( htop(p) <= 1.e-10_r8 )then
-                  if (lun%itype(l) == istcrop) then
-                     z0m(p) = 0._r8
-                     displa(p) = 0._r8
-                  else
-                     write(iulog,*) ' nstep = ', get_nstep(), ' htop = ', htop(p)
-                     call endrun(subgrid_index=p, subgrid_level=subgrid_level_patch, msg=errMsg(sourcefile, __LINE__))
-                  end if
+                  z0m(p) = 0._r8
+                  displa(p) = 0._r8
                else
-                   z0m(p) = htop(p) * (1._r8 - displa(p) / htop(p)) * exp(-0.4_r8 * U_ustar + &
-                               log(pftcon%z0v_cw(patch%itype(p))) - 1._r8 + pftcon%z0v_cw(patch%itype(p))**(-1._r8))
+                  z0m(p) = htop(p) * (1._r8 - displa(p) / htop(p)) * exp(-0.4_r8 * U_ustar + &
+                              log(pftcon%z0v_cw(patch%itype(p))) - 1._r8 + pftcon%z0v_cw(patch%itype(p))**(-1._r8))
                end if
 
             end if


### PR DESCRIPTION
### Description of changes

For tiny htop, remove endrun and add z0m = 0 and displa = 0.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Fixes #2264 

Are answers expected to change (and if so in what way)?
No, in the test-suites.
In longer simulation, prevents failure.

Any User Interface Changes (namelist or namelist defaults changes)?
No.

Testing performed, if any:
The fix works. Tried alternate suggestion that failed, as documented in #2264.