### PR TITLE
Add run_neon SystemTest

### DIFF
--- a/cime_config/SystemTests/runneon.py
+++ b/cime_config/SystemTests/runneon.py
@@ -1,0 +1,101 @@
+"""
+CTSM-specific test that uses the run_neon.py methods for setting up, building, and running a NEON
+site
+"""
+
+import os
+import sys
+from CIME.SystemTests.system_tests_common import SystemTestsCommon
+
+_CTSM_PYTHON = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, "python"
+)
+sys.path.insert(1, _CTSM_PYTHON)
+import ctsm.site_and_regional.run_neon as rn  # python: disable=wrong-import-position
+
+
+class RUNNEON(SystemTestsCommon):
+    # pylint: disable=too-many-instance-attributes
+    """
+    CTSM-specific test that uses the run_neon.py methods for setting up, building, and running a
+    NEON site
+    """
+
+    def __init__(self, case):
+        # initialize an object interface to the SMS system test
+        SystemTestsCommon.__init__(self, case)
+
+        caseroot = self._case.get_value("CASEROOT")
+        argv = [
+            "run_neon",
+            "--neon-sites",
+            "ABBY",
+            "--output-root",
+            caseroot,
+        ]
+
+        (
+            self._cesmroot,
+            site_list,
+            self._output_root,
+            self._run_type,
+            self._experiment,
+            self._prism,
+            self._overwrite,
+            self._run_length,
+            self._base_case_root,
+            run_from_postad,
+            self._setup_only,
+            self._no_batch,
+            self._rerun,
+            self._user_version,
+            available_list,
+            self._res,
+            self._compset,
+        ) = rn.setup(description="", argv=argv)
+
+        if not available_list:
+            raise RuntimeError("available_list not defined")
+        self._neon_site = None
+        for neon_site in available_list:
+            if neon_site.name in site_list:
+                self._neon_site = neon_site
+                break
+        if self._neon_site is None:
+            raise RuntimeError(
+                f"available_list does not contain any member of site_list: {site_list}"
+            )
+
+        if run_from_postad:
+            self._neon_site.finidat = None
+
+    def build_phase(self, sharedlib_only=False, model_only=False):
+        """
+        Builds the case
+        """
+        if not model_only:
+            self._base_case_root = self._neon_site.build_base_case(
+                self._cesmroot,
+                self._output_root,
+                self._res,
+                self._compset,
+                self._overwrite,
+                self._setup_only,
+            )
+
+    def run_phase(self):
+        """
+        Runs the case
+        """
+        self._neon_site.run_case(
+            self._base_case_root,
+            self._run_type,
+            self._prism,
+            self._run_length,
+            self._user_version,
+            self._overwrite,
+            self._setup_only,
+            self._no_batch,
+            self._rerun,
+            self._experiment,
+        )

--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -113,6 +113,16 @@ This defines various CTSM-specific system tests
     <HIST_N>$STOP_N</HIST_N>
   </test>
 
+  <test NAME="RUNNEON">
+    <DESC>Test run_neon setup. Test options are (mostly?) ignored.</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>never</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+  </test>
+
   <test NAME="RXCROPMATURITY">
     <DESC>Generate prescribed maturity requirements, then test with them</DESC>
     <INFO_DBUG>1</INFO_DBUG>

--- a/python/ctsm/run_sys_tests.py
+++ b/python/ctsm/run_sys_tests.py
@@ -737,7 +737,7 @@ def _check_py_env(test_attributes):
     # pylint: disable=import-error disable
 
     # Check requirements for FSURDATMODIFYCTSM, if needed
-    if any("FSURDATMODIFYCTSM" in t for t in test_attributes):
+    if any("FSURDATMODIFYCTSM" in t or "RUNNEON" in t for t in test_attributes):
         try:
             import ctsm.modify_input_files.modify_fsurdat
         except ModuleNotFoundError as err:

--- a/python/ctsm/site_and_regional/run_neon.py
+++ b/python/ctsm/site_and_regional/run_neon.py
@@ -167,7 +167,7 @@ def parse_neon_listing(listing_file, valid_neon_sites):
     return available_list
 
 
-def setup(description):
+def setup(description, argv=None):
     """
     Determine valid neon sites. Make an output directory if it does not exist.
     """
@@ -177,6 +177,9 @@ def setup(description):
         os.path.join(cesmroot, "cime_config", "usermods_dirs", "NEON", "[!d]*")
     )
     valid_neon_sites = sorted([v.split("/")[-1] for v in valid_neon_sites])
+    
+    if argv is None:
+        argv = sys.argv
 
     (
         site_list,
@@ -192,7 +195,7 @@ def setup(description):
         no_batch,
         rerun,
         user_version,
-    ) = get_parser(sys.argv, description, valid_neon_sites)
+    ) = get_parser(argv, description, valid_neon_sites)
 
     if output_root:
         logger.debug("output_root : %s", output_root)

--- a/python/ctsm/site_and_regional/run_neon.py
+++ b/python/ctsm/site_and_regional/run_neon.py
@@ -167,10 +167,9 @@ def parse_neon_listing(listing_file, valid_neon_sites):
     return available_list
 
 
-def main(description):
+def setup(description):
     """
     Determine valid neon sites. Make an output directory if it does not exist.
-    Loop through requested sites and run CTSM at that site.
     """
     cesmroot = path_to_ctsm_root()
     # Get the list of supported neon sites from usermods
@@ -212,6 +211,52 @@ def main(description):
         compset = "IHist1PtClm51Bgc"
     else:
         compset = "I1PtClm51Bgc"
+    return (
+        cesmroot,
+        site_list,
+        output_root,
+        run_type,
+        experiment,
+        prism,
+        overwrite,
+        run_length,
+        base_case_root,
+        run_from_postad,
+        setup_only,
+        no_batch,
+        rerun,
+        user_version,
+        available_list,
+        res,
+        compset,
+    )
+
+
+def main(description):
+    """
+    After setting up, loop through requested sites and run CTSM there.
+    """
+
+    # Set up
+    (
+        cesmroot,
+        site_list,
+        output_root,
+        run_type,
+        experiment,
+        prism,
+        overwrite,
+        run_length,
+        base_case_root,
+        run_from_postad,
+        setup_only,
+        no_batch,
+        rerun,
+        user_version,
+        available_list,
+        res,
+        compset,
+    ) = setup(description)
 
     # --  Looping over neon sites
 


### PR DESCRIPTION
### Description of changes
Adds `RUNNEON` SystemTest, which is designed to replicate a simple `./run_neon` call in a way that can be added to aux_clm.

Not yet working!

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Testing performed, if any:**
Testing with
```
./run_sys_tests -t RUNNEON_Ld1.CLM_USRDAT.HIST_DATM%1PT_CLM51%BGC_SICE_SOCN_SROF_SGLC_SWAV_SESP.derecho_intel.clm-default --skip-compare --skip-generate
```
fails in the `SHAREDLIB_BUILD` phase. See `/glade/derecho/scratch/samrabin/tests_0201-142855de/RUNNEON_Ld1.CLM_USRDAT.HIST_DATM%1PT_CLM51%BGC_SICE_SOCN_SROF_SGLC_SWAV_SESP.derecho_intel.clm-default.0201-142855de/ABBY/bld/cesm.bldlog.240201-143035` for example log file.

### Remaining tasks:
- [ ] Get `build_phase()` to work
- [ ] Ensure `run_phase()` works
- [ ] Rework `run_phase()` to not submit a separate job, but rather to run in the existing job