### PR TITLE
Improve CLMBuildNamelist ability to detect NEON runs

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -678,6 +678,11 @@ sub setup_cmdl_chk_res {
   }
 }
 
+sub begins_with
+{
+    return substr($_[0], 0, length($_[1])) eq $_[1];
+}
+
 sub setup_cmdl_resolution {
   my ($opts, $nl_flags, $definition, $defaults, $envxml_ref) = @_;
 
@@ -713,7 +718,7 @@ sub setup_cmdl_resolution {
   $nl_flags->{'neon'} = ".false.";
   $nl_flags->{'neonsite'} = "";
   if ( $nl_flags->{'res'} eq "CLM_USRDAT" ) {
-    if ( $opts->{'clm_usr_name'} eq "NEON" ) {
+    if ( begins_with($opts->{'clm_usr_name'}, "NEON") ) {
        $nl_flags->{'neon'} = ".true.";
        $nl_flags->{'neonsite'} = $envxml_ref->{'NEONSITE'};
        $log->verbose_message( "This is a NEON site with NEONSITE = " . $nl_flags->{'neonsite'} );


### PR DESCRIPTION
### Description of changes
@samsrabin recommended mods in the issue #2801 to fix the test.

### Specific notes

Contributors other than yourself, if any:
@samsrabin 

CTSM Issues Fixed (include github issue #):
Fixes #2801 

Are answers expected to change (and if so in what way)?
No

Any User Interface Changes (namelist or namelist defaults changes)?
No

Does this create a need to change or add documentation? Did you do so?
No

Testing performed, if any:
./create_test SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_intel.clm-NEON-MOAB--clm-PRISM
worked on derecho (the original test that was failing was an izumi test, but I was avoiding izumi due to flakiness)