### PR TITLE
Bug fix for izumi nag tests to pass (PR into tmp-241219)

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -114,7 +114,7 @@
   </test>
 
   <test name="SMS_D.f10_f10_mg37.I2000Clm60BgcCrop.derecho_nvhpc.clm-crop">
-    <phase name="BUILD">
+    <phase name="SHAREDLIB_BUILD">
       <status>FAIL</status>
       <issue>#1733</issue>
     </phase>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -1317,6 +1317,15 @@
       <option name="comment"  >Science support for I1850Clm50BgcCropCru at f19</option>
     </options>
   </test>
+  <test name="ERP_D_Ld5_P48x1" grid="f10_f10_mg37" compset="I2000Clm50BgcCru" testmods="clm/flexCN_FUN_BNF">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_clm"/>
+      <machine name="izumi" compiler="nag" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+    </options>
+  </test>
   <test name="ERP_D_Ld5_P48x1" grid="f10_f10_mg37" compset="I2000Clm50BgcCru" testmods="clm/flexCN_FUN">
     <machines>
       <machine name="izumi" compiler="nag" category="aux_clm"/>

--- a/cime_config/testdefs/testmods_dirs/clm/flexCN_FUN_BNF/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/flexCN_FUN_BNF/include_user_mods
@@ -1,0 +1,1 @@
+../flexCN_FUN

--- a/cime_config/testdefs/testmods_dirs/clm/flexCN_FUN_BNF/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/flexCN_FUN_BNF/user_nl_clm
@@ -1,0 +1,2 @@
+ nfix_method = 'Bytnerowicz'
+

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,74 @@
 ===============================================================
+Tag name: tmp-241219.n03.ctsm5.3.016
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Wed 08 Jan 2025 06:09:41 PM MST
+One-line Summary: Bug fix for izumi nag tests to pass
+
+Purpose and description of changes
+----------------------------------
+
+ Allocation statements should have been (0:mxpft) instead of (mxpft).
+ I introduced the bug in a small refactor requested in #2917.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+Fixes #2924
+
+Notes of particular relevance for developers:
+---------------------------------------------
+Changes to tests or testing:
+ Added tests that I should have added in the tmp-241219.n01.ctsm5.3.016 tag:
+ ERP_D_Ld5_P48x1.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-flexCN_FUN_BNF
+ ERP_D_Ld5_P48x1.f10_f10_mg37.I2000Clm50BgcCru.derecho_intel.clm-flexCN_FUN_BNF
+
+Testing summary:
+----------------
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here:
+ derecho used tmp-241219.n02.ctsm5.3.016
+ izumi used ctsm5.3.016 because it was the best available baseline
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: No but read caveat.
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: a few Fates cases
+    - what platforms/compilers: izumi; only because I compared to ctsm5.3.016
+    - nature of change: same as in the tmp-241219.n02.ctsm5.3.016 tag
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/2925
+
+===============================================================
+===============================================================
 Tag name: tmp-241219.n02.ctsm5.3.016
 Originator(s): glemieux (Gregory Lemieux, LBNL, glemieux@lbl.gov)
 Date: Wed 08 Jan 2025 10:52:49 AM MST

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,12 +1,11 @@
 ===============================================================
 Tag name: tmp-241219.n03.ctsm5.3.016
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
-Date: Wed 08 Jan 2025 06:09:41 PM MST
+Date: Thu 09 Jan 2025 11:39:37 AM MST
 One-line Summary: Bug fix for izumi nag tests to pass
 
 Purpose and description of changes
 ----------------------------------
-
  Allocation statements should have been (0:mxpft) instead of (mxpft).
  I introduced the bug in a small refactor requested in #2917.
 
@@ -30,7 +29,7 @@ Does this tag change answers significantly for any of the following physics conf
 Bugs fixed
 ----------
 List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
-Fixes #2924
+ Fixes #2924
 
 Notes of particular relevance for developers:
 ---------------------------------------------
@@ -49,7 +48,7 @@ Testing summary:
     izumi ------- OK
 
 If the tag used for baseline comparisons was NOT the previous tag, note that here:
- derecho used tmp-241219.n02.ctsm5.3.016
+ derecho used tmp-241219.n02.ctsm5.3.016 (i.e. the previous tag)
  izumi used ctsm5.3.016 because it was the best available baseline
 
 Answer changes
@@ -61,6 +60,11 @@ Changes answers relative to baseline: No but read caveat.
     - what code configurations: a few Fates cases
     - what platforms/compilers: izumi; only because I compared to ctsm5.3.016
     - nature of change: same as in the tmp-241219.n02.ctsm5.3.016 tag
+
+ Note: Also on izumi I see the following failure in all the tests that 'failed to initialize'
+       that I had to go back to build and run, whether with ./case.build or ./create_test. For example:
+       FAIL ERP_D_Ld5_P48x1.f10_f10_mg37.I2000Clm50BgcCru.izumi_nag.clm-noFUN_flexCN BASELINE ctsm5.3.016: ERROR CPRNC failed to open files
+       I am aware that others have also seen this behavior.
 
 Other details
 -------------

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,7 +1,8 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-tmp-241219.n02.ctsm5.3.016  01/08/2025 FATES hydro test update
-tmp-241219.n01.ctsm5.3.016  12/24/2024 Merge b4b-dev
+tmp-241219.n03.ctsm5.3.016  01/09/2025 Bug fix for izumi nag tests to pass (slevis)
+tmp-241219.n02.ctsm5.3.016  01/08/2025 FATES hydro test update (glemieux)
+tmp-241219.n01.ctsm5.3.016  12/24/2024 Merge b4b-dev (slevis)
        ctsm5.3.016     erik 12/19/2024 Rpointer files for restart now have the simulation date in the filename
        ctsm5.3.015     erik 12/18/2024 Update cdeps with cam7 nextsw cday changes
        ctsm5.3.014     erik 12/03/2024 Bring in several fixes for testing in the previous cesm3_0_beta03/04 tags

--- a/src/biogeochem/CNFUNMod.F90
+++ b/src/biogeochem/CNFUNMod.F90
@@ -169,17 +169,17 @@ module CNFUNMod
     if ( .not. readv ) call endrun( msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))
     params_inst%ndays_off=tempr
 
-    allocate(params_inst%nfix_tmin(mxpft))
+    allocate(params_inst%nfix_tmin(0:mxpft))
     tString='nfix_tmin'
     call ncd_io(trim(tString), params_inst%nfix_tmin(:), 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))
 
-    allocate(params_inst%nfix_topt(mxpft))
+    allocate(params_inst%nfix_topt(0:mxpft))
     tString='nfix_topt'
     call ncd_io(trim(tString), params_inst%nfix_topt(:), 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))
 
-    allocate(params_inst%nfix_tmax(mxpft))
+    allocate(params_inst%nfix_tmax(0:mxpft))
     tString='nfix_tmax'
     call ncd_io(trim(tString), params_inst%nfix_tmax(:), 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(sourcefile, __LINE__))
@@ -535,7 +535,7 @@ module CNFUNMod
   real(r8) :: total_N_resistance   ! C to of N for whole soil -leaf
   !  pathway
   real(r8) :: free_RT_frac=0.0_r8  !fraction of N retranslocation which is automatic/free.
-  !  SHould be made into a PFT parameter. 
+  !  Should be made into a PFT parameter.
   
   real(r8) :: paid_for_n_retrans
   real(r8) :: free_n_retrans
@@ -1136,13 +1136,13 @@ stp:  do istp = ecm_step, am_step        ! TWO STEPS
 
                select case (nfix_method)
                case ('Houlton')
-                 costNit(j,icostFix) = fun_cost_fix(fixer,&
-                         a_fix(ivt(p)),b_fix(ivt(p)),c_fix(ivt(p)),&
-                         big_cost,crootfr(p,j),s_fix(ivt(p)),tc_soisno(c,j))
+                  costNit(j,icostFix) = fun_cost_fix(fixer, &
+                          a_fix(ivt(p)), b_fix(ivt(p)), c_fix(ivt(p)), &
+                          big_cost, crootfr(p,j), s_fix(ivt(p)), tc_soisno(c,j))
                case ('Bytnerowicz')  ! no acclimation calculation
-                 costNit(j,icostFix) = fun_cost_fix_Bytnerowicz_noAcc(fixer, &
-                         params_inst%nfix_tmin(ivt(p)), params_inst%nfix_topt(ivt(p)), params_inst%nfix_tmax(ivt(p)), &
-                         big_cost,crootfr(p,j),s_fix(ivt(p)),tc_soisno(c,j))
+                  costNit(j,icostFix) = fun_cost_fix_Bytnerowicz_noAcc(fixer, &
+                          params_inst%nfix_tmin(ivt(p)), params_inst%nfix_topt(ivt(p)), params_inst%nfix_tmax(ivt(p)), &
+                          big_cost,crootfr(p,j), s_fix(ivt(p)), tc_soisno(c,j))
                case default
                   errCode = ' ERROR: unknown nfix_method value: ' // nfix_method
                   call endrun( msg=trim(errCode) // errMsg(sourcefile, __LINE__))


### PR DESCRIPTION
### Description of changes
Allocation statements should have been (0:mxpft) instead of (mxpft).
I introduced the bug in a small refactor requested in #2917.

### Specific notes

CTSM Issues Fixed (include github issue #):
Fixes #2924 

Are answers expected to change (and if so in what way)?
Not relative to ctsm5.3.016.

Testing performed, if any:
```
PASS SMS_D_Ld65.f10_f10_mg37.I2000Clm60BgcCrop.izumi_nag.clm-FireLi2024GSWP
PASS SMS_D.f10_f10_mg37.I2000Clm60BgcCrop.izumi_nag.clm-crop
PASS ERP_D_Ld5_P48x1.f10_f10_mg37.I1850Clm60Bgc.izumi_nag.clm-ciso
```
I will submit aux_clm next.