### PR TITLE
[Fang summer '24 PR 1] Fix bugs and develop crop fire modeling

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -312,7 +312,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <boreal_peatfire_c        fire_method="li2021gswpfrc" >0.09d-4</boreal_peatfire_c>
 <pot_hmn_ign_counts_alpha fire_method="li2021gswpfrc" >0.010d00</pot_hmn_ign_counts_alpha>
 <non_boreal_peatfire_c    fire_method="li2021gswpfrc" >0.17d-3</non_boreal_peatfire_c>
-<cropfire_a1              fire_method="li2021gswpfrc" >1.6d-4</cropfire_a1>
+<cropfire_a1              fire_method="li2021gswpfrc" >0.21d00</cropfire_a1>
 <occur_hi_gdp_tree        fire_method="li2021gswpfrc" >0.33d00</occur_hi_gdp_tree>
 <lfuel                    fire_method="li2021gswpfrc" >75.d00</lfuel>
 <ufuel                    fire_method="li2021gswpfrc" >1050.d00</ufuel>

--- a/src/biogeochem/CNDriverMod.F90
+++ b/src/biogeochem/CNDriverMod.F90
@@ -936,7 +936,7 @@ contains
             num_exposedvegp, filter_exposedvegp, num_noexposedvegp, filter_noexposedvegp, &
             atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, waterdiagnosticbulk_inst, wateratm2lndbulk_inst, &
             waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-            cnveg_state_inst, cnveg_carbonstate_inst, &
+            crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, &
             totlitc_col=soilbiogeochem_carbonstate_inst%totlitc_col(begc:endc), &
             decomp_cpools_vr_col=soilbiogeochem_carbonstate_inst%decomp_cpools_vr_col(begc:endc,1:nlevdecomp_full,1:ndecomp_pools), &
             t_soi17cm_col=temperature_inst%t_soi17cm_col(begc:endc))

--- a/src/biogeochem/CNFireLi2014Mod.F90
+++ b/src/biogeochem/CNFireLi2014Mod.F90
@@ -87,7 +87,7 @@ contains
        num_exposedvegp, filter_exposedvegp, num_noexposedvegp, filter_noexposedvegp, &
        atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, waterdiagnosticbulk_inst, &
        wateratm2lndbulk_inst, waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-       cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+       crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
     !
     ! !DESCRIPTION:
     ! Computes column-level burned area
@@ -98,6 +98,7 @@ contains
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
     use pftconMod            , only: nbrdlf_evr_trp_tree, nbrdlf_dcd_trp_tree, nbrdlf_evr_shrub
     use dynSubgridControlMod , only: run_has_transient_landcover
+    use CropType             , only: crop_type
     !
     ! !ARGUMENTS:
     class(cnfire_li2014_type)                             :: this
@@ -120,6 +121,7 @@ contains
     class(soil_water_retention_curve_type), intent(in)    :: soil_water_retention_curve
     type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
     type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    type(crop_type)                       , intent(in)    :: crop_inst
     real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
     real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
     real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)

--- a/src/biogeochem/CNFireLi2016Mod.F90
+++ b/src/biogeochem/CNFireLi2016Mod.F90
@@ -89,7 +89,7 @@ contains
        num_exposedvegp, filter_exposedvegp, num_noexposedvegp, filter_noexposedvegp, &
        atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, waterdiagnosticbulk_inst, &
        wateratm2lndbulk_inst, waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-       cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+       crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
     !
     ! !DESCRIPTION:
     ! Computes column-level burned area
@@ -101,6 +101,7 @@ contains
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
     use pftconMod            , only: nbrdlf_evr_trp_tree, nbrdlf_dcd_trp_tree, nbrdlf_evr_shrub
     use dynSubgridControlMod , only : run_has_transient_landcover
+    use CropType             , only: crop_type
     !
     ! !ARGUMENTS:
     class(cnfire_li2016_type)                             :: this
@@ -123,6 +124,7 @@ contains
     class(soil_water_retention_curve_type), intent(in)    :: soil_water_retention_curve
     type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
     type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    type(crop_type)                       , intent(in)    :: crop_inst
     real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
     real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
     real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)

--- a/src/biogeochem/CNFireLi2021Mod.F90
+++ b/src/biogeochem/CNFireLi2021Mod.F90
@@ -534,7 +534,7 @@ contains
             if((use_crop .and. (.not. croplive(p))) &
                    .or. (.not. use_crop)) then
                 burndate(p) = kda
-                baf_crop(c) = baf_crop(c)+0.21_r8 / secsphr * fhd * fgdp * patch%wtcol(p)
+                baf_crop(c) = baf_crop(c)+cropfire_a1 / secsphr * fhd * fgdp * patch%wtcol(p)
            end if 
        end if
      end do

--- a/src/biogeochem/CNFireLi2021Mod.F90
+++ b/src/biogeochem/CNFireLi2021Mod.F90
@@ -89,7 +89,7 @@ contains
        num_exposedvegp, filter_exposedvegp, num_noexposedvegp, filter_noexposedvegp, &
        atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, waterdiagnosticbulk_inst, &
        wateratm2lndbulk_inst, waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-       cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+       crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
     !
     ! !DESCRIPTION:
     ! Computes column-level burned area
@@ -97,10 +97,11 @@ contains
     ! !USES:
     use clm_time_manager     , only: get_step_size_real, get_curr_days_per_year, get_curr_date, get_nstep
     use clm_varcon           , only: secspday, secsphr
-    use clm_varctl           , only: spinup_state
+    use clm_varctl           , only: spinup_state, use_crop
     use pftconMod            , only: nc4_grass, nc3crop, ndllf_evr_tmp_tree
     use pftconMod            , only: nbrdlf_evr_trp_tree, nbrdlf_dcd_trp_tree, nbrdlf_evr_shrub
     use dynSubgridControlMod , only : run_has_transient_landcover
+    use CropType             , only: crop_type
     !
     ! !ARGUMENTS:
     class(cnfire_li2021_type)                             :: this
@@ -123,6 +124,7 @@ contains
     class(soil_water_retention_curve_type), intent(in)    :: soil_water_retention_curve
     type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
     type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    type(crop_type)                       , intent(in)    :: crop_inst
     real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
     real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
     real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)
@@ -237,7 +239,8 @@ contains
          leafc_col          => cnveg_carbonstate_inst%leafc_col                , & ! Output: [real(r8) (:)     ]  leaf carbon at column level
          deadstemc_col      => cnveg_carbonstate_inst%deadstemc_col            , & ! Output: [real(r8) (:)     ]  deadstem carbon at column level
          fuelc              => cnveg_carbonstate_inst%fuelc_col                , & ! Output: [real(r8) (:)     ]  fuel load coutside cropland
-         fuelc_crop         => cnveg_carbonstate_inst%fuelc_crop_col             & ! Output: [real(r8) (:)     ]  fuel load for cropland
+         fuelc_crop         => cnveg_carbonstate_inst%fuelc_crop_col           ,  & ! Output: [real(r8) (:)     ]  fuel load for cropland
+         croplive              => crop_inst%croplive_patch                       & ! Input:  [logical  (:)   ]  flag, true if planted, not harvested
          )
 
       transient_landcover = run_has_transient_landcover()
@@ -522,21 +525,18 @@ contains
            hdmlf = this%forc_hdm(g)
 
            ! calculate human density impact on ag. fire
-           fhd = 0.04_r8+0.96_r8*exp(-1._r8*SHR_CONST_PI*(hdmlf/350._r8)**0.5_r8)
+           fhd = 0.2_r8+0.8_r8*exp(-1._r8*SHR_CONST_PI*(hdmlf/400._r8)) 
 
            ! calculate impact of GDP on ag. fire
-           fgdp = 0.01_r8+0.99_r8*exp(-1._r8*SHR_CONST_PI*(gdp_lf(c)/10._r8))
+           fgdp = 0.05_r8+0.95_r8*exp(-1._r8*SHR_CONST_PI*(gdp_lf(c)/20._r8))
 
            ! calculate burned area
-           fb   = max(0.0_r8,min(1.0_r8,(fuelc_crop(c)-lfuel)/(ufuel-lfuel)))
-
-           ! crop fire only for generic crop types at this time
-           ! managed crops are treated as grasses if crop model is turned on
-           baf_crop(c) = baf_crop(c) + cropfire_a1/secsphr*fhd*fgdp*patch%wtcol(p)
-           if( fb*fhd*fgdp*patch%wtcol(p)  >  0._r8)then
-              burndate(p)=kda
-           end if
-        end if
+            if((use_crop .and. (.not. croplive(p))) &
+                   .or. (.not. use_crop)) then
+                burndate(p) = kda
+                baf_crop(c) = baf_crop(c)+0.21_r8 / secsphr * fhd * fgdp * patch%wtcol(p)
+           end if 
+       end if
      end do
      !
      ! calculate peatland fire

--- a/src/biogeochem/CNFireNoFireMod.F90
+++ b/src/biogeochem/CNFireNoFireMod.F90
@@ -62,13 +62,14 @@ contains
        atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, &
        waterdiagnosticbulk_inst, wateratm2lndbulk_inst, &
        waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-       cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+       crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
     !
     ! !DESCRIPTION:
     ! Computes column-level burned area 
     !
     ! !USES:
     use subgridAveMod                      , only : p2c
+    use CropType                           , only : crop_type
     !
     ! !ARGUMENTS:
     class(cnfire_nofire_type)                             :: this
@@ -91,6 +92,7 @@ contains
     class(soil_water_retention_curve_type), intent(in)    :: soil_water_retention_curve
     type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
     type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    type(crop_type)                       , intent(in)    :: crop_inst
     real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
     real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
     real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)

--- a/src/biogeochem/FATESFireBase.F90
+++ b/src/biogeochem/FATESFireBase.F90
@@ -206,7 +206,7 @@ module FATESFireBase
        atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, &
        waterdiagnosticbulk_inst, wateratm2lndbulk_inst, &
        waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-       cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+       crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
     !
     ! !DESCRIPTION:
     ! Computes column-level burned area  (NOT USED FOR FATES)
@@ -220,6 +220,7 @@ module FATESFireBase
     use SoilStateType                      , only : soilstate_type
     use SoilWaterRetentionCurveMod         , only : soil_water_retention_curve_type
     use atm2lndType                        , only : atm2lnd_type
+    use CropType                           , only: crop_type
     !
     ! !ARGUMENTS:
     class(fates_fire_base_type)                           :: this
@@ -242,6 +243,8 @@ module FATESFireBase
     class(soil_water_retention_curve_type), intent(in)    :: soil_water_retention_curve
     type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
     type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    type(crop_type)                       , intent(in) :: crop_inst
+
     real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
     real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
     real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)

--- a/src/main/FireMethodType.F90
+++ b/src/main/FireMethodType.F90
@@ -119,7 +119,7 @@ module FireMethodType
        atm2lnd_inst, energyflux_inst, saturated_excess_runoff_inst, &
        waterdiagnosticbulk_inst, wateratm2lndbulk_inst, &
        waterstatebulk_inst, soilstate_inst, soil_water_retention_curve, &
-       cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
+       crop_inst, cnveg_state_inst, cnveg_carbonstate_inst, totlitc_col, decomp_cpools_vr_col, t_soi17cm_col)
     !
     ! !DESCRIPTION:
     ! Computes column-level burned area 
@@ -137,6 +137,7 @@ module FireMethodType
     use SoilWaterRetentionCurveMod         , only : soil_water_retention_curve_type
     use CNVegStateType                     , only : cnveg_state_type
     use CNVegCarbonStateType               , only : cnveg_carbonstate_type
+    use CropType                           , only : crop_type
     import :: fire_method_type
     !
     ! !ARGUMENTS:
@@ -160,6 +161,7 @@ module FireMethodType
     class(soil_water_retention_curve_type), intent(in)    :: soil_water_retention_curve
     type(cnveg_state_type)                , intent(inout) :: cnveg_state_inst
     type(cnveg_carbonstate_type)          , intent(inout) :: cnveg_carbonstate_inst
+    type(crop_type)                       , intent(in)    :: crop_inst
     real(r8)                              , intent(in)    :: totlitc_col(bounds%begc:)
     real(r8)                              , intent(in)    :: decomp_cpools_vr_col(bounds%begc:,1:,1:)
     real(r8)                              , intent(in)    :: t_soi17cm_col(bounds%begc:)


### PR DESCRIPTION
### Description of changes
In the CNFireLi2021Mod.F90
1. Fixed the bug described in https://github.com/ESCOMP/CTSM/issues/2566 to avoid incorrect accumulation of baf_crop and ensure that crop fires do not occur during the crop growing season;
2. Confined crop fires to periods after harvest and before planting when crop module is active;
3. Removed the dependency of baf_crop on fuel availability;
4. Improved the modeling of the influence of socio-economic factors on crop burned area
5. Recalibrated the cropfire_a1 constant based on GFED5 crop burned area; 
6. Modify the declaration of CNFireArea in these F90 files to include the variable crop_inst, declare the variable crop_inst, and import and utilize crop_type from the module CropType.

In addition, the modules CNDriverMod.F90, CNFireLi2014Mod.F90, CNFireLi2016Mod.F90, CNFireNoFireMod.F90, FATESFireBase.F90, and FireMethodType.F90 include the subroutine CNFireArea. (6) is implemented in these modules.

### Specific notes

**Contributors other than yourself, if any:** None

CTSM Issues Fixed (include github issue #):
- Resolves #2566

**Are answers expected to change (and if so in what way)?** Yes. Global burned area increases about 30 Mha/yr. Crop fires only occur after harvest and before planting.

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- Historic Bgc and BgcCrop runs. 