### PR TITLE
add hillslope_fsat_equals_zero

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3525,6 +3525,7 @@ sub setup_logic_hillslope {
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_pft_distribution_method' );
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_soil_profile_method' );
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_hillslope_routing', 'use_hillslope'=>$nl_flags->{'use_hillslope'} );
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_fsat_equals_zero', 'use_hillslope'=>$nl_flags->{'use_hillslope'} );
   my $use_hillslope = $nl->get_value('use_hillslope');
   my $use_hillslope_routing = $nl->get_value('use_hillslope_routing');
   if ( (! &value_is_true($use_hillslope)) && &value_is_true($use_hillslope_routing) ) {

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -596,6 +596,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <hillslope_pft_distribution_method           >Standard</hillslope_pft_distribution_method>
 <hillslope_soil_profile_method               >Uniform</hillslope_soil_profile_method>
 <downscale_hillslope_meteorology             >.true.</downscale_hillslope_meteorology>
+<hillslope_fsat_equals_zero                  >.true.</hillslope_fsat_equals_zero>
 
 <!-- Plant hydraulic stress -->
 <use_hydrstress                                                       >.false.</use_hydrstress>

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -828,6 +828,11 @@ Toggle to turn on meteorological downscaling in hillslope model
 Toggle to turn on surface water routing in the hillslope hydrology model
 </entry>
 
+<entry id="hillslope_fsat_equals_zero" type="logical" category="physics"
+        group="clm_inparm" valid_values="" value=".true.">
+If true, set fsat to zero for hillslope columns
+</entry>
+
 <entry id="hillslope_head_gradient_method" type="char*256" category="physics"
         group="hillslope_hydrology_inparm" valid_values="Kinematic,Darcy">
 Method for calculating hillslope saturated head gradient

--- a/src/biogeophys/SaturatedExcessRunoffMod.F90
+++ b/src/biogeophys/SaturatedExcessRunoffMod.F90
@@ -12,8 +12,8 @@ module SaturatedExcessRunoffMod
   use shr_log_mod  , only : errMsg => shr_log_errMsg
   use decompMod    , only : bounds_type
   use abortutils   , only : endrun
-  use clm_varctl   , only : iulog, use_vichydro, crop_fsat_equals_zero
-  use clm_varcon   , only : spval
+  use clm_varctl   , only : iulog, use_vichydro, crop_fsat_equals_zero, hillslope_fsat_equals_zero
+  use clm_varcon   , only : spval,ispval
   use LandunitType , only : landunit_type
   use landunit_varcon  , only : istcrop
   use ColumnType   , only : column_type
@@ -263,6 +263,19 @@ contains
           c = filter_hydrologyc(fc)
           l = col%landunit(c)
           if(lun%itype(l) == istcrop) fsat(c) = 0._r8
+       end do
+    endif
+
+    ! ------------------------------------------------------------------------
+    ! Set fsat to zero for upland hillslope columns
+    ! ------------------------------------------------------------------------
+    if (hillslope_fsat_equals_zero) then
+       do fc = 1, num_hydrologyc
+          c = filter_hydrologyc(fc)
+          if(col%is_hillslope_column(c) .and. col%active(c)) then
+             ! Set fsat to zero for upland columns
+             if (col%cold(c) /= ispval) fsat(c) = 0._r8
+          endif
        end do
     endif
 

--- a/src/main/clm_varctl.F90
+++ b/src/main/clm_varctl.F90
@@ -414,6 +414,8 @@ module clm_varctl
   logical, public :: use_hillslope = .false. ! true => use multi-column hillslope hydrology
   logical, public :: downscale_hillslope_meteorology = .false. ! true => downscale meteorological forcing in hillslope model
   logical, public :: use_hillslope_routing = .false. ! true => use surface water routing in hillslope hydrology
+  logical, public :: hillslope_fsat_equals_zero = .false. ! set saturated excess runoff to zero for hillslope columns
+
 
   !----------------------------------------------------------
   ! excess ice physics switch

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -270,6 +270,8 @@ contains
 
     namelist /clm_inparm/ use_hillslope_routing
 
+    namelist /clm_inparm/ hillslope_fsat_equals_zero
+
     namelist /clm_inparm/ use_hydrstress
 
     namelist /clm_inparm/ use_dynroot
@@ -840,6 +842,8 @@ contains
 
     call mpi_bcast (use_hillslope_routing, 1, MPI_LOGICAL, 0, mpicom, ier)
 
+    call mpi_bcast (hillslope_fsat_equals_zero, 1, MPI_LOGICAL, 0, mpicom, ier)
+
     call mpi_bcast (use_hydrstress, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     call mpi_bcast (use_dynroot, 1, MPI_LOGICAL, 0, mpicom, ier)
@@ -1124,8 +1128,9 @@ contains
 
     write(iulog,*) '   land-ice albedos      (unitless 0-1)   = ', albice
     write(iulog,*) '   hillslope hydrology    = ', use_hillslope
-    write(iulog,*) '   downscale hillslope meteorology    = ', downscale_hillslope_meteorology
+    write(iulog,*) '   downscale hillslope meteorology  = ', downscale_hillslope_meteorology
     write(iulog,*) '   hillslope routing      = ', use_hillslope_routing
+    write(iulog,*) '   hillslope_fsat_equals_zero       = ', hillslope_fsat_equals_zero
     write(iulog,*) '   pre-defined soil layer structure = ', soil_layerstruct_predefined
     write(iulog,*) '   user-defined soil layer structure = ', soil_layerstruct_userdefined
     write(iulog,*) '   user-defined number of soil layers = ', soil_layerstruct_userdefined_nlevsoi


### PR DESCRIPTION
### Description of changes
Add a namelist variable to toggle fsat calculation for hillslope columns
### Specific notes
the topmodel-based fsat surface runoff scheme is not appropriate for upland hillslope columns, so allow user to set upland hillslope column fsat values to zero

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** yes, for hillslope cases; changing fsat will change surface runoff

**Any User Interface Changes (namelist or namelist defaults changes)?** New parameter `hillslope_fsat_equals_zero` (default true).

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** `aux_clm` mostly okay compared to `tmp-240620.n02.ctsm5.2.007`. However, test `LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.derecho_intel.clm-lilac` has some weird namelist results:
```
2024-06-24 13:17:38: NLCOMP
Missing baseline namelist '/glade/campaign/cgd/tss/ctsm_baselines/tmp-240620.n02.ctsm5.2.007/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.derecho_intel.c
lm-lilac/CaseDocs/nuopc.runconfig'
Comparison failed between '/glade/derecho/scratch/samrabin/tests_0624-131520de/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.derecho_intel.clm-lilac.GC.06
24-131520de_int/CaseDocs/lnd_in' with '/glade/campaign/cgd/tss/ctsm_baselines/tmp-240620.n02.ctsm5.2.007/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.der
echo_intel.clm-lilac/CaseDocs/lnd_in'
Differences in namelist 'clm_inparm':
  missing variable: 'fatmlndfrc'
  missing variable: 'hist_fincl2'
  missing variable: 'hist_fincl3'
  missing variable: 'hist_mfilt'
  missing variable: 'hist_mfilt(1)'
  missing variable: 'hist_ndens'
  missing variable: 'hist_nhtfrq'
  missing variable: 'hist_nhtfrq(1)'
  found extra variable: 'hillslope_fsat_equals_zero'
Missing baseline namelist '/glade/campaign/cgd/tss/ctsm_baselines/tmp-240620.n02.ctsm5.2.007/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.derecho_intel.c
lm-lilac/CaseDocs/drv_flds_in'
Missing baseline namelist '/glade/campaign/cgd/tss/ctsm_baselines/tmp-240620.n02.ctsm5.2.007/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.derecho_intel.c
lm-lilac/CaseDocs/nuopc.runseq'
Comparison failed between '/glade/derecho/scratch/samrabin/tests_0624-131520de/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.derecho_intel.clm-lilac.GC.06
24-131520de_int/CaseDocs/drv_in' with '/glade/campaign/cgd/tss/ctsm_baselines/tmp-240620.n02.ctsm5.2.007/LILACSMOKE_D_Ld2.f10_f10_mg37.I2000Ctsm50NwpSpAsRs.der
echo_intel.clm-lilac/CaseDocs/drv_in'
Found extra namelist: debug_inparm
Found extra namelist: papi_inparm
Found extra namelist: prof_inparm
```
The only expected one of those was `found extra variable: 'hillslope_fsat_equals_zero'`. However, `diff`ing `lnd_in` and `lilac_in` from the baseline vs. the new test shows none of those differences. I'm thus going to ignore this.
