### PR TITLE
Do not use Meier roughness by default, even with 5.1.

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -499,7 +499,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 
 <z0param_method>ZengWang2007</z0param_method>
-<z0param_method phys="clm5_1">Meier2022</z0param_method>
 
 <use_z0m_snowmelt z0param_method="Meier2022" >.true.</use_z0m_snowmelt>
 <use_z0m_snowmelt >.false.</use_z0m_snowmelt>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,68 @@
 ===============================================================
+Tag name: ctsm5.1.dev156
+Originator(s): samrabin (Sam Rabin, UCAR/TSS, samrabin@ucar.edu)
+Date: Thu Nov 30 15:27:18 MST 2023
+One-line Summary: Do not use Meier roughness by default
+
+Purpose and description of changes
+----------------------------------
+
+ctsm5.1.dev155 had turned on Meier2022 surface roughness calculation by default for 5.1 compsets. Several bugs have recently emerged that were not caught by pre-merge testing, so this tag reverts that change. Thus, the ZengWang2007 method is default for all compsets again.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Notes of particular relevance for users
+---------------------------------------
+
+Changes made to namelist defaults (e.g., changed parameter values): 5.1 compsets now use ZengWang2007 method (instead of Meier2022) for roughness calculation.
+
+
+Testing summary:
+----------------
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    cheyenne ---- OK
+    izumi ------- PASS
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: 5.1 compsets
+    - what platforms/compilers: All
+    - nature of change (roundoff; larger than roundoff/same climate; new climate): new climate
+
+  No climate-evaluating run performed, as this change is reverting part of a commit thats barely a week old.
+
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+* #2273: Do not use Meier roughness by default, even with 5.1. (https://github.com/ESCOMP/CTSM/pull/2273)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev155
 Originator(s): samrabin (Sam Rabin, UCAR/TSS, samrabin@ucar.edu)
 Date: Mon Nov 27 21:16:51 MST 2023

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev156 samrabin 11/30/2023 Do not use Meier roughness by default.
     ctsm5.1.dev155 samrabin 11/27/2023 Use baset_latvary parameters
     ctsm5.1.dev154   slevis 11/22/2023 New params files with changes for Meier roughness, MIMICS, and SNICAR, and changes to leafcn and k*_nonmyc
     ctsm5.1.dev153  afoster 11/17/2023 Call new FATES-side FatesReadParameters


### PR DESCRIPTION
### Description of changes

ctsm5.1.dev155 had turned on Meier2022 surface roughness calculation by default for 5.1 compsets. Several bugs (#2238, #2264) have recently emerged that were not caught by pre-merge testing, so this tag reverts that change. Thus, the ZengWang2007 method is default for all compsets again.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** Yes, for 5.1 compsets.

**Any User Interface Changes (namelist or namelist defaults changes)?** 5.1 compsets now use ZengWang2007 roughness calculation method instead of Meier2022.

**Testing performed, if any:** aux_clm shows differences only in tests with 5.1 compsets.
