### PR TITLE
add surface water outflow parameter

### DIFF
--- a/src/biogeophys/SurfaceWaterMod.F90
+++ b/src/biogeophys/SurfaceWaterMod.F90
@@ -41,6 +41,7 @@ module SurfaceWaterMod
   type, private :: params_type
      real(r8) :: pc              ! Threshold probability for surface water (unitless)
      real(r8) :: mu              ! Connectivity exponent for surface water (unitless)
+     real(r8) :: h2osfc_outflow_scalar    ! H2osfc outflow scalar (unitless)
   end type params_type
   type(params_type), private ::  params_inst
 
@@ -68,7 +69,9 @@ contains
     call readNcdioScalar(ncid, 'pc', subname, params_inst%pc)
     ! Connectivity exponent for surface water (unitless)
     call readNcdioScalar(ncid, 'mu', subname, params_inst%mu)
-
+    ! H2osfc outflow scalar (unitless)
+    call readNcdioScalar(ncid, 'h2osfc_outflow_scalar', subname, params_inst%h2osfc_outflow_scalar)
+    
   end subroutine readParams
 
   !-----------------------------------------------------------------------
@@ -486,7 +489,8 @@ contains
           k_wet=1.0e-4_r8 * sin((rpi/180._r8) * topo_slope(c))
           if (col%is_hillslope_column(c)) then
              ! require a minimum value to ensure non-zero outflow
-             k_wet = 1e-4_r8 * max(col%hill_slope(c),min_hill_slope)
+             !k_wet = 1e-4 * max(col%hill_slope(c),min_hill_slope)
+             k_wet = params_inst%h2osfc_outflow_scalar * max(col%hill_slope(c),min_hill_slope)
           endif
           qflx_h2osfc_surf(c) = k_wet * frac_infclust * (h2osfc(c) - h2osfc_thresh(c))
 


### PR DESCRIPTION
### Description of changes
change hard coded constant to a parameter on the parameter file

### Specific notes
netcdf file was modified by adding the following:
h2osfc_outflow_scalar = 0.002
double h2osfc_outflow_scalar ;
		h2osfc_outflow_scalar:long_name = "h2osfc outflow scalar" ;
		h2osfc_outflow_scalar:units = "unitless"
Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
when use_hillslope = .true.  surface water outflow will change.  The original constant was 1e-4, the new parameter value is currently 2e-3
Any User Interface Changes (namelist or namelist defaults changes)?

Does this create a need to change or add documentation? Did you do so?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on derecho for intel/gnu and izumi for intel/gnu/nag/nvhpc is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
