### PR TITLE
ctsm5.3.025: Update default FATES parameter file to API 37.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 [submodule "fates"]
 path = src/fates
 url = https://github.com/NGEET/fates
-fxtag = sci.1.80.11_api.37.0.0
+fxtag = sci.1.81.0_api.37.1.0
 fxrequired = AlwaysRequired
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/NCAR/fates-release

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -532,7 +532,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- FATES default parameter file                                       -->
 <!-- ================================================================== -->
 
-<fates_paramfile>lnd/clm2/paramdata/fates_params_api.36.1.0_14pft_c241003.nc</fates_paramfile>
+<fates_paramfile>lnd/clm2/paramdata/fates_params_api.37.1.0_14pft_c250214.nc</fates_paramfile>
 
 
 <!-- ================================================================== -->

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,89 @@
 ===============================================================
+Tag name: ctsm5.3.025
+Originator(s): glemieux (Gregory Lemieux, LBNL, glemieux@lbl.gov)
+Date: Tue Feb 18 02:02:34 PM PST 2025
+One-line Summary: FATES default parameter file update
+
+Purpose and description of changes
+----------------------------------
+
+This tag updates the default parameter file for FATES bringing in a number of updates:
+   - adds parameters for land use grazing
+   - updates the FATES z0mr turbulence parameters for consistency with CLM
+   - adds FATES pft-dependent btran model switches for a forthcoming update
+   - updates the default hydro solver switch to Picard 2D
+
+This also updates the default FATES tag which includes two issue fixes and introduces
+the aforementioned land use grazing capability.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+   Fixes FATES#1316 -- z0mr parameters are all the same in the default parameter file
+   Fixes FATES#773 -- update the default hydraulics solver?
+
+Notes of particular relevance for users
+---------------------------------------
+Changes to CTSM's user interface (e.g., new/renamed XML or namelist variables):
+   The FATES tag update includes new history outputs associated with land use grazing.
+
+Changes made to namelist defaults (e.g., changed parameter values):
+   The fates default parameter file has been updated.  See the associated FATES pull
+   requests for more detail.
+
+
+Testing summary:
+----------------
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho -----
+    izumi -------
+
+  fates tests: (give name of baseline if different from CTSM tagname, normally fates baselines are fates-<FATES TAG>-<CTSM TAG>)
+    derecho ----- OK
+    izumi -------
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes, for FATES tests only
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations:
+    - what platforms/compilers:
+    - nature of change (roundoff; larger than roundoff/same climate; new climate):
+
+
+Other details
+-------------
+List any git submodules updated (cime, rtm, mosart, cism, fates, etc.):
+   fates: sci.1.80.11_api.37.0.0 -> sci.1.81.0_api.37.1.0
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+   https://github.com/ESCOMP/CTSM/pull/2965
+   https://github.com/NGEET/fates/pull/1334
+
+===============================================================
+===============================================================
 Tag name: ctsm5.3.024
 Originator(s): xinchang (Cathy Xinchang Li, U of Illinois - Urbana-Champaign)
 Date: Tue Feb 11 09:56:24 MST 2025

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -59,7 +59,7 @@ Testing summary:
 
   fates tests: (give name of baseline if different from CTSM tagname, normally fates baselines are fates-<FATES TAG>-<CTSM TAG>)
     derecho ----- OK
-    izumi -------
+    izumi ------- OK
 
 Answer changes
 --------------

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name: ctsm5.3.025
 Originator(s): glemieux (Gregory Lemieux, LBNL, glemieux@lbl.gov)
-Date: Tue Feb 18 02:02:34 PM PST 2025
+Date: Thu Feb 20 14:24:45 MST 2025
 One-line Summary: FATES default parameter file update
 
 Purpose and description of changes

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.025 glemieux 02/18/2025 FATES default parameter file update
        ctsm5.3.024 xinchang 02/11/2025 Change choice of pressure in CLMU building energy model
        ctsm5.3.023  afoster 02/08/2025 merge b4b-dev
        ctsm5.3.022 glemieux 02/06/2025 Update FATES namelist build to avoid Meier2022

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-       ctsm5.3.025 glemieux 02/18/2025 FATES default parameter file update
+       ctsm5.3.025 glemieux 02/20/2025 FATES default parameter file update
        ctsm5.3.024 xinchang 02/11/2025 Change choice of pressure in CLMU building energy model
        ctsm5.3.023  afoster 02/08/2025 merge b4b-dev
        ctsm5.3.022 glemieux 02/06/2025 Update FATES namelist build to avoid Meier2022


### PR DESCRIPTION
### Description of changes

This simple PR updates the default fates parameter file as well as the fates tag.

### Specific notes

This parameter file should be coordinated with ngeet/fates#1334 fates pull request.

To do:
- [x] add new default parameter file to svn server
- [x] update fates submodule commit hash to associated fates tag

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Does this create a need to change or add documentation? Did you do so?

Testing performed, if any: regular fates
