### PR TITLE
Fix cleanup in build-namelist_test.pl

### DIFF
--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -412,7 +412,7 @@ foreach my $site ( "ABBY", "BLAN", "CPER", "DEJU", "GRSM", "HEAL", "KONA", "LENO
          }
       }
    }
-   system( "/bin/rm $namelistfile" );
+   system( "/bin/rm -f $namelistfile" );
    &cleanup();
 }
 print "\n===============================================================================\n";
@@ -466,7 +466,7 @@ foreach my $site (
    if ( defined($opts{'generate'}) ) {
       $cfiles->copyfiles( "$options", $mode );
    }
-   system( "/bin/rm $namelistfile" );
+   system( "/bin/rm -f $namelistfile" );
    &cleanup();
 }
 
@@ -1971,7 +1971,7 @@ foreach my $phys ( "clm4_5", 'clm5_0', 'clm5_1', 'clm6_0' ) {
 }
 &cleanup();
 
-system( "/bin/rm $finidat" );
+system( "/bin/rm -f $finidat" );
 
 print "\n==================================================\n";
 print " Dumping output  \n";
@@ -1982,7 +1982,7 @@ $xFail->parseOutput($captOut);
 print "Successfully ran all testing for build-namelist\n\n";
 
 &cleanup( "config" );
-system( "/bin/rm $tempfile" );
+system( "/bin/rm -f $tempfile" );
 
 sub cleanup {
 #
@@ -1993,10 +1993,10 @@ sub cleanup {
   print "Cleanup files created\n";
   if ( defined($type) ) {
      if ( $type eq "config" ) {
-        system( "/bin/rm config_cache.xml" );
+        system( "/bin/rm -f config_cache.xml" );
      }
   } else {
-     system( "/bin/rm $tempfile *_in" );
+     system( "/bin/rm -f $tempfile *_in" );
   }
 }
 


### PR DESCRIPTION
### Description of changes
This PR is intended to fix the failure of `build-namelist_test.pl` to clean up after itself.

Unfortunately, at the moment it doesn't.

### Specific notes

**Contributors other than yourself, if any:** None

CTSM Issues Fixed:
- Will resolve #2876

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** Running `build-namelist_test.pl`.