### PR TITLE
Fix crop phenology bugs with Gregorian calendar

### DIFF
--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2502,6 +2502,29 @@ contains
   end function PlantDate_to_PlantJday
 
 
+  subroutine UpdateSowingWindows()
+    !
+    ! !DESCRIPTION:
+    ! Updates sowing windows with dates for this year.
+    !
+    ! !USES:
+    use pftconMod, only: npcropmin, npcropmax
+    !
+    ! !LOCAL VARIABLES
+    integer :: n
+
+    do n = npcropmin, npcropmax
+      if (pftcon%is_pft_known_to_model(n)) then
+         minplantjday(n, inNH) = PlantDate_to_PlantJday(pftcon%mnNHplantdate(n))
+         maxplantjday(n, inNH) = PlantDate_to_PlantJday(pftcon%mxNHplantdate(n))
+
+         minplantjday(n, inSH) = PlantDate_to_PlantJday(pftcon%mnSHplantdate(n))
+         maxplantjday(n, inSH) = PlantDate_to_PlantJday(pftcon%mxSHplantdate(n))
+      end if
+   end do
+  end subroutine UpdateSowingWindows
+
+
   !-----------------------------------------------------------------------
   subroutine CropPhenologyInit(bounds)
     !
@@ -2532,15 +2555,7 @@ contains
     ! Convert planting dates into julian day
     minplantjday(:,:) = huge(1)
     maxplantjday(:,:) = huge(1)
-    do n = npcropmin, npcropmax
-       if (pftcon%is_pft_known_to_model(n)) then
-          minplantjday(n, inNH) = PlantDate_to_PlantJday(pftcon%mnNHplantdate(n))
-          maxplantjday(n, inNH) = PlantDate_to_PlantJday(pftcon%mxNHplantdate(n))
-
-          minplantjday(n, inSH) = PlantDate_to_PlantJday(pftcon%mnSHplantdate(n))
-          maxplantjday(n, inSH) = PlantDate_to_PlantJday(pftcon%mxSHplantdate(n))
-       end if
-    end do
+    call UpdateSowingWindows()
 
     ! Figure out what hemisphere each PATCH is in
     do p = bounds%begp, bounds%endp

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1927,6 +1927,10 @@ contains
       jday    = get_prev_calday()
       call get_prev_date(kyr, kmo, kda, mcsec)
 
+      if (is_beg_curr_year()) then
+         call UpdateSowingWindows()
+      end if
+
       if (use_fertilizer) then
        ndays_on = 20._r8 ! number of days to fertilize
       else

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2210,7 +2210,7 @@ contains
             end if
 
             ! days past planting may determine harvest
-            idpp = DaysPastPlanting(idop(p), jday)
+            idpp = DaysPastPlanting(idop(p))
 
             ! onset_counter initialized to zero when .not. croplive
             ! offset_counter relevant only at time step of harvest
@@ -2723,26 +2723,19 @@ contains
   end subroutine PlantCrop
 
   !-----------------------------------------------------------------------
-  function DaysPastPlanting(idop, jday_in)
+  function DaysPastPlanting(idop)
     ! !USES:
     use clm_time_manager, only : get_prev_calday, get_curr_days_per_year
     !
     ! !ARGUMENTS:
     integer,           intent(in) :: idop ! patch day of planting
-    integer, optional, intent(in) :: jday_in ! julian day of the year
     !
     ! !LOCAL VARIABLES
     integer :: DaysPastPlanting
     integer :: jday
 
-    ! Must use separate jday_in and jday because we can't redefine an intent(in)
-    ! variable, even if it wasn't provided in the function call.
-    if (present(jday_in)) then
-       jday = jday_in
-    else
-       ! Use prev instead of curr to avoid jday=1 in last timestep of year
-       jday = get_prev_calday()
-    end if
+    ! Use prev instead of curr to avoid jday=1 in last timestep of year
+    jday = get_prev_calday()
 
     if (jday >= idop) then
        DaysPastPlanting = jday - idop

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1792,7 +1792,7 @@ contains
     ! handle CN fluxes during the phenological onset                       & offset periods.
     
     ! !USES:
-    use clm_time_manager , only : get_prev_calday, get_curr_days_per_year, is_beg_curr_year
+    use clm_time_manager , only : get_prev_calday, get_prev_days_per_year, is_beg_curr_year
     use clm_time_manager , only : get_average_days_per_year
     use clm_time_manager , only : get_prev_date
     use clm_time_manager , only : is_doy_in_interval, is_end_curr_day
@@ -1921,7 +1921,7 @@ contains
          )
 
       ! get time info
-      dayspyr = get_curr_days_per_year()
+      dayspyr = get_prev_days_per_year()
       avg_dayspyr = get_average_days_per_year()
       jday    = get_prev_calday()
       call get_prev_date(kyr, kmo, kda, mcsec)

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2726,6 +2726,7 @@ contains
   function DaysPastPlanting(idop)
     ! !USES:
     use clm_time_manager, only : get_prev_calday, get_curr_days_per_year
+    use clm_varcon      , only : secspday
     !
     ! !ARGUMENTS:
     integer,           intent(in) :: idop ! patch day of planting
@@ -2742,7 +2743,7 @@ contains
     else
        ! get_curr_days_per_year() or get_prev_days_per_year() would only differ in the last timestep
        ! of the year, but in that case this line is not reached.
-       DaysPastPlanting = jday - idop + get_curr_days_per_year()
+       DaysPastPlanting = jday - idop + get_curr_days_per_year(offset = -365*int(secspday))
     end if
 
   end function DaysPastPlanting

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -61,6 +61,7 @@ module CNPhenologyMod
   public :: SeasonalCriticalDaylength ! Critical day length needed for Seasonal decidious offset
   public :: get_swindow
   public :: was_sown_in_this_window
+  public :: PlantDate_to_PlantJday
 
   ! !PRIVITE MEMBER FIUNCTIONS:
   private :: CNPhenologyClimate             ! Get climatological everages to figure out triggers for Phenology
@@ -2477,6 +2478,24 @@ contains
   end subroutine CropPhase
 
 
+  function PlantDate_to_PlantJday(plantdate) result(jday)
+    !
+    ! !DESCRIPTION:
+    ! Converts a plantdate from parameter file (e.g., mn[NS]Hplantdate) to a jday
+    ! that's actually used in the model (e.g., minplantjday).
+    !
+    ! !USES:
+    use clm_time_manager, only: get_calday
+    ! !ARGUMENTS
+    integer, intent(in) :: plantdate
+    !
+    ! Return value
+    integer :: jday
+
+    jday = int( get_calday( plantdate, 0 ) )
+  end function PlantDate_to_PlantJday
+
+
   !-----------------------------------------------------------------------
   subroutine CropPhenologyInit(bounds)
     !
@@ -2509,11 +2528,11 @@ contains
     maxplantjday(:,:) = huge(1)
     do n = npcropmin, npcropmax
        if (pftcon%is_pft_known_to_model(n)) then
-          minplantjday(n, inNH) = int( get_calday( pftcon%mnNHplantdate(n), 0 ) )
-          maxplantjday(n, inNH) = int( get_calday( pftcon%mxNHplantdate(n), 0 ) )
+          minplantjday(n, inNH) = PlantDate_to_PlantJday(pftcon%mnNHplantdate(n))
+          maxplantjday(n, inNH) = PlantDate_to_PlantJday(pftcon%mxNHplantdate(n))
 
-          minplantjday(n, inSH) = int( get_calday( pftcon%mnSHplantdate(n), 0 ) )
-          maxplantjday(n, inSH) = int( get_calday( pftcon%mxSHplantdate(n), 0 ) )
+          minplantjday(n, inSH) = PlantDate_to_PlantJday(pftcon%mnSHplantdate(n))
+          maxplantjday(n, inSH) = PlantDate_to_PlantJday(pftcon%mxSHplantdate(n))
        end if
     end do
 

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2747,8 +2747,8 @@ contains
     if (jday >= idop) then
        DaysPastPlanting = jday - idop
     else
-      ! As long as crops have at most a 365-day growing season, using get_curr_days_per_year()
-      ! should give the same result of this function as using get_prev_days_per_year().
+       ! get_curr_days_per_year() or get_prev_days_per_year() would only differ in the last timestep
+       ! of the year, but in that case this line is not reached.
        DaysPastPlanting = jday - idop + get_curr_days_per_year()
     end if
 

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2485,14 +2485,20 @@ contains
     ! that's actually used in the model (e.g., minplantjday).
     !
     ! !USES:
-    use clm_time_manager, only: get_calday
+    use clm_time_manager, only: get_calday, get_prev_date
     ! !ARGUMENTS
     integer, intent(in) :: plantdate
+    !
+    ! !LOCAL VARIABLES
+    integer :: kyr, kmo, kda, mcsec
     !
     ! Return value
     integer :: jday
 
-    jday = int( get_calday( plantdate, 0 ) )
+    ! Get year to add to plantdate
+    call get_prev_date(kyr, kmo, kda, mcsec)
+
+    jday = int( get_calday(10000*kyr + plantdate, 0 ) )
   end function PlantDate_to_PlantJday
 
 

--- a/src/biogeochem/test/CNPhenology_test/CMakeLists.txt
+++ b/src/biogeochem/test/CNPhenology_test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set (pfunit_sources
-  test_CNPhenology.pf)
+  test_CNPhenology.pf
+  test_CNPhenology_gregorian.pf)
 
 add_pfunit_ctest(CNPhenology
   TEST_SOURCES "${pfunit_sources}"

--- a/src/biogeochem/test/CNPhenology_test/test_CNPhenology.pf
+++ b/src/biogeochem/test/CNPhenology_test/test_CNPhenology.pf
@@ -501,4 +501,97 @@ contains
 
   end subroutine test_was_sown_in_this_window_sameday
 
+  @Test
+  subroutine test_DaysPastPlanting_mar25_feb9(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Feb. 9 in a non-leap year
+    call unittest_timemgr_set_curr_date(1, 2, 9, this%dtime)
+
+    idop = 84  ! Mar. 25
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(321, idpp)
+
+  end subroutine test_DaysPastPlanting_mar25_feb9
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_mar25(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Mar. 25 in a non-leap year
+    call unittest_timemgr_set_curr_date(1, 3, 25, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(44, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_mar25
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_EODdec31(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Last timestep of Dec. 31 in a non-leap year
+    call unittest_timemgr_set_curr_date(3, 1, 1, 0)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(325, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_EODdec31
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_BODjan1(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! First timestep of Jan. 1 in a non-leap year following
+    ! another non-leap year
+    call unittest_timemgr_set_curr_date(3, 1, 1, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(326, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_BODjan1
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_mar25_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Mar. 25 in a leap year, although that doesn't matter in
+    ! this test module because there are no leap days
+    call unittest_timemgr_set_curr_date(4, 3, 25, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(44, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_mar25_leap
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_jan2_lastYrLeap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Jan. 2 in the year AFTER a leap year, although that doesn't
+    ! matter in this test module because there are no leap days
+    call unittest_timemgr_set_curr_date(5, 1, 2, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(327, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_jan2_lastYrLeap
+
 end module test_CNPhenology

--- a/src/biogeochem/test/CNPhenology_test/test_CNPhenology.pf
+++ b/src/biogeochem/test/CNPhenology_test/test_CNPhenology.pf
@@ -594,4 +594,25 @@ contains
 
   end subroutine test_DaysPastPlanting_feb9_jan2_lastYrLeap
 
+  @Test
+  subroutine test_PlantDate_to_PlantJday_jan1(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    @assertEqual(1, PlantDate_to_PlantJday(101))
+  end subroutine test_PlantDate_to_PlantJday_jan1
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_mar25(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    @assertEqual(84, PlantDate_to_PlantJday(325))
+  end subroutine test_PlantDate_to_PlantJday_mar25
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_dec31(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    @assertEqual(365, PlantDate_to_PlantJday(1231))
+  end subroutine test_PlantDate_to_PlantJday_dec31
+
 end module test_CNPhenology

--- a/src/biogeochem/test/CNPhenology_test/test_CNPhenology_gregorian.pf
+++ b/src/biogeochem/test/CNPhenology_test/test_CNPhenology_gregorian.pf
@@ -1,0 +1,212 @@
+module test_CNPhenology_gregorian
+
+  ! Tests of CNPhenologyMod specific to the Gregorian calendar
+
+  use funit
+  use unittestSubgridMod
+  use CNPhenologyMod
+  use unittestTimeManagerMod, only : unittest_timemgr_setup, unittest_timemgr_teardown
+  use unittestTimeManagerMod, only : unittest_timemgr_set_curr_date
+  use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch, setup_n_veg_patches
+  use shr_kind_mod , only : r8 => shr_kind_r8
+  use pftconMod
+
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: TestCNPhenology
+     integer  :: dtime
+     real(r8) :: fracday
+     real(r8) :: onset_gdd
+     real(r8) :: onset_gddflag
+     real(r8) :: soilt
+     real(r8) :: soila10
+     real(r8) :: t_a5min
+     real(r8) :: dayl
+     real(r8) :: snow_5day
+     real(r8) :: ws_flag
+     real(r8) :: crit_onset_gdd
+     real(r8) :: season_decid_temperate
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type TestCNPhenology
+
+  real(r8), parameter :: tol = 1.e-13_r8
+
+contains
+
+  subroutine setUp(this)
+    use clm_varctl, only : use_crop
+    use clm_varcon, only: clm_varcon_init, zisoi, secspday
+    use clm_varpar, only: nlevlak, nlevgrnd, nlevdecomp_full
+    class(TestCNPhenology), intent(inout) :: this
+    real(r8), parameter :: my_zisoi(5) = [0.01_r8, 0.02_r8, 2._r8, 4._r8, 6._r8]
+
+    use_crop = .false.
+    this%dtime = 1800
+    this%fracday = real(this%dtime,r8) / secspday
+    ! Setup time manager
+    call unittest_timemgr_setup(dtime=this%dtime, use_gregorian_calendar=.true.)
+
+    this%onset_gdd = 0._r8      ! Will be reset...
+    this%onset_gddflag = 0._r8  ! Will be reset...
+    ! Temperatures
+    this%soilt = 273._r8        ! Below freezing
+    this%soila10 = 273._r8      ! Below freezing
+    this%t_a5min = 273._r8      ! Below freezing
+
+    this%dayl = 19500._r8       ! Below half of critical dayl 
+    this%snow_5day = 1._r8      ! Above threshold
+    this%ws_flag = 1._r8        ! After winter solstice
+    this%crit_onset_gdd = 1._r8
+    this%season_decid_temperate = 0._r8  ! Non temperate plant
+
+    call setup_single_veg_patch(pft_type=1)
+
+    nlevgrnd = size(my_zisoi)
+    nlevlak = 10
+    nlevdecomp_full = nlevgrnd
+    call clm_varcon_init( is_simple_buildtemp = .true.)
+    zisoi(0) = 0._r8
+    zisoi(1:nlevgrnd) = my_zisoi(:)
+
+    call CNPhenologySetParams()
+    call CNPhenologyInit( bounds )
+    call pftcon%InitForTesting()
+    pftcon%season_decid_temperate =  this%season_decid_temperate
+
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    use clm_varcon, only: clm_varcon_clean
+    class(TestCNPhenology), intent(inout) :: this
+
+    call unittest_timemgr_teardown()
+    call clm_varcon_clean()
+    call unittest_subgrid_teardown()
+    call pftcon%Clean()
+
+  end subroutine tearDown
+
+  @Test
+  subroutine test_DaysPastPlanting_mar25_feb9(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Feb. 9 in a non-leap year preceded by a non-leap year
+    call unittest_timemgr_set_curr_date(3, 2, 9, this%dtime)
+
+    idop = 84  ! Mar. 25
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(321, idpp)
+
+  end subroutine test_DaysPastPlanting_mar25_feb9
+
+  @Test
+  subroutine test_DaysPastPlanting_mar25_feb9_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Feb. 9 in a leap year
+    call unittest_timemgr_set_curr_date(4, 2, 9, this%dtime)
+
+    idop = 84  ! Mar. 25
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(321, idpp)
+
+  end subroutine test_DaysPastPlanting_mar25_feb9_leap
+
+  @Test
+  subroutine test_DaysPastPlanting_mar25_feb9_lastYrLeap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Feb. 9 in a non-leap year preceded by a leap year
+    call unittest_timemgr_set_curr_date(5, 2, 9, this%dtime)
+
+    idop = 84  ! Mar. 25
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(322, idpp)
+
+  end subroutine test_DaysPastPlanting_mar25_feb9_lastYrLeap
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_mar25(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Mar. 25 in a non-leap year, day 84
+    call unittest_timemgr_set_curr_date(1, 3, 25, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(44, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_mar25
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_mar25_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Mar. 25 in a leap year, day 85
+    call unittest_timemgr_set_curr_date(4, 3, 25, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(45, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_mar25_leap
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_jan2_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Jan. 2 in a leap year
+    call unittest_timemgr_set_curr_date(4, 1, 2, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(327, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_jan2_leap
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_EODdec31_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Last timestep of Dec. 31 in a leap year
+    call unittest_timemgr_set_curr_date(5, 1, 1, 0)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(326, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_EODdec31_leap
+
+  @Test
+  subroutine test_DaysPastPlanting_feb9_jan2_lastYrLeap(this)
+    class(TestCNPhenology), intent(inout) :: this
+    integer :: idop, idpp
+
+    ! Jan. 2 in the year AFTER a leap year
+    call unittest_timemgr_set_curr_date(5, 1, 2, this%dtime)
+
+    idop = 40  ! Feb. 9
+    idpp = DaysPastPlanting(idop)
+
+    @assertEqual(328, idpp)
+
+  end subroutine test_DaysPastPlanting_feb9_jan2_lastYrLeap
+
+end module test_CNPhenology_gregorian

--- a/src/biogeochem/test/CNPhenology_test/test_CNPhenology_gregorian.pf
+++ b/src/biogeochem/test/CNPhenology_test/test_CNPhenology_gregorian.pf
@@ -240,6 +240,17 @@ contains
   end subroutine test_PlantDate_to_PlantJday_dec31
 
   @Test
+  subroutine test_PlantDate_to_PlantJday_dec31_begyr(this)
+    use clm_time_manager, only: is_beg_curr_year
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Beginning of a non-leap year
+    call unittest_timemgr_set_curr_date(5, 1, 1, this%dtime)
+
+    @assertEqual(365, PlantDate_to_PlantJday(1231))
+  end subroutine test_PlantDate_to_PlantJday_dec31_begyr
+
+  @Test
   subroutine test_PlantDate_to_PlantJday_jan1_leap(this)
     class(TestCNPhenology), intent(inout) :: this
 
@@ -268,5 +279,16 @@ contains
 
     @assertEqual(366, PlantDate_to_PlantJday(1231))
   end subroutine test_PlantDate_to_PlantJday_dec31_leap
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_dec31_leap_begyr(this)
+    use clm_time_manager, only: is_beg_curr_year
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Beginning of a leap year
+    call unittest_timemgr_set_curr_date(4, 1, 1, this%dtime)
+
+    @assertEqual(366, PlantDate_to_PlantJday(1231))
+  end subroutine test_PlantDate_to_PlantJday_dec31_leap_begyr
 
 end module test_CNPhenology_gregorian

--- a/src/biogeochem/test/CNPhenology_test/test_CNPhenology_gregorian.pf
+++ b/src/biogeochem/test/CNPhenology_test/test_CNPhenology_gregorian.pf
@@ -56,7 +56,7 @@ contains
     this%soila10 = 273._r8      ! Below freezing
     this%t_a5min = 273._r8      ! Below freezing
 
-    this%dayl = 19500._r8       ! Below half of critical dayl 
+    this%dayl = 19500._r8       ! Below half of critical dayl
     this%snow_5day = 1._r8      ! Above threshold
     this%ws_flag = 1._r8        ! After winter solstice
     this%crit_onset_gdd = 1._r8
@@ -208,5 +208,65 @@ contains
     @assertEqual(328, idpp)
 
   end subroutine test_DaysPastPlanting_feb9_jan2_lastYrLeap
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_jan1(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Only year here should matter: non-leap
+    call unittest_timemgr_set_curr_date(5, 7, 24, this%dtime)
+
+    @assertEqual(1, PlantDate_to_PlantJday(101))
+  end subroutine test_PlantDate_to_PlantJday_jan1
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_mar25(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Only year here should matter: non-leap
+    call unittest_timemgr_set_curr_date(5, 7, 24, this%dtime)
+
+    @assertEqual(84, PlantDate_to_PlantJday(325))
+  end subroutine test_PlantDate_to_PlantJday_mar25
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_dec31(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Only year here should matter: non-leap
+    call unittest_timemgr_set_curr_date(5, 7, 24, this%dtime)
+
+    @assertEqual(365, PlantDate_to_PlantJday(1231))
+  end subroutine test_PlantDate_to_PlantJday_dec31
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_jan1_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Only year here should matter: leap
+    call unittest_timemgr_set_curr_date(4, 7, 24, this%dtime)
+
+    @assertEqual(1, PlantDate_to_PlantJday(101))
+  end subroutine test_PlantDate_to_PlantJday_jan1_leap
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_mar25_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Only year here should matter: leap
+    call unittest_timemgr_set_curr_date(4, 7, 24, this%dtime)
+
+    @assertEqual(85, PlantDate_to_PlantJday(325))
+  end subroutine test_PlantDate_to_PlantJday_mar25_leap
+
+  @Test
+  subroutine test_PlantDate_to_PlantJday_dec31_leap(this)
+    class(TestCNPhenology), intent(inout) :: this
+
+    ! Only year here should matter: leap
+    call unittest_timemgr_set_curr_date(4, 7, 24, this%dtime)
+
+    @assertEqual(366, PlantDate_to_PlantJday(1231))
+  end subroutine test_PlantDate_to_PlantJday_dec31_leap
 
 end module test_CNPhenology_gregorian


### PR DESCRIPTION
### Description of changes

As @billsacks documented in #1595, there were two crop phenology bugs that could occur during leap years. This PR:
- Changes the calculation of days past planting to use the number of days in the _previous_ year (fixing [2] in that issue).
- Makes it so that the Julian dates (1-366) of the sowing windows are re-calculated at the beginning of each year (fixing [1] in that issue).

My latter solution is a bit more complicated than Bill's suggested solution of just adding 10000 to the read-in MMDD number. However, it has the (slight) advantage of always conforming to the specified date, rather than being shifted a day early in leap years.

### Specific notes

**Contributors other than yourself, if any:** @billsacks 

**CTSM Issues Fixed:**
- Resolves #1595 

**Are answers expected to change (and if so in what way)?** Yes, in leap years.

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Testing performed, if any:**
Unit tests of the behaviors in question failed initially and now pass.

`aux_clm` unexpectedly showed no diffs. This turned out to be because the only aux_clm test with a Gregorian calendar is `SMS_Ly5_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropQianRs.izumi_gnu.clm-gregorian_cropMonthOutput`, which only compares against the output from the `...h2.1854-12-31-00000.nc` file, which isn't a leap year. We thus should probably add a test with a Gregorian calendar that tests outputs from a leap year.

## Remaining tasks
- [ ] ? Add a test that compares outputs from a leap year.