### PR TITLE
Add soil NO fluxes into the N cycle.

### DIFF
--- a/src/biogeochem/CNDriverMod.F90
+++ b/src/biogeochem/CNDriverMod.F90
@@ -44,6 +44,7 @@ module CNDriverMod
   use SoilWaterRetentionCurveMod      , only : soil_water_retention_curve_type
   use CLMFatesInterfaceMod            , only : hlm_fates_interface_type
   use CropReprPoolsMod                    , only : nrepr
+  use DryDepVelocity                  , only : drydepvel_type !mvm for soil NOx canopy reduction 06/19/2023
   !
   ! !PUBLIC TYPES:
   implicit none
@@ -104,7 +105,8 @@ contains
        wateratm2lndbulk_inst, canopystate_inst, soilstate_inst, temperature_inst,          &
        soil_water_retention_curve, crop_inst, ch4_inst,            &
        dgvs_inst, photosyns_inst, saturated_excess_runoff_inst, energyflux_inst,                   &
-       nutrient_competition_method, cnfire_method, dribble_crophrv_xsmrpool_2atm)
+       nutrient_competition_method, cnfire_method, dribble_crophrv_xsmrpool_2atm, &
+       drydepvel_inst) !added mvm for NO canopy reduction 06/23/2023
     !
     ! !DESCRIPTION:
     ! The core CN code is executed here. Calculates fluxes for maintenance
@@ -209,6 +211,7 @@ contains
     class(fire_method_type)                 , intent(inout) :: cnfire_method
     logical                                 , intent(in)    :: dribble_crophrv_xsmrpool_2atm
     type(hlm_fates_interface_type)          , intent(inout) :: clm_fates
+    type(drydepvel_type)                    , intent(inout)    :: drydepvel_inst  !mvm for soil NOx canopy reduction
     !
     ! !LOCAL VARIABLES:
     real(r8):: cn_decomp_pools(bounds%begc:bounds%endc,1:nlevdecomp,1:ndecomp_pools)
@@ -467,7 +470,9 @@ contains
                                      cnveg_carbonflux_inst,cnveg_nitrogenstate_inst,cnveg_nitrogenflux_inst,   &
                                      soilbiogeochem_carbonflux_inst,&
                                      soilbiogeochem_state_inst,soilbiogeochem_nitrogenstate_inst,              &
-                                     soilbiogeochem_nitrogenflux_inst,canopystate_inst)
+                                soilbiogeochem_nitrogenflux_inst,canopystate_inst, &
+!mvm for soil NOx 06/19/2023
+                                drydepvel_inst)
      call t_stopf('soilbiogeochemcompetition')
 
     ! distribute the available N between the competing patches  on the basis of 

--- a/src/biogeochem/CNVegetationFacade.F90
+++ b/src/biogeochem/CNVegetationFacade.F90
@@ -96,6 +96,7 @@ module CNVegetationFacade
   use SoilBiogeochemPrecisionControlMod , only: SoilBiogeochemPrecisionControl
   use SoilWaterRetentionCurveMod      , only : soil_water_retention_curve_type
   use CLMFatesInterfaceMod            , only : hlm_fates_interface_type
+  use DryDepVelocity                  , only : drydepvel_type !mvm for soil NOx canopy reduction 06/20/2023
   !
   implicit none
   private
@@ -127,6 +128,7 @@ module CNVegetationFacade
      type(cn_balance_type)          :: cn_balance_inst
      class(fire_method_type), allocatable :: cnfire_method
      type(dgvs_type)                :: dgvs_inst
+     type(drydepvel_type)           :: drydepvel_inst  !mvm for soil NOx canopy reduction
 
      ! Control variables
      logical, private :: reseed_dead_plants              ! Flag to indicate if should reseed dead plants when starting up the model
@@ -906,7 +908,7 @@ contains
        wateratm2lndbulk_inst, canopystate_inst, soilstate_inst, temperature_inst, &
        soil_water_retention_curve, crop_inst, ch4_inst, &
        photosyns_inst, saturated_excess_runoff_inst, energyflux_inst,          &
-       nutrient_competition_method, fireemis_inst)
+       nutrient_competition_method, fireemis_inst, drydepvel_inst) !mvm
     !
     ! !DESCRIPTION:
     ! Do the main science for CN vegetation that needs to be done before hydrology-drainage
@@ -962,6 +964,7 @@ contains
     class(nutrient_competition_method_type) , intent(inout) :: nutrient_competition_method
     type(fireemis_type)                     , intent(inout) :: fireemis_inst
     type(hlm_fates_interface_type)          , intent(inout) :: clm_fates
+    type(drydepvel_type)                    , intent(inout) :: drydepvel_inst  !mvm for soil NOx canopy reduction
     !
     ! !LOCAL VARIABLES:
 
@@ -996,7 +999,7 @@ contains
          wateratm2lndbulk_inst, canopystate_inst, soilstate_inst, temperature_inst, &
          soil_water_retention_curve, crop_inst, ch4_inst, &
          this%dgvs_inst, photosyns_inst, saturated_excess_runoff_inst, energyflux_inst,          &
-         nutrient_competition_method, this%cnfire_method, this%dribble_crophrv_xsmrpool_2atm)
+         nutrient_competition_method, this%cnfire_method, this%dribble_crophrv_xsmrpool_2atm, drydepvel_inst) !mvm
 
     ! fire carbon emissions 
     call CNFireEmisUpdate(bounds, num_soilp, filter_soilp, &

--- a/src/biogeophys/WaterStateType.F90
+++ b/src/biogeophys/WaterStateType.F90
@@ -36,6 +36,10 @@ module WaterStateType
      real(r8), pointer :: h2osoi_liq_col         (:,:) ! col liquid water (kg/m2) (new) (-nlevsno+1:nlevgrnd)    
      real(r8), pointer :: h2osoi_ice_col         (:,:) ! col ice lens (kg/m2) (new) (-nlevsno+1:nlevgrnd)    
      real(r8), pointer :: h2osoi_vol_col         (:,:) ! col volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]  (nlevgrnd)
+!mvm 06/19/2023 soil nox 
+     real(r8), pointer :: h2osoi_vol_old_col     (:,:) ! col volumetric soil water for previous time step (0<=h2osoi_vol<=watsat) [m3/m3]  (nlevgrnd)  mvm 01/20/2018
+     real(r8), pointer :: ldry_col         (:,:)     ! col dry period rain pulses for NOx from nitrification as state variable [hours]
+
      real(r8), pointer :: h2osoi_vol_prs_grc     (:,:) ! grc volumetric soil water prescribed (0<=h2osoi_vol<=watsat) [m3/m3]  (nlevgrnd)
      real(r8), pointer :: h2osfc_col             (:)   ! col surface water (mm H2O)
      real(r8), pointer :: snocan_patch           (:)   ! patch canopy snow water (mm H2O)
@@ -120,6 +124,16 @@ contains
          container = tracer_vars, &
          bounds = bounds, subgrid_level = subgrid_level_column, &
          dim2beg = 1, dim2end = nlevmaxurbgrnd)
+!mvm soil nox 06/23/2023
+    call AllocateVar2d(var = this%h2osoi_vol_old_col, name = 'h2osoi_vol_old_col', &
+         container = tracer_vars, &
+         bounds = bounds, subgrid_level = subgrid_level_column, &
+         dim2beg = 1, dim2end = nlevmaxurbgrnd)
+   call AllocateVar2d(var = this%ldry_col, name = 'ldry_col', &
+         container = tracer_vars, &
+         bounds = bounds, subgrid_level = subgrid_level_column, &
+         dim2beg = 1, dim2end = nlevmaxurbgrnd)
+
     call AllocateVar2d(var = this%h2osoi_vol_prs_grc, name = 'h2osoi_vol_prs_grc', &
          container = tracer_vars, &
          bounds = bounds, subgrid_level = subgrid_level_gridcell, &

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -1019,7 +1019,8 @@ contains
                water_inst%wateratm2lndbulk_inst, canopystate_inst, soilstate_inst, temperature_inst, &
                soil_water_retention_curve, crop_inst, ch4_inst, &
                photosyns_inst, saturated_excess_runoff_inst, energyflux_inst,          &
-               nutrient_competition_method, fireemis_inst)
+               nutrient_competition_method, fireemis_inst,                      &
+               drydepvel_inst)             !mvm 06/19/2023 for canopy reduction in soil NOx)
 
           call t_stopf('ecosysdyn')
 
@@ -1526,6 +1527,9 @@ contains
          h2osoi_ice         => waterstatebulk_inst%h2osoi_ice_col            , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
          h2osoi_liq         => waterstatebulk_inst%h2osoi_liq_col            , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          frac_iceold        => waterdiagnosticbulk_inst%frac_iceold_col           , & ! Output: [real(r8) (:,:) ]  fraction of ice relative to the tot water
+         h2osoi_vol          => waterstatebulk_inst%h2osoi_vol_col           , & ! Input: [real(r8) (:,:) ]  volumetric soil water (m3/m3)   mvm 06/19/2023
+         h2osoi_vol_old     => waterstatebulk_inst%h2osoi_vol_old_col        , & ! Output: [real(r8) (:,:) ]  volumetric soil water for previous time step m3/m3   mvm 06/19/2023
+
          elai               => canopystate_inst%elai_patch               , & ! Input:  [real(r8) (:)   ]  one-sided leaf area index with burying by snow
          esai               => canopystate_inst%esai_patch               , & ! Input:  [real(r8) (:)   ]  one-sided stem area index with burying by snow
          frac_veg_nosno     => canopystate_inst%frac_veg_nosno_patch     , & ! Output: [integer  (:)   ]  fraction of vegetation not covered by snow (0 OR 1) [-]
@@ -1544,6 +1548,8 @@ contains
       end do
 
       do c = bounds%begc,bounds%endc
+         !save volumetric water from previous time step (mvm)
+         h2osoi_vol_old(c, :)=h2osoi_vol(c, :)
          ! Reset flux from beneath soil/ice column
          eflx_bot(c)  = 0._r8
       end do

--- a/src/soilbiogeochem/SoilBiogeochemNStateUpdate1Mod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNStateUpdate1Mod.F90
@@ -247,12 +247,28 @@ contains
 
                ! Account for nitrification fluxes
                ns%smin_nh4_vr_col(c,j) = ns%smin_nh4_vr_col(c,j) - nf%f_nit_vr_col(c,j) * dt
+ 
+           !mvm 06/19/2023 --commented to consider removal of N2O and NOx 
+           !    ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) + nf%f_nit_vr_col(c,j) * dt &
+           !         * (1._r8 - nitrif_n2o_loss_frac)
 
-               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) + nf%f_nit_vr_col(c,j) * dt &
-                    * (1._r8 - nitrif_n2o_loss_frac)
+              !mvm: Adding nitrified NH4 to NO3
+               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) + nf%f_nit_vr_col(c,j) * dt
+              !mvm: Deducting N2O leakage from nitrification
+               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_n2o_nit_vr_col(c,j) * dt
+              !mvm: Deducting NOx leakage from nitrification. Only NOx_nit not trapped in the canopy leaves the system 
+               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_nox_nit_atmos_vr_col(c,j) * dt
+               
 
-               ! Account for denitrification fluxes
-               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_denit_vr_col(c,j) * dt
+               !mvm: 06/19/2023 commented Account for denitrification fluxes
+        !      ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_denit_vr_col(c,j) * dt
+      
+               ! Deducting denitrification fluxes (denit accounts for N2O denit, N2 and NOx denit)
+               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_n2o_denit_vr_col(c,j) * dt
+               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_n2_denit_vr_col(c,j) * dt
+               ! Not all NOx denit leaves the system, only f_nox_denit_atmos         
+               ns%smin_no3_vr_col(c,j) = ns%smin_no3_vr_col(c,j) - nf%f_nox_denit_atmos_vr_col(c,j)* dt
+                          
 
                ! flux that prevents N limitation (when Carbon_only is set; put all into NH4)
                ns%smin_nh4_vr_col(c,j) = ns%smin_nh4_vr_col(c,j) + nf%supplement_to_sminn_vr_col(c,j)*dt

--- a/src/soilbiogeochem/SoilBiogeochemNitrifDenitrifMod.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrifDenitrifMod.F90
@@ -16,7 +16,7 @@ module SoilBiogeochemNitrifDenitrifMod
   use abortutils                      , only : endrun
   use decompMod                       , only : bounds_type
   use SoilStatetype                   , only : soilstate_type
-  use WaterStateBulkType                  , only : waterstatebulk_type
+  use WaterStateBulkType              , only : waterstatebulk_type
   use TemperatureType                 , only : temperature_type
   use SoilBiogeochemCarbonFluxType    , only : soilbiogeochem_carbonflux_type
   use SoilBiogeochemNitrogenStateType , only : soilbiogeochem_nitrogenstate_type
@@ -47,7 +47,8 @@ module SoilBiogeochemNitrifDenitrifMod
 
   type(params_type), private :: params_inst
 
-  logical, public :: no_frozen_nitrif_denitrif = .false.  ! stop nitrification and denitrification in frozen soils
+  !mvm, false to true
+  logical, public :: no_frozen_nitrif_denitrif = .true.  ! stop nitrification and denitrification in frozen soils
 
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
@@ -147,6 +148,9 @@ contains
     ! !USES:
     use clm_time_manager  , only : get_curr_date
     use CNSharedParamsMod , only : CNParamsShareInst
+!mvm 06/15/2023 to convert cphase from patch to column 
+    use subgridAveMod    , only : p2c  !added mvm 01/24/2018 for canopy reduction function
+ 
     !
     ! !ARGUMENTS:
     type(bounds_type)                       , intent(in)    :: bounds  
@@ -187,6 +191,13 @@ contains
     real(r8) :: organic_max              ! organic matter content (kg/m3) where
                                          ! soil is assumed to act like peat
     character(len=32) :: subname='nitrif_denitrif' ! subroutine name
+    real(r8) :: k1_nitr      !mvm added for nitrification rate. k1 is the fraction ofnet_nmin_vr that is assumed to be nitrified each day 
+    !mvm added for nox_n2o ratio
+    real(r8) :: Dr ! relative gas diffusivity in soil compare to air
+    real(r8) :: fno3_co2     !mvm added for denitrification rate
+
+
+
     !-----------------------------------------------------------------------
 
     associate(                                                                                                    & 
@@ -241,7 +252,12 @@ contains
          pot_f_nit_vr                  =>    soilbiogeochem_nitrogenflux_inst%pot_f_nit_vr_col                  , & ! Output:  [real(r8) (:,:) ]  (gN/m3/s) potential soil nitrification flux     
 
          pot_f_denit_vr                =>    soilbiogeochem_nitrogenflux_inst%pot_f_denit_vr_col                , & ! Output:  [real(r8) (:,:) ]  (gN/m3/s) potential soil denitrification flux   
-         n2_n2o_ratio_denit_vr         =>    soilbiogeochem_nitrogenflux_inst%n2_n2o_ratio_denit_vr_col           & ! Output:  [real(r8) (:,:) ]  ratio of N2 to N2O production by denitrification [gN/gN]
+         n2_n2o_ratio_denit_vr         =>    soilbiogeochem_nitrogenflux_inst%n2_n2o_ratio_denit_vr_col         ,  & ! Output:  [real(r8) (:,:) ]  ratio of N2 to N2O production by denitrification [gN/gN]
+!mvm 06/15/2023 added for soil NOx fluxes
+         afps_vr                        =>   soilbiogeochem_nitrogenflux_inst%afps_vr_col                       , & !Output:  [real(r8) (:,:) ] portion of soil pore space that is filled with air
+         gross_nmin_vr                   =>    soilbiogeochem_nitrogenflux_inst%gross_nmin_vr_col                , &  ! Input: [real(r8) (:,:)   ] ! added by mvm to add missing term in nitrification rate
+         nox_n2o_ratio_vr               => soilbiogeochem_nitrogenflux_inst%nox_n2o_ratio_vr_col                 &  !Output:  [real(r8) (:,:) ]  ratio of NOx to N2O production, for soil NOx emissions [gN/gN]
+!mvm 11/11/2019 
          )
 
       surface_tension_water = params_inst%surface_tension_water
@@ -258,6 +274,11 @@ contains
       pH(bounds%begc:bounds%endc) = 6.5_r8  !!! set all soils with the same pH as placeholder here
       co2diff_con(1) =   0.1325_r8
       co2diff_con(2) =   0.0009_r8
+!mvm 06/15/2023 added to correct for missing organic matter turn-over
+!Parton et al.,(2001)
+      k1_nitr=0.2_r8 
+
+
 
       do j = 1, nlevdecomp
          do fc = 1,num_soilc
@@ -327,8 +348,12 @@ contains
             k_nitr_vr(c,j) = k_nitr_max_perday/secspday * k_nitr_t_vr(c,j) * k_nitr_h2o_vr(c,j) * k_nitr_ph_vr(c,j)
 
             ! first-order decay of ammonium pool with scalar defined above
-            pot_f_nit_vr(c,j) = max(smin_nh4_vr(c,j) * k_nitr_vr(c,j), 0._r8)
-
+           !   pot_f_nit_vr(c,j) = max(smin_nh4_vr(c,j) * k_nitr_vr(c,j), 0._r8)
+            
+!mvm 06/15/2023 added  missing N from SOM turn over term, as in Parton et al 2001 Equation 2
+!Note, use gross_nmin as net_nmin is near zero following Nevison et al., (2022a) doi:10.1002/eap.2530
+            pot_f_nit_vr(c,j) = max(k1_nitr * gross_nmin_vr(c,j) + smin_nh4_vr(c,j) * k_nitr_vr(c,j), 0._r8)
+           
             ! limit to oxic fraction of soils
             pot_f_nit_vr(c,j)  = pot_f_nit_vr(c,j) * (1._r8 - anaerobic_frac(c,j))
 
@@ -389,7 +414,28 @@ contains
             fr_WFPS(c,j) = max(0.1_r8, 0.015_r8 * wfps_vr(c,j) - 0.32_r8)
 
             ! final ratio expression 
-            n2_n2o_ratio_denit_vr(c,j) = max(0.16_r8*ratio_k1(c,j), ratio_k1(c,j)*exp(-0.8_r8 * ratio_no3_co2(c,j))) * fr_WFPS(c,j)
+      !      n2_n2o_ratio_denit_vr(c,j) = max(0.16_r8*ratio_k1(c,j), ratio_k1(c,j)*exp(-0.8_r8 * ratio_no3_co2(c,j))) * fr_WFPS(c,j)
+            
+            !DAYCENT4.5 EQUATION mvm:modified n2_n2o_ratio_denit to be consistent with daycent code
+            fno3_co2 = max(0.16_r8*ratio_k1(c,j), ratio_k1(c,j)*exp(-0.8_r8 * ratio_no3_co2(c,j)))
+            n2_n2o_ratio_denit_vr(c,j) = max(0.1_r8,fno3_co2*fr_WFPS(c,j))
+            
+            !mvm 06/15/2023 NOx FLUXES
+            ! Estimating the ratio of NOx emission rate to that of N2O from nitrification and denitrifiation using the equation in:
+            ! Parton, W. J. et al (2001). Generalized model for NOx and N2O emissions 
+            !from soils. Journal of Geophysical Research: Atmospheres, 106(D15), 17403-17419.
+            
+            !Dr is the relative gas diffusivity in soil compared to air; Parton et al., (2001), 
+            !which is calculated from air-filled porosity
+            !(AFPS, i.e., the portion of soil pore space that is filled by air; Davidson and Trumbore, 1995) 
+            !Dr=0.209*AFPS**4/3, with AFPS, the air-filled porosity (1-WFPS), See Huang et al 2015
+           
+            afps_vr(c,j) = 1._r8-max(min(h2osoi_vol(c,j)/watsat(c,j), 1._r8), 0._r8)
+            Dr = 0.209_r8*afps_vr(c,j)**(4._r8/3._r8)
+            
+            nox_n2o_ratio_vr(c,j) = 15.2_r8 + (35.5_r8 * atan(0.68_r8 * rpi * (10.0_r8 * Dr - 1.86_r8))) / rpi
+
+            nox_n2o_ratio_vr(c,j) = max(0._r8, nox_n2o_ratio_vr(c,j))
 
          end do
 

--- a/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrogenFluxType.F90
@@ -66,7 +66,27 @@ module SoilBiogeochemNitrogenFluxType
      real(r8), pointer :: f_n2o_denit_col                           (:)     ! col flux of N2o from denitrification [gN/m^2/s]
      real(r8), pointer :: f_n2o_nit_vr_col                          (:,:)   ! col flux of N2o from nitrification [gN/m^3/s]
      real(r8), pointer :: f_n2o_nit_col                             (:)     ! col flux of N2o from nitrification [gN/m^2/s]
-
+!mvm for N2 fluxes
+     real(r8), pointer :: f_n2_denit_vr_col                         (:,:)   ! col flux of N2 from denitrification [gN/m^3/s]
+     real(r8), pointer :: f_n2_denit_col                            (:)     ! col flux of N2 from denitrification [gN/m^2/s]
+!mvm for NOx fluxes
+     real(r8), pointer :: nox_n2o_ratio_vr_col                      (:,:)   ! col ratio of NOx to N2O production by nitrification and denitrification [gN/gN]
+     real(r8), pointer :: f_nox_denit_vr_col                        (:,:)   ! col flux of NOx from denitrifiation [gN/m3/s]  
+     real(r8), pointer :: f_nox_denit_col                           (:)     ! col (integrated)  flux of NOx from denitrifiation [gN/m2/s]  
+     real(r8), pointer :: f_nox_nit_vr_col                          (:,:)   ! col flux of NOx from nitrification [gN/m3/s] 
+     real(r8), pointer :: f_nox_nit_col                             (:)     ! col (integrated) flux of NOx from nitrification [gN/m2/s] 
+     real(r8), pointer :: h2osoi_diff_vr_col                       (:,:)   ! col volumtric water content different [m3/m3]. FOR DIAGNOSTICS
+    real(r8), pointer :: pot_f_nox_denit_vr_col                        (:,:)   ! col potential flux of NOx from denitrifiation [gN/m3/s]  
+     real(r8), pointer :: pot_f_nox_denit_col                           (:)     ! col potential (integrated)  flux of NOx from denitrifiation [gN/m2/s]  
+     real(r8), pointer :: pot_f_nox_nit_vr_col                          (:,:)   ! col potential flux of NOx from nitrification [gN/m3/s] 
+     real(r8), pointer :: pot_f_nox_nit_col                             (:)     ! col potential (integrated) flux of NOx from nitrification [gN/m2/s] 
+     real(r8), pointer :: f_nox_denit_atmos_vr_col                    (:,:)   ! col flux of NOx from denitrifiation with canopy reduction [gN/m3/s]  
+     real(r8), pointer :: f_nox_denit_atmos_col                       (:)     ! col (integrated)  flux of NOx from denitrifiation with canopy reduction [gN/m2/s]  
+     real(r8), pointer :: f_nox_nit_atmos_vr_col                      (:,:)   ! col flux of NOx from nitrification with canopy reduction [gN/m3/s] 
+     real(r8), pointer :: f_nox_nit_atmos_col                         (:)     ! col (integrated) flux of NOx from nitrification with canopy reduction [gN/m2/s] 
+!for coupling to atmosphere
+     real(r8), pointer :: soil_nox_total_col                               (:)     ! col (integrated) flux of NOx from nitrification and denitrification with canopy reduction [gN/m2/s]. This is the output to the atmosphere
+    real(r8), pointer :: afps_vr_col                               (:,:) !mvm air soi porosity
      ! immobilization / uptake fluxes
      real(r8), pointer :: actual_immob_no3_vr_col                   (:,:)   ! col vertically-resolved actual immobilization of NO3 (gN/m3/s)
      real(r8), pointer :: actual_immob_nh4_vr_col                   (:,:)   ! col vertically-resolved actual immobilization of NH4 (gN/m3/s)
@@ -224,7 +244,27 @@ contains
     allocate(this%f_n2o_denit_vr_col                (begc:endc,1:nlevdecomp_full)) ; this%f_n2o_denit_vr_col         (:,:) = nan
     allocate(this%f_n2o_nit_col                     (begc:endc))                   ; this%f_n2o_nit_col              (:)   = nan
     allocate(this%f_n2o_nit_vr_col                  (begc:endc,1:nlevdecomp_full)) ; this%f_n2o_nit_vr_col           (:,:) = nan
-
+!mvm 06/19/2023 Soil NOx fluxes
+    allocate(this%nox_n2o_ratio_vr_col              (begc:endc,1:nlevdecomp_full)) ; this%nox_n2o_ratio_vr_col       (:,:) = nan
+    allocate(this%f_nox_denit_col                   (begc:endc))                   ; this%f_nox_denit_col            (:)   = nan
+    allocate(this%f_nox_denit_vr_col                (begc:endc,1:nlevdecomp_full)) ; this%f_nox_denit_vr_col         (:,:) = nan
+    allocate(this%f_nox_nit_col                     (begc:endc))                   ; this%f_nox_nit_col              (:)   = nan
+    allocate(this%f_nox_nit_vr_col                  (begc:endc,1:nlevdecomp_full)) ; this%f_nox_nit_vr_col           (:,:) = nan
+    allocate(this%h2osoi_diff_vr_col                (begc:endc,1:nlevdecomp_full)) ; this%h2osoi_diff_vr_col          (:,:) = nan !for nox nit rain pulse
+    allocate(this%pot_f_nox_denit_col               (begc:endc))                   ; this%pot_f_nox_denit_col         (:)   = nan
+    allocate(this%pot_f_nox_denit_vr_col            (begc:endc,1:nlevdecomp_full)) ; this%pot_f_nox_denit_vr_col     (:,:) = nan
+    allocate(this%pot_f_nox_nit_col                 (begc:endc))                   ; this%pot_f_nox_nit_col           (:)   = nan
+    allocate(this%pot_f_nox_nit_vr_col              (begc:endc,1:nlevdecomp_full)) ; this%pot_f_nox_nit_vr_col        (:,:) = nan
+    allocate(this%f_n2_denit_col                    (begc:endc))                   ; this%f_n2_denit_col            (:)   = nan
+    allocate(this%f_n2_denit_vr_col                 (begc:endc,1:nlevdecomp_full)) ; this%f_n2_denit_vr_col         (:,:) = nan
+!mvm canopy reduction factor 06/19/2023 diagnostic
+    allocate(this%f_nox_denit_atmos_col             (begc:endc))                   ; this%f_nox_denit_atmos_col            (:)   = nan
+    allocate(this%f_nox_denit_atmos_vr_col          (begc:endc,1:nlevdecomp_full)) ; this%f_nox_denit_atmos_vr_col         (:,:) = nan
+    allocate(this%f_nox_nit_atmos_col               (begc:endc))                   ; this%f_nox_nit_atmos_col              (:)   = nan
+    allocate(this%f_nox_nit_atmos_vr_col            (begc:endc,1:nlevdecomp_full)) ; this%f_nox_nit_atmos_vr_col           (:,:) = nan
+!mvm for CAM-CHem 06/19/2023
+    allocate(this%soil_nox_total_col                (begc:endc))                   ; this%soil_nox_total_col         (:)   = nan
+    allocate(this%afps_vr_col                       (begc:endc,1:nlevdecomp_full)) ; this%afps_vr_col                (:,:) = nan
     allocate(this%smin_no3_massdens_vr_col          (begc:endc,1:nlevdecomp_full)) ; this%smin_no3_massdens_vr_col   (:,:) = nan
     allocate(this%soil_bulkdensity_col              (begc:endc,1:nlevdecomp_full)) ; this%soil_bulkdensity_col       (:,:) = nan
     allocate(this%k_nitr_t_vr_col                   (begc:endc,1:nlevdecomp_full)) ; this%k_nitr_t_vr_col            (:,:) = nan
@@ -596,6 +636,17 @@ contains
             ptr_col=this%n2_n2o_ratio_denit_vr_col, default='inactive')
     end if
 
+
+    !mvm 06/19/2023 Soil NOx emissions
+    if (use_nitrif_denitrif) then
+       this%nox_n2o_ratio_vr_col(begc:endc,:) = spval            
+       call hist_addfld_decomp (fname='NOx_N2O_RATIO', units='gN/gN', type2d='levdcmp', &
+            avgflag='A', long_name='NOx to N2O ratio', &
+            ptr_col=this%nox_n2o_ratio_vr_col, default='inactive')
+    end if
+
+
+
     if (use_nitrif_denitrif) then
        this%actual_immob_no3_vr_col(begc:endc,:) = spval
        call hist_addfld_decomp (fname='ACTUAL_IMMOB_NO3', units='gN/m^3/s', type2d='levdcmp', &
@@ -826,6 +877,40 @@ contains
        call hist_addfld1d (fname='F_N2O_DENIT', units='gN/m^2/s', &
             avgflag='A', long_name='denitrification N2O flux', &
             ptr_col=this%f_n2o_denit_col)
+
+       this%f_nox_nit_col(begc:endc) = spval
+       call hist_addfld1d (fname='F_NOx_NIT', units='gN/m^2/s', &
+            avgflag='A', long_name='nitrification NOx flux', &
+            ptr_col=this%f_nox_nit_col)
+
+       this%f_nox_denit_col(begc:endc) = spval
+       call hist_addfld1d (fname='F_NOx_DENIT', units='gN/m^2/s', &
+            avgflag='A', long_name='denitrification NOx flux', &
+            ptr_col=this%f_nox_denit_col)
+
+       this%f_n2_denit_col(begc:endc) = spval
+       call hist_addfld1d (fname='F_N2_DENIT', units='gN/m^2/s', &
+            avgflag='A', long_name='denitrification N2 flux', &
+            ptr_col=this%f_n2_denit_col)
+
+  !mvm: soil nox to atmosphere
+       this%f_nox_nit_atmos_col(begc:endc) = spval
+       call hist_addfld1d (fname='F_NOx_NIT_ATMOS', units='gN/m^2/s', &
+            avgflag='A', long_name='nitrification NOx flux with canopy reduction', &
+            ptr_col=this%f_nox_nit_atmos_col)
+       
+       this%f_nox_denit_atmos_col(begc:endc) = spval
+       call hist_addfld1d (fname='F_NOx_DENIT_ATMOS', units='gN/m^2/s', &
+            avgflag='A', long_name='denitrification NOx flux with canopy reduction', &
+            ptr_col=this%f_nox_denit_atmos_col)
+
+!soil NOx to CAM-Chem
+       this%soil_nox_total_col(begc:endc) = spval
+       call hist_addfld1d (fname='SOIL_NOx', units='gN/m^2/s', &
+            avgflag='A', long_name='total soil NOx (nit+denit with canopy reduction)', &
+            ptr_col=this%soil_nox_total_col)
+
+      
     end if
 
     if (use_crop) then
@@ -923,7 +1008,19 @@ contains
              this%smin_nh4_to_plant_vr_col(i,j)          = value_column
              this%f_n2o_denit_vr_col(i,j)                = value_column
              this%f_n2o_nit_vr_col(i,j)                  = value_column
-
+!mvm 06/23/2023 Soil NOx emissions
+             this%f_n2_denit_vr_col(i,j)                 = value_column
+             this%f_nox_denit_vr_col(i,j)                = value_column
+             this%f_nox_nit_vr_col(i,j)                  = value_column
+             this%nox_n2o_ratio_vr_col(i,j)              = value_column
+             this%pot_f_nox_denit_vr_col(i,j)            = value_column
+             this%pot_f_nox_nit_vr_col(i,j)              = value_column
+!mvm 06/23/2023 canopy reduction
+             this%f_nox_denit_atmos_vr_col(i,j)          = value_column
+             this%f_nox_nit_atmos_vr_col(i,j)            = value_column
+!for rain pulse diagnostic
+             this%h2osoi_diff_vr_col(i,j)                = value_column
+             this%afps_vr_col(i,j)                       = value_column
              this%smin_no3_massdens_vr_col(i,j)          = value_column
              this%k_nitr_t_vr_col(i,j)                   = value_column
              this%k_nitr_ph_vr_col(i,j)                  = value_column
@@ -980,6 +1077,16 @@ contains
           this%f_n2o_nit_col(i)              = value_column
           this%smin_no3_leached_col(i)       = value_column
           this%smin_no3_runoff_col(i)        = value_column
+!mvm 06/19/2023 soil nox
+          this%f_n2_denit_col(i)             = value_column
+          this%f_nox_denit_col(i)            = value_column
+          this%f_nox_nit_col(i)              = value_column
+          this%f_nox_denit_atmos_col(i)      = value_column
+          this%f_nox_nit_atmos_col(i)        = value_column
+          this%pot_f_nox_denit_col(i)        = value_column
+          this%pot_f_nox_nit_col(i)          = value_column
+ !mvm for CAM-chem
+          this%soil_nox_total_col(i)         = value_column
        else
           this%sminn_to_denit_excess_col(i)  = value_column
           this%sminn_leached_col(i)          = value_column
@@ -1162,6 +1269,36 @@ contains
                   this%f_n2o_denit_col(c) + &
                   this%f_n2o_denit_vr_col(c,j) * dzsoi_decomp(j)
 
+ !mvm 06/19/2023 Soil NOx emissions
+            this%f_n2_denit_col(c) = &
+                  this%f_n2_denit_col(c) + &
+                  this%f_n2_denit_vr_col(c,j) * dzsoi_decomp(j)
+             
+
+             this%f_nox_nit_col(c) = &
+                  this%f_nox_nit_col(c) + &
+                  this%f_nox_nit_vr_col(c,j) * dzsoi_decomp(j)
+
+             this%f_nox_denit_col(c) = &
+                  this%f_nox_denit_col(c) + &
+                  this%f_nox_denit_vr_col(c,j) * dzsoi_decomp(j)
+
+           this%f_nox_nit_atmos_col(c) = &
+                  this%f_nox_nit_atmos_col(c) + &
+                  this%f_nox_nit_atmos_vr_col(c,j) * dzsoi_decomp(j)
+
+             this%f_nox_denit_atmos_col(c) = &
+                  this%f_nox_denit_atmos_col(c) + &
+                  this%f_nox_denit_atmos_vr_col(c,j) * dzsoi_decomp(j)
+
+             this%pot_f_nox_nit_col(c) = &
+                  this%pot_f_nox_nit_col(c) + &
+                  this%pot_f_nox_nit_vr_col(c,j) * dzsoi_decomp(j)
+
+             this%pot_f_nox_denit_col(c) = &
+                  this%pot_f_nox_denit_col(c) + &
+                  this%pot_f_nox_denit_vr_col(c,j) * dzsoi_decomp(j)
+
              ! leaching/runoff flux
              this%smin_no3_leached_col(c) = &
                   this%smin_no3_leached_col(c) + &
@@ -1177,6 +1314,8 @@ contains
        do fc = 1,num_soilc
           c = filter_soilc(fc)
           this%denit_col(c) = this%f_denit_col(c)
+ !mvm 06/19/2023 for coupling. Total soil N fluxes pass to the atmosphere
+            this%soil_nox_total_col(c)=this%f_nox_nit_atmos_col(c)+this%f_nox_denit_atmos_col(c) 
        end do
 
     end if

--- a/src/soilbiogeochem/SoilBiogeochemNitrogenStateType.F90
+++ b/src/soilbiogeochem/SoilBiogeochemNitrogenStateType.F90
@@ -61,6 +61,9 @@ module SoilBiogeochemNitrogenStateType
      real(r8)          :: totvegcthresh                  ! threshold for total vegetation carbon to zero out decomposition pools
 
      ! Matrix-cn
+! rain pulse for soil NOx (mvm 06/23/2023)
+     real(r8), pointer :: ldry_vr_col                              (:,:)   ! dry period for rain pulses for NOx from nitrification [hours]
+     real(r8), pointer :: pfactor_vr_col                              (:,:)   ! pulsing factor [unitless]
 
    contains
 
@@ -143,6 +146,10 @@ contains
     end if
     allocate(this%decomp_soiln_vr_col(begc:endc,1:nlevdecomp_full))
     this%decomp_soiln_vr_col(:,:)= nan
+
+!mvm 06/19/2023 rain pulse for NOx: dry period and pulse factor
+    allocate(this%ldry_vr_col      (begc:endc,1:nlevdecomp_full)) ; this%ldry_vr_col      (:,:) = nan
+    allocate(this%pfactor_vr_col      (begc:endc,1:nlevdecomp_full)) ; this%pfactor_vr_col      (:,:) = nan 
 
   end subroutine InitAllocate
 
@@ -409,6 +416,10 @@ contains
              do j = 1, nlevdecomp_full
                 this%smin_nh4_vr_col(c,j) = 0._r8
                 this%smin_no3_vr_col(c,j) = 0._r8
+!mvm 06/19/2023 soil nox rain pulse
+                this%ldry_vr_col(c,j) = 0._r8 
+                this%pfactor_vr_col(c,j) = 0._r8
+  
              end do
              this%smin_nh4_col(c) = 0._r8
              this%smin_no3_col(c) = 0._r8
@@ -729,6 +740,10 @@ contains
           if (use_nitrif_denitrif) then
              this%smin_no3_vr_col(i,j) = value_column
              this%smin_nh4_vr_col(i,j) = value_column
+!mvm 06/19/2023 soil Nox rain pulse
+             this%ldry_vr_col(i,j)     = value_column 
+             this%pfactor_vr_col(i,j)  = value_column
+ 
           end if
        end do
     end do


### PR DESCRIPTION
This scheme is based on Parton et al (2001), and includes canopy reduction (Yan et al, 2005) and rain pulses (Yan et al 2005; Hudman et al 2012)

It is not connected to soil pH from the surface file, that is, it considers the fixed soil pH value of 6.5 given in
SoilBiogeochemCompetitionMod.F90

It also includes the dependency of the N mineralization-based term on potential nitrification rates that was implemented in Parton et al. (2001), which was missing
from previous versions of CLM5 as pointed out by Nevison et al., (2022).

This scheme -with more complexity as it is linked to spatially distributed soil pH and considers weathering effect on denitrification and NH3 volatilization- is described and evaluated in Val Martin et al (2023).

References

Hudman, R. C., Moore, N. E., Mebust, A. K., Martin, R. V., Russell, A. R., Valin, L. C., and Cohen, R. C.: Steps towards a mechanistic model of global soil nitric oxide emissions: implementation and space based-constraints, Atmos. Chem. Phys., 12, 7779–7795, https://doi.org/10.5194/acp-12-7779-2012, 2012.

Nevison, C., Goodale, C., Hess, P., Wieder, W. R., Vira, J., and Groffman, P. M.: Nitrification and Denitrification in the Community Land Model Compared with Observations at Hubbard Brook Forest, Ecol. Appl., 32, e2530, https://doi.org/10.1002/eap.2530, 2022

Parton, W. J., Holland, E. A., Del Grosso, S. J., Hartman, M. D., Martin, R. E., Mosier, A. R., Ojima, D. S., and Schimel, D. S.: Generalized model for NOx and N2O emissions from soils, J. Geophys. Res.-Atmos., 106, 17403–17419, https://doi.org/10.1029/2001JD900101, 2001.

Val Martin, M., Blanc-Betes, E., Fung, K. M., Kantzas, E. P., Kantola, I. B., Chiaravalloti, I., Taylor, L. L., Emmons, L. K., Wieder, W. R., Planavsky, N. J., Masters, M. D., DeLucia, E. H., Tai, A. P. K., and Beerling, D. J.: Improving nitrogen cycling in a land surface model (CLM5) to quantify soil N2O, NO, and NH3 emissions from enhanced rock weathering with croplands, Geosci. Model Dev., 16, 5783–5801, https://doi.org/10.5194/gmd-16-5783-2023, 2023.

Yan, X., Ohara, T., and Akimoto, H.: Statistical modelling of global soil NOx emissions, Global Biogeochem. Cy., 19, GB3019, https://doi.org/10.1029/2004GB002276, 2005.

### Description of changes

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
