### PR TITLE
Add line about documentation in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@ Are answers expected to change (and if so in what way)?
 
 Any User Interface Changes (namelist or namelist defaults changes)?
 
+Does this create a need to change or add documentation? Did you do so?
+
 Testing performed, if any:
 (List what testing you did to show your changes worked as expected)
 (This can be manual testing or running of the different test suites)


### PR DESCRIPTION
### Description of changes

As discussed in the CTSM SE meeting today, this PR adds a line about documentation to the PR template.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Testing performed, if any:** None