### PR TITLE
Merge tag: Turn on meier2022 and bring in #2212

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2262,6 +2262,7 @@ sub setup_logic_crop_inparm {
                  'use_crop'=>$nl->get_value('use_crop') );
      
      my $crop_residue_removal_frac = $nl->get_value('crop_residue_removal_frac');
+     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'crop_residue_removal_frac' );
      if ( $crop_residue_removal_frac < 0.0 or $crop_residue_removal_frac > 1.0 ) {
         $log->fatal_error("crop_residue_removal_frac must be in range [0, 1]");
      }
@@ -2275,6 +2276,8 @@ sub setup_logic_crop_inparm {
 
 sub setup_logic_tillage {
   my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
+
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'tillage_mode' );
 
   my $tillage_mode = remove_leading_and_trailing_quotes( $nl->get_value( "tillage_mode" ) );
   if ( $tillage_mode ne "off" && $tillage_mode ne "" && not &value_is_true($nl->get_value('use_crop')) ) {

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1637,7 +1637,7 @@ sub process_namelist_inline_logic {
   ###############################
   # namelist group: tillage     #
   ###############################
-  setup_logic_tillage($opts,  $nl_flags, $definition, $defaults, $nl);
+  setup_logic_tillage($opts, $nl_flags, $definition, $defaults, $nl, $physv);
 
   ###############################
   # namelist group: ch4par_in   #
@@ -2275,12 +2275,13 @@ sub setup_logic_crop_inparm {
 #-------------------------------------------------------------------------------
 
 sub setup_logic_tillage {
-  my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
+  my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
 
-  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'tillage_mode' );
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'tillage_mode',
+              'use_crop'=>$nl_flags->{'use_crop'}, 'phys'=>$physv->as_string() );
 
   my $tillage_mode = remove_leading_and_trailing_quotes( $nl->get_value( "tillage_mode" ) );
-  if ( $tillage_mode ne "off" && $tillage_mode ne "" && not &value_is_true($nl->get_value('use_crop')) ) {
+  if ( $tillage_mode ne "off" && $tillage_mode ne "" && not &value_is_true($nl_flags->{'use_crop'}) ) {
       $log->fatal_error( "Tillage only works on crop columns, so use_crop must be true if tillage is enabled." );
   }
 }

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1571,6 +1571,7 @@ sub process_namelist_inline_logic {
   setup_logic_irrigate($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_start_type($opts, $nl_flags, $nl);
   setup_logic_decomp_performance($opts,  $nl_flags, $definition, $defaults, $nl);
+  setup_logic_roughness_methods($opts, $nl_flags, $definition, $defaults, $nl, $physv);
   setup_logic_snicar_methods($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_snow($opts, $nl_flags, $definition, $defaults, $nl);
   setup_logic_glacier($opts, $nl_flags, $definition, $defaults, $nl,  $envxml_ref);
@@ -2000,6 +2001,25 @@ sub setup_logic_decomp_performance {
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'nsegspc', 'hgrid'=>$nl_flags->{'res'});
 }
 
+#-------------------------------------------------------------------------------
+
+sub setup_logic_roughness_methods {
+  my ($opts, $nl_flags, $definition, $defaults, $nl, $physv) = @_;
+
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'z0param_method',
+              'phys'=>$nl_flags->{'phys'} );
+
+  my $var = remove_leading_and_trailing_quotes( $nl->get_value("z0param_method") );
+  if ( $var ne "Meier2022" && $var ne "ZengWang2007" ) {
+    $log->fatal_error("$var is incorrect entry for the namelist variable z0param_method; expected Meier2022 or ZengWang2007");
+  }
+  my $phys = $physv->as_string();
+  if ( $phys eq "clm4_5" || $phys eq "clm5_0" ) {
+    if ( $var eq "Meier2022" ) {
+      $log->fatal_error("z0param_method = $var and phys = $phys, but this method has been tested only with clm5_1 and later versions; to use with earlier versions, disable this error, and add Meier2022 parameters to the corresponding params file");
+    }
+  }
+}
 #-------------------------------------------------------------------------------
 
 sub setup_logic_snicar_methods {

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -498,11 +498,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Default surface roughness parameterization                         -->
 <!-- ================================================================== -->
 
-<!-- begin slevis TESTING
 <z0param_method>ZengWang2007</z0param_method>
 <z0param_method phys="clm5_1">Meier2022</z0param_method>
-end slevis TESTING -->
-<z0param_method>Meier2022</z0param_method>
 
 <use_z0m_snowmelt z0param_method="Meier2022" >.true.</use_z0m_snowmelt>
 <use_z0m_snowmelt >.false.</use_z0m_snowmelt>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2815,7 +2815,7 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <!-- =========================================  -->
 
 <tillage_mode>off</tillage_mode>
-<tillage_mode phys="clm5_1">low</tillage_mode>
+<tillage_mode use_crop=".true." phys="clm5_1">low</tillage_mode>
 
 <use_original_tillage_phases>.false.</use_original_tillage_phases>
 <max_tillage_depth>0.26d00</max_tillage_depth>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -498,7 +498,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Default surface roughness parameterization                         -->
 <!-- ================================================================== -->
 
+<!-- begin slevis TESTING
 <z0param_method>ZengWang2007</z0param_method>
+<z0param_method phys="clm5_1">Meier2022</z0param_method>
+end slevis TESTING -->
+<z0param_method>Meier2022</z0param_method>
 
 <use_z0m_snowmelt z0param_method="Meier2022" >.true.</use_z0m_snowmelt>
 <use_z0m_snowmelt >.false.</use_z0m_snowmelt>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -555,6 +555,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_grainproduct use_crop=".true." phys="clm5_1" >.true.</use_grainproduct> <!-- 1-year grain product pool default to on for clm50 if crop is turned on -->
 
 <crop_residue_removal_frac>0.d+0</crop_residue_removal_frac>
+<crop_residue_removal_frac phys="clm5_1">0.5d00</crop_residue_removal_frac>
 
 <!-- Crop model options -->
 <baset_mapping           use_crop=".true." phys="clm4_5" >constant</baset_mapping>
@@ -2814,6 +2815,8 @@ use_crop=".true.">lnd/clm2/surfdata_map/ctsm5.1.dev052/landuse.timeseries_mpasa1
 <!-- =========================================  -->
 
 <tillage_mode>off</tillage_mode>
+<tillage_mode phys="clm5_1">low</tillage_mode>
+
 <use_original_tillage_phases>.false.</use_original_tillage_phases>
 <max_tillage_depth>0.26d00</max_tillage_depth>
 

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -228,4 +228,25 @@
     </phase>
   </test>
 
+  <test name="ERS_D_Ld15.f45_f45_mg37.I2000Clm50FatesRs.derecho_intel.clm-FatesColdTwoStream">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>#2325</issue>
+    </phase>
+  </test>
+
+  <test name="ERS_D_Ld15.f45_f45_mg37.I2000Clm50FatesRs.izumi_nag.clm-FatesColdTwoStream">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>#2325</issue>
+    </phase>
+  </test>
+
+  <test name="ERS_D_Ld15.f45_f45_mg37.I2000Clm50FatesRs.derecho_gnu.clm-FatesColdTwoStreamNoCompFixedBioGeo">
+    <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>#2325</issue>
+    </phase>
+  </test>
+
 </expectedFails>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,80 @@
 ===============================================================
+Tag name: ctsm5.1.dev165
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310), oleson (Keith Oleson), samrabin (Sam Rabin)
+Date: Fri 19 Jan 2024 06:40:36 PM MST
+One-line Summary: Turn Meier2022, tillage, and residue removal on for ctsm5.1, fix #2212
+
+Purpose and description of changes
+----------------------------------
+
+Answer-changing merge-tag:
+- Turn Meier2022 on for ctsm5.1. Had turned off temporarily while fixing a bug.
+- Bring in Urban answer fix #2212.
+- Turn tillage and residue removal on for ctsm5.1.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[x] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+CTSM issues fixed (include CTSM Issue #):
+Fixes #2212
+
+Notes of particular relevance for users
+---------------------------------------
+Changes made to namelist defaults (e.g., changed parameter values):
+- Making Meier2022 the default for ctsm5.1 again.
+- Making tillage low by default for ctsm5.1.
+- Making residue removal 0.5 by default for ctsm5.1.
+
+Testing summary:
+----------------
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  [ If a tag changes answers relative to baseline comparison the
+    following should be filled in (otherwise remove this section).
+    And always remove these three lines and parts that don't apply. ]
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: ALL
+    - what platforms/compilers: ALL
+    - nature of change:i
+ clm45 and clm50: larger than roundoff
+ clm51: possibly climate changing
+        Effect of Meier2022 was documented here: https://github.com/NCAR/LMWG_dev/issues/38
+        Effect of tillage and residue removal may require an Answer Changing Tag simulation
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/2323
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev164
 Originator(s): rgknox (Ryan Knox)
 Date: Wed 17 Jan 2024 12:38:18 PM MST

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,7 +1,8 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev165   slevis 01/19/2024 Turn Meier2022, tillage, residue removal on for ctsm5.1, fix #2212
     ctsm5.1.dev164   rgknox 01/17/2024 Compatibility and tests for FATES 2-Stream
-    ctsm5.1.dev163      sam 01/10/2024 Add tillage and residue removal
+    ctsm5.1.dev163 samrabin 01/10/2024 Add tillage and residue removal
     ctsm5.1.dev162 samrabin 01/05/2024 Improvements to processing of crop calendar files
     ctsm5.1.dev161 samrabin 01/04/2024 Refactor 20-year running means of crop GDD accumulation
     ctsm5.1.dev160 glemieux 12/30/2023 FATES landuse version 1

--- a/src/biogeophys/UrbBuildTempOleson2015Mod.F90
+++ b/src/biogeophys/UrbBuildTempOleson2015Mod.F90
@@ -383,9 +383,11 @@ contains
 
     ! Get terms from soil temperature equations to compute conduction flux
     ! Negative is toward surface - heat added
-    ! Note that the conduction flux here is in W m-2 wall area but for purposes of solving the set of
-    ! simultaneous equations this must be converted to W m-2 floor area. This is done below when 
-    ! setting up the equation coefficients.
+    ! Note that the convection and conduction fluxes for the walls are in W m-2 wall area 
+    ! but for purposes of solving the set of simultaneous equations this must be converted to W m-2 
+    ! floor or roof area. This is done below when setting up the equation coefficients by multiplying by building_hwr.
+    ! Note also that the longwave radiation terms for the walls are in terms of W m-2 floor area since the view
+    ! factors implicitly convert from per unit wall area to per unit floor or roof area.
 
     do fc = 1,num_nolakec
        c = filter_nolakec(fc)
@@ -424,10 +426,8 @@ contains
          ! This view factor implicitly converts from per unit wall area to per unit floor area
          vf_wf(l)  = 0.5_r8*(1._r8 - vf_rf(l))
 
-         ! This view factor implicitly converts from per unit floor area to per unit wall area
-         vf_fw(l) = vf_wf(l) / building_hwr(l)
+         vf_fw(l) = vf_wf(l)
 
-         ! This view factor implicitly converts from per unit roof area to per unit wall area
          vf_rw(l)  = vf_fw(l)
 
          ! This view factor implicitly converts from per unit wall area to per unit roof area
@@ -831,7 +831,7 @@ contains
                         + em_floori(l)*sb*t_floor_bef(l)**4._r8 &
                         + 4._r8*em_floori(l)*sb*t_floor_bef(l)**3.*(t_floor(l) - t_floor_bef(l))
 
-         qrd_building(l) = qrd_roof(l) + building_hwr(l)*(qrd_sunw(l) + qrd_shdw(l)) + qrd_floor(l)
+         qrd_building(l) = qrd_roof(l) + qrd_sunw(l) + qrd_shdw(l) + qrd_floor(l)
 
          if (abs(qrd_building(l)) > .10_r8 ) then
            write (iulog,*) 'urban inside building net longwave radiation balance error ',qrd_building(l)


### PR DESCRIPTION
### Description of changes

Answer-changing merge-tag:
- Turn Meier2022 on for ctsm5.1. Had turned off temporarily while fixing a bug.
- Bring in Urban answer fix #2212.
- Turn tillage and residue removal on for ctsm5.1. Decisions posted below.

### Specific notes

Contributors other than yourself, if any:
@olyson @samsrabin 

CTSM Issues Fixed (include github issue #):
Fixes #2212 

Are answers expected to change (and if so in what way)?
Yes, for ctsm5.1 cases by making Meier2022 on, tillage low, and residue removal 0.5 by default.
Yes, for clm45/clm50 by including the #2212 fix.

Any User Interface Changes (namelist or namelist defaults changes)?
Making Meier2022 the default for ctsm5.1 again.
Making tillage low by default for ctsm5.1.
Making residue removal 0.5 by default for ctsm5.1.

Testing performed, if any: