### PR TITLE
mksurfdata_esmf: Refactor mksoiltex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,12 +75,11 @@ ctsm.input_data_list.previous
 /tools/mksurfdata_esmf/mksurfdata_in
 /tools/mksurfdata_esmf/surfdata_*.nc
 /tools/mksurfdata_esmf/landuse.timeseries_*.nc
-/tools/mksurfdata_esmf/mksurfdata_jobscript_multi.sh
-/tools/mksurfdata_esmf/mksurfdata_jobscript_single.sh
 /tools/mksurfdata_esmf/pio_iotype.txt
 /tools/mksurfdata_esmf/*.sh
 /tools/mksurfdata_esmf/tool_bld
 /tools/mksurfdata_esmf/pio_iotype.txt
+/tools/mksurfdata_esmf/mpibind*.log
 
 # mksurfdata unit tests
 unit_test_build

--- a/python/ctsm/toolchain/gen_mksurfdata_jobscript_single.py
+++ b/python/ctsm/toolchain/gen_mksurfdata_jobscript_single.py
@@ -34,13 +34,16 @@ def base_get_parser(default_js_name="mksurfdata_jobscript_single.sh"):
     parser.print_usage = parser.print_help
     add_logging_args(parser)
 
+    default_account = os.environ.get("ACCOUNT")
+    if default_account is None:
+        default_account = "P93300641"
     parser.add_argument(
         "--account",
         help="""account number (default: %(default)s)""",
         action="store",
         dest="account",
         required=False,
-        default="P93300641",
+        default=default_account,
     )
     parser.add_argument(
         "--number-of-nodes",

--- a/tools/mksurfdata_esmf/Makefile
+++ b/tools/mksurfdata_esmf/Makefile
@@ -52,7 +52,7 @@ SUBSETDATA_POINT_ALLLU = $(SUBSETDATA_POINT) --include-nonveg
 SUBSETDATA_POINT_URBAN = $(SUBSETDATA_POINT) --include-nonveg
 
 # Subset data sites...
-SUBSETDATA_1X1_BRAZIL := --lat -7 --lon -55 --site 1x1_brazil
+SUBSETDATA_1X1_BRAZIL := --lat -7 --lon 305 --site 1x1_brazil
 SUBSETDATA_1X1_NUMAIA := --lat 40.6878 --lon 267.0228 --site 1x1_numaIA
 SUBSETDATA_1X1_SMALL_IA  := --lat 40.6878 --lon 267.0228 --site 1x1_smallvilleIA \
 		--dompft 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 \

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -48,7 +48,7 @@ contains
     end if
   end subroutine mksoiltex_check_layer_negative
 
-  subroutine mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, name, val_neg_4, val_neg_other, data_i, data_o, data_modifier, organic_o)
+  subroutine mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, name, val_neg_4, val_neg_other, data_i, data_o)
     !
     ! Arguments
     integer, intent(in) :: no
@@ -59,28 +59,11 @@ contains
     real(r4), intent(in) :: val_neg_other  ! Fallback value if read-in value is negative but not -4
     real(r4), intent(in) :: data_i(:,:,:)
     real(r4), intent(out) :: data_o(:,:)
-    real(r4), optional, intent(in) :: data_modifier(:,:,:)
-    real(r4), optional, intent(out) :: organic_o(:,:)
     !
     ! Local variables
     integer :: l
     integer :: ier
     logical :: is_sand_dune
-    real(r4), allocatable  :: organic_i(:,:,:)
-
-    ! Apply data_modifer, if needed (organic_o OPTION 2)
-    if (present(data_modifier)) then
-       if (.not. present(organic_o)) then
-          call shr_sys_abort('mksoiltex_i_to_o: data_modifier not needed if not providing organic_o')
-       else if (trim(name) /= 'orgc') then
-          call shr_sys_abort('mksoiltex_i_to_o: organic_o should only be provided along with orgc')
-       end if
-       allocate(organic_i(nlay,n_scid,n_mapunits), stat=ier)
-       if (ier/=0) call shr_sys_abort()
-       organic_i = data_i * data_modifier
-    else if (present(organic_o)) then
-       call shr_sys_abort('mksoiltex_i_to_o: If providing organic_o, also provide data_modifier')
-    end if
 
     ! Fill first layer of output array with first positive value on SCID dim of input array
     data_o(no,1) = data_i(1,1,lookup_index)

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -52,7 +52,7 @@ contains
     ! Local variables
     integer :: l
     integer :: ier
-    logical :: is_neg_4
+    logical :: is_sand_dune
     logical :: organic2
     real(r4), allocatable  :: organic_i(:,:,:)
 
@@ -87,8 +87,8 @@ contains
 
     ! Handle cases where no positive value was found
     if (data_o(no,1) < 0._r4) then
-       is_neg_4 = int(data_o(no,1)) == -4  ! TODO: Rename. Maybe indicates sand dune?
-       if (is_neg_4) then
+       is_sand_dune = int(data_o(no,1)) == -4
+       if (is_sand_dune) then
           data_o(no,:) = val_neg_4
           if (organic2) organic_o(no,:) = val_neg_4  ! TODO: This should probably be under conditionals looking at organic_o instead of data_o, but that's not how it was in the original
        else

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -35,6 +35,19 @@ module mksoiltexMod
 contains
 !=================================================================================
 
+  subroutine mksoiltex_check_layer_negative(data, no, lookup_index, name)
+    !
+    ! Arguments
+    real(r4), intent(in) :: data
+    integer, intent(in) :: no
+    integer, intent(in) :: lookup_index
+    character(*), intent(in) :: name
+    if (data < 0._r4) then
+       write(6,*)'ERROR: at no, lookup_index = ',no,lookup_index
+       call shr_sys_abort('could not find a value >= 0 for '//name)
+    end if
+  end subroutine mksoiltex_check_layer_negative
+
   subroutine mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, name, val_neg_4, val_neg_other, data_i, data_o, data_modifier, organic_o)
     !
     ! Arguments
@@ -90,13 +103,8 @@ contains
        end if
     end if
 
-    ! Ensure negative values are handled
-    ! TODO: Remove as unnecessary?
-    ! TODO: Also handle organic_o? Not handled in original
-    if (data_o(no,1) < 0._r4) then
-       write(6,*)'ERROR: at no, lookup_index = ',no,lookup_index
-       call shr_sys_abort('could not find a value >= 0 for '//name)
-    end if
+    ! Error on negative values in top layer
+    call mksoiltex_check_layer_negative(data_o(no,1), no, lookup_index, name)
 
     ! Top soil layer is filled above. Here, we fill the other layers.
     do l = 2,nlay
@@ -433,6 +441,8 @@ contains
           do l = 1, nlay
              organic_o(no,l) = orgc_o(no,l) * bulk_o(no,l) * &
                   (100._r4 - cfrag_o(no,l)) * 0.01_r4 / 0.58_r4
+             ! Error on negative values in any layer
+             call mksoiltex_check_layer_negative(organic_o(no,l), no, lookup_index, "organic")
           end do
 
        end if

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -53,18 +53,15 @@ contains
     integer :: l
     integer :: ier
     logical :: is_sand_dune
-    logical :: organic2
     real(r4), allocatable  :: organic_i(:,:,:)
 
     ! Apply data_modifer, if needed (organic_o OPTION 2)
-    organic2 = .false.
     if (present(data_modifier)) then
        if (.not. present(organic_o)) then
           call shr_sys_abort('mksoiltex_i_to_o: data_modifier not needed if not providing organic_o')
        else if (trim(name) /= 'orgc') then
           call shr_sys_abort('mksoiltex_i_to_o: organic_o should only be provided along with orgc')
        end if
-       organic2 = .true.
        allocate(organic_i(nlay,n_scid,n_mapunits), stat=ier)
        if (ier/=0) call shr_sys_abort()
        organic_i = data_i * data_modifier
@@ -74,12 +71,10 @@ contains
 
     ! Fill first layer of output array with first positive value on SCID dim of input array
     data_o(no,1) = data_i(1,1,lookup_index)
-    if (organic2) organic_o(no,1) = organic_i(1,1,lookup_index)
     if (data_o(no,1) < 0._r4) then
        do l = 2,n_scid
           if (data_i(1,l,lookup_index) >= 0._r4) then
              data_o(no,1) = data_i(1,l,lookup_index)
-             if (organic2) organic_o(no,1) = organic_i(1,l,lookup_index)  ! TODO: This should probably be under a conditional looking at organic_i instead of data_i, but that's not how it was in the original
              exit
           end if
        end do
@@ -90,10 +85,8 @@ contains
        is_sand_dune = int(data_o(no,1)) == -4
        if (is_sand_dune) then
           data_o(no,:) = val_neg_4
-          if (organic2) organic_o(no,:) = val_neg_4  ! TODO: This should probably be under conditionals looking at organic_o instead of data_o, but that's not how it was in the original
        else
           data_o(no,:) = val_neg_other
-          if (organic2) organic_o(no,:) = val_neg_other  ! TODO: This should probably be under conditionals looking at organic_o instead of data_o, but that's not how it was in the original
        end if
     end if
 
@@ -108,12 +101,10 @@ contains
     ! Top soil layer is filled above. Here, we fill the other layers.
     do l = 2,nlay
        data_o(no,l) = data_i(l,1,lookup_index)
-       if (organic2) organic_o(no,l) = organic_i(l,1,lookup_index)
 
        ! If a layer is negative, fill it with the previous layer's value
        if (data_o(no,l) < 0._r4) then
           data_o(no,l) = data_o(no,l-1)
-          if (organic2) organic_o(no,l) = organic_o(no,l-1)  ! TODO: This should probably be under a conditional looking at organic_o instead of data_o, but that's not how it was in the original
        end if
     end do
 
@@ -178,7 +169,6 @@ contains
     type(var_desc_t)       :: pio_varid_bulk
     type(var_desc_t)       :: pio_varid_phaq
     type(var_desc_t)       :: pio_varid_organic
-    integer, parameter     :: organic_o_option = 1
     integer                :: starts(3)     ! starting indices for reading lookup table
     integer                :: counts(3)     ! dimension counts for reading lookup table
     integer                :: srcTermProcessing_Value = 0
@@ -194,10 +184,6 @@ contains
        write(ndiag,'(a)') ' Input mapunit file is '//trim(file_mapunit_i)
        write(ndiag,'(a)') ' Input lookup table file is '//trim(file_lookup_i)
        write(ndiag,'(a)') ' Input mesh/grid file is '//trim(file_mesh_i)
-    end if
-
-    if (organic_o_option < 1 .or. organic_o_option > 2) then
-       call shr_sys_abort('organic_o_option must be 1 or 2')
     end if
 
     ! Determine ns_o and allocate output data
@@ -428,15 +414,8 @@ contains
                "bulk", 1.5_r4, 1.5_r4, bulk_i, bulk_o)  ! TODO: 1.5 ok for sand dunes and -7?
           call mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, &
                "phaq", 7._r4, 7._r4, phaq_i, phaq_o)
-          if (organic_o_option == 1) then
-             call mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, &
-                  "orgc", 1._r4, 0._r4, orgc_i, orgc_o)
-          else
-             call mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, &
-                  "orgc", 1._r4, 0._r4, orgc_i, orgc_o, &
-                  orgc_i * bulk_i * float(100 - cfrag_i) * 0.01_r4 / 0.58_r4, &
-                  organic_o)
-          end if
+          call mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, &
+               "orgc", 1._r4, 0._r4, orgc_i, orgc_o)
 
           ! ---------------------------------------------------------------
           ! organic_o OPTION 1, as we plan to calculate organic in the CTSM
@@ -449,13 +428,12 @@ contains
           ! (calculated from orgc_i, cfrag_i, and bulk_i) to organic_o. This
           ! approach first calculates organic_i and then regrids to organic_o
           ! rather than regridding all the terms first and then calculating
-          ! organic_o. That would be organic_o_option 2.
-          if (organic_o_option == 1) then
-             do l = 1, nlay
-                organic_o(no,l) = orgc_o(no,l) * bulk_o(no,l) * &
-                                  (100._r4 - cfrag_o(no,l)) * 0.01_r4 / 0.58_r4
-             end do
-          end if
+          ! organic_o. That would be organic_o_option 2, last available in
+          ! commit d5f389a97.
+          do l = 1, nlay
+             organic_o(no,l) = orgc_o(no,l) * bulk_o(no,l) * &
+                  (100._r4 - cfrag_o(no,l)) * 0.01_r4 / 0.58_r4
+          end do
 
        end if
 

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -93,7 +93,7 @@ contains
     ! Ensure negative values are handled
     ! TODO: Remove as unnecessary?
     ! TODO: Also handle organic_o? Not handled in original
-    if (data_o(no,1) < 0._r4 .and. trim(name) /= "sand") then
+    if (data_o(no,1) < 0._r4) then
        write(6,*)'ERROR: at no, lookup_index = ',no,lookup_index
        call shr_sys_abort('could not find a value >= 0 for '//name)
     end if

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -409,13 +409,13 @@ contains
                "orgc", 1._r4, 0._r4, orgc_i, orgc_o)
 
           ! ---------------------------------------------------------------
-          ! organic_o OPTION 1, as we plan to calculate organic in the CTSM
+          ! Calculating organic_o
           ! ---------------------------------------------------------------
           ! Calculate organic from orgc_o, cfrag_o, and bulk_o, i.e. after
           ! these terms have been regridded. The plan is to move this
           ! calculation step from here to the CTSM. This approach keeps
           ! ORGC the same in fsurdat as in the raw data.
-          ! Alternative approach considered but not selected: Regrid organic_i
+          !     Alternative approach previously available: Regrid organic_i
           ! (calculated from orgc_i, cfrag_i, and bulk_i) to organic_o. This
           ! approach first calculates organic_i and then regrids to organic_o
           ! rather than regridding all the terms first and then calculating

--- a/tools/mksurfdata_esmf/src/mksoiltexMod.F90
+++ b/tools/mksurfdata_esmf/src/mksoiltexMod.F90
@@ -50,6 +50,8 @@ contains
 
   subroutine mksoiltex_i_to_o(no, lookup_index, n_scid, nlay, n_mapunits, name, val_neg_4, val_neg_other, data_i, data_o)
     !
+    ! Fill output soil layers for a given texture component
+    !
     ! Arguments
     integer, intent(in) :: no
     integer, intent(in) :: lookup_index


### PR DESCRIPTION
### Description of changes

Refactors `mksoiltex()` subroutine to make it easier to understand and avoid duplicated code.

Also:
- Checks for negative values in top sand layer (was already happening for other soil components)
- Changes `gen_mksurfdata_jobscript_single.py` to use user's `ACCOUNT` environment variable as default.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
As of eacff1077:
- [x] Builds without error
- [x] Runs without error
- [x] f19 outputs are ~~bit-for-bit identical~~ acceptably different with previous version (organic_o option 1)—roundoff-level diffs due to refactoring.
- ~~f19 outputs are bit-for-bit identical with previous version (disabled organic_o option 2)~~ Removing that code
- [ ] **(IN PROGRESS)** Check that `make all` generates all datasets without error.

### Other remaining tasks
- [x] Rename `is_neg_4` to be more meaningful. **Changed to `is_sand_dune` with d5f389a97**
- [x] Remove organic_o option 2. **Done with 99acaf648**
- [x] Check sand and `organic_o` for negative values; see [this comment](https://github.com/ESCOMP/CTSM/pull/2737#discussion_r2023587435).
