### PR TITLE
Initializing itype as spval for fates patches

### DIFF
--- a/src/biogeophys/SurfaceAlbedoMod.F90
+++ b/src/biogeophys/SurfaceAlbedoMod.F90
@@ -864,23 +864,6 @@ contains
           end if
     end do
 
-    ! Weight reflectance/transmittance by lai and sai
-       ! Only perform on vegetated patches where coszen > 0
-
-    do fp = 1,num_vegsol
-       p = filter_vegsol(fp)
-       wl(p) = elai(p) / max( elai(p)+esai(p), mpe )
-       ws(p) = esai(p) / max( elai(p)+esai(p), mpe )
-    end do
-
-    do ib = 1, numrad
-       do fp = 1,num_vegsol
-          p = filter_vegsol(fp)
-          rho(p,ib) = max( rhol(patch%itype(p),ib)*wl(p) + rhos(patch%itype(p),ib)*ws(p), mpe )
-          tau(p,ib) = max( taul(patch%itype(p),ib)*wl(p) + taus(patch%itype(p),ib)*ws(p), mpe )
-       end do
-    end do
-
     ! Diagnose number of canopy layers for radiative transfer, in increments of dincmax.
     ! Add to number of layers so long as cumulative leaf+stem area does not exceed total
     ! leaf+stem area. Then add any remaining leaf+stem area to next layer and exit the loop.
@@ -1051,7 +1034,24 @@ contains
             fcansno(bounds%begp:bounds%endp), surfalb_inst)
 
     else
-
+       
+       ! Weight reflectance/transmittance by lai and sai
+       ! Only perform on vegetated patches where coszen > 0
+       
+       do fp = 1,num_vegsol
+          p = filter_vegsol(fp)
+          wl(p) = elai(p) / max( elai(p)+esai(p), mpe )
+          ws(p) = esai(p) / max( elai(p)+esai(p), mpe )
+       end do
+       
+       do ib = 1, numrad
+          do fp = 1,num_vegsol
+             p = filter_vegsol(fp)
+             rho(p,ib) = max( rhol(patch%itype(p),ib)*wl(p) + rhos(patch%itype(p),ib)*ws(p), mpe )
+             tau(p,ib) = max( taul(patch%itype(p),ib)*wl(p) + taus(patch%itype(p),ib)*ws(p), mpe )
+          end do
+       end do
+       
        call TwoStream (bounds, filter_vegsol, num_vegsol, &
             coszen_patch(bounds%begp:bounds%endp), &
             rho(bounds%begp:bounds%endp, :), &

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -18,6 +18,7 @@ module clm_driver
   use clm_time_manager       , only : get_nstep, is_beg_curr_day, is_beg_curr_year
   use clm_time_manager       , only : get_prev_date, is_first_step
   use clm_varpar             , only : nlevsno, nlevgrnd
+  use clm_varcon             , only : spval
   use clm_varorb             , only : obliqr
   use spmdMod                , only : masterproc, mpicom
   use decompMod              , only : get_proc_clumps, get_clump_bounds, get_proc_bounds, bounds_type
@@ -704,16 +705,23 @@ contains
        ! bugs.
        allocate(downreg_patch(bounds_clump%begp:bounds_clump%endp))
        allocate(leafn_patch(bounds_clump%begp:bounds_clump%endp))
-       downreg_patch = bgc_vegetation_inst%get_downreg_patch(bounds_clump)
-       leafn_patch = bgc_vegetation_inst%get_leafn_patch(bounds_clump)
-
        allocate(froot_carbon(bounds_clump%begp:bounds_clump%endp))
        allocate(croot_carbon(bounds_clump%begp:bounds_clump%endp))
-       froot_carbon = bgc_vegetation_inst%get_froot_carbon_patch( &
-            bounds_clump, canopystate_inst%tlai_patch(bounds_clump%begp:bounds_clump%endp))
-       croot_carbon = bgc_vegetation_inst%get_croot_carbon_patch( &
-            bounds_clump, canopystate_inst%tlai_patch(bounds_clump%begp:bounds_clump%endp))
 
+       if(use_fates)then
+          downreg_patch(:) = spval
+          leafn_patch(:) = spval
+          froot_carbon(:) = spval
+          croot_carbon(:) = spval
+       else
+          downreg_patch = bgc_vegetation_inst%get_downreg_patch(bounds_clump)
+          leafn_patch = bgc_vegetation_inst%get_leafn_patch(bounds_clump)
+          froot_carbon = bgc_vegetation_inst%get_froot_carbon_patch( &
+               bounds_clump, canopystate_inst%tlai_patch(bounds_clump%begp:bounds_clump%endp))
+          croot_carbon = bgc_vegetation_inst%get_croot_carbon_patch( &
+               bounds_clump, canopystate_inst%tlai_patch(bounds_clump%begp:bounds_clump%endp))
+       end if
+          
        call CanopyFluxes(bounds_clump,                                                      &
             filter(nc)%num_exposedvegp, filter(nc)%exposedvegp,                             &
             clm_fates,nc,                                                                   &

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -930,8 +930,10 @@ module CLMFatesInterfaceMod
             c = this%f2hmap(nc)%fcolumn(s)
             pi = col%patchi(c)+1
             pf = col%patchf(c)
-!            patch%itype(pi:pf) = ispval
+            patch%itype(pi:pf) = ispval
             patch%is_fates(pi:pf) = .true.
+            !write(iulog,*)'SETTING ISPVAL'
+            !call endrun(msg=errMsg(sourcefile, __LINE__))
          end do
 
       end do


### PR DESCRIPTION
### Description of changes

On FATES patches, there should be no notion of pft associated with the patch, and therefore patch%itype should always be invalid.  Even for FATES-SP, the patch should be associated with the FATES pft, which is not associated with itype. In this set of changes, itype is set to spval on fates patches. This will help prevent bugs in the future, because its use in a fates context should trigger errors, particularly in debug mode.

### Specific notes

Addresses part of: #2932

Contributors other than yourself, if any:

@rosiealice @ekluzek @glemieux others

CTSM Issues Fixed (include github issue #):

Fixes: #2933

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Does this create a need to change or add documentation? Did you do so? No

Testing performed, if any:

One off tests to see if the model would run with Zeng and Wang turbulent transport.  It does. Ran into machine issues testing with Meier2022, which should crash.


(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on derecho for intel/gnu and izumi for intel/gnu/nag/nvhpc is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
