### PR TITLE
change the order of passing the "use_fates_luh" flag

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -305,6 +305,7 @@ module CLMFatesInterfaceMod
      integer                                        :: pass_nocomp
      integer                                        :: pass_sp
      integer                                        :: pass_masterproc
+     integer                                        :: pass_luh
      logical                                        :: verbose_output
      type(fates_param_reader_ctsm_impl)             :: var_reader
      
@@ -348,6 +349,14 @@ module CLMFatesInterfaceMod
         end if
         call set_fates_ctrlparms('masterproc',ival=pass_masterproc)
 
+        ! FATES landuse modes
+        if(use_fates_luh) then
+           pass_luh = 1
+        else
+           pass_luh = 0
+        end if
+        call set_fates_ctrlparms('use_luh2',ival=pass_luh)
+        
      end if
 
 
@@ -540,16 +549,12 @@ module CLMFatesInterfaceMod
 
         ! FATES landuse modes
         if(use_fates_luh) then
-           pass_use_luh = 1
            pass_num_luh_states = num_landuse_state_vars
            pass_num_luh_transitions = num_landuse_transition_vars
         else
-           pass_use_luh = 0
            pass_num_luh_states = 0
            pass_num_luh_transitions = 0
         end if
-
-        call set_fates_ctrlparms('use_luh2',ival=pass_use_luh)
         call set_fates_ctrlparms('num_luh2_states',ival=pass_num_luh_states)
         call set_fates_ctrlparms('num_luh2_transitions',ival=pass_num_luh_transitions)
 

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -301,11 +301,11 @@ module CLMFatesInterfaceMod
      integer,intent(in)                             :: surf_numpft
      integer,intent(in)                             :: surf_numcft
      integer,intent(out)                            :: maxsoil_patches
-     integer                                        :: pass_biogeog
-     integer                                        :: pass_nocomp
-     integer                                        :: pass_sp
+     integer                                        :: pass_use_fixed_biogeog
+     integer                                        :: pass_use_nocomp
+     integer                                        :: pass_use_sp
      integer                                        :: pass_masterproc
-     integer                                        :: pass_luh
+     integer                                        :: pass_use_luh2
      logical                                        :: verbose_output
      type(fates_param_reader_ctsm_impl)             :: var_reader
      
@@ -322,25 +322,25 @@ module CLMFatesInterfaceMod
         ! Send parameters individually
         
         if(use_fates_fixed_biogeog)then
-           pass_biogeog = 1
+           pass_use_fixed_biogeog = 1
         else
-           pass_biogeog = 0
+           pass_use_fixed_biogeog = 0
         end if
-        call set_fates_ctrlparms('use_fixed_biogeog',ival=pass_biogeog)
+        call set_fates_ctrlparms('use_fixed_biogeog',ival=pass_use_fixed_biogeog)
         
         if(use_fates_nocomp)then
-           pass_nocomp = 1
+           pass_use_nocomp = 1
         else
-           pass_nocomp = 0
+           pass_use_nocomp = 0
         end if
-        call set_fates_ctrlparms('use_nocomp',ival=pass_nocomp)
+        call set_fates_ctrlparms('use_nocomp',ival=pass_use_nocomp)
         
         if(use_fates_sp)then
-           pass_sp = 1
+           pass_use_sp = 1
         else
-           pass_sp = 0
+           pass_use_sp = 0
         end if
-        call set_fates_ctrlparms('use_sp',ival=pass_sp)
+        call set_fates_ctrlparms('use_sp',ival=pass_use_sp)
         
         if(masterproc)then
            pass_masterproc = 1
@@ -351,11 +351,11 @@ module CLMFatesInterfaceMod
 
         ! FATES landuse modes
         if(use_fates_luh) then
-           pass_luh = 1
+           pass_use_luh2 = 1
         else
-           pass_luh = 0
+           pass_use_luh2 = 0
         end if
-        call set_fates_ctrlparms('use_luh2',ival=pass_luh)
+        call set_fates_ctrlparms('use_luh2',ival=pass_use_luh2)
         
      end if
 
@@ -404,7 +404,6 @@ module CLMFatesInterfaceMod
      integer                                        :: pass_is_restart
      integer                                        :: pass_cohort_age_tracking
      integer                                        :: pass_tree_damage
-     integer                                        :: pass_use_luh
      integer                                        :: pass_use_potentialveg
      integer                                        :: pass_num_luh_states
      integer                                        :: pass_num_luh_transitions


### PR DESCRIPTION
### Description of changes

The flag that specifies using LUH datasets is passed earlier in the call sequence so that it can be used to guide memory allocations.  If landuse is turned on, particularly in fates nocomp mode, then the space required for patch allocations changes.  Therefore this flag has to be passed earlier, before these allocations are decided on.

### Specific notes

This PR does not need to be synchronized with, but does need to precede: https://github.com/NGEET/fates/pull/1226

Contributors other than yourself, if any: @ckoven 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)? none, b4b

Any User Interface Changes (namelist or namelist defaults changes)? no

Does this create a need to change or add documentation? Did you do so? no need

Testing performed, if any:

TBD, but some tests with the FATES test suite so far
