### PR TITLE
One-line fix for izumi NEON-MOAB test error introduced in #2472

### DIFF
--- a/cime_config/usermods_dirs/NEON/defaults/user_nl_clm
+++ b/cime_config/usermods_dirs/NEON/defaults/user_nl_clm
@@ -18,6 +18,8 @@
 ! Set glc_do_dynglacier  with GLC_TWO_WAY_COUPLING               env variable
 !----------------------------------------------------------------------------------
 
+fsurdat = "$DIN_LOC_ROOT/lnd/clm2/surfdata_map/NEON/surfdata_1x1_NEON_${NEONSITE}_hist_78pfts_CMIP6_simyr2000_c230601.nc"
+
 ! h1 output stream 
 hist_fincl2 = 'AR','ELAI','FCEV','FCTR','FGEV','FIRA','FSA','FSH','GPP','H2OSOI',
              'HR','SNOW_DEPTH','TBOT','TSOI','SOILC_vr','FV','NET_NMIN_vr'


### PR DESCRIPTION
### Description of changes

Put fsurdat back in 
`/cime_config/usermods_dirs/NEON/defaults/user_nl_clm`
to avoid setup error due to missing fsurdat in 
`SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm51Bgc.izumi_nag.clm-NEON-MOAB--clm-PRISM`

### Specific notes

Contributors other than yourself, if any:
@wwieder 

CTSM Issues Fixed (include github issue #):
No issue opened.

Are answers expected to change (and if so in what way)?
No.

Testing performed, if any:
The same test now passes.