### PR TITLE
fix units for vector hh output

### DIFF
--- a/src/main/histFileMod.F90
+++ b/src/main/histFileMod.F90
@@ -3147,16 +3147,16 @@ contains
                   units='m', ncid=nfid(t))             
              call ncd_defvar(varname='hillslope_area', xtype=ncd_double, &
                   dim1name=namec, long_name='hillslope column area', &
-                  units='m', ncid=nfid(t))             
+                  units='m2', ncid=nfid(t))
              call ncd_defvar(varname='hillslope_elev', xtype=ncd_double, &
                   dim1name=namec, long_name='hillslope column elevation', &
                   units='m', ncid=nfid(t))             
              call ncd_defvar(varname='hillslope_slope', xtype=ncd_double, &
                   dim1name=namec, long_name='hillslope column slope', &
-                  units='m', ncid=nfid(t))             
+                  units='m/m', ncid=nfid(t))
              call ncd_defvar(varname='hillslope_aspect', xtype=ncd_double, &
                   dim1name=namec, long_name='hillslope column aspect', &
-                  units='m', ncid=nfid(t))             
+                  units='radians', ncid=nfid(t))
              call ncd_defvar(varname='hillslope_index', xtype=ncd_int, &
                   dim1name=namec, long_name='hillslope index', &
                   ncid=nfid(t))             


### PR DESCRIPTION
### Description of changes
Change units on vector history fields for hillslope variables
### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
no
Any User Interface Changes (namelist or namelist defaults changes)?
no
Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
