### PR TITLE
Dust namelist moved to cmeps

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -48,9 +48,12 @@ tag = cime6.0.217_httpsbranch03
 required = True
 
 [cmeps]
-tag = cmeps0.14.50
+#tag = cmeps0.14.50
+#branch = dust_emis_mod
+hash = d79e34f67df825f9265bdaaf3091f8995d5df1a2
 protocol = git
-repo_url = https://github.com/ESCOMP/CMEPS.git
+#repo_url = https://github.com/ESCOMP/CMEPS.git
+repo_url = https://github.com/ekluzek/CMEPS.git
 local_path = components/cmeps
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -50,7 +50,7 @@ required = True
 [cmeps]
 #tag = cmeps0.14.50
 #branch = dust_emis_mod
-hash = d79e34f67df825f9265bdaaf3091f8995d5df1a2
+hash = e22c4eafd595964d88a1077961a809a60b794431
 protocol = git
 #repo_url = https://github.com/ESCOMP/CMEPS.git
 repo_url = https://github.com/ekluzek/CMEPS.git


### PR DESCRIPTION
### Description of changes

Remove the dust emissions namelist items from CTSM and use the namelist in the drv_flds_in for CMEPS. Also
update the CMEPS version to handle this.

This updates CTSM to use the namelist control in CMEPS (in https://github.com/ESCOMP/CMEPS/pull/429). So the CMEPS external needs to be updated, and the namelist control in CTSM changed to use CMEPS rather than the internal CTSM control settings and the CTSM ones removed.

Add a unit test for the CMEPS code to make sure it's working correctly.

- [x] unit test
- [x] Add drv_flds_in namelist definition in CMEPS
- [ ] Finalize CMEPS tag point to it here
- [x] Update drv_flds_in namelist definition in CTSM
- [x] Add capability to set the dust emissions settings in drv_flds_in
- [ ] Update build-namelist tester to get the new capability working
- [x] Remove the old dust namelist items in CTSM
- [ ] Run standard testing and make sure everything is working

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
  Fixes #2376
  Fixes #2150
  Fixes #2170
  Fixes #2524

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)?
  Namelist items removed from CTSM and into the drv_flds_in namelist in CMEPS

Testing performed, if any: will run standard testing, have run a few singleton tests so far
