### PR TITLE
Set eflx_building_lun to spval properly

### DIFF
--- a/src/biogeophys/EnergyFluxType.F90
+++ b/src/biogeophys/EnergyFluxType.F90
@@ -579,7 +579,7 @@ contains
             avgflag='A', long_name='urban heating flux', &
             ptr_col=this%eflx_urban_heat_col, set_nourb=0._r8, c2l_scale_type='urbanf')
     else
-       this%eflx_urban_ac_lun(begl:endl) = spval
+       this%eflx_building_lun(begl:endl) = spval
        call hist_addfld1d (fname='EFLXBUILD', units='W/m^2',  &
             avgflag='A', long_name='building heat flux from change in interior building air temperature', &
             ptr_lunit=this%eflx_building_lun, set_nourb=0._r8, l2g_scale_type='unity')


### PR DESCRIPTION
### Description of changes

Set eflx_building_lun to spval properly

### Specific notes

Contributors other than yourself, if any: @cathyxinchangli 

CTSM Issues Fixed (include github issue #): #2793

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Does this create a need to change or add documentation? Did you do so? No

Testing performed, if any:
Ran aux_clm.
Unexpected failures:

```
FAIL ERI_D.ne30pg3_t232.I1850Clm60BgcCropG.derecho_intel.clm-clm60cam7LndTuningModeLDust COMPARE_base_hybrid
FAIL ERI_D.ne30pg3_t232.I1850Clm60BgcCropG.derecho_intel.clm-clm60cam7LndTuningModeLDust COMPARE_base_rest
```
These failed because there was one variable not bfb, DPFCT_ROCK.
Unsure why that would be different.


