### PR TITLE
Fix numbering error in CLM50_Tech_Note_Fluxes.rst

### DIFF
--- a/doc/source/tech_note/Fluxes/CLM50_Tech_Note_Fluxes.rst
+++ b/doc/source/tech_note/Fluxes/CLM50_Tech_Note_Fluxes.rst
@@ -1213,7 +1213,7 @@ The numerical solution for vegetation temperature and the fluxes of momentum, se
 
 #. Magnitude of the wind velocity incident on the leaves :math:`U_{av}` (:eq:`5.117` )
 
-#. Leaf boundary layer resistance :math:`r_{b}` (:eq:`5.136` )
+#. Leaf boundary layer resistance :math:`r_{b}` (:eq:`5.122` )
 
 #. Aerodynamic resistances :math:`r_{ah} ^{{'} }` and :math:`r_{aw} ^{{'} }`(:eq:`5.116` )
 


### PR DESCRIPTION
### Description of changes

Just a tiny two character edit to the surface fluxes documentation.
A link labelled as pointing to an equation for leaf boundary layer resistance was instead pointing to one for canopy air temperature; I've changed it to point to what seems to be the correct equation.

### Specific notes

Contributors other than yourself, if any: 
N/A

CTSM Issues Fixed (include github issue #): 
N/A

Are answers expected to change (and if so in what way)? 
N/A

Any User Interface Changes (namelist or namelist defaults changes)? 
No.

Does this create a need to change or add documentation? Did you do so?
It is a minor documentation edit.

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on derecho for intel/gnu and izumi for intel/gnu/nag/nvhpc is the standard for tags on master)

No testing performed.

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
