### PR TITLE
Merge-tag to resolve issue #2366

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,85 @@
 ===============================================================
+Tag name: ctsm5.1.dev168
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Fri 16 Feb 2024 01:27:41 PM MST
+One-line Summary: Remove a source of negative snocan in CanopyFluxesMod
+
+Purpose and description of changes
+----------------------------------
+
+In ctsm5.2 testing, this test
+LWISO_Ld10.f10_f10_mg37.I2000Clm50BgcCrop.derecho_gnu.clm-coldStart
+complained of a tiny negative ice1_grc tracer not matching the bulk
+value. My troubleshooting led me to more than tiny negative snocan
+originating in a line of code that this PR now changes to prevent
+negative values.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+CTSM issues fixed (include CTSM Issue #):
+Fixes #2366
+
+Notes of particular relevance for developers:
+---------------------------------------------
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+ It was suggested at the ctsm software meeting yesterday that, in addition to
+ including "max(0._r8," in this line of code, that I reorder the code
+ by bringing "liqcan(p) =" before "snocan(p) =". I have decided against this
+ because the existing order repeats in a following paragraph of code right
+ after this one. It's likely that the group's suggestion would have worked, but
+ I did not want to delay this PR for a longer evaluation because CTSM5.2 is
+ waiting for this merge, in order to proceed with next steps.
+
+
+Testing summary:
+----------------
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: YES
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: all
+    - what platforms/compilers: all
+    - nature of change: roundoff
+ A short test, e.g.
+ SMS_Ln9.ne30pg2_ne30pg2_mg17.I1850Clm50Sp.derecho_intel.clm-clm50cam6LndTuningMode
+ has these maximum differences:
+RMS H2OCAN 4.7359E-19            NORMALIZED  4.0163E-18
+RMS SNOCAN 4.4873E-19            NORMALIZED  9.1036E-18
+ while the differences grow in longer tests.
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/2371
+
+===============================================================
+===============================================================
 Tag name: ctsm5.1.dev167
 Originator(s): samrabin (Sam Rabin, UCAR/TSS, samrabin@ucar.edu)
 Date: Thu 08 Feb 2024 01:56:05 PM MST

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+    ctsm5.1.dev168   slevis 02/16/2024 Remove a source of negative snocan in CanopyFluxesMod
     ctsm5.1.dev167 samrabin 02/08/2024 Delete _FillValue and history from parameter files
     ctsm5.1.dev166 multiple 01/24/2024 BFB merge tag
     ctsm5.1.dev165   slevis 01/19/2024 Turn Meier2022, tillage, residue removal on for ctsm5.1, fix #2212

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -1605,7 +1605,8 @@ bioms:   do f = 1, fn
          if (t_veg(p) > tfrz ) then ! above freezing, update accumulation in liqcan
             if ((qflx_evap_veg(p)-qflx_tran_veg(p))*dtime > liqcan(p)) then ! all liq evap
                ! In this case, all liqcan will evap. Take remainder from snocan
-               snocan(p)=snocan(p)+liqcan(p)+(qflx_tran_veg(p)-qflx_evap_veg(p))*dtime	 
+               snocan(p) = max(0._r8, &
+                  snocan(p) + liqcan(p) + (qflx_tran_veg(p) - qflx_evap_veg(p)) * dtime)
             end if
             liqcan(p) = max(0._r8,liqcan(p)+(qflx_tran_veg(p)-qflx_evap_veg(p))*dtime)
 

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -732,7 +732,7 @@ contains
                   end if
                else
                   if (col%itype(c) == icol_road_perv .or. col%itype(c) == icol_road_imperv) then
-                     this%t_soisno_col(c,1:nlevgrnd) = 274._r8
+                     this%t_soisno_col(c,1:nlevgrnd) = 272._r8
                   else if (col%itype(c) == icol_sunwall .or. col%itype(c) == icol_shadewall &
                        .or. col%itype(c) == icol_roof) then
                      ! Set sunwall, shadewall, roof to fairly high temperature to avoid initialization
@@ -741,7 +741,7 @@ contains
                   end if
                end if
             else
-               this%t_soisno_col(c,1:nlevgrnd) = 272._r8
+               this%t_soisno_col(c,1:nlevgrnd) = 274._r8
                if (use_excess_ice .and. (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop)) then
                   this%t_soisno_col(c,1:nlevgrnd) = SHR_CONST_TKFRZ - 5.0_r8 !needs to be below freezing to properly initiate excess ice
                end if

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -732,7 +732,7 @@ contains
                   end if
                else
                   if (col%itype(c) == icol_road_perv .or. col%itype(c) == icol_road_imperv) then
-                     this%t_soisno_col(c,1:nlevgrnd) = 272._r8
+                     this%t_soisno_col(c,1:nlevgrnd) = 274._r8
                   else if (col%itype(c) == icol_sunwall .or. col%itype(c) == icol_shadewall &
                        .or. col%itype(c) == icol_roof) then
                      ! Set sunwall, shadewall, roof to fairly high temperature to avoid initialization
@@ -741,7 +741,7 @@ contains
                   end if
                end if
             else
-               this%t_soisno_col(c,1:nlevgrnd) = 274._r8
+               this%t_soisno_col(c,1:nlevgrnd) = 272._r8
                if (use_excess_ice .and. (lun%itype(l) == istsoil .or. lun%itype(l) == istcrop)) then
                   this%t_soisno_col(c,1:nlevgrnd) = SHR_CONST_TKFRZ - 5.0_r8 !needs to be below freezing to properly initiate excess ice
                end if


### PR DESCRIPTION
### Description of changes

#2366 removes an instance of negative snocan in CanopyFluxesMod.F90 to resolve a test failure. Issue #2366 points out that snocan appears negative elsewhere, as well, and that possibly this is ok.

### Specific notes

Contributors other than yourself, if any:
@billsacks 

CTSM Issues Fixed (include github issue #):
Fixes #2366

Are answers expected to change (and if so in what way)?
Yes and let's see in what way.

Any User Interface Changes (namelist or namelist defaults changes)?
No.

Testing performed, if any:
#2366 shows the LWISO test passing when not permitting negative snocan.
Next I will submit the test-suites.