### PR TITLE
Remove unused variable elevclass_o in mkglcmecMod.F90

### DIFF
--- a/tools/mksurfdata_esmf/src/mkglcmecMod.F90
+++ b/tools/mksurfdata_esmf/src/mkglcmecMod.F90
@@ -100,6 +100,7 @@ contains
        call shr_sys_abort()
     end if
 
+    allocate(elevclass_o(size(elevclass)))
     elevclass_o(:) = elevclass(:)
 
     if (root_task)  write(ndiag, '(a)') trim(subname)//" writing out GLC_MEC"

--- a/tools/mksurfdata_esmf/src/mkglcmecMod.F90
+++ b/tools/mksurfdata_esmf/src/mkglcmecMod.F90
@@ -49,7 +49,6 @@ contains
     ! local variables:
     type(var_desc_t)      :: pio_varid
     type(io_desc_t)       :: pio_iodesc
-    real(r8), allocatable :: elevclass_o(:)          ! elevation classes
     integer               :: rcode
     character(len=*), parameter :: subname = 'mkglcmecInit'
     !-----------------------------------------------------------------------
@@ -99,9 +98,6 @@ contains
             " to work with CLM: "
        call shr_sys_abort()
     end if
-
-    allocate(elevclass_o(size(elevclass)))
-    elevclass_o(:) = elevclass(:)
 
     if (root_task)  write(ndiag, '(a)') trim(subname)//" writing out GLC_MEC"
     rcode = pio_inq_varid(pioid_o, 'GLC_MEC', pio_varid)


### PR DESCRIPTION
### Description of changes

User found that the mksurfdata_esmf tool fails on a certain computer with this error:
`Program received signal SIGSEGV: Segmentation fault - invalid memory reference.`
and works when elevclass_o gets allocated before use in mkglcmecMod.F90.

Original post here:
https://bb.cgd.ucar.edu/cesm/threads/mksurfdata_esmf-done-around-glcmec.9624/post-57405

### Specific notes

Contributors other than yourself, if any:
@olyson and @YuanSun-UoM

CTSM Issues Fixed (include github issue #):
Resolves #2802 

Are answers expected to change (and if so in what way)?
No.

Any User Interface Changes (namelist or namelist defaults changes)?
No.

Does this create a need to change or add documentation? Did you do so?
No.

Testing performed, if any:
As posted in issue #2802, I'm testing on derecho...
PASS qsub mksurfdata_jobscript_single_2000.sh so as to compare today's output to that generated yesterday, now in /glade/derecho/scratch/slevis/temp_work/new_rawdata/tools/mksurfdata_esmf/bkup_T42
PASS ./run_ctsm_py_tests -s and ./run_ctsm_py_tests -u
PASS make black and make lint
PASS build-namelist_test.pl
IN PROGRESS aux_clm