### PR TITLE
Move FSURDATMODIFYCTSM test to Derecho

### DIFF
--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -3308,8 +3308,8 @@
 
   <test name="FSURDATMODIFYCTSM_D_Mmpi-serial_Ld1" grid="5x5_amazon" compset="I2000Clm50SpRs">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_clm"/>
-      <machine name="cheyenne" compiler="intel" category="clm_pymods"/>
+      <machine name="derecho" compiler="gnu" category="aux_clm"/>
+      <machine name="derecho" compiler="gnu" category="clm_pymods"/>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>


### PR DESCRIPTION
### Description of changes

FSURDATMODIFYCTSM test (in aux_clm and clm_pymods) changed from `cheyenne_intel` to `derecho_gnu`. (Derecho Intel doesn't work with debug mode, which might be important for this test.)

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):**
- Resolves #2362

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Testing performed, if any:**
- `FSURDATMODIFYCTSM_D_Mmpi-serial_Ld1.5x5_amazon.I2000Clm50SpRs.derecho_gnu` test passes