### PR TITLE
Change CTSM machine default for Derecho to develop queue w/ 16 cpus

### DIFF
--- a/python/ctsm/machine_defaults.py
+++ b/python/ctsm/machine_defaults.py
@@ -77,13 +77,13 @@ MACHINE_DEFAULTS = {
         create_test_queue=CREATE_TEST_QUEUE_UNSPECIFIED,
         job_launcher_defaults={
             JOB_LAUNCHER_QSUB: QsubDefaults(
-                queue="main",
+                queue="develop",
                 walltime="03:50:00",
                 extra_args="",
                 # The following assumes a single node, with a single mpi proc; we may want
                 # to add more flexibility in the future, making the node / proc counts
                 # individually selectable
-                required_args="-l select=1:ncpus=128:mpiprocs=1 -V -r n -k oed",
+                required_args="-l select=1:ncpus=32:mpiprocs=1 -V -r n -k oed",
             )
         },
     ),

--- a/python/ctsm/machine_defaults.py
+++ b/python/ctsm/machine_defaults.py
@@ -83,7 +83,7 @@ MACHINE_DEFAULTS = {
                 # The following assumes a single node, with a single mpi proc; we may want
                 # to add more flexibility in the future, making the node / proc counts
                 # individually selectable
-                required_args="-l select=1:ncpus=32:mpiprocs=1 -V -r n -k oed",
+                required_args="-l select=1:ncpus=16:mpiprocs=1 -V -r n -k oed",
             )
         },
     ),


### PR DESCRIPTION
### Description of changes
When calling `run_sys_tests` on Derecho, each `STDIN` process requests 128 CPUs on the main queue. This PR makes it so that, by default, a more reasonable number of CPUs is requested on the develop queue.

So far, I've only made that one change. I'm assuming we'll need to discuss whether 32 is the best choice, whether anything else should change, etc.

### Specific notes

**Contributors other than yourself, if any:** @ekluzek 

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**

`./run_sys_tests -t SMS_Ln9.ne3pg3_ne3pg3_mg37.I2000Clm50Sp.derecho_gnu.clm-clm50cam6LndTuningMode --skip-compare --skip-generate -v` makes the right qsub command:
```
INFO: Running: </glade/u/home/samrabin/ctsm_runsystests-dev-queue/cime/scripts/create_test --test-id 0821-152211de --output-root /glade/derecho/scratch/samrabin/tests_0821-152211de SMS_Ln9.ne3pg3_ne3pg3_mg37.I2000Clm50Sp.derecho_gnu.clm-clm50cam6LndTuningMode --baseline-root /glade/campaign/cgd/tss/ctsm_baselines --project P93300041 --retry 0> via <qsub -q develop -l walltime=03:50:00 -o /glade/derecho/scratch/samrabin/tests_0821-152211de/STDOUT.0821-152211de -e /glade/derecho/scratch/samrabin/tests_0821-152211de/STDERR.0821-152211de -A P93300041 -l select=1:ncpus=32:mpiprocs=1 -V -r n -k oed>
```

- [x] Python tests