### PR TITLE
ctsm5.3.030: Fix FATES branch runs

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -277,8 +277,12 @@
     </phase>
   </test>
 
-  <test name="ERS_D_Ld20.f45_f45_mg37.I2000Clm50FatesRs.derecho_intel.clm-FatesColdTwoStream">
+  <test name="ERI_D_Ld20.f45_f45_mg37.I2000Clm50FatesRs.derecho_intel.clm-FatesColdTwoStream">
     <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>#2325</issue>
+    </phase>
+    <phase name="RUN">
       <status>FAIL</status>
       <issue>#2325</issue>
     </phase>

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -185,8 +185,12 @@
     </phase>
   </test>
 
-  <test name="ERS_D_Ld20.f45_f45_mg37.I2000Clm50FatesRs.izumi_nag.clm-FatesColdTwoStream">
+  <test name="ERI_D_Ld20.f45_f45_mg37.I2000Clm50FatesRs.izumi_nag.clm-FatesColdTwoStream">
     <phase name="COMPARE_base_rest">
+      <status>FAIL</status>
+      <issue>#2325</issue>
+    </phase>
+    <phase name="RUN">
       <status>FAIL</status>
       <issue>#2325</issue>
     </phase>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -2845,6 +2845,8 @@
   </test>
   <test name="ERI_D_Ld5" grid="f10_f10_mg37" compset="I2000Clm50Fates" testmods="clm/FatesCold">
     <machines>
+      <machine name="derecho" compiler="intel" category="aux_clm"/>
+      <machine name="derecho" compiler="intel" category="fates"/>
       <machine name="izumi" compiler="nag" category="aux_clm"/>
     </machines>
     <options>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -2795,7 +2795,7 @@
       <option name="comment">Ensure functionality of the tree damage option in FATES</option>
     </options>
   </test>
-  <test name="ERS_D_Ld20" grid="f45_f45_mg37" compset="I2000Clm50FatesRs" testmods="clm/FatesColdTwoStream">
+  <test name="ERI_D_Ld20" grid="f45_f45_mg37" compset="I2000Clm50FatesRs" testmods="clm/FatesColdTwoStream">
     <machines>
       <machine name="derecho" compiler="intel" category="fates"/>
       <machine name="derecho" compiler="intel" category="aux_clm"/>
@@ -3234,7 +3234,7 @@
       <option name="comment">Exact restart debug FATES test providing coverage for Clm45 physics.</option>
     </options>
   </test>
-  <test name="ERS_Ld60" grid="f45_f45_mg37" compset="I2000Clm50FatesCruRsGs" testmods="clm/Fates">
+  <test name="ERI_Ld60" grid="f45_f45_mg37" compset="I2000Clm50FatesCruRsGs" testmods="clm/Fates">
     <machines>
       <machine name="derecho" compiler="intel" category="fates"/>
       <machine name="lawrencium-lr3" compiler="intel" category="fates"/>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -2843,7 +2843,7 @@
       <option name="wallclock">00:40:00</option>
     </options>
   </test>
-  <test name="ERI_D_Ld5" grid="f10_f10_mg37" compset="I2000Clm50Fates" testmods="clm/FatesCold">
+  <test name="ERI_D_Ld20" grid="f10_f10_mg37" compset="I2000Clm50Fates" testmods="clm/FatesCold">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_clm"/>
       <machine name="derecho" compiler="intel" category="fates"/>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -2843,6 +2843,14 @@
       <option name="wallclock">00:40:00</option>
     </options>
   </test>
+  <test name="ERI_D_Ld5" grid="f10_f10_mg37" compset="I2000Clm50Fates" testmods="clm/FatesCold">
+    <machines>
+      <machine name="izumi" compiler="nag" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:40:00</option>
+    </options>
+  </test>
   <test name="ERS_Ld397" grid="f10_f10_mg37" compset="I2000Clm50Fates" testmods="clm/FatesCold">
     <machines>
       <machine name="derecho" compiler="gnu" category="fates"/>

--- a/cime_config/testdefs/testmods_dirs/clm/Fates/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/Fates/user_nl_clm
@@ -1,5 +1,5 @@
 !!   USES THE DEFAULT INITIALIZATION FILE SPECIFIED IN bld/namelist_files/namelist_defaults_ctsm.xml
-hist_mfilt        = 365
+hist_mfilt        = 1
 hist_nhtfrq       = -24
 hist_empty_htapes = .true.
 hist_ndens = 1

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdAllVars/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdAllVars/user_nl_clm
@@ -1,5 +1,5 @@
 !finidat = '$DIN_LOC_ROOT/lnd/clm2/initdata_map/iclm45fates-finit-s1.4.0-a3.0.0-f45.clm2.r.0111-01-01-00000.nc'
-hist_mfilt        = 365
+hist_mfilt        = 1
 hist_nhtfrq       = -24
 hist_empty_htapes = .false.
 fates_spitfire_mode = 1

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdDryDepSatPhen/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdDryDepSatPhen/user_nl_clm
@@ -1,4 +1,4 @@
 
-hist_mfilt        = 365
+hist_mfilt        = 1
 hist_nhtfrq       = -24
 

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdHydro/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdHydro/user_nl_clm
@@ -1,4 +1,4 @@
-hist_mfilt        = 365
+hist_mfilt        = 1
 hist_nhtfrq       = -24
 hist_empty_htapes = .true.
 use_fates_planthydro= .true.

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdMeganSatPhen/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdMeganSatPhen/user_nl_clm
@@ -1,4 +1,4 @@
 
-hist_mfilt        = 365
+hist_mfilt        = 1
 hist_nhtfrq       = -24
 

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdSatPhen/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdSatPhen/user_nl_clm
@@ -1,4 +1,4 @@
 
-hist_mfilt        = 365
+hist_mfilt        = 1
 hist_nhtfrq       = -24
 

--- a/cime_config/testdefs/testmods_dirs/clm/GddGen/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/GddGen/user_nl_clm
@@ -6,6 +6,7 @@ generate_crop_gdds = .true.
 use_mxmat = .false.
 
 ! (h3) Daily outputs for GDD generation and figure-making
+! Note that hist_mfilt ≠ 1 means that ERI tests will probably fail
 hist_fincl4 = 'GDDACCUM', 'GDDHARV'
 hist_nhtfrq(4) = -24
 hist_mfilt(4) = 365

--- a/cime_config/testdefs/testmods_dirs/clm/fire_emis/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/fire_emis/user_nl_clm
@@ -14,7 +14,7 @@
 ! Set maxpatch_glc       with GLC_NEC                            option
 !----------------------------------------------------------------------------------
 
- hist_mfilt = 1,30
+ hist_mfilt = 1,1
  hist_nhtfrq = 0,-24
  hist_avgflag_pertape = 'A','A'
  hist_fincl1 = 'M_LEAFC_TO_FIRE','M_LEAFC_STORAGE_TO_FIRE','M_LEAFC_XFER_TO_FIRE','M_LIVESTEMC_TO_FIRE',

--- a/cime_config/testdefs/testmods_dirs/clm/glcMEC_long/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/glcMEC_long/user_nl_clm
@@ -1,2 +1,2 @@
  hist_nhtfrq    =0,0
- hist_mfilt     = 1,12
+ hist_mfilt     = 1,1

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,69 @@
 ===============================================================
+Tag name: ctsm5.3.030
+Originator(s): samrabin (Sam Rabin, UCAR/TSS)
+Date: Fri Mar  7 10:06:35 MST 2025
+One-line Summary: Fix FATES branch runs
+
+Purpose and description of changes
+----------------------------------
+
+In FATES branch runs, prevents attempts to re-allocate arrays that already are allocated (in the restart file). This prevents run failures. However, it exposes a failure in the COMPARE_base_hybrid step of ERI tests, due to a bad hist_mfilt; this is also fixed.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+[Remove any lines that don't apply. Remove entire section if nothing applies.]
+
+List of CTSM issues fixed (include CTSM Issue # and description):
+- Resolves NGEET/fates#653: [FATES Issue #653: Branch runs fail at double allocation of FATES structures](https://github.com/NGEET/fates/issues/653)
+- Resolves NGEET/fates#1271: [FATES Issue #1271: FATES doesn't work in branch runs](https://github.com/NGEET/fates/issues/1271)
+- Resolves ESCOMP/CTSM#2903: [CTSM Issue #2903: FATES doesn't work in branch runs](https://github.com/ESCOMP/CTSM/issues/2903)
+- Resolves ESCOMP/CTSM#2953: [CTSM Issue #2953: Add several ERI tests to the FATES testlists](https://github.com/ESCOMP/CTSM/issues/2953)
+
+
+Notes of particular relevance for developers:
+---------------------------------------------
+
+Changes to tests or testing: Some FATES ERI tests added.
+
+
+Testing summary:
+----------------
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+  fates tests:
+    derecho ----- OK
+    izumi ------- OK
+
+
+Other details
+-------------
+
+Pull Requests that document the changes (include PR ids):
+- [CTSM PR #2955: ctsm5.3.030: Fix FATES branch runs by samsrabin](https://github.com/ESCOMP/CTSM/pull/2955)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.3.029
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
 Date: Wed 05 Mar 2025 09:42:13 AM MST

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.030 samrabin 03/07/2025 Fix FATES branch runs
        ctsm5.3.029   slevis 03/05/2025 Make Bytnerowicz the default nfix_method for clm6
        ctsm5.3.028 samrabin 03/03/2025 Move Izumi intel and gnu tests to Derecho
        ctsm5.3.027 glemieux 03/02/2025 FATES parameter file switch migration

--- a/src/main/clm_initializeMod.F90
+++ b/src/main/clm_initializeMod.F90
@@ -738,7 +738,7 @@ contains
     deallocate(wt_nat_patch)
 
     ! Initialise the fates model state structure
-    if ( use_fates .and. .not.is_restart() .and. finidat == ' ') then
+    if ( use_fates .and. .not. (is_restart() .or. nsrest .eq. nsrBranch) .and. finidat == ' ') then
        ! If fates is using satellite phenology mode, make sure to call the SatellitePhenology
        ! procedure prior to init_coldstart which will eventually call leaf_area_profile
        if ( use_fates_sp ) then

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -78,6 +78,7 @@ module CLMFatesInterfaceMod
    use clm_varctl        , only : use_nitrif_denitrif
    use clm_varctl        , only : use_lch4
    use clm_varctl        , only : fates_history_dimlevel
+   use clm_varctl        , only : nsrest, nsrBranch
    use clm_varcon        , only : tfrz
    use clm_varcon        , only : spval
    use clm_varcon        , only : denice
@@ -497,7 +498,7 @@ module CLMFatesInterfaceMod
         ! This has no variable on the FATES side yet (RGK)
         !call set_fates_ctrlparms('sf_anthro_suppression_def',ival=anthro_suppression)
 
-        if(is_restart()) then
+        if(is_restart() .or. nsrest .eq. nsrBranch) then
            pass_is_restart = 1
         else
            pass_is_restart = 0


### PR DESCRIPTION
### Description of changes
In FATES branch runs, prevents attempts to re-allocate arrays that already are allocated (in the restart file). This prevents run failures. However, it exposes a failure in the `COMPARE_base_hybrid` step of ERI tests, due to a bad `hist_mfilt`; this is also fixed.

Remaining tasks:
- [x] Fix `COMPARE_base_hybrid` failure.
- [x] Add FATES `ERI` tests to `aux_clm` and `fates` test suites.

### Notes for testing

Baseline comparisons may fail for the following testmods:
- `Fates`
- `FatesColdAllVars`
- `FatesColdDryDepSatPhen`
- `FatesColdHydro`
- `FatesColdMeganSatPhen`
- `FatesColdSatPhen`
- `fire_emis`
- `glcMEC_long`

However, this is only because I have changed `hist_mfilt` for those to 1. (From 365 for the `Fates` testmods; from 30 for `fire_emis`; from 12 for `glcMEC_long`). This ensures that the dates in the history filenames are the same for both parts of the ERI test.

When this is next in the merge queue:
1. Generate `fates` suite baseline for ctsm5.3.029.
2. Rebase onto the latest tag.
3. Check out the commit from before changing `mfilt`. Run `aux_clm` and `fates` suites, comparing to the latest baseline (ctsm5.3.029), expecting no diffs.
4. Check out the commit after changing `mfilt`. Run `aux_clm` and `fates` suites, generating ctsm5.3.030 baseline, comparing to the latest baseline (ctsm5.3.029), expecting baseline comparison failures (a) only for testmods whose `mfilt` changed and (b) only because of missing baseline files.
5. Check out the tip of this branch. Generate baselines for FATES tests that changed from ERS to ERI.

### Specific notes

Contributors other than yourself, if any: @ckoven 

CTSM Issues Fixed:
- Resolves NGEET/fates#653
- Resolves NGEET/fates#1271
- Resolves ESCOMP/CTSM#2903
- Resolves ESCOMP/CTSM#2953

**Are answers expected to change (and if so in what way)?** No, although see "Notes for testing" above.

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- `ERI_Ld60.f45_f45_mg37.I2000Clm50FatesCruRsGs.derecho_intel.clm-Fates` passes.
- Complete testing (as described above) done.