### PR TITLE
Change a NIWO test to HARV and update expected failures

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -76,13 +76,6 @@
     </phase>
   </test>
   
-  <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_gnu.clm-FatesFireLightningPopDens--clm-NEON-FATES-NIWO">
-    <phase name="SHAREDLIB_BUILD">
-      <status>FAIL</status>
-      <issue>#2310</issue>
-    </phase>
-  </test>
-
   <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_gnu.clm-FatesPRISM--clm-NEON-FATES-YELL">
     <phase name="SHAREDLIB_BUILD">
       <status>FAIL</status>

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -244,10 +244,6 @@
       <status>FAIL</status>
       <issue>#2310</issue>
     </phase>
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>#2310</issue>
-    </phase>
   </test>
 
   <!-- Other external test list failures (MOSART, RTM, etc. -->

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -58,29 +58,14 @@
     </phase>
   </test>
 
-  <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-NIWO">
+  <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-HARV">
     <phase name="SHAREDLIB_BUILD">
-      <status>FAIL</status>
-      <issue>#2310</issue>
-    </phase>
-    <phase name="RUN">
       <status>FAIL</status>
       <issue>#2310</issue>
     </phase>
   </test>
   
   <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-NEON-MOAB--clm-PRISM">
-    <phase name="SHAREDLIB_BUILD">
-      <status>FAIL</status>
-      <issue>#2310</issue>
-    </phase>
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>#2310</issue>
-    </phase>
-  </test>
-  
-  <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_gnu.clm-FatesFireLightningPopDens--clm-NEON-FATES-NIWO">
     <phase name="SHAREDLIB_BUILD">
       <status>FAIL</status>
       <issue>#2310</issue>

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -76,6 +76,13 @@
     </phase>
   </test>
   
+  <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_gnu.clm-FatesFireLightningPopDens--clm-NEON-FATES-NIWO">
+    <phase name="SHAREDLIB_BUILD">
+      <status>FAIL</status>
+      <issue>#2310</issue>
+    </phase>
+  </test>
+
   <test name="SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_gnu.clm-FatesPRISM--clm-NEON-FATES-YELL">
     <phase name="SHAREDLIB_BUILD">
       <status>FAIL</status>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1873,7 +1873,7 @@
       <option name="comment">Want to keep a little single-point testing on HPC machines</option>
     </options>
   </test>
-  <test name="SMS_Ld10_D_Mmpi-serial" grid="CLM_USRDAT" compset="I1PtClm60Bgc" testmods="clm/default--clm/NEON/NIWO">
+  <test name="SMS_Ld10_D_Mmpi-serial" grid="CLM_USRDAT" compset="I1PtClm60Bgc" testmods="clm/default--clm/NEON/HARV">
     <machines>
       <machine name="derecho"  compiler="gnu" category="aux_clm"/>
       <machine name="izumi"    compiler="nag"   category="aux_clm"/>


### PR DESCRIPTION
### Description of changes
Motivated by problems with the NIWO test in #640 (this [comment](https://github.com/ESCOMP/CTSM/pull/640#issuecomment-2143101361))

@wwieder recommended switching the NIWO test to HARV.

@ekluzek recommended opening a PR to give this change more visibility. I implemented the change in #640 as well.

### Specific notes

Contributors other than yourself, if any:
@wwieder 

Are answers expected to change (and if so in what way)?
No, but one NIWO test has been changed to a HARV test.

Testing performed, if any:
I ran the tests
```
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-HARV
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Fates.derecho_intel.clm-FatesFireLightningPopDens--clm-NEON-FATES-NIWO
```
- the former to show that the new test passes
- the latter because this test does not fail, and I updated the expected failures
- the latter also appears as derecho_gnu, but only in the expected fails (not in testlist), so i'm removing