### PR TITLE
Clm60 finidat updates for ne30, f09, f19 grids

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1354,18 +1354,32 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- CTSM6_0 - use clm6_0_GSWP3v1 BgcCrop at f09 for all clm5_1/clm6_0 options -->
-<!-- use_init_interp true because the file was created with ctsm5.3 datasets -->
+<!-- TODO slevis VALID COMMENT? use_init_interp true because the file was created with ctsm5.3 datasets -->
 <finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
          phys="clm5_1" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
+</finidat>
+<!-- Corresponding ne30 -->
+<finidat hgrid="ne30np4" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
+         phys="clm6_0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_pSASU.clm2.r.0121-01-01-00000.nc
+</finidat>
+<!-- Corresponding f19 -->
+<finidat hgrid="1.9x2.5" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
+         phys="clm6_0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm530_f19_PPE_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 
 <!--
@@ -1408,12 +1422,12 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          lnd_tuning_mode="clm5_1_GSWP3v1" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.2/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c240223.nc
 </finidat>
-<!-- NB: This pSASU finidat is from an f09 1850 (rather than f19 2000) spin-up -->
+<!-- NB: This pSASU finidat is from an f09 2000 spin-up -->
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20110101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
 </finidat>
 
 
@@ -1493,21 +1507,25 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 
 <!-- clm5_1 and cam7.0 -->
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm5_1" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
 </finidat>
 
 <!-- clm6_0 and cam7.0 -->
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
+</finidat>
+<finidat hgrid="ne30np4"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         phys="clm6_0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.2000-01-01-00000.nc
 </finidat>
 
 <!-- clm5_0 and cam7.0 -->
@@ -1532,7 +1550,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
          lnd_tuning_mode="clm5_1_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
+>lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1567,13 +1585,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm5_1" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
-</finidat>
 
 <!-- 2003 -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1596,7 +1607,13 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
          lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
+>lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+</finidat>
+<finidat hgrid="ne30np4"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
+         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
+>lnd/clm2/initdata_map/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1631,13 +1648,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
-</finidat>
 
 <!-- 2003 -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1706,22 +1716,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr2000_c200728.nc
 </finidat>
 
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm5_1" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
-</finidat>
-
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
-</finidat>
-
 <!-- 2003 -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."
@@ -1744,7 +1738,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
          lnd_tuning_mode="clm5_1_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
+>lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1779,14 +1773,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm5_1" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
-</finidat>
-
 <!-- 2003 -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."
@@ -1809,7 +1795,13 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
          lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
+>lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+</finidat>
+<finidat hgrid="ne30np4"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
+         lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
+>lnd/clm2/initdata_map/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1844,14 +1836,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-<!-- NB: This pSASU finidat is from an 1850 spin-up -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
-</finidat>
-
 <!-- 2003 -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -774,8 +774,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
                   hgrid="0.9x1.25"            >.true.</use_init_interp>
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" phys="clm6_0"
                   hgrid="1.9x2.5"            >.true.</use_init_interp>
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" phys="clm6_0"
-                  hgrid="1.9x2.5"            >.true.</use_init_interp>
 <!-- These next two are for SP mode and CLM6.0 with CAM7.0 only -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam7.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTIC.ne30x4"    >.true.</use_init_interp>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -936,6 +936,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm6_0_GSWP3v1 use_excess_ice=.true.
 </init_interp_attributes>
 
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
+			hgrid="ne30np4.pg3"
+>hgrid=ne30np4.pg3 mask=t232
+</init_interp_attributes>
 
 <!-- present day -->
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm4_5_GSWP3v1"
@@ -1148,6 +1152,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 			hgrid="ne30np4"
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0"
+			hgrid="ne30np4.pg3"
+>hgrid=ne30np4.pg3 maxpft=79 mask=t232 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
+</init_interp_attributes>
 
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_cam6.0"
 			hgrid="C24"
@@ -1263,6 +1271,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
+			hgrid="ne30np4.pg3"
+>hgrid=ne30np4.pg3 mask=t232
+</init_interp_attributes>
+
 <!-- 2003 -->
 <init_interp_attributes sim_year="2003" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
                         hgrid="1.9x2.5" use_cn=".false." maxpft="17"
@@ -1368,9 +1381,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->
-<finidat hgrid="ne30np4" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
+<finidat hgrid="ne30np4.pg3" mask="t232" sim_year="1850"
          phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_pSASU.clm2.r.0121-01-01-00000.nc
 </finidat>
@@ -1521,7 +1532,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
 </finidat>
-<finidat hgrid="ne30np4"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="t232" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
@@ -1609,10 +1620,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
 >lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
-<finidat hgrid="ne30np4"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
+<finidat hgrid="ne30np4.pg3"  mask="t232" sim_year="1979"
+         phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_map/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
@@ -1796,12 +1805,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
          lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
 >lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
-</finidat>
-<finidat hgrid="ne30np4"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -937,6 +937,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
+			hgrid="1.9x2.5"
+>hgrid=1.9x2.5 mask=gx1v7
+</init_interp_attributes>
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"
 >hgrid=ne30np4.pg3 mask=t232
 </init_interp_attributes>
@@ -1386,9 +1390,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_pSASU.clm2.r.0121-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
-<finidat hgrid="1.9x2.5" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
+<finidat hgrid="1.9x2.5" mask="gx1v7" sim_year="1850"
          phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm530_f19_PPE_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -938,11 +938,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="1.9x2.5"
->hgrid=1.9x2.5 mask=gx1v7
+>mask=gx1v7 use_cn=.true. do_transient_pfts=.false. use_excess_ice=.true. use_crop=.false. irrigate=.false.
 </init_interp_attributes>
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"
->hgrid=ne30np4.pg3 mask=t232
+>mask=t232 use_cn=.true. do_transient_pfts=.false. use_excess_ice=.true. use_crop=.true. irrigate=.false.
 </init_interp_attributes>
 
 <!-- present day -->
@@ -1275,9 +1275,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
-			hgrid="ne30np4.pg3"
->hgrid=ne30np4.pg3 mask=t232
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
+                        hgrid="ne30np4.pg3" use_cn=".false." maxpft="17"
+>hgrid=ne30np4.pg3 maxpft=17 mask=t232 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
 <!-- 2003 -->
@@ -1371,27 +1371,30 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- CTSM6_0 - use clm6_0_GSWP3v1 BgcCrop at f09 for all clm5_1/clm6_0 options -->
-<!-- TODO slevis VALID COMMENT? use_init_interp true because the file was created with ctsm5.3 datasets -->
 <finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
-         phys="clm5_1" use_init_interp=".true."
+         phys="clm5_1"
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->
-<finidat hgrid="ne30np4.pg3" mask="t232" sim_year="1850"
-         phys="clm6_0" use_init_interp=".true."
+<finidat hgrid="ne30np4.pg3" mask="t232" use_cn=".true." use_cndv=".false." use_fates=".false."
+         sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
+         use_crop=".true." irrigate=".false."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_pSASU.clm2.r.0121-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
-<finidat hgrid="1.9x2.5" mask="gx1v7" sim_year="1850"
-         phys="clm6_0" use_init_interp=".true."
+<finidat hgrid="1.9x2.5" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
+         use_crop=".false." irrigate=".false."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm530_f19_PPE_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 
@@ -1435,7 +1438,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          lnd_tuning_mode="clm5_1_GSWP3v1" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.2/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c240223.nc
 </finidat>
-<!-- NB: This pSASU finidat is from an f09 2000 spin-up -->
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20110101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
@@ -1537,7 +1539,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="t232" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.2000-01-01-00000.nc
 </finidat>
 
@@ -1562,8 +1564,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+         lnd_tuning_mode="clm5_1_cam7.0"
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1619,12 +1621,14 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+         lnd_tuning_mode="clm6_0_cam7.0"
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
-<finidat hgrid="ne30np4.pg3"  mask="t232" sim_year="1979"
-         phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_map/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
+<finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="t232" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
+         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1748,8 +1752,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+         lnd_tuning_mode="clm5_1_cam6.0"
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1805,8 +1809,8 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+         lnd_tuning_mode="clm6_0_cam6.0"
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -756,18 +756,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!--
      clm5_1 physics with CAM7.0 grids...
 -->
-<!-- These first five are for SP mode and CLM5.1 only -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam7.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="0.9x1.25"            >.true.</use_init_interp>
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam7.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"             >.true.</use_init_interp>
+<!-- These next two are for SP mode and CLM5.1 only -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam7.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTIC.ne30x4"    >.true.</use_init_interp>
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam7.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTICGRIS.ne30x8">.true.</use_init_interp>
-<!-- 2003 -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2003" lnd_tuning_mode="clm5_1_cam7.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"                 >.true.</use_init_interp>
 
 <!-- 2013 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2013" lnd_tuning_mode="clm5_1_cam7.0"
@@ -776,18 +769,18 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!--
      clm6_0 physics with CAM7.0 grids...
 -->
-<!-- These first five are for SP mode and CLM6.0 only -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam7.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="0.9x1.25"            >.true.</use_init_interp>
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam7.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"             >.true.</use_init_interp>
+<!-- These are for 1979 for f09 and f19 for any atmospheric forcing -->
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" phys="clm6_0"
+                  hgrid="0.9x1.25"            >.true.</use_init_interp>
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" phys="clm6_0"
+                  hgrid="1.9x2.5"            >.true.</use_init_interp>
+<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" phys="clm6_0"
+                  hgrid="1.9x2.5"            >.true.</use_init_interp>
+<!-- These next two are for SP mode and CLM6.0 with CAM7.0 only -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam7.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTIC.ne30x4"    >.true.</use_init_interp>
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam7.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTICGRIS.ne30x8">.true.</use_init_interp>
-<!-- 2003 -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2003" lnd_tuning_mode="clm6_0_cam7.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"                 >.true.</use_init_interp>
 
 <!-- 2013 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2013" lnd_tuning_mode="clm6_0_cam7.0"
@@ -815,18 +808,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!--
      clm5_1 physics with CAM6.0 grids (duplicates above)
 -->
-<!-- These first five are for SP mode and CLM5.1 only -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="0.9x1.25"            >.true.</use_init_interp>
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"             >.true.</use_init_interp>
+<!-- These next two are for SP mode and CLM5.1 only -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam6.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTIC.ne30x4"    >.true.</use_init_interp>
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm5_1_cam6.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTICGRIS.ne30x8">.true.</use_init_interp>
-<!-- 2003 -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2003" lnd_tuning_mode="clm5_1_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"                 >.true.</use_init_interp>
 
 <!-- 2013 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2013" lnd_tuning_mode="clm5_1_cam6.0"
@@ -835,18 +821,11 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!--
      clm6_0 physics with CAM6.0 grids...
 -->
-<!-- These first five are for SP mode and CLM6.0 only -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="0.9x1.25"            >.true.</use_init_interp>
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"             >.true.</use_init_interp>
+<!-- These first two are for SP mode and CLM6.0 only -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam6.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTIC.ne30x4"    >.true.</use_init_interp>
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="1979" lnd_tuning_mode="clm6_0_cam6.0"
                   maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="ne0np4.ARCTICGRIS.ne30x8">.true.</use_init_interp>
-<!-- 2003 -->
-<use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2003" lnd_tuning_mode="clm6_0_cam6.0"
-                  maxpft="17"        use_cn=".false."    use_crop=".false." hgrid="1.9x2.5"                 >.true.</use_init_interp>
 
 <!-- 2013 -->
 <use_init_interp  use_cndv=".false." use_fates=".false." sim_year="2013" lnd_tuning_mode="clm6_0_cam6.0"
@@ -1236,37 +1215,29 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 
 <!-- If an exact match for these grids and start years -->
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
-                        hgrid="0.9x1.25" use_cn=".false." maxpft="17"
->hgrid=0.9x1.25 maxpft=17 mask=gx1v7 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
-</init_interp_attributes>
-
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
-                        hgrid="1.9x2.5" use_cn=".false." maxpft="17"
->hgrid=1.9x2.5 maxpft=17 mask=gx1v7 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
-</init_interp_attributes>
-
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
-                        hgrid="ne0np4.ARCTIC.ne30x4" use_cn=".false." maxpft="17"
->hgrid=ne0np4.ARCTIC.ne30x4 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
-</init_interp_attributes>
-
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
-                        hgrid="ne0np4.ARCTICGRIS.ne30x8" use_cn=".false." maxpft="17"
->hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
-</init_interp_attributes>
-
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
                         hgrid="0.9x1.25"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
+>maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
+
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
                         hgrid="1.9x2.5"
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
+
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
+                        hgrid="ne0np4.ARCTIC.ne30x4" use_cn=".false." maxpft="17"
+>hgrid=ne0np4.ARCTIC.ne30x4 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
+</init_interp_attributes>
+
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
+                        hgrid="ne0np4.ARCTICGRIS.ne30x8" use_cn=".false." maxpft="17"
+>hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
+</init_interp_attributes>
+
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"
->hgrid=ne30np4.pg3 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
+>maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
@@ -1277,12 +1248,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
                         hgrid="ne0np4.ARCTICGRIS.ne30x8" use_cn=".false." maxpft="17"
 >hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
-</init_interp_attributes>
-
-<!-- 2003 -->
-<init_interp_attributes sim_year="2003" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
-                        hgrid="1.9x2.5" use_cn=".false." maxpft="17"
->hgrid=1.9x2.5 maxpft=17 mask=gx1v7 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
 <!-- 2013 IC's - exact match for CONUS grid ... -->
@@ -1563,13 +1528,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
 </finidat>
 
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.1.9x2.5_gx1v7_simyr1979_c200806.nc
-</finidat>
-
 <!-- Present day no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
@@ -1595,15 +1553,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-
-<!-- 2003 -->
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHISTSp.2000-01-01.1.9x2.5_gx1v7_simyr2003_c200807.nc
-</finidat>
-
 
 <!-- 2013 -->
 <finidat hgrid="ne0np4CONUS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1653,15 +1602,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-
-<!-- 2003 -->
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHISTSp.2000-01-01.1.9x2.5_gx1v7_simyr2003_c200807.nc
-</finidat>
-
 
 <!-- 2013 -->
 <finidat hgrid="ne0np4CONUS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1738,14 +1678,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.FHISTSp.2013-01-01.ne0CONUSne30x8_mt12_simyr2013_c200806.nc
 </finidat>
 <!-- Repeat above for clm5_1 -->
-<!-- clm5_1 and cam6.0-->
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.1.9x2.5_gx1v7_simyr1979_c200806.nc
-</finidat>
-
 <!-- Present day no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
@@ -1771,14 +1703,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-<!-- 2003 -->
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHISTSp.2000-01-01.1.9x2.5_gx1v7_simyr2003_c200807.nc
-</finidat>
-
 
 <!-- 2013 -->
 <finidat hgrid="ne0np4CONUS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1815,14 +1739,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- Present day for coupled cases at 1-degree or lower resolutions  -->
-<!-- 2003 -->
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="20030101"  sim_year="2003" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHISTSp.2000-01-01.1.9x2.5_gx1v7_simyr2003_c200807.nc
-</finidat>
-
 
 <!-- 2013 -->
 <finidat hgrid="ne0np4CONUS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -942,7 +942,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </init_interp_attributes>
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"
->mask=t232 use_cn=.true. do_transient_pfts=.false. use_excess_ice=.true. use_crop=.true. irrigate=.false.
+>mask=tx2_3v2 use_cn=.true. do_transient_pfts=.false. use_excess_ice=.true. use_crop=.true. irrigate=.false.
 </init_interp_attributes>
 
 <!-- present day -->
@@ -965,11 +965,16 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_GSWP3v1"
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
+
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm5_1"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm5_1_GSWP3v1 use_excess_ice=.true.
+>hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nex=10 do_transient_pfts=.false. use_excess_ice=.true.
 </init_interp_attributes>
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm6_0_GSWP3v1 use_excess_ice=.true.
+>hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nex=10 do_transient_pfts=.false. use_excess_ice=.true.
+</init_interp_attributes>
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0"
+			hgrid="ne30np4.pg3"
+>hgrid=ne30np4.pg3 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_CRUv7"
@@ -1156,10 +1161,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 			hgrid="ne30np4"
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
-<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0"
-			hgrid="ne30np4.pg3"
->hgrid=ne30np4.pg3 maxpft=79 mask=t232 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
-</init_interp_attributes>
 
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_cam6.0"
 			hgrid="C24"
@@ -1255,14 +1256,17 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
-                        hgrid="0.9x1.25" use_cn=".false." maxpft="17"
->hgrid=0.9x1.25 maxpft=17 mask=gx1v7 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
+                        hgrid="0.9x1.25"
+>hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
-
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
-                        hgrid="1.9x2.5" use_cn=".false." maxpft="17"
->hgrid=1.9x2.5 maxpft=17 mask=gx1v7 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
+                        hgrid="1.9x2.5"
+>hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
+</init_interp_attributes>
+<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
+			hgrid="ne30np4.pg3"
+>hgrid=ne30np4.pg3 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
@@ -1273,11 +1277,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
                         hgrid="ne0np4.ARCTICGRIS.ne30x8" use_cn=".false." maxpft="17"
 >hgrid=ne0np4.ARCTICGRIS.ne30x8 maxpft=17 mask=tx0.1v2 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
-</init_interp_attributes>
-
-<init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
-                        hgrid="ne30np4.pg3" use_cn=".false." maxpft="17"
->hgrid=ne30np4.pg3 maxpft=17 mask=t232 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
 <!-- 2003 -->
@@ -1375,27 +1374,27 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
          phys="clm5_1"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_pSASU.clm60.r.0161-01-01.nc
 </finidat>
 <finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
          phys="clm6_0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_pSASU.clm2.r.0161-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_pSASU.clm60.r.0161-01-01.nc
 </finidat>
 <!-- Corresponding ne30 -->
-<finidat hgrid="ne30np4.pg3" mask="t232" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="ne30np4.pg3" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".true." irrigate=".false."
          phys="clm6_0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_pSASU.clm2.r.0121-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_BgcCrop_exice_pSASU.clm60.r.0121-01-01.nc
 </finidat>
 <!-- Corresponding f19 -->
 <finidat hgrid="1.9x2.5" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".false." irrigate=".false."
          phys="clm6_0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm530_f19_PPE_pSASU.clm2.r.0161-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm530_f19_g17_Bgc_exice_pSASU.clm60.r.0161-01-01.nc
 </finidat>
 
 <!--
@@ -1437,12 +1436,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          lnd_tuning_mode="clm5_1_GSWP3v1" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.2/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c240223.nc
-</finidat>
-<finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20110101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
 </finidat>
 
 
@@ -1523,24 +1516,26 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- clm5_1 and cam7.0 -->
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm5_1" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.2000-01-01.nc
 </finidat>
 
 <!-- clm6_0 and cam7.0 -->
+<!-- slevis-lmwg, ekluzek 2024/10/11: do_transient_pfts was removed here to bypass a bug that doesn't allow
+           do_transient_pfts=.true. when use_init_interp=.false. -->
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.2000-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.2000-01-01.nc
 </finidat>
-<finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="t232" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+<finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.2000-01-01-00000.nc
+         phys="clm6_0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_BgcCrop_exice_hist.clm60.r.2000-01-01.nc
 </finidat>
 
 <!-- clm5_0 and cam7.0 -->
@@ -1560,12 +1555,12 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          lnd_tuning_mode="clm5_0_cam7.0" use_init_interp=".true."
 >lnd/clm2/initdata_map/clmi.FHISTSp.2013-01-01.ne0CONUSne30x8_mt12_simyr2013_c200806.nc
 </finidat>
-<!-- Repeat above for clm5_1 -->
-<finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam7.0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+<!-- Repeat for clm5_1 -->
+<finidat hgrid="0.9x1.25" maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         phys="clm5_1" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
 </finidat>
 
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1618,24 +1613,19 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.FHISTSp.2013-01-01.ne0CONUSne30x8_mt12_simyr2013_c200806.nc
 </finidat>
 <!-- Repeat above for clm6_0 -->
-<finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam7.0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
+<!-- slevis-lmwg, ekluzek 2024/10/11: do_transient_pfts was removed here to bypass a bug that doesn't allow
+           do_transient_pfts=.true. when use_init_interp=.false. -->
+<finidat hgrid="0.9x1.25" maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         phys="clm6_0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
 </finidat>
-<finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="t232" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_hist.clm2.r.1979-01-01-00000.nc
-</finidat>
-
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam7.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.1.9x2.5_gx1v7_simyr1979_c200806.nc
+<finidat hgrid="ne30np4.pg3" maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         phys="clm6_0" use_init_interp=".true."
+>lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
 </finidat>
 
 <!-- Present day no crop spinup ARCTIC grid with irrigation on -->
@@ -1749,13 +1739,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 <!-- Repeat above for clm5_1 -->
 <!-- clm5_1 and cam6.0-->
-<finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm5_1_cam6.0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
-</finidat>
-
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1806,19 +1789,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 <!-- Repeat above for clm6_0 -->
 <!-- clm6_0 and cam6.0-->
-<finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam6.0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_hist.clm2.r.1979-01-01-00000.nc
-</finidat>
-
-<finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
-         lnd_tuning_mode="clm6_0_cam6.0" use_init_interp=".true."
->lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.1.9x2.5_gx1v7_simyr1979_c200806.nc
-</finidat>
 
 <!-- Present day no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1621,7 +1621,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
 </finidat>
-<finidat hgrid="ne30np4.pg3" maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="ne30np4.pg3" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,87 @@
 ===============================================================
+Tag name: ctsm5.3.007
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Thu 10 Oct 2024 10:12:18 AM MDT
+One-line Summary: Clm60 finidat updates for ne30, f09, f19 grids
+
+Purpose and description of changes
+----------------------------------
+ Updates appear in namelist_defaults_ctsm.xml.
+ As before, I updated clm51, too, to keep it same as clm60 (and clm51 will go away soon).
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm6_0
+
+[ ] clm5_1
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+ Relates to (fixes?) #2403; needs more work to close?
+
+Notes of particular relevance for users
+---------------------------------------
+Changes made to namelist defaults (e.g., changed parameter values):
+ Clm60 and clm51 finidat updates for ne30, f09, f19 grids.
+
+Changes to the datasets (e.g., parameter, surface or initial files):
+ Clm60 and clm51 finidat updates for ne30, f09, f19 grids.
+
+Testing summary:
+----------------
+
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  build-namelist tests (if CLMBuildNamelist.pm has changed):
+
+    derecho - TODO
+
+  python testing (if python code has changed; see instructions in python/README.md; document testing done):
+
+    derecho - TODO
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- TODO
+    izumi ------- TODO
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes.
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: clm60 (and clm51 which goes away very soon)
+    - what platforms/compilers: all
+    - nature of change: larger than roundoff/same climate
+
+Other details
+-------------
+List any git submodules updated (cime, rtm, mosart, cism, fates, etc.):
+
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/2821
+
+===============================================================
+===============================================================
+Tag name: ctsm5.3.006
+===============================================================
+===============================================================
 Tag name: ctsm5.3.005
 Originator(s): dmleung (Danny Leung)
 Date: Thu 10 Oct 2024 03:15:52 AM MDT
@@ -132,7 +215,14 @@ Testing summary:
 Answer changes
 --------------
 
-Changes answers relative to baseline: Not in real runs, only our testing.
+Changes answers relative to baseline: Yes
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: Hillslope (tests only)
+    - what platforms/compilers: Tests on Izumi and Derecho
+    - nature of change: Larger than roundoff
+
+   Only our tests are affected because I had to make changes to the test setup for compatibility; this included changing mesh file and hillslope data for some tests/testmods.
 
 
 Other details

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,13 +1,17 @@
 ===============================================================
 Tag name: ctsm5.3.007
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
-Date: Thu 10 Oct 2024 10:12:18 AM MDT
+Date: Mon 13 Oct 2024 10:12:18 AM MDT
 One-line Summary: Clm60 finidat updates for ne30, f09, f19 grids
 
 Purpose and description of changes
 ----------------------------------
  Updates appear in namelist_defaults_ctsm.xml.
- As before, I updated clm51, too, to keep it same as clm60 (and clm51 will go away soon).
+ For the most part I updated clm51, too, to keep it same as clm60, knowing
+ that clm51 will go away soon.
+ I had significant help from Erik Kluzek in disentangling the .xml settings
+ so that cases would pick up the correct finidat settings and other namelist
+ settings.
 
 Significant changes to scientifically-supported configurations
 --------------------------------------------------------------
@@ -31,7 +35,7 @@ Does this tag change answers significantly for any of the following physics conf
 Bugs fixed
 ----------
 List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
- Relates to (fixes?) #2403; needs more work to close?
+ Relates to #2403; needs more work to close?
 
 Notes of particular relevance for users
 ---------------------------------------
@@ -48,16 +52,16 @@ Testing summary:
 
   build-namelist tests (if CLMBuildNamelist.pm has changed):
 
-    derecho - TODO
+    derecho - PASS
 
   python testing (if python code has changed; see instructions in python/README.md; document testing done):
 
-    derecho - TODO
+    derecho - PASS
 
   regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
 
-    derecho ----- TODO
-    izumi ------- TODO
+    derecho ----- OK
+    izumi ------- OK
 
 
 Answer changes
@@ -66,7 +70,7 @@ Answer changes
 Changes answers relative to baseline: Yes.
 
   Summarize any changes to answers, i.e.,
-    - what code configurations: clm60 (and clm51 which goes away very soon)
+    - what code configurations: clm60 and clm51; the latter goes away soon
     - what platforms/compilers: all
     - nature of change: larger than roundoff/same climate
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,17 +1,15 @@
 ===============================================================
 Tag name: ctsm5.3.007
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
-Date: Mon 13 Oct 2024 10:12:18 AM MDT
+Date: Mon 13 Oct 2024 11:04:18 AM MDT
 One-line Summary: Clm60 finidat updates for ne30, f09, f19 grids
 
 Purpose and description of changes
 ----------------------------------
  Updates appear in namelist_defaults_ctsm.xml.
- For the most part I updated clm51, too, to keep it same as clm60, knowing
- that clm51 will go away soon.
+ For the most part I updated clm51 to match clm60, though clm51 will go away soon.
  I had significant help from Erik Kluzek in disentangling the .xml settings
- so that cases would pick up the correct finidat settings and other namelist
- settings.
+ so that cases would pick up the correct finidat and other namelist settings.
 
 Significant changes to scientifically-supported configurations
 --------------------------------------------------------------
@@ -35,7 +33,7 @@ Does this tag change answers significantly for any of the following physics conf
 Bugs fixed
 ----------
 List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
- Relates to #2403; needs more work to close?
+ Relates to #2403 but may need more work to close the issue
 
 Notes of particular relevance for users
 ---------------------------------------
@@ -76,8 +74,6 @@ Changes answers relative to baseline: Yes.
 
 Other details
 -------------
-List any git submodules updated (cime, rtm, mosart, cism, fates, etc.):
-
 Pull Requests that document the changes (include PR ids):
  https://github.com/ESCOMP/ctsm/pull/2821
 

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,7 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.007   slevis 10/11/2024 Clm60 finidat updates for ne30, f09, f19 grids
+       ctsm5.3.006
        ctsm5.3.005     erik 10/10/2024 Hardcoded tuning adjustments for Leung_2024 dust emissions
        ctsm5.3.004 samrabin 10/07/2024 Move hillslope data off surface datasets
        ctsm5.3.003 multiple 10/07/2024 FATES default parameter file update

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-       ctsm5.3.007   slevis 10/11/2024 Clm60 finidat updates for ne30, f09, f19 grids
+       ctsm5.3.007   slevis 10/14/2024 Clm60 finidat updates for ne30, f09, f19 grids
        ctsm5.3.006 samrabin 10/11/2024 Merge b4b-dev
        ctsm5.3.005     erik 10/10/2024 Hardcoded tuning adjustments for Leung_2024 dust emissions
        ctsm5.3.004 samrabin 10/07/2024 Move hillslope data off surface datasets


### PR DESCRIPTION
### Description of changes
finidat updates needed for cesm's beta04 tag.

### Specific notes

Contributors other than yourself, if any:
@ekluzek @olyson 

CTSM Issues Fixed (include github issue #):
Relates to #2403 (I'm not confident that this fully resolves it though)

Are answers expected to change (and if so in what way)?
Yes, for clm6 ne30, f09, f19 cases, because pointing to new finidat files.

Any User Interface Changes (namelist or namelist defaults changes)?
Updated namelist_defaults with new finidat files.

Does this create a need to change or add documentation? Did you do so?
No but reminder to
- [x] Update the ChangeLog about testing and about other contributors.

Testing performed, if any:
izumi `./run_sys_tests -s aux_clm -c ctsm5.3.003 --skip-generate`
Compared to 003 because 004 was not available.
004 would differ from 003 only for the hillslope test, which is a clm6 test, so I expect it to differ already due to my mods.
So then, expected due my mods:
New FAILs for clm6 tests in the NLCOMP phase (due to namelist changes) and the BASELINE phase (due to changing answers).