### PR TITLE
Delete _FillValue and history from parameter files

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -484,9 +484,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_1" >lnd/clm2/paramdata/ctsm51_params.c240105.nc</paramfile>
-<paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c240105.nc</paramfile>
-<paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c240105.nc</paramfile>
+<paramfile phys="clm5_1" >lnd/clm2/paramdata/ctsm51_params.c240207.nc</paramfile>
+<paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c240207.nc</paramfile>
+<paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c240207.nc</paramfile>
 
 <!-- ================================================================== -->
 <!-- FATES default parameter file                                       -->

--- a/cime_config/testdefs/testmods_dirs/clm/ciso_cwd_hr/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/ciso_cwd_hr/user_nl_clm
@@ -1,2 +1,2 @@
-paramfile = '$DIN_LOC_ROOT/lnd/clm2/paramdata/ctsm51_ciso_cwd_hr_params.c240105.nc'
+paramfile = '$DIN_LOC_ROOT/lnd/clm2/paramdata/ctsm51_ciso_cwd_hr_params.c240207.nc'
 hist_fincl1 = 'CWDC_HR','C13_CWDC_HR','C14_CWDC_HR','CWD_HR_L2','CWD_HR_L2_vr','CWD_HR_L3','CWD_HR_L3_vr'

--- a/py_env_create
+++ b/py_env_create
@@ -23,7 +23,7 @@ if [ $error != 0 ]; then
    exit -1
 fi
 rm condahelp.txt
-ctsm_python=ctsm_pylib
+ctsm_python=ctsm_pylib3
 
 
 condadir="$dir/python"

--- a/python/conda_env_ctsm_py.txt
+++ b/python/conda_env_ctsm_py.txt
@@ -18,9 +18,9 @@ scipy
 netcdf4
 requests
 packaging
-numpy=1.18.5
+numpy
 xarray=0.17.0
 xesmf
-numba=0.55.2  # Avoid 0.56 until numpy>=1.20.  This is the minimum for xesmf
+numba  # Avoid 0.56 until numpy>=1.20.  This is the minimum for xesmf
 pylint=2.8.3
 black=22.3.0  # NOTE: The version here needs to be coordinated with the black github action under ../.github/workflows


### PR DESCRIPTION
### Description of changes

Updates parameter files to `c240207`. These are the same as `c240105` except:
- Attribute `_FillValue` has been removed from all variables
- Global attributes `history`, `history_of_appended_files`, and `latest_git_log` have been removed

### Specific notes

**Contributors other than yourself, if any:** None

CTSM Issues Fixed:
- Fixes #2347

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Testing performed, if any:**
- aux_clm in progress
- `ncdump -v bgc_rf_l1s1` prints the value instead of `_`