### PR TITLE
Always check finidat_interp_dest.status

### DIFF
--- a/src/cpl/nuopc/lnd_comp_nuopc.F90
+++ b/src/cpl/nuopc/lnd_comp_nuopc.F90
@@ -626,7 +626,6 @@ contains
          version_in=model_version, &
          hostname_in=hostname, &
          username_in=username)
-
     call initialize1(dtime=dtime_sync)
 
     ! ---------------------

--- a/src/cpl/nuopc/lnd_comp_nuopc.F90
+++ b/src/cpl/nuopc/lnd_comp_nuopc.F90
@@ -626,6 +626,7 @@ contains
          version_in=model_version, &
          hostname_in=hostname, &
          username_in=username)
+
     call initialize1(dtime=dtime_sync)
 
     ! ---------------------

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -520,17 +520,7 @@ contains
        else
           if (trim(finidat) == trim(finidat_interp_dest)) then
              ! Check to see if status file for finidat exists
-             klen = len_trim(finidat_interp_dest) - 3 ! remove the .nc
-             locfn = finidat_interp_dest(1:klen)//'.status'
-             inquire(file=trim(locfn), exist=lexists)
-             if (.not. lexists) then
-                if (masterproc) then
-                   write(iulog,'(a)')' failed to find file '//trim(locfn)
-                   write(iulog,'(a)')' this indicates a problem in creating '//trim(finidat_interp_dest)
-                   write(iulog,'(a)')' remove '//trim(finidat_interp_dest)//' and try again'
-                end if
-                call endrun()
-             end if
+             call check_missing_initdata_status(finidat_interp_dest)
           end if
           if (masterproc) then
              write(iulog,'(a)')'Reading initial conditions from file '//trim(finidat)

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -174,7 +174,7 @@ contains
     use SatellitePhenologyMod         , only : SatellitePhenologyInit, readAnnualVegetation, interpMonthlyVeg, SatellitePhenology
     use SnowSnicarMod                 , only : SnowAge_init, SnowOptics_init
     use lnd2atmMod                    , only : lnd2atm_minimal
-    use controlMod                    , only : NLFilename
+    use controlMod                    , only : NLFilename, check_missing_initdata_status
     use clm_instMod                   , only : clm_fates
     use BalanceCheckMod               , only : BalanceCheckInit
     use CNSharedParamsMod             , only : CNParamsSetSoilDepth

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -571,6 +571,7 @@ contains
     ! ----------------------------------------------------------------------
     ! Read in other namelists for other modules
     ! ----------------------------------------------------------------------
+
     call mpi_bcast (use_init_interp, 1, MPI_LOGICAL, 0, mpicom, ierr)
     if (use_init_interp) then
        call initInterp_readnl( NLFilename )
@@ -580,6 +581,7 @@ contains
     !For future version, I suggest to  put the following two calls inside their
     !own modules, which are called from their own initializing methods
     call init_hydrology( NLFilename )
+
     call soil_resistance_readnl ( NLFilename )
     call CanopyFluxesReadNML    ( NLFilename )
     call CanopyHydrology_readnl ( NLFilename )
@@ -592,6 +594,7 @@ contains
     ! ----------------------------------------------------------------------
     ! Broadcast all control information if appropriate
     ! ----------------------------------------------------------------------
+
     call control_spmd()
 
     ! ----------------------------------------------------------------------
@@ -1218,7 +1221,7 @@ contains
     end if
   end subroutine control_print
 
-  
+
   !-----------------------------------------------------------------------
   subroutine check_missing_initdata_status(finidat_interp_dest)
    !
@@ -1302,8 +1305,9 @@ contains
     inquire(file=trim(finidat_interp_dest), exist=lexists)
     if (lexists) then
 
-      ! Check that the status file also exists (i.e., that finidat_interp_dest was written successfully)
-      call check_missing_initdata_status(finidat_interp_dest)
+       ! Check that the status file also exists (i.e., that finidat_interp_dest was written successfully)
+       call check_missing_initdata_status(finidat_interp_dest)
+
        ! open the input file and check for the name of the input source file
        status = nf90_open(trim(finidat_interp_dest), 0, ncid)
        if (status /= nf90_noerr) call handle_err(status)

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -59,10 +59,10 @@ module controlMod
   public :: control_setNL ! Set namelist filename
   public :: control_init  ! initial run control information
   public :: control_print ! print run control information
+  public :: check_missing_initdata_status  ! check for missing finidat_interp_dest .status file
   !
   !
   ! !PRIVATE MEMBER FUNCTIONS:
-  private :: check_missing_initdata_status  ! check for missing finidat_interp_dest .status file
   private :: apply_use_init_interp  ! apply the use_init_interp namelist option, if set
   !
   ! !PRIVATE TYPES:

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -571,7 +571,6 @@ contains
     ! ----------------------------------------------------------------------
     ! Read in other namelists for other modules
     ! ----------------------------------------------------------------------
-
     call mpi_bcast (use_init_interp, 1, MPI_LOGICAL, 0, mpicom, ierr)
     if (use_init_interp) then
        call initInterp_readnl( NLFilename )
@@ -581,7 +580,6 @@ contains
     !For future version, I suggest to  put the following two calls inside their
     !own modules, which are called from their own initializing methods
     call init_hydrology( NLFilename )
-
     call soil_resistance_readnl ( NLFilename )
     call CanopyFluxesReadNML    ( NLFilename )
     call CanopyHydrology_readnl ( NLFilename )
@@ -594,7 +592,6 @@ contains
     ! ----------------------------------------------------------------------
     ! Broadcast all control information if appropriate
     ! ----------------------------------------------------------------------
-
     call control_spmd()
 
     ! ----------------------------------------------------------------------
@@ -1307,8 +1304,6 @@ contains
 
       ! Check that the status file also exists (i.e., that finidat_interp_dest was written successfully)
       call check_missing_initdata_status(finidat_interp_dest)
-
-       write(iulog, *) 'ssr apply_use_init_interp: point 3'
        ! open the input file and check for the name of the input source file
        status = nf90_open(trim(finidat_interp_dest), 0, ncid)
        if (status /= nf90_noerr) call handle_err(status)

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -62,6 +62,7 @@ module controlMod
   !
   !
   ! !PRIVATE MEMBER FUNCTIONS:
+  private :: check_missing_initdata_status  ! check for missing finidat_interp_dest .status file
   private :: apply_use_init_interp  ! apply the use_init_interp namelist option, if set
   !
   ! !PRIVATE TYPES:
@@ -1220,6 +1221,38 @@ contains
     end if
   end subroutine control_print
 
+  
+  !-----------------------------------------------------------------------
+  subroutine check_missing_initdata_status(finidat_interp_dest)
+   !
+   ! !DESCRIPTION:
+   ! Checks that the finidat_interp_dest .status file was written (i.e., that write of
+   ! finidat_interp_dest succeeded)
+   !
+   ! !ARGUMENTS:
+   character(len=*), intent(in)    :: finidat_interp_dest
+   !
+   ! !LOCAL VARIABLES:
+   logical                    :: lexists
+   integer                    :: klen
+   character(len=SHR_KIND_CL) :: status_file
+   character(len=*), parameter :: subname = 'check_missing_initdata_status'
+   !-----------------------------------------------------------------------
+
+    klen = len_trim(finidat_interp_dest) - 3 ! remove the .nc
+    status_file = finidat_interp_dest(1:klen)//'.status'
+    inquire(file=trim(status_file), exist=lexists)
+    if (.not. lexists) then
+       if (masterproc) then
+          write(iulog,'(a)')' failed to find file '//trim(status_file)
+          write(iulog,'(a)')' this indicates a problem in creating '//trim(finidat_interp_dest)
+          write(iulog,'(a)')' remove '//trim(finidat_interp_dest)//' and try again'
+       end if
+       call endrun(subname//': finidat_interp_dest file exists but is probably bad')
+    end if
+
+  end subroutine check_missing_initdata_status
+
 
   !-----------------------------------------------------------------------
   subroutine apply_use_init_interp(finidat_interp_dest, finidat, finidat_interp_source)
@@ -1271,6 +1304,11 @@ contains
 
     inquire(file=trim(finidat_interp_dest), exist=lexists)
     if (lexists) then
+
+      ! Check that the status file also exists (i.e., that finidat_interp_dest was written successfully)
+      call check_missing_initdata_status(finidat_interp_dest)
+
+       write(iulog, *) 'ssr apply_use_init_interp: point 3'
        ! open the input file and check for the name of the input source file
        status = nf90_open(trim(finidat_interp_dest), 0, ncid)
        if (status /= nf90_noerr) call handle_err(status)


### PR DESCRIPTION
### Description of changes

Adds a check for the existence of the `finidat_interp_dest.status` file.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):**
- Fixes #2596 

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- These commits solved the problem on the branch I initially encountered it on
- I haven't yet done `aux_clm` testing; waiting for initial PR approval.
