### PR TITLE
Allow "manual" resets of all accumulator types

### DIFF
--- a/src/biogeochem/CNDVType.F90
+++ b/src/biogeochem/CNDVType.F90
@@ -439,7 +439,7 @@ contains
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     use clm_time_manager , only : get_step_size, get_nstep, get_curr_date
     use pftconMod        , only : ndllf_dcd_brl_tree
-    use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
+    use accumulMod       , only : update_accum_field, extract_accum_field, markreset_accum_field
     !
     ! !ARGUMENTS:
     class(dgvs_type)  , intent(inout) :: this
@@ -493,8 +493,11 @@ contains
        rbufslp(p) = max(0._r8, &
             (t_a10_patch(p) - SHR_CONST_TKFRZ - dgv_ecophyscon%twmax(ndllf_dcd_brl_tree)) &
             * dtime/SHR_CONST_CDAY)
-       if (month==1 .and. day==1 .and. secs==int(dtime)) rbufslp(p) = accumResetVal
     end do
+    if (month==1 .and. day==1 .and. secs==int(dtime)) then
+       ! Reset annually
+       call markreset_accum_field('AGDD')
+    end if
     call update_accum_field  ('AGDDTW', rbufslp, nstep)
     call extract_accum_field ('AGDDTW', this%agddtw_patch, nstep)
 
@@ -503,11 +506,11 @@ contains
     do p = begp,endp
        rbufslp(p) = max(0.0_r8, &
             (t_ref2m_patch(p) - (SHR_CONST_TKFRZ + 5.0_r8)) * dtime/SHR_CONST_CDAY)
-       !
-       ! Fix (for bug 1858) from Sam Levis to reset the annual AGDD variable
-       ! 
-       if (month==1 .and. day==1 .and. secs==int(dtime)) rbufslp(p) = accumResetVal
     end do
+    if (month==1 .and. day==1 .and. secs==int(dtime)) then
+       ! Reset annually
+       call markreset_accum_field('AGDD')
+    end if
     call update_accum_field  ('AGDD', rbufslp, nstep)
     call extract_accum_field ('AGDD', this%agdd_patch, nstep)
 

--- a/src/biogeochem/CropType.F90
+++ b/src/biogeochem/CropType.F90
@@ -772,7 +772,7 @@ contains
     ! Should only be called if use_crop is true.
     !
     ! !USES:
-    use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
+    use accumulMod       , only : update_accum_field, extract_accum_field, markreset_accum_field
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     use clm_time_manager , only : get_step_size, get_nstep
     use clm_varpar       , only : nlevsno, nlevmaxurbgrnd
@@ -848,7 +848,8 @@ contains
              rbufslp(p) = rbufslp(p) * this%vf_patch(p)
           end if
        else
-          rbufslp(p) = accumResetVal
+          call markreset_accum_field('HUI', p)
+          call markreset_accum_field('GDDACCUM', p)
        end if
     end do
     call update_accum_field  ('HUI', rbufslp, nstep)
@@ -872,7 +873,7 @@ contains
              rbufslp(p) = rbufslp(p) * this%vf_patch(p)
           end if
        else
-          rbufslp(p) = accumResetVal
+          call markreset_accum_field('GDDTSOI', p)
        end if
     end do
     call update_accum_field  ('GDDTSOI', rbufslp, nstep)

--- a/src/biogeophys/EnergyFluxType.F90
+++ b/src/biogeophys/EnergyFluxType.F90
@@ -988,7 +988,7 @@ contains
     !
     ! USES
     use clm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date
-    use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
+    use accumulMod       , only : update_accum_field, extract_accum_field
     use abortutils       , only : endrun
     !
     ! !ARGUMENTS:

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -1363,7 +1363,7 @@ contains
     ! USES
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     use clm_time_manager , only : get_step_size, get_nstep, is_end_curr_day, get_curr_date, is_end_curr_year
-    use accumulMod       , only : update_accum_field, extract_accum_field, accumResetVal
+    use accumulMod       , only : update_accum_field, extract_accum_field, markreset_accum_field
     use CNSharedParamsMod, only : upper_soil_layer
     !
     ! !ARGUMENTS:
@@ -1544,7 +1544,7 @@ contains
           if (patch%active(p)) then
              g = patch%gridcell(p)
              if (month==1 .and. day==1 .and. secs==dtime) then
-                rbufslp(p) = accumResetVal ! reset gdd
+                call markreset_accum_field('GDD0', p)  ! reset gdd
              else if (( month > 3 .and. month < 10 .and. grc%latdeg(g) >= 0._r8) .or. &
                   ((month > 9 .or.  month < 4) .and. grc%latdeg(g) <  0._r8)     ) then
                 rbufslp(p) = max(0._r8, min(26._r8, this%t_ref2m_patch(p)-SHR_CONST_TKFRZ)) * dtime/SHR_CONST_CDAY
@@ -1563,7 +1563,7 @@ contains
           if (patch%active(p)) then
              g = patch%gridcell(p)
              if (month==1 .and. day==1 .and. secs==dtime) then
-                rbufslp(p) = accumResetVal ! reset gdd
+                call markreset_accum_field('GDD8', p)  ! reset gdd
              else if (( month > 3 .and. month < 10 .and. grc%latdeg(g) >= 0._r8) .or. &
                   ((month > 9 .or.  month < 4) .and. grc%latdeg(g) <  0._r8)     ) then
                 rbufslp(p) = max(0._r8, min(30._r8, &
@@ -1583,7 +1583,7 @@ contains
           if (patch%active(p)) then
              g = patch%gridcell(p)
              if (month==1 .and. day==1 .and. secs==dtime) then
-                rbufslp(p) = accumResetVal ! reset gdd
+                call markreset_accum_field('GDD10', p)  ! reset gdd
              else if (( month > 3 .and. month < 10 .and. grc%latdeg(g) >= 0._r8) .or. &
                   ((month > 9 .or.  month < 4) .and. grc%latdeg(g) <  0._r8)     ) then
                 rbufslp(p) = max(0._r8, min(30._r8, &

--- a/src/main/accumulMod.F90
+++ b/src/main/accumulMod.F90
@@ -681,7 +681,7 @@ contains
        if (this%active(k)) then
           kf = k - begi + 1
           if (nint(field(kf)) == -99999) then
-             this%val(k,level) = 0._r8
+             this%val(k,level) = 0._r8  ! TODO SSR: Should 0 instead be this%initval?
              this%nsteps(k,level) = 0
           else
              this%val(k,level) = &

--- a/src/main/accumulMod.F90
+++ b/src/main/accumulMod.F90
@@ -40,6 +40,7 @@ module accumulMod
   public :: print_accum_fields   ! Print info about accumulator fields
   public :: extract_accum_field  ! Extracts the current value of an accumulator field
   public :: update_accum_field   ! Update the current value of an accumulator field
+  public :: markreset_accum_field  ! Mark (value(s) in) an accumulator field as needing to be reset
   public :: clean_accum_fields   ! Deallocate space and reset accum fields list
 
   interface extract_accum_field
@@ -76,6 +77,7 @@ module accumulMod
      logical, pointer   :: active(:)!whether each point (patch, column, etc.) is active
      real(r8)           :: initval  !initial value of accumulated field
      real(r8), pointer  :: val(:,:) !accumulated field
+     logical , pointer  :: reset(:,:) !whether accumulated field needs to be reset
      integer            :: period   !field accumulation period (in model time steps)
      logical            :: scale_by_thickness  ! true/false flag to scale vertically interpolated variable by soil thickness or not
      character(len=128) :: old_name !previous name of variable (may be present in restart files)
@@ -111,8 +113,6 @@ module accumulMod
        real(r8), intent(in) :: field(:)  ! field values for current time step
      end subroutine update_accum_field_interface
   end interface
-
-  real(r8), parameter, public :: accumResetVal = -99999._r8 ! used to do an annual reset ( put in for bug 1858)
 
   integer, parameter :: ACCTYPE_TIMEAVG  = 1
   integer, parameter :: ACCTYPE_RUNMEAN  = 2
@@ -294,6 +294,9 @@ contains
        end if
     end if
     accum(nf)%val(beg1d:end1d,1:numlev) = init_value
+
+    allocate(accum(nf)%reset(beg1d:end1d,numlev))
+    accum(nf)%reset(beg1d:end1d,1:numlev) = .false.
 
     allocate(accum(nf)%nsteps(beg1d:end1d,numlev))
     accum(nf)%nsteps(beg1d:end1d,1:numlev) = 0
@@ -572,6 +575,7 @@ contains
     ! !LOCAL VARIABLES:
     integer :: begi,endi         !subgrid beginning,ending indices
     integer :: k, kf
+    logical :: time_to_reset
 
     character(len=*), parameter :: subname = 'update_accum_field_timeavg'
     !-----------------------------------------------------------------------
@@ -583,14 +587,17 @@ contains
     ! time average field: reset every accumulation period; normalize at end of
     ! accumulation period
 
-    if ((mod(nstep,this%period) == 1 .or. this%period == 1) .and. (nstep /= 0))then
-       do k = begi,endi
-          if (this%active(k)) then
-             this%val(k,level) = 0._r8
-             this%nsteps(k,level) = 0
-          end if
-       end do
-    end if
+    time_to_reset = (mod(nstep,this%period) == 1 .or. this%period == 1) .and. nstep /= 0
+    do k = begi,endi
+       if (this%active(k) .and. (time_to_reset .or. this%reset(k,level))) then
+          this%val(k,level) = 0._r8
+          this%nsteps(k,level) = 0
+          this%reset(k,level) = .false.
+       end if
+    end do
+
+    ! Ignore reset requests that occurred when patch was inactive
+    this%reset(begi:endi,level) = .false.
 
     do k = begi,endi
        if (this%active(k)) then
@@ -636,6 +643,13 @@ contains
 
     do k = begi,endi
        if (this%active(k)) then
+          if (this%reset(k,level)) then
+             this%nsteps(k,level) = 0
+             this%val(k,level) = this%initval
+             this%reset(k,level) = .false.
+             ! SSR 2024-06-05: Note that, unlike other accumulator types, runmean preserves reset
+             ! requests that occurred when the patch was inactive.
+          end if
           kf = k - begi + 1
           this%nsteps(k,level) = this%nsteps(k,level) + 1
           ! Cap nsteps at 'period' - partly to avoid overflow, but also because it doesn't
@@ -680,18 +694,71 @@ contains
     do k = begi,endi
        if (this%active(k)) then
           kf = k - begi + 1
-          if (nint(field(kf)) == -99999) then
+          if (this%reset(k,level)) then
+             ! SSR 2024-06-05: Note that, unlike the other accumulator types, runaccum can not
+             ! reset AND update in the same call of its update_accum_field subroutine.
              this%val(k,level) = 0._r8  ! TODO SSR: Should 0 instead be this%initval?
              this%nsteps(k,level) = 0
+             this%reset(k,level) = .false.
           else
              this%val(k,level) = &
                   min(max(this%val(k,level) + field(kf), 0._r8), 99999._r8)
              this%nsteps(k,level) = this%nsteps(k,level) + 1
           end if
-       end if
+      end if
     end do
 
+    ! Ignore reset requests that occurred when patch was inactive
+    this%reset(begi:endi,level) = .false.
+
   end subroutine update_accum_field_runaccum
+
+
+  !-----------------------------------------------------------------------
+  subroutine markreset_accum_field(name, kf, level)
+    !
+    ! !DESCRIPTION:
+    ! Mark accumulator values as needing to be reset. Note that resetting happens in
+    ! update_accum_field subroutines.
+    !
+    ! !ARGUMENTS:
+    character(len=*),  intent(in)  :: name  ! field name
+    integer, optional, intent(in)  :: kf    ! point index to update (in field, not accumulator's val)
+    integer, optional, intent(in)  :: level ! level index to update (in accumulator's val; 1 for a 1-d field)
+    !
+    ! !LOCAL VARIABLES:
+    integer :: nf          ! field index within the accum(nf) array
+    integer :: begi, endi  ! subgrid beginning, ending indices
+    integer :: k           ! index in accumulator's beg1d:end1d
+    integer :: numlev      ! number of levels in this accumulator
+
+    character(len=*), parameter :: subname = 'markreset_accum_field'
+    !-----------------------------------------------------------------------
+
+    call find_field(field_name=name, caller_name=subname, field_index=nf)
+    begi = accum(nf)%beg1d
+    endi = accum(nf)%end1d
+    numlev = accum(nf)%numlev
+
+    if (present(kf)) then
+       k = kf + begi - 1
+       SHR_ASSERT_FL(k >= begi .and. k <= endi, sourcefile, __LINE__)
+       if (present(level)) then
+          ! Reset one level of a single point
+          accum(nf)%reset(k,level) = .true.
+       else
+          ! Reset all levels of a single point
+          accum(nf)%reset(k,1:numlev) = .true.
+       end if
+    else if (present(level)) then
+       ! Reset one level of all points
+       accum(nf)%reset(begi:endi,level) = .true.
+    else
+       ! Reset all levels of all points
+       accum(nf)%reset(begi:endi,1:numlev) = .true.
+    end if
+
+  end subroutine markreset_accum_field
 
 
   !------------------------------------------------------------------------

--- a/src/main/accumulMod.F90
+++ b/src/main/accumulMod.F90
@@ -41,6 +41,7 @@ module accumulMod
   public :: extract_accum_field  ! Extracts the current value of an accumulator field
   public :: update_accum_field   ! Update the current value of an accumulator field
   public :: markreset_accum_field  ! Mark (value(s) in) an accumulator field as needing to be reset
+  public :: get_accum_reset      ! Get reset array of accumulator
   public :: clean_accum_fields   ! Deallocate space and reset accum fields list
 
   interface extract_accum_field
@@ -768,6 +769,32 @@ contains
     end if
 
   end subroutine markreset_accum_field
+
+
+  !-----------------------------------------------------------------------
+  function get_accum_reset(name) result(reset)
+   !
+   ! !DESCRIPTION:
+   ! Get reset array for an accumulator
+   !
+   ! !ARGUMENTS:
+   character(len=*),  intent(in)  :: name  ! field name
+   !
+   ! !RESULT:
+   logical, pointer :: reset(:,:)
+   !
+   ! !LOCAL VARIABLES:
+   integer :: nf          ! field index within the accum(nf) array
+
+   character(len=*), parameter :: subname = 'get_reset'
+   !-----------------------------------------------------------------------
+
+   call find_field(field_name=name, caller_name=subname, field_index=nf)
+
+   allocate(reset(size(accum(nf)%reset, dim=1), size(accum(nf)%reset, dim=2)))
+   reset(:,:) = accum(nf)%reset
+
+  end function get_accum_reset
 
 
   !------------------------------------------------------------------------

--- a/src/main/test/accumul_test/test_accumul.pf
+++ b/src/main/test/accumul_test/test_accumul.pf
@@ -275,6 +275,30 @@ contains
   end subroutine timeavg_basic
 
   @Test
+  subroutine timeavg_reset(this)
+    ! Test reset of timeavg field
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: accum_period = 3
+    real(r8), parameter :: values(accum_period+1) = [11._r8, 12._r8, 13._r8, 14._r8]
+    logical, parameter :: reset(accum_period+1) = [.false., .true., .false., .false.]
+    real(r8) :: val_output
+    real(r8) :: expected
+
+    ! Setup
+    call setup_single_veg_patch(pft_type=1)
+    call this%init_sl_patch_field(name=fieldname, accum_type='timeavg', &
+         accum_period = accum_period)
+
+    ! Exercise
+    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, reset=reset)
+
+    ! Verify
+    expected = sum(values(2:4))/accum_period
+    @assertEqual(expected, val_output, tolerance=tol)
+  end subroutine timeavg_reset
+
+  @Test
   subroutine timeavg_wrongTime(this)
     ! Test a timeavg field when it's the wrong time for producing an average
     class(TestAccumul), intent(inout) :: this
@@ -319,6 +343,32 @@ contains
     expected = sum(values(accum_period+1:2*accum_period))/accum_period
     @assertEqual(expected, val_output, tolerance=tol)
   end subroutine timeavg_onlyLatestPeriod
+
+  @Test
+  subroutine timeavg_onlyLatestPeriod_redundantReset(this)
+    ! Manually requesting a reset when one was going to happen anyway should have no effect.
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: accum_period = 3
+    real(r8), parameter :: values(accum_period*2) = &
+         [11._r8, 12._r8, 13._r8, 21._r8, 22._r8, 23._r8]
+    logical, parameter :: reset(accum_period*2) = &
+         [.false., .false., .false., .true., .false., .false.]
+    real(r8) :: val_output
+    real(r8) :: expected
+
+    ! Setup
+    call setup_single_veg_patch(pft_type=1)
+    call this%init_sl_patch_field(name=fieldname, accum_type='timeavg', &
+         accum_period = accum_period)
+
+    ! Exercise
+    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, reset=reset)
+
+    ! Verify
+    expected = sum(values(accum_period+1:2*accum_period))/accum_period
+    @assertEqual(expected, val_output, tolerance=tol)
+  end subroutine timeavg_onlyLatestPeriod_redundantReset
 
   @Test
   subroutine timeavg_newlyActive(this)
@@ -521,6 +571,54 @@ contains
     expected_ts5 = (2._r8 * expected_ts4 + values(5)) / 3._r8
     @assertEqual(expected_ts5, val_output, tolerance=tol)
   end subroutine runmean_afterPeriod
+
+  @Test
+  subroutine runmean_afterPeriod_reset(this)
+    ! Test runmean accumulation after accum_period is reached, with a reset
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: accum_period = 3
+    real(r8), parameter :: values(5) = [11._r8,  22._r8,  43._r8,  110._r8, 17._r8]
+    logical,  parameter :: reset(5)  = [.false., .false., .false., .true.,  .false.]
+    real(r8) :: val_output
+    real(r8) :: expected_ts5
+
+    ! Setup
+    call setup_single_veg_patch(pft_type=1)
+    call this%init_sl_patch_field(name=fieldname, accum_type='runmean', &
+         accum_period = accum_period)
+
+    ! Exercise
+    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, reset=reset)
+
+    ! Verify
+    expected_ts5 = (values(4) + values(5)) / 2._r8
+    @assertEqual(expected_ts5, val_output, tolerance=tol)
+  end subroutine runmean_afterPeriod_reset
+
+  @Test
+  subroutine runmean_afterPeriod_resetWhileInactive(this)
+    ! Test runmean accumulation after accum_period is reached, with a reset while the patch was inactive. Unlike the other accumulator types, runmean should preserve this reset request and apply it when the patch is active again. This may or may not be the ideal behavior; we can change this if some other
+    ! behavior would be better in this situation.
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: accum_period = 3
+    real(r8), parameter :: values(5)  = [11._r8,  22._r8,  43._r8,  110._r8, 17._r8]
+    logical,  parameter :: pactive(5) = [.true.,  .true.,  .true.,  .false., .true.]
+    logical,  parameter :: reset(5)   = [.false., .false., .false., .true.,  .false.]
+    real(r8) :: val_output
+
+    ! Setup
+    call setup_single_veg_patch(pft_type=1)
+    call this%init_sl_patch_field(name=fieldname, accum_type='runmean', &
+         accum_period = accum_period)
+
+    ! Exercise
+    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, pactive=pactive, reset=reset)
+
+    ! Verify
+    @assertEqual(values(5), val_output, tolerance=tol)
+  end subroutine runmean_afterPeriod_resetWhileInactive
 
   @Test
   subroutine runmean_newlyActive(this)

--- a/src/main/test/accumul_test/test_accumul.pf
+++ b/src/main/test/accumul_test/test_accumul.pf
@@ -5,7 +5,7 @@ module test_accumul
   use funit
   use accumulMod
   use unittestSubgridMod
-  use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch
+  use unittestSimpleSubgridSetupsMod, only : setup_single_veg_patch, setup_n_veg_patches
   use shr_kind_mod , only : r8 => shr_kind_r8
   use clm_varcon, only : spval
   use PatchType, only : patch
@@ -19,6 +19,7 @@ module test_accumul
      procedure :: tearDown
      procedure :: init_sl_patch_field
      procedure :: init_ml_patch_field
+     procedure :: init_ml_mpatch_field
      procedure :: update_and_extract_sl_patch_field
      procedure :: update_and_extract_ml_patch_field
   end type TestAccumul
@@ -97,6 +98,36 @@ contains
          type2d = 'irrelevant', &  ! type2d just needed for restart
          scale_by_thickness = .false.)
   end subroutine init_ml_patch_field
+
+  subroutine init_ml_mpatch_field(this, name, accum_type, accum_period, nlev, init_value)
+     ! Call init_accum_field for a multi-level, multi-patch field
+     class(TestAccumul), intent(in) :: this
+     character(len=*), intent(in) :: name
+     character(len=*), intent(in) :: accum_type ! timeavg, runmean, runaccum
+     integer, intent(in) :: accum_period
+     integer, intent(in) :: nlev
+     real(r8), intent(in), optional :: init_value ! if absent, use 0
+
+     real(r8) :: l_init_value
+
+     if (present(init_value)) then
+        l_init_value = init_value
+     else
+        l_init_value = 0._r8
+     end if
+
+     call init_accum_field(&
+          name = name, &
+          units = 'none', &
+          desc = 'no desc', &
+          accum_type = accum_type, &
+          accum_period = accum_period, &
+          numlev = nlev, &
+          subgrid_type = 'pft', &
+          init_value = l_init_value, &
+          type2d = 'patch', &
+          scale_by_thickness = .false.)
+   end subroutine init_ml_mpatch_field
 
   subroutine update_and_extract_sl_patch_field(this, fieldname, values, val_output, &
        pactive, timestep_start, reset)
@@ -835,5 +866,183 @@ contains
     @assertEqual(expected1, val_output1, tolerance=tol)
     @assertEqual(expected2, val_output2, tolerance=tol)
   end subroutine multipleFields
+
+  ! ------------------------------------------------------------------------
+  ! Tests of markreset_accum_field()
+  ! ------------------------------------------------------------------------
+
+  @Test
+  subroutine markreset_nopoints_nolevels(this)
+    ! Make sure that NOT calling markreset_accum_field() means no point-levels are marked for reset.
+    !
+    ! Note that type of accumulator and values don't matter.
+
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: npatches = 2
+    integer, parameter :: nlevels = 5
+    real(r8), parameter :: pwtcol(npatches) = [0.5, 0.5]
+    integer, parameter :: pft_type(npatches) = [1, 2]
+    integer, parameter :: accum_period = 3
+    integer, parameter :: expected(npatches, nlevels) = transpose(reshape([ &
+         0, 0, 0, 0, 0, &
+         0, 0, 0, 0, 0 &
+         ], [nlevels, npatches]))
+    logical :: reset_output(npatches, nlevels)
+    integer :: reset_output_int(npatches, nlevels)
+    integer :: l, p
+
+    ! Setup
+    call setup_n_veg_patches(pwtcol, pft_type)
+    call this%init_ml_mpatch_field(name=fieldname, accum_type='timeavg', &
+         accum_period = accum_period, nlev=nlevels)
+
+    ! Exercise
+    reset_output = get_accum_reset(fieldname)
+
+    ! Verify
+    do l = 1,nlevels
+       do p = 1,npatches
+          if (reset_output(p,l)) then
+             reset_output_int(p,l) = 1
+          else
+             reset_output_int(p,l) = 0
+          end if
+       end do
+    end do
+    @assertEqual(expected, reset_output_int)
+  end subroutine markreset_nopoints_nolevels
+
+  @Test
+  subroutine markreset_1point_nolevels(this)
+    ! Make sure that calling markreset_accum_field() with kf but no level works right (marks
+    ! all levels of that patch for reset).
+    ! Note that type of accumulator and values don't matter.
+
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: npatches = 2
+    integer, parameter :: nlevels = 5
+    real(r8), parameter :: pwtcol(npatches) = [0.5, 0.5]
+    integer, parameter :: pft_type(npatches) = [1, 2]
+    integer, parameter :: accum_period = 3
+    integer, parameter :: expected(npatches, nlevels) = transpose(reshape([ &
+         1, 1, 1, 1, 1, &
+         0, 0, 0, 0, 0 &
+         ], [nlevels, npatches]))
+    logical :: reset_output(npatches, nlevels)
+    integer :: reset_output_int(npatches, nlevels)
+    integer :: l, p
+
+    ! Setup
+    call setup_n_veg_patches(pwtcol, pft_type)
+    call this%init_ml_mpatch_field(name=fieldname, accum_type='timeavg', &
+         accum_period = accum_period, nlev=nlevels)
+
+    ! Exercise
+    call markreset_accum_field(fieldname, kf=1)
+    reset_output = get_accum_reset(fieldname)
+
+    ! Verify
+    do l = 1,nlevels
+       do p = 1,npatches
+          if (reset_output(p,l)) then
+             reset_output_int(p,l) = 1
+          else
+             reset_output_int(p,l) = 0
+          end if
+       end do
+    end do
+    @assertEqual(expected, reset_output_int)
+  end subroutine markreset_1point_nolevels
+
+  @Test
+  subroutine markreset_allpoints_1level(this)
+    ! Make sure that calling markreset_accum_field() with level but no kf works right (marks that
+    ! level for reset for all points).
+    !
+    ! Note that type of accumulator and values don't matter.
+
+    class(TestAccumul), intent(inout) :: this
+    character(len=*), parameter :: fieldname = 'foo'
+    integer, parameter :: npatches = 2
+    integer, parameter :: nlevels = 5
+    real(r8), parameter :: pwtcol(npatches) = [0.5, 0.5]
+    integer, parameter :: pft_type(npatches) = [1, 2]
+    integer, parameter :: accum_period = 3
+    integer, parameter :: expected(npatches, nlevels) = transpose(reshape([ &
+         0, 0, 1, 0, 0, &
+         0, 0, 1, 0, 0 &
+         ], [nlevels, npatches]))
+    logical :: reset_output(npatches, nlevels)
+    integer :: reset_output_int(npatches, nlevels)
+    integer :: l, p
+
+    ! Setup
+    call setup_n_veg_patches(pwtcol, pft_type)
+    call this%init_ml_mpatch_field(name=fieldname, accum_type='timeavg', &
+         accum_period = accum_period, nlev=nlevels)
+
+    ! Exercise
+    call markreset_accum_field(fieldname, level=3)
+    reset_output = get_accum_reset(fieldname)
+
+    ! Verify
+    do l = 1,nlevels
+       do p = 1,npatches
+          if (reset_output(p,l)) then
+             reset_output_int(p,l) = 1
+          else
+             reset_output_int(p,l) = 0
+          end if
+       end do
+    end do
+    @assertEqual(expected, reset_output_int)
+end subroutine markreset_allpoints_1level
+
+@Test
+subroutine markreset_allpoints_alllevels(this)
+  ! Make sure that calling markreset_accum_field() with neither kf nor level works right (marks
+  ! all for reset).
+  !
+  ! Note that type of accumulator and values don't matter.
+
+  class(TestAccumul), intent(inout) :: this
+  character(len=*), parameter :: fieldname = 'foo'
+  integer, parameter :: npatches = 2
+  integer, parameter :: nlevels = 5
+  real(r8), parameter :: pwtcol(npatches) = [0.5, 0.5]
+  integer, parameter :: pft_type(npatches) = [1, 2]
+  integer, parameter :: accum_period = 3
+  integer, parameter :: expected(npatches, nlevels) = transpose(reshape([ &
+       1, 1, 1, 1, 1, &
+       1, 1, 1, 1, 1 &
+       ], [nlevels, npatches]))
+  logical :: reset_output(npatches, nlevels)
+  integer :: reset_output_int(npatches, nlevels)
+  integer :: l, p
+
+  ! Setup
+  call setup_n_veg_patches(pwtcol, pft_type)
+  call this%init_ml_mpatch_field(name=fieldname, accum_type='timeavg', &
+       accum_period = accum_period, nlev=nlevels)
+
+  ! Exercise
+  call markreset_accum_field(fieldname)
+  reset_output = get_accum_reset(fieldname)
+
+  ! Verify
+  do l = 1,nlevels
+     do p = 1,npatches
+        if (reset_output(p,l)) then
+           reset_output_int(p,l) = 1
+        else
+           reset_output_int(p,l) = 0
+        end if
+     end do
+  end do
+  @assertEqual(expected, reset_output_int)
+end subroutine markreset_allpoints_alllevels
+
 
 end module test_accumul

--- a/src/main/test/accumul_test/test_accumul.pf
+++ b/src/main/test/accumul_test/test_accumul.pf
@@ -99,7 +99,7 @@ contains
   end subroutine init_ml_patch_field
 
   subroutine update_and_extract_sl_patch_field(this, fieldname, values, val_output, &
-       pactive, timestep_start)
+       pactive, timestep_start, reset)
     ! Calls update_accum_field once for each value in 'values', assuming that the values
     ! come once per timestep. For the first call, all input values are set equal to
     ! values(1); for the second call, all input values are set equal to values(2); etc.
@@ -122,16 +122,23 @@ contains
     ! If present, this specifies the starting nstep value. If absent, we start with 1.
     integer, optional, intent(in) :: timestep_start
 
+    ! If present, same size as 'values', indicating whether each should be associated with a reset
+    logical, optional, intent(in) :: reset(:)
+
     integer :: n_timesteps
     integer :: timestep
     integer :: timestep_offset
     real(r8), pointer :: vals_input(:)
     real(r8), pointer :: vals_output(:)
     logical, allocatable :: l_pactive(:)  ! local version of pactive
+    logical, allocatable :: l_reset(:)    ! local version of reset
 
     n_timesteps = size(values)
     if (present(pactive)) then
        @assertEqual(n_timesteps, size(pactive))
+    end if
+    if (present(reset)) then
+       @assertEqual(n_timesteps, size(reset))
     end if
 
     allocate(l_pactive(n_timesteps))
@@ -147,11 +154,21 @@ contains
        timestep_offset = 0
     end if
 
+    allocate(l_reset(n_timesteps))
+    if (present(reset)) then
+       l_reset(:) = reset(:)
+    else
+       l_reset(:) = .false.
+    end if
+
     allocate(vals_input(bounds%begp:bounds%endp))
     allocate(vals_output(bounds%begp:bounds%endp))
     do timestep = 1, n_timesteps
        vals_input(:) = values(timestep)
        patch%active(bounds%begp) = l_pactive(timestep)
+       if (l_reset(timestep)) then
+          call markreset_accum_field(fieldname)
+       end if
        call update_accum_field(fieldname, vals_input, timestep+timestep_offset)
     end do
     call extract_accum_field(fieldname, vals_output, n_timesteps+timestep_offset)
@@ -599,7 +616,8 @@ contains
     class(TestAccumul), intent(inout) :: this
     character(len=*), parameter :: fieldname = 'foo'
     integer, parameter :: accum_period = 3  ! irrelevant for this type
-    real(r8), parameter :: values(5) = [11._r8, 12._r8, accumResetVal, 13._r8, 24._r8]
+    real(r8), parameter :: values(5) = [11._r8,  12._r8,  -99999._r8, 13._r8,  24._r8]
+    logical , parameter :: reset(5)  = [.false., .false., .true.,     .false., .false.]
     real(r8) :: val_output
     real(r8) :: expected
 
@@ -609,7 +627,7 @@ contains
          accum_period = accum_period)
 
     ! Exercise
-    call this%update_and_extract_sl_patch_field(fieldname, values, val_output)
+    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, reset=reset)
 
     ! Verify
     expected = sum(values(4:5))
@@ -626,7 +644,8 @@ contains
     class(TestAccumul), intent(inout) :: this
     character(len=*), parameter :: fieldname = 'foo'
     integer, parameter :: accum_period = 3  ! irrelevant for this type
-    real(r8), parameter :: values(5) = [11._r8,  accumResetVal, 12._r8,  13._r8, 24._r8]
+    real(r8), parameter :: values(5) = [11._r8,  -99999._r8, 12._r8,  13._r8,  24._r8]
+    logical , parameter :: reset(5)  = [.false., .true.,     .false., .false., .false.]
     logical, parameter :: pactive(5) = [.false., .false.,       .false., .true., .true.]
     real(r8) :: val_output
     real(r8) :: expected
@@ -649,7 +668,7 @@ contains
     ! Test runaccum with a point that starts active, becomes inactive, then later becomes
     ! active again.
     !
-    ! Should ignore values and accumResetVal in the inactive steps.
+    ! Should ignore values and reset request in the inactive steps.
     !
     ! Also, should continue where it left off - i.e., including the values accumulated
     ! when it was first active. This may or may not be the ideal behavior; we can change
@@ -657,7 +676,8 @@ contains
     class(TestAccumul), intent(inout) :: this
     character(len=*), parameter :: fieldname = 'foo'
     integer, parameter :: accum_period = 3  ! irrelevant for this type
-    real(r8), parameter :: values(5) = [11._r8,  accumResetVal, 12._r8,  17._r8, 24._r8]
+    real(r8), parameter :: values(5) = [11._r8,  -99999._r8, 12._r8,  17._r8,  24._r8]
+    logical , parameter :: reset(5)  = [.false., .true.,     .false., .false., .false.]
     logical, parameter :: pactive(5) = [.true., .false.,       .false., .true., .true.]
     real(r8) :: val_output
     real(r8) :: expected
@@ -668,7 +688,7 @@ contains
          accum_period = accum_period)
 
     ! Exercise
-    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, pactive=pactive)
+    call this%update_and_extract_sl_patch_field(fieldname, values, val_output, pactive=pactive, reset=reset)
 
     ! Verify
     expected = values(1) + values(4) + values(5)


### PR DESCRIPTION
## Description of changes

There are three types of accumulators specified in `accumulMod`: `timeavg`, `runmean`, and `runaccum`. `timeavg` is reset (value set to 0) every N steps, where N is the length of the period over which the field is being averaged. `runaccum` can be reset "manually" whenever the value passed in to the "update" subroutine is -99999.

`runmean`, in contrast, has no way to reset. This ends up being a problem for me with the crop calendar work, so I wanted to add that ability.

This PR adds the ability for `runmean` to be manually reset. It does the same for `timeavg`, and it makes it so that `runaccum` doesn't use the -99999 method anymore. See Design Note below for more details.

**Note: This PR can be pointed to b4b-dev instead of master once b4b-dev is brought up to date with ctsm5.2.007.**

## Specific notes

**Contributors other than yourself, if any:** @ekluzek 

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- Existing `accumulMod` unit tests pass.
- Added new `accumulMod` unit tests, which also pass.
- `aux_clm` passed as of commit 7ff674a80. Almost certainly still passes as of 818671f3, but needs to be re-run to be sure. Or at the very least, I need to make sure it builds on all compilers on Derecho and Izumi.

---------------------------------------

## Design note

### Design Considerations

#### General Contraints

The `timeavg` method doesn't make sense for `runmean`, so I was thinking I would use the method from `runaccum`. But as I thought about it more, there were some things I didn't like:
- All variables we use `runaccum` for at the moment are by definition zero or positive, but theoretically some new variable might be added for which -99999 could be a valid value. I call this the "overloading" problem: Usually the update value is a real value, but sometimes it's a flag saying the accumulator should be reset.
- If a patch is inactive when -99999 is passed in to `update_accum_field()` for `timeavg` or `runaccum`, it will not be reset. I call this the "missed reset" problem.
- `runaccum` can't both reset and update itself in the same call of `update_accum_field_runaccum()`. If a reset is requested, the value for that timestep is lost. I call this the "missed update" problem.

Whatever I do to solve the first issue, I want it to also be used for `runmean` so there aren't multiple reset methods floating around. With regard to the other two issues, I want `runmean`'s reset implementation to behave how I need it to, but I don't want to change `runaccum` because fixing the "missed update" problem will be answer-changing. (We should probably fix that and the "missed reset" problem, but that will require more of a discussion—I'd like my current PR to be bit-for-bit.)

Finally, even though it's not necessary for my current work, I wanted to add a way for `timeavg` fields to be manually reset.

For my purposes, I want to be able to reset (all levels of) a given point. However, there may also be situations where one might want to reset (all levels of) *all* points, one level of all points, or one level of one point.

### Solutions
One way to tell `update_accum_field()` that some point-levels should be reset, while avoiding the "overloading problem," could be to pass in an optional logical array. However, that would get messy. It would require a lot of boilerplate code to be added to the two `update_accum_field_[sm]l()` procedures and to the `update_accum_field_(timeavg,runmean,runaccum)` subroutines.

Instead, I decided to give the `accum_field` type a new logical member. Because my crop calendar work requires the ability to reset *only* certain patches, I'm implementing this as an array of the same size as `val`—i.e., number of points (patches, columns, etc.) by number of levels. This new array is to be called `reset`.

`reset` will be changed using a new subroutine, `markreset_accum_field()`. This will optionally accept two indices indicating which points and/or levels, if any, should have `reset` set to `.true.`. If neither optional index is provided, `reset` will be set to `.true.` for all point-levels.

To avoid the "missed reset" problem, I could have made it so that all points with `reset == .true.` are reset whether they're active or not. However, that could lead to spurious values of the accumulator if the point becomes active again and its accumulator queried (with `extract_accum_field()`) before a new (first) value is accumulated (with `update_accum_field()`). So instead, if an inactive point has `reset == .true.`, its value is not reset and its `reset` remains `.true.`. If and when the point becomes active again, its value will be reset and its `reset` will be set to `.false.`. That's why I named the above subroutine `markreset_accum_field`: It *marks* point-levels as needing to be reset, but doesn't actually reset them.

Avoiding the "missed update" problem is simple enough—don't put the "reset" and "update" code blocks on either side of an if/else.

Note, again, that I will not be solving the "missed reset" and "missed update" problems where they already exist (`timeavg`/`runaccum` and `runaccum`, respectively).

### Design and Architecture

#### Algorithm or Pseudo code for main components

![screenshot_0934](https://github.com/ESCOMP/CTSM/assets/10454527/55327e18-37f1-4b7f-bbe1-e304739bf831)
![screenshot_0935](https://github.com/ESCOMP/CTSM/assets/10454527/163cd2cc-b744-4a18-b911-0962de344b4d)
![screenshot_0936](https://github.com/ESCOMP/CTSM/assets/10454527/adae17f9-462e-4749-bc27-41c8d5c5cc6e)



