### PR TITLE
Make CRUJRA2024 the default datm input for Clm6 plus add a corresponding compset for Clm5

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ $CTSMROOT/README                                          09/05/2024
 
 Community Terrestrial Systems Model (CTSM) science version 5.3 series -- source code, tools, 
 offline-build and test scripts. This gives you everything you need
-to run CTSM with CESM with the CMEPS driver and CDEPS data models to provide CRU NCEP or GSWP3 forcing data in 
+to run CTSM with CESM with the CMEPS driver and CDEPS data models to provide CRU or GSWP3 forcing data in
 place of a modeled atmosphere.
 
 CMEPS is the Community Mediator for Earth Prediction Systems. And CDEPS is the

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -37,7 +37,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <lnd_tuning_mode phys="clm4_5" >clm4_5_CRUv7</lnd_tuning_mode>
 <lnd_tuning_mode phys="clm5_0" >clm5_0_cam6.0</lnd_tuning_mode>
-<lnd_tuning_mode phys="clm6_0" >clm6_0_GSWP3v1</lnd_tuning_mode>
+<lnd_tuning_mode phys="clm6_0" >clm6_0_CRUJRA2024</lnd_tuning_mode>
 
 <!-- Component name for output files (could depdend on the physics version) -->
 <compname >clm2</compname>
@@ -846,6 +846,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm6_0_GSWP3v1 use_excess_ice=.true.
 </init_interp_attributes>
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
+>hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm6_0_CRUJRA2024 use_excess_ice=.true.
+</init_interp_attributes>
 
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="1.9x2.5"
@@ -1262,7 +1265,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.I1850Clm50SpCru.1706-01-01.0.9x1.25_gx1v7_simyr1850_c200806.nc
 </finidat>
 
-<!-- CTSM6_0 - use clm6_0_GSWP3v1 BgcCrop at f09 for all clm6_0 options -->
+<!-- CTSM6_0 - use clm6_0_CRUJRA2024 BgcCrop at f09 for all clm6_0 options -->
 <finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
@@ -2356,6 +2359,8 @@ lnd/clm2/surfdata_esmf/NEON/ctsm5.3.0/surfdata_1x1_NEON_TOOL_hist_2000_78pfts_c2
 <stream_fldfilename_zendersoilerod dust_emis_method="Zender_2003" zender_soil_erod_source="lnd" lnd_tuning_mode="clm5_0_GSWP3v1"
 >lnd/clm2/dustemisdata/dst_source2x2tunedcam6-2x2-forCLM_cdf5_c230312.nc</stream_fldfilename_zendersoilerod>
 <stream_fldfilename_zendersoilerod dust_emis_method="Zender_2003" zender_soil_erod_source="lnd" lnd_tuning_mode="clm6_0_GSWP3v1"
+>lnd/clm2/dustemisdata/dst_source2x2tunedcam6-2x2-forCLM_cdf5_c230312.nc</stream_fldfilename_zendersoilerod>
+<stream_fldfilename_zendersoilerod dust_emis_method="Zender_2003" zender_soil_erod_source="lnd" lnd_tuning_mode="clm6_0_CRUJRA2024"
 >lnd/clm2/dustemisdata/dst_source2x2tunedcam6-2x2-forCLM_cdf5_c230312.nc</stream_fldfilename_zendersoilerod>
 
 <stream_meshfile_zendersoilerod dust_emis_method="Zender_2003" zender_soil_erod_source="lnd"

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -260,7 +260,7 @@ li2014qianfrc: Reference paper Li, et. al.(2014) tuned with QIAN atmospheric for
 li2016crufrc:  Reference paper Li, et. al.(2016) tuned with CRU-NCEP atmospheric forcing
 li2021gswpfrc: No reference paper yet, tuned with GSWP3 atmospheric forcing
 li2024gswpfrc: No reference paper yet, tuned with GSWP3 atmospheric forcing
-li2024crujra:  No reference paper yet, tuned with CRU-JRA forcing
+li2024crujra:  No reference paper yet, tuned with CRU-JRA forcing (CRUJRA)
 </entry>
 
 <entry id="pot_hmn_ign_counts_alpha" type="real" category="clm_physics"
@@ -2220,10 +2220,10 @@ hist means do NOT use a future scenario, just use historical data.
 Land mask description
 </entry> 
 
-<!-- lnd_tuning_mode, there needs to be a setting for: CRUv7, GSWP3v1, cam6.0, and cam7.0 for each valid physics option -->
+<!-- lnd_tuning_mode, there needs to be a setting for: CRUJRA2024, CRUv7, GSWP3v1, cam6.0, and cam7.0 for each valid physics option -->
 <entry id="lnd_tuning_mode" type="char*20" category="default_settings"
        group="default_settings"
-       valid_values="clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam7.0,clm4_5_cam6.0,clm4_5_cam5.0,clm4_5_cam4.0,clm5_0_cam7.0,clm5_0_cam6.0,clm5_0_cam5.0,clm5_0_cam4.0,clm5_0_CRUv7,clm5_0_GSWP3v1,clm6_0_GSWP3v1,clm6_0_cam7.0,clm6_0_cam6.0,clm6_0_cam5.0,clm6_0_cam4.0">
+       valid_values="clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_cam7.0,clm4_5_cam6.0,clm4_5_cam5.0,clm4_5_cam4.0,clm5_0_cam7.0,clm5_0_cam6.0,clm5_0_cam5.0,clm5_0_cam4.0,clm5_0_CRUv7,clm5_0_GSWP3v1,clm6_0_GSWP3v1,clm6_0_CRUJRA2024,clm6_0_cam7.0,clm6_0_cam6.0,clm6_0_cam5.0,clm6_0_cam4.0">
 General configuration of model version and atmospheric forcing to tune the model to run under.
 This sets the model to run with constants and initial conditions that were set to run well under 
 the configuration of model version and atmospheric forcing. To run well constants would need to be changed

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -1976,11 +1976,13 @@ foreach my $phys ( "clm4_5", "clm5_0", "clm6_0" ) {
   my $mode = "-phys $phys";
   &make_config_cache($phys);
   my @forclist = ();
-  @forclist = ( "CRUv7", "GSWP3v1", "cam7.0", "cam6.0", "cam5.0", "cam4.0" );
+  @forclist = ( "CRUJRA2024", "CRUv7", "GSWP3v1", "cam7.0", "cam6.0", "cam5.0", "cam4.0" );
   foreach my $forc ( @forclist ) {
      foreach my $bgc ( "sp", "bgc" ) {
         my $lndtuningmode = "${phys}_${forc}";
-        if ( $lndtuningmode eq "clm6_0_CRUv7" ) {
+        if ( $lndtuningmode eq "clm6_0_CRUv7" or
+             $lndtuningmode eq "clm4_5_CRUJRA2024" or
+             $lndtuningmode eq "clm5_0_CRUJRA2024") {
            next;
         }
         my $clmoptions = "-res $res -mask $mask -sim_year $simyr -envxml_dir . -lnd_tuning_mod $lndtuningmode -bgc $bgc";

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -110,6 +110,7 @@ def buildnml(case, caseroot, compname):
         "clm6_0_NLDAS2": "clm6_0_GSWP3v1",
         "clm6_0_ERA5": "clm6_0_GSWP3v1",
         "clm6_0_CRUv7": "clm6_0_GSWP3v1",
+        "clm6_0_CRUJRA2024": "clm6_0_GSWP3v1",
     }
     for mode, closest in closest_tuning.items():
         if lnd_tuning_mode == mode:

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -63,6 +63,7 @@
           Options for all combinations of CLM physics and atm forcing are given. The buildnml and namelist_defaults will narrow it down to the ones
           that have been tuned. The buildnml will also warn you if a tuning combination is based on another set.
           Atm forcing options:
+               CRUJRA2024
                CRUv7
                GSWP3
                CAM4.0
@@ -76,10 +77,10 @@
           Other atm forcing options are invalid to run CLM and will result in an error.
     </desc>
     <default_value>UNSET</default_value>
-    <!-- 10 forcing options for each CLM physics option: CRUv7, GSWP3, cam7.0, cam6.0, cam5.0, cam4.0, QIAN, 1PT, NLDAS2, ERA5 -->
-    <valid_values>clm5_0_cam6.0,clm5_0_cam7.0,clm5_0_cam5.0,clm5_0_cam4.0,clm5_0_GSWP3v1,clm5_0_CRUv7,clm5_0_QIAN,clm5_0_1PT,clm5_0_NLDAS2,clm5_0_ERA5,clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_QIAN,clm4_5_cam6.0,clm4_5_cam7.0,clm4_5_cam5.0,clm4_5_cam4.0,clm4_5_1PT,clm4_5_NLDAS2,clm4_5_ERA5,clm6_0_CRUv7,clm6_0_GSWP3v1,clm6_0_cam6.0,clm6_0_cam7.0,clm6_0_cam5.0,clm6_0_cam4.0,clm6_0_QIAN,clm6_0_1PT,clm6_0_NLDAS2,clm6_0_ERA5</valid_values>
+    <!-- 10 forcing options for each CLM physics option: CRUJRA2024, CRUv7, GSWP3, cam7.0, cam6.0, cam5.0, cam4.0, QIAN, 1PT, NLDAS2, ERA5 -->
+    <valid_values>clm5_0_cam6.0,clm5_0_cam7.0,clm5_0_cam5.0,clm5_0_cam4.0,clm5_0_GSWP3v1,clm5_0_CRUv7,clm5_0_QIAN,clm5_0_1PT,clm5_0_NLDAS2,clm5_0_ERA5,clm4_5_CRUv7,clm4_5_GSWP3v1,clm4_5_QIAN,clm4_5_cam6.0,clm4_5_cam7.0,clm4_5_cam5.0,clm4_5_cam4.0,clm4_5_1PT,clm4_5_NLDAS2,clm4_5_ERA5,clm6_0_CRUv7,clm6_0_GSWP3v1,clm6_0_CRUJRA2024,clm6_0_cam6.0,clm6_0_cam7.0,clm6_0_cam5.0,clm6_0_cam4.0,clm6_0_QIAN,clm6_0_1PT,clm6_0_NLDAS2,clm6_0_ERA5</valid_values>
     <values match="last">
-      <!-- Options for atm forcing are: CRU, CRUv7, GSWP3, cam6.0 (also used for DATM%CPLHIST), cam5.0, cam4.0, QIAN, WISOQIA, 1PT, NLDAS2, and ERA5) -->
+      <!-- Options for atm forcing are: CRUJRA2024, CRUv7, GSWP3, cam6.0 (also used for DATM%CPLHIST), cam5.0, cam4.0, QIAN, WISOQIA, 1PT, NLDAS2, and ERA5) -->
       <!-- All the clm4_5 physics options -->
       <value compset="SATM_CLM45"        >clm4_5_CRUv7</value>
       <value compset="DATM%CRUv7_CLM45"  >clm4_5_CRUv7</value>
@@ -113,8 +114,9 @@
       <value compset="DATM%NLDAS2_CLM50" >clm5_0_NLDAS2</value>
       <value compset="DATM%ERA5_CLM50"   >clm5_0_ERA5</value>
       <!-- All the clm6_0 physics options -->
+      <value compset="DATM%CRUJRA2024_CLM60">clm6_0_CRUJRA2024</value>
+      <value compset="DATM%CRU_CLM60"    >clm6_0_CRUJRA2024</value>
       <value compset="DATM%CRUv7_CLM60"  >clm6_0_CRUv7</value>
-      <value compset="DATM%CRU_CLM60"    >clm6_0_CRUv7</value>
       <value compset="SATM_CLM60"        >clm6_0_GSWP3v1</value>
       <value compset="DATM%GSWP3v1_CLM60">clm6_0_GSWP3v1</value>
       <value compset="CAM[^_]+_CLM60"    >clm6_0_cam6.0</value>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -85,12 +85,12 @@
   </compset>
   <compset>
     <alias>I2000Clm60SpRs</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>I2000Clm60Sp</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
   </compset>
@@ -98,7 +98,7 @@
   <!-- Primarily for testing -->
   <compset>
     <alias>I2000Clm60SpRs</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing -->
@@ -135,12 +135,12 @@
 
   <compset>
     <alias>I2000Clm60BgcCrop</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>I2000Clm60Bgc</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing -->
@@ -159,6 +159,10 @@
   </compset>
 
   <compset>
+    <alias>I1850Clm60SpCrujra</alias>
+    <lname>1850_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
+  <compset>
     <alias>I1850Clm60SpCru</alias>
     <lname>1850_DATM%CRUv7_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
@@ -172,25 +176,25 @@
 
   <compset>
     <alias>I1850Clm60BgcCrop</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- currently needed for CESM remove when no longer needed -->
   <compset>
     <alias>I1850Clm60BgcCrop</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>I1850Clm60Sp</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
   </compset>
 
   <compset>
     <alias>I1850Clm60Bgc</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
 
@@ -202,7 +206,7 @@
   </compset>
   <compset>
     <alias>I1850Clm60BgcCropCmip6</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%BGC-CROP-CMIP6DECK_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC-CROP-CMIP6DECK_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- Primarily for testing the CMIP6WACCMDECK compset option -->
@@ -213,7 +217,7 @@
   </compset>
   <compset>
     <alias>I1850Clm60BgcCropCmip6waccm</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%BGC-CROP-CMIP6WACCMDECK_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC-CROP-CMIP6WACCMDECK_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <!-- clm5_0 (CMIP6) version with BGC-Crop and CRU forcing -->
@@ -225,6 +229,10 @@
   </compset>
 
   <!-- latest CLM version with BGC-Crop and CRU forcing -->
+  <compset>
+    <alias>I1850Clm60BgcCropCrujra</alias>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
   <compset>
     <alias>I1850Clm60BgcCropCru</alias>
     <lname>1850_DATM%CRUv7_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
@@ -264,7 +272,7 @@
   <!---I FATES compsets -->
   <compset>
     <alias>I2000Clm60Fates</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%FATES_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%FATES_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
   <compset>
     <alias>I2000Clm50Fates</alias>
@@ -275,12 +283,16 @@
     <lname>2000_DATM%CRUv7_CLM50%FATES_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
   <compset>
+    <alias>I2000Clm60FatesSpCrujraRsGs</alias>
+    <lname>2000_DATM%CRUJRA2024_CLM60%FATES-SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+  </compset>
+  <compset>
     <alias>I2000Clm60FatesSpCruRsGs</alias>
     <lname>2000_DATM%CRUv7_CLM60%FATES-SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
   <compset>
     <alias>I2000Clm60FatesSpRsGs</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%FATES-SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%FATES-SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
   <compset>
     <alias>I2000Clm50FatesCru</alias>
@@ -293,7 +305,7 @@
   </compset>
   <compset>
     <alias>I2000Clm60FatesRs</alias>
-    <lname>2000_DATM%GSWP3v1_CLM60%FATES_SICE_SOCN_SROF_SGLC_SWAV</lname>
+    <lname>2000_DATM%CRUJRA2024_CLM60%FATES_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -303,13 +315,13 @@
 
   <compset>
      <alias>I1850Clm60BgcNoAnthro</alias>
-     <lname>1850_DATM%GSWP3v1_CLM60%BGC-NOANTHRO_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%CRUJRA2024_CLM60%BGC-NOANTHRO_SICE_SOCN_RTM_SGLC_SWAV</lname>
      <science_support grid="f09_g17"/>
    </compset>
 
   <compset>
      <alias>I1850Clm60SpNoAnthro</alias>
-     <lname>1850_DATM%GSWP3v1_CLM60%SP-NOANTHRO_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%CRUJRA2024_CLM60%SP-NOANTHRO_SICE_SOCN_RTM_SGLC_SWAV</lname>
      <science_support grid="f09_g17"/>
    </compset>
 
@@ -333,30 +345,30 @@
 
   <compset>
      <alias>I1850Clm60SpNoAnthro</alias>
-     <lname>1850_DATM%GSWP3v1_CLM60%SP-NOANTHRO_SICE_SOCN_RTM_SGLC_SWAV</lname>
+     <lname>1850_DATM%CRUJRA2024_CLM60%SP-NOANTHRO_SICE_SOCN_RTM_SGLC_SWAV</lname>
     <science_support grid="f09_g17"/>
    </compset>
 
   <compset>
     <alias>IHistClm60Sp</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>HIST_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
   </compset>
 
   <compset>
     <alias>IHistClm60SpRs</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+    <lname>HIST_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IHistClm60Bgc</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM60%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>HIST_DATM%CRUJRA2024_CLM60%BGC_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>IHistClm60BgcCrop</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>HIST_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -373,6 +385,10 @@
     <science_support grid="f19_g17"/>
   </compset>
 
+  <compset>
+    <alias>IHistClm60SpCrujra</alias>
+    <lname>HIST_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+  </compset>
   <compset>
     <alias>IHistClm60SpCru</alias>
     <lname>HIST_DATM%CRUv7_CLM60%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
@@ -447,7 +463,7 @@
   <!-- Latest CLM version -->
   <compset>
     <alias>ISSP585Clm60BgcCrop</alias>
-    <lname>SSP585_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
+    <lname>SSP585_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>
 
 
@@ -641,7 +657,7 @@
   <!-- Latest CLM version -->
   <compset>
     <alias>I1850Clm60BgcCropG</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
     <science_support grid="ne30pg3_t232"/>
@@ -649,7 +665,7 @@
 
   <compset>
     <alias>IHistClm60BgcCropG</alias>
-    <lname>HIST_DATM%GSWP3v1_CLM60%BGC-CROP_SICE_SOCN_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
+    <lname>HIST_DATM%CRUJRA2024_CLM60%BGC-CROP_SICE_SOCN_MOSART_CISM2%GRIS-EVOLVE_SWAV</lname>
     <science_support grid="f09_g17"/>
     <science_support grid="f19_g17"/>
     <science_support grid="ne30pg3_t232"/>
@@ -663,7 +679,7 @@
 
   <compset>
     <alias>I1850Clm60SpRs</alias>
-    <lname>1850_DATM%GSWP3v1_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
+    <lname>1850_DATM%CRUJRA2024_CLM60%SP_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
 

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -3379,6 +3379,16 @@
       <option name="comment">30 day exact restart test with threading for FATES fixed biogeography reduced complexity mode on an f45 grid.</option>
     </options>
   </test>
+  <test name="ERP_P128x2_Ld30" grid="f45_f45_mg37" compset="I2000Clm60FatesSpCrujraRsGs" testmods="clm/FatesColdSatPhen">
+    <machines>
+      <machine name="derecho" compiler="intel" category="fates"/>
+      <machine name="derecho" compiler="intel" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:40:00</option>
+      <option name="comment">30 day exact restart test with threading for FATES fixed biogeography reduced complexity mode on an f45 grid and CRUJRA2024 instead of CRUv7 datm.</option>
+    </options>
+  </test>
   <test name="ERS_Ld60" grid="f45_f45_mg37" compset="I2000Clm50FatesCruRsGs" testmods="clm/FatesColdLogging">
     <machines>
       <machine name="derecho" compiler="intel" category="fates"/>

--- a/python/ctsm/subset_data.py
+++ b/python/ctsm/subset_data.py
@@ -571,6 +571,10 @@ def setup_files(args, defaults, cesmroot):
         abort("inputdata directory does not exist")
 
     # DATM data
+    # TODO issue #1895: allow datm_crujra, which also affects
+    #      tools/site_and_regional/default_data_1850.cfg
+    #      tools/site_and_regional/default_data_2000.cfg
+    #      python/ctsm/test/testinputs/default_data.cfg
     datm_type = "datm_gswp3"
     dir_output_datm = "datmdata"
     dir_input_datm = os.path.join(clmforcingindir, defaults.get(datm_type, "dir"))


### PR DESCRIPTION
### Description of changes

Change the default datm input from GSWP3v1 to CRUJRA2024 for Clm6.
Add a CRUJRA2024 compset for clm5.

See #1895 for definition of DONE.

### Specific notes

Contributors other than yourself (I hope I didn't forget any):
@wwieder @adrifoster @swensosc @djk2120 @ekluzek @olyson 

CTSM Issues Fixed (include github issue #):
Resolves #1895 

Are answers expected to change (and if so in what way)?
Yes, because Clm6 tests that do not specify the datm input will now get CRUJRA2024 instead of GSWP3v1.

Any User Interface Changes (namelist or namelist defaults changes)?
Adding Crujra to compset names.

Does this create a need to change or add documentation? Did you do so?
It does, and I did not, yet.

Testing performed, if any:
None this far.