### PR TITLE
Add new scheme Li2024 of ozone plant damage

### DIFF
--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -1174,9 +1174,10 @@ Initial seed Carbon to use at planting
 </entry>
 
 <entry id="o3_veg_stress_method" type="char*32" category="physics"
-       group="clm_inparm" valid_values="unset,stress_lombardozzi2015,stress_falk" value="unset">
+       group="clm_inparm" valid_values="unset,stress_li2024,stress_lombardozzi2015,stress_falk" value="unset">
        Parameter to set the type of ozone vegetation stress method 
-       unset                  = (default) ozone stress vegetation method is off 
+	unset                  = (default) ozone stress vegetation method is off
+       stress_li2024          = ozone stress vegetation functions from Fang Li 2024
        stress_lombardozzi2015 = ozone stress vegetation functions from Danica Lombardozzi 2015
        stress_falk            = ozone stress vegetation functions from Stefanie Falk (issue #1224)
 <default>Default: "unset"</default>

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1681,7 +1681,8 @@ bioms:   do f = 1, fn
               rb        = frictionvel_inst%rb1_patch(bounds%begp:bounds%endp), &
               ram       = frictionvel_inst%ram1_patch(bounds%begp:bounds%endp), &
               tlai      = canopystate_inst%tlai_patch(bounds%begp:bounds%endp),  &
-	      forc_o3   = atm2lnd_inst%forc_o3_grc(bounds%begg:bounds%endg))
+	      forc_o3   = atm2lnd_inst%forc_o3_grc(bounds%begg:bounds%endg),  &
+              sabv      = solarabs_inst%sabv_patch(bounds%begp:bounds%endp))
 
          !---------------------------------------------------------
          !update Vc,max and Jmax by LUNA model

--- a/src/biogeophys/OzoneBaseMod.F90
+++ b/src/biogeophys/OzoneBaseMod.F90
@@ -64,7 +64,7 @@ module OzoneBaseMod
      end subroutine Restart_interface
 
      subroutine CalcOzoneUptake_interface(this, bounds, num_exposedvegp, filter_exposedvegp, &
-          forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3)
+          forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3, sabv)
        use decompMod    , only : bounds_type
        use shr_kind_mod , only : r8 => shr_kind_r8
        import :: ozone_base_type
@@ -81,6 +81,8 @@ module OzoneBaseMod
        real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
        real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
        real(r8) , intent(in) :: forc_o3( bounds%begg: )   ! atmospheric ozone (mol/mol)
+       real(r8) , intent(in) :: sabv ( bounds%begp: )     ! solar radiation absorbed by vegetation (W/m**2)
+
      end subroutine CalcOzoneUptake_interface
 
      subroutine CalcOzoneStress_interface(this, bounds, &

--- a/src/biogeophys/OzoneMod.F90
+++ b/src/biogeophys/OzoneMod.F90
@@ -779,6 +779,7 @@ subroutine CalcOzoneUptakeLFOnePoint( &
        o3coefg = 1._r8
     else
        ! Determine parameter values for this pft
+       ! TODO lifang0209: Update functions
        if(pft_type >= 1 .and. pft_type <= 3)then  !Needleleaf tree
         o3coefv = max(0._r8, min(1._r8, 0.991_r8 - 0.043_r8 * log(o3uptake)))
         o3coefg = max(0._r8, min(1._r8, 1.003_r8 - 0.038_r8 * log(o3uptake)))

--- a/src/biogeophys/OzoneOffMod.F90
+++ b/src/biogeophys/OzoneOffMod.F90
@@ -94,7 +94,7 @@ contains
   end subroutine Restart
 
   subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
-       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3)
+       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3, sabv)
 
     class(ozone_off_type) , intent(inout) :: this
     type(bounds_type)      , intent(in)    :: bounds
@@ -108,6 +108,8 @@ contains
     real(r8) , intent(in) :: ram( bounds%begp: )       ! aerodynamical resistance (s/m)
     real(r8) , intent(in) :: tlai( bounds%begp: )      ! one-sided leaf area index, no burying by snow
     real(r8) , intent(in) :: forc_o3( bounds%begg: )   ! atmospheric ozone (mol/mol)
+    real(r8) , intent(in) :: sabv ( bounds%begp: )     ! solar radiation absorbed by vegetation (W/m**2)
+
 
     ! Enforce expected array sizes (mainly so that a debug-mode threaded test with
     ! ozone-off can pick up problems with the call to this routine)
@@ -119,6 +121,7 @@ contains
     SHR_ASSERT_ALL_FL((ubound(ram) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(tlai) == (/bounds%endp/)), sourcefile, __LINE__)
     SHR_ASSERT_ALL_FL((ubound(forc_o3) == (/bounds%endg/)), sourcefile, __LINE__)
+    SHR_ASSERT_ALL_FL((ubound(sabv) == (/bounds%endp/)), sourcefile, __LINE__)
 
     ! Do nothing: In the ozone off case, we don't need to track ozone uptake
 

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -1346,7 +1346,7 @@ contains
     real(r8) , pointer :: rs_z        (:,:)
     real(r8) , pointer :: ci_z        (:,:)
     real(r8) , pointer :: o3coefv     (:)  ! o3 coefficient used in photo calculation
-    real(r8) , pointer :: o3coefg     (:)  ! o3 coefficient used in rs calculation
+    real(r8) , pointer :: o3coefg     (:)  ! o3 coefficient used in gs calculation
     real(r8) , pointer :: alphapsnsun (:)
     real(r8) , pointer :: alphapsnsha (:)
 
@@ -1435,7 +1435,7 @@ contains
          vcmaxcint =>    surfalb_inst%vcmaxcintsun_patch     ! Input:  [real(r8) (:)   ]  leaf to canopy scaling coefficient
          alphapsn  =>    photosyns_inst%alphapsnsun_patch    ! Input:  [real(r8) (:)   ]  13C fractionation factor for PSN ()
          o3coefv   =>    ozone_inst%o3coefvsun_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in photosynthesis calculation
-         o3coefg   =>    ozone_inst%o3coefgsun_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in rs calculation
+         o3coefg   =>    ozone_inst%o3coefgsun_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in gs calculation
          ci_z      =>    photosyns_inst%cisun_z_patch        ! Output: [real(r8) (:,:) ]  intracellular leaf CO2 (Pa)
          rs        =>    photosyns_inst%rssun_patch          ! Output: [real(r8) (:)   ]  leaf stomatal resistance (s/m)
          rs_z      =>    photosyns_inst%rssun_z_patch        ! Output: [real(r8) (:,:) ]  canopy layer: leaf stomatal resistance (s/m)
@@ -1452,7 +1452,7 @@ contains
          vcmaxcint =>    surfalb_inst%vcmaxcintsha_patch     ! Input:  [real(r8) (:)   ]  leaf to canopy scaling coefficient
          alphapsn  =>    photosyns_inst%alphapsnsha_patch    ! Input:  [real(r8) (:)   ]  13C fractionation factor for PSN ()
          o3coefv   =>    ozone_inst%o3coefvsha_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in photosynthesis calculation
-         o3coefg   =>    ozone_inst%o3coefgsha_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in rs calculation
+         o3coefg   =>    ozone_inst%o3coefgsha_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in gs calculation
          ci_z      =>    photosyns_inst%cisha_z_patch        ! Output: [real(r8) (:,:) ]  intracellular leaf CO2 (Pa)
          rs        =>    photosyns_inst%rssha_patch          ! Output: [real(r8) (:)   ]  leaf stomatal resistance (s/m)
          rs_z      =>    photosyns_inst%rssha_z_patch        ! Output: [real(r8) (:,:) ]  canopy layer: leaf stomatal resistance (s/m)
@@ -1934,9 +1934,9 @@ contains
 
                ! Convert gs_mol (umol H2O/m**2/s) to gs (m/s) and then to rs (s/m)
 
-               gs = gs_mol(p,iv) / cf
+               gs = gs_mol(p,iv) / cf * o3coefg(p)
                rs_z(p,iv) = min(1._r8/gs, rsmax0)
-               rs_z(p,iv) = rs_z(p,iv) / o3coefg(p)
+               rs_z(p,iv) = rs_z(p,iv)
 
                ! Photosynthesis. Save rate-limiting photosynthesis
 
@@ -2857,7 +2857,7 @@ contains
     real(r8) , pointer :: rs_z_sun        (:,:) ! canopy layer: leaf stomatal resistance, sunlit (s/m)
     real(r8) , pointer :: ci_z_sun        (:,:) ! intracellular leaf CO2, sunlit (Pa)
     real(r8) , pointer :: o3coefv_sun     (:)   ! o3 coefficient used in photo calculation, sunlit
-    real(r8) , pointer :: o3coefg_sun     (:)   ! o3 coefficient used in rs calculation, sunlit
+    real(r8) , pointer :: o3coefg_sun     (:)   ! o3 coefficient used in gs calculation, sunlit
     real(r8) , pointer :: lai_z_sha       (:,:) ! leaf area index for canopy layer, shaded
     real(r8) , pointer :: par_z_sha       (:,:) ! par absorbed per unit lai for canopy layer, shaded (w/m**2)
     real(r8) , pointer :: vcmaxcint_sha   (:)   ! leaf to canopy scaling coefficient, shaded
@@ -2873,7 +2873,7 @@ contains
     real(r8) , pointer :: rs_z_sha        (:,:) ! canopy layer: leaf stomatal resistance, shaded (s/m)
     real(r8) , pointer :: ci_z_sha        (:,:) ! intracellular leaf CO2, shaded (Pa)
     real(r8) , pointer :: o3coefv_sha     (:)   ! o3 coefficient used in photo calculation, shaded
-    real(r8) , pointer :: o3coefg_sha     (:)   ! o3 coefficient used in rs calculation, shaded
+    real(r8) , pointer :: o3coefg_sha     (:)   ! o3 coefficient used in gs calculation, shaded
     real(r8) :: sum_nscaler
     real(r8) :: total_lai                
     integer  :: nptreemax                
@@ -2999,7 +2999,7 @@ contains
       vcmaxcint_sun =>    surfalb_inst%vcmaxcintsun_patch     ! Input:  [real(r8) (:)   ]  leaf to canopy scaling coefficient
       alphapsn_sun  =>    photosyns_inst%alphapsnsun_patch    ! Input:  [real(r8) (:)   ]  13C fractionation factor for PSN ()
       o3coefv_sun   =>    ozone_inst%o3coefvsun_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in photosynthesis calculation
-      o3coefg_sun   =>    ozone_inst%o3coefgsun_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in rs calculation
+      o3coefg_sun   =>    ozone_inst%o3coefgsun_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in gs calculation
       ci_z_sun      =>    photosyns_inst%cisun_z_patch        ! Output: [real(r8) (:,:) ]  intracellular leaf CO2 (Pa)
       rs_sun        =>    photosyns_inst%rssun_patch          ! Output: [real(r8) (:)   ]  leaf stomatal resistance (s/m)
       rs_z_sun      =>    photosyns_inst%rssun_z_patch        ! Output: [real(r8) (:,:) ]  canopy layer: leaf stomatal resistance (s/m)
@@ -3015,7 +3015,7 @@ contains
       vcmaxcint_sha =>    surfalb_inst%vcmaxcintsha_patch     ! Input:  [real(r8) (:)   ]  leaf to canopy scaling coefficient
       alphapsn_sha  =>    photosyns_inst%alphapsnsha_patch    ! Input:  [real(r8) (:)   ]  13C fractionation factor for PSN ()
       o3coefv_sha   =>    ozone_inst%o3coefvsha_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in photosynthesis calculation
-      o3coefg_sha   =>    ozone_inst%o3coefgsha_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in rs calculation
+      o3coefg_sha   =>    ozone_inst%o3coefgsha_patch         ! Input:  [real(r8) (:)   ]  O3 coefficient used in gs calculation
       ci_z_sha      =>    photosyns_inst%cisha_z_patch        ! Output: [real(r8) (:,:) ]  intracellular leaf CO2 (Pa)
       rs_sha        =>    photosyns_inst%rssha_patch          ! Output: [real(r8) (:)   ]  leaf stomatal resistance (s/m)
       rs_z_sha      =>    photosyns_inst%rssha_z_patch        ! Output: [real(r8) (:,:) ]  canopy layer: leaf stomatal resistance (s/m)
@@ -3621,12 +3621,12 @@ contains
 
                ! Convert gs_mol (umol H2O/m**2/s) to gs (m/s) and then to rs (s/m)
 
-               gs = gs_mol_sun(p,iv) / cf
+               gs = gs_mol_sun(p,iv) / cf * o3coefg_sun(p)
                rs_z_sun(p,iv) = min(1._r8/gs, rsmax0)
-               rs_z_sun(p,iv) = rs_z_sun(p,iv) / o3coefg_sun(p)
-               gs = gs_mol_sha(p,iv) / cf
+               rs_z_sun(p,iv) = rs_z_sun(p,iv) 
+               gs = gs_mol_sha(p,iv) / cf * o3coefg_sha(p)
                rs_z_sha(p,iv) = min(1._r8/gs, rsmax0)
-               rs_z_sha(p,iv) = rs_z_sha(p,iv) / o3coefg_sha(p)
+               rs_z_sha(p,iv) = rs_z_sha(p,iv)
 
                ! Photosynthesis. Save rate-limiting photosynthesis
 

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -1933,7 +1933,12 @@ contains
                ci_z(p,iv) = max( ci_z(p,iv), 1.e-06_r8 )
 
                ! Convert gs_mol (umol H2O/m**2/s) to gs (m/s) and then to rs (s/m)
-
+               
+               ! Fang Li revised o3 impact on gs
+               ! now: multiply gs response factor (o3coefg) with gs
+               ! clm5.0: skipped the effect on gs and had rs divided by o3coefg, 
+               ! which led to a one timestep delay in the o3 impact on gs,
+               ! although the impact on an annual scale is quite small
                gs = gs_mol(p,iv) / cf * o3coefg(p)
                rs_z(p,iv) = min(1._r8/gs, rsmax0)
                rs_z(p,iv) = rs_z(p,iv)
@@ -3620,7 +3625,12 @@ contains
                ci_z_sha(p,iv) = max( ci_z_sha(p,iv), 1.e-06_r8 )
 
                ! Convert gs_mol (umol H2O/m**2/s) to gs (m/s) and then to rs (s/m)
-
+               
+               ! Fang Li revised o3 impact on gs
+               ! now: multiply gs response factor (o3coefg) with gs
+               ! clm5.0: skipped the effect on gs and had rs divided by o3coefg,
+               ! which led to a one timestep delay in the o3 impact on gs,
+               ! although the impact on an annual scale is quite small
                gs = gs_mol_sun(p,iv) / cf * o3coefg_sun(p)
                rs_z_sun(p,iv) = min(1._r8/gs, rsmax0)
                rs_z_sun(p,iv) = rs_z_sun(p,iv) 

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -227,7 +227,7 @@ module clm_varctl
   ! atmospheric CO2 molar ratio (by volume) (umol/mol)
   real(r8), public :: co2_ppmv     = 355._r8            !
 
-  ! ozone vegitation stress method, valid values: unset, stress_lombardozzi2015, stress_falk
+  ! ozone vegitation stress method, valid values: unset, stress_li2024, stress_lombardozzi2015, stress_falk
   character(len=64), public    :: o3_veg_stress_method = 'unset'
 
   real(r8), public  :: o3_ppbv = 100._r8


### PR DESCRIPTION
### Description of changes
Changes include: 
OzoneMod.F90: add an option for scheme of Li2024:
Include add: (i) CalcOzoneUptakeLi2024OnePoint to calculate ozone uptake for a single point, and change the name of old module for Lombardozzi2015 and Falk schemes as CalcOzoneUptakeLFOnePoint. (ii) add CalcOzoneStressLi2024 and CalcOzoneStressLi2024OnePoint to calculate ozone stress. 

Change CanopyFluxesMod.F90, OzoneBaseMod.F90, OzoneOffMod.F90 to read the variable sabv that CalcOzoneUptake use.
subroutine CalcOzoneUptake(this, bounds, num_exposedvegp, filter_exposedvegp, &
       forc_pbot, forc_th, rssun, rssha, rb, ram, tlai, forc_o3, sabv)

In bld/namelist_files/namelist_definition_ctsm.xml: add stress_li2024 as the new option

### Specific notes

Contributors other than yourself, if any: @slevis-lmwg @dlawrenncar @danicalombardozzi @ekluzek 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Yes, when using the new scheme

Any User Interface Changes (namelist or namelist defaults changes)?
new namelist option: stress_li2024 

Testing performed, if any:
@lifang0209 ran I2000Sp and I2000BgcCrop
