### PR TITLE
fates parameter file auto-build for all tests

### DIFF
--- a/cime_config/testdefs/testmods_dirs/clm/Fates/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/Fates/shell_commands
@@ -1,2 +1,16 @@
 ./xmlchange CLM_BLDNML_OPTS="-no-megan" --append
 ./xmlchange BFBFLAG="TRUE"
+
+CASE=`./xmlquery CASE --value`
+SRCROOT=`./xmlquery SRCROOT --value`
+
+#CIME_OUTPUT_ROOT=`./xmlquery CIME_OUTPUT_ROOT --value`
+# CASEDIR=`./xmlquery CASEROOT --value`
+# env_test.xml IS NOT AVAILABLE TESTROOT=`./xmlquery TESTROOT --value`
+# env_test.xml IS NOT AVAILABLE TESTID=`./xmlquery TESTID --value`
+# env_test.xml IS NOT AVAILABLE TESTARGV=`./xmlquery TEST_ARGV --value`
+
+FATESDIR=$SRCROOT/src/fates
+FATESPARAMFILE=${SRCROOT}/src/fates/parameter_files/binaries/${CASE}-params.nc
+
+ncgen -o $FATESPARAMFILE $FATESDIR/parameter_files/fates_params_default.cdl

--- a/cime_config/testdefs/testmods_dirs/clm/Fates/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Fates/user_nl_clm
@@ -4,6 +4,7 @@ hist_nhtfrq       = -24
 hist_empty_htapes = .true.
 hist_ndens = 1
 fates_spitfire_mode = 1
+fates_paramfile='${SRCROOT}/src/fates/parameter_files/binaries/${CASE}-params.nc'
 hist_fincl1       = 'FATES_NCOHORTS', 'FATES_TRIMMING', 'FATES_AREA_PLANTS',
 'FATES_AREA_TREES', 'FATES_COLD_STATUS', 'FATES_GDD',
 'FATES_NCHILLDAYS', 'FATES_NCOLDDAYS', 'FATES_DAYSINCE_COLDLEAFOFF','FATES_DAYSINCE_COLDLEAFON',

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdSeedDisp/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdSeedDisp/shell_commands
@@ -1,9 +1,7 @@
-SRCDIR=`./xmlquery SRCROOT --value`
-CASEDIR=`./xmlquery CASEROOT --value`
-FATESDIR=$SRCDIR/src/fates/
-FATESPARAMFILE=$SRCDIR/fates_params_seeddisp_4x5.nc
-
-ncgen -o $FATESPARAMFILE $FATESDIR/parameter_files/fates_params_default.cdl
+CASE=`./xmlquery CASE --value`
+SRCROOT=`./xmlquery SRCROOT --value`
+FATESDIR=$SRCROOT/src/fates
+FATESPARAMFILE=${SRCROOT}/src/fates/parameter_files/binaries/${CASE}-params.nc
 
 $FATESDIR/tools/modify_fates_paramfile.py --O --fin $FATESPARAMFILE --fout $FATESPARAMFILE --var fates_seed_dispersal_fraction --val 0.2 --allpfts
 $FATESDIR/tools/modify_fates_paramfile.py --O --fin $FATESPARAMFILE --fout $FATESPARAMFILE --var fates_seed_dispersal_max_dist --val 2500000 --allpfts

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdSeedDisp/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdSeedDisp/user_nl_clm
@@ -1,3 +1,2 @@
-fates_paramfile = '$SRCROOT/fates_params_seeddisp_4x5.nc'
 fates_seeddisp_cadence = 1
 hist_fincl1       = 'FATES_SEEDS_IN_GRIDCELL_PF', 'FATES_SEEDS_OUT_GRIDCELL_PF'

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStream/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStream/shell_commands
@@ -1,8 +1,5 @@
-SRCDIR=`./xmlquery SRCROOT --value`
-CASEDIR=`./xmlquery CASEROOT --value`
-FATESDIR=$SRCDIR/src/fates
-FATESPARAMFILE=$CASEDIR/fates_params_twostream.nc
-
-ncgen -o $FATESPARAMFILE $FATESDIR/parameter_files/fates_params_default.cdl
-
+CASE=`./xmlquery CASE --value`
+SRCROOT=`./xmlquery SRCROOT --value`
+FATESDIR=$SRCROOT/src/fates
+FATESPARAMFILE=${SRCROOT}/src/fates/parameter_files/binaries/${CASE}-params.nc
 $FATESDIR/tools/modify_fates_paramfile.py --O --fin $FATESPARAMFILE --fout $FATESPARAMFILE --var fates_rad_model --val 2 --allpfts

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStream/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStream/user_nl_clm
@@ -1,1 +1,1 @@
-fates_paramfile = '$CASEROOT/fates_params_twostream.nc'
+

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStreamNoCompFixedBioGeo/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStreamNoCompFixedBioGeo/shell_commands
@@ -1,8 +1,5 @@
-SRCDIR=`./xmlquery SRCROOT --value`
-CASEDIR=`./xmlquery CASEROOT --value`
-FATESDIR=$SRCDIR/src/fates
-FATESPARAMFILE=$CASEDIR/fates_params_twostream.nc
-
-ncgen -o $FATESPARAMFILE $FATESDIR/parameter_files/fates_params_default.cdl
-
+CASE=`./xmlquery CASE --value`
+SRCROOT=`./xmlquery SRCROOT --value`
+FATESDIR=$SRCROOT/src/fates
+FATESPARAMFILE=${SRCROOT}/src/fates/parameter_files/binaries/${CASE}-params.nc
 $FATESDIR/tools/modify_fates_paramfile.py --O --fin $FATESPARAMFILE --fout $FATESPARAMFILE --var fates_rad_model --val 2 --allpfts

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStreamNoCompFixedBioGeo/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStreamNoCompFixedBioGeo/user_nl_clm
@@ -1,2 +1,1 @@
-fates_paramfile = '$CASEROOT/fates_params_twostream.nc'
 use_fates_fixed_biogeog=.true.


### PR DESCRIPTION
### Description of changes

This enables the automatic building of the fates parameter file binary for all tests.  This calls ncgen from the shell_commands script in the Fates/ testdef folder, to operate on the fates default file that is version controlled.

### Specific notes

This implementation is incomplete. In order to get this to work for all tests, **I had to place the newly built binaries in the a new folder in the fates source tree**.  The reason for this is because some of the tests are multi-phase (PEM, ERP, etc). Each of these phases needs access to either the same parameter file, or an exact copy of it. However, the shell_commands (as far as my  test show) script is only called the first time, so both parts of the test need access to the same file.  Unfortunately, the xml files in both parts of the tests, do not provide any file-paths that are common to phase (I looked pretty thoroughly but maybe missed something), located somewhere on the scratch partition.  For instance, they both have different cases, which makes it tough for us to locate the parameter file on the second test, if it has a different case as the first.  I also tried using CIME_OUTPUT_ROOT, the sharedlib build location.

There is an xml entry in env_test.xml that is TEST_ARGV.  This holds the root folder for the current test environment, and the id of the specific test currently run. With these two bits of information we could place a binary file that is accessible to all phases of a test. However, this information does not seem to be available via xml query at the time we run the shell_commands script.

Another location that might be better than the source, at least for the time being would be to put all these files in the CIME_OUTPUT_ROOT, which is usually just the scratch folder where all cases and tests go. Each parameter file could have the test name and hash in it, to prevent redundancy.  The downside is that the root scratch folder starts to fill up.

Contributors other than yourself, if any:

@ekluzek @glemieux @adrifoster 

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
