### PR TITLE
Remove redundant fates setup includes

### DIFF
--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdHydro/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdHydro/include_user_mods
@@ -1,3 +1,2 @@
 ../Fates
 ../FatesCold
-../FatesSetupParamBuild

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStream/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStream/include_user_mods
@@ -1,3 +1,2 @@
 ../Fates
 ../FatesCold
-../FatesSetupParamBuild

--- a/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStreamNoCompFixedBioGeo/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/clm/FatesColdTwoStreamNoCompFixedBioGeo/include_user_mods
@@ -1,4 +1,3 @@
 ../Fates
 ../FatesCold
 ../FatesColdNoComp
-../FatesSetupParamBuild


### PR DESCRIPTION
### Description of changes

Removed  `../FatesSetupParamBuild` from `nclude_user_mods` where no parameter file changes are needed after #2904 

### Specific notes

Contributors other than yourself, if any:

No

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

No

Any User Interface Changes (namelist or namelist defaults changes)?

No

Does this create a need to change or add documentation? Did you do so?

No

Testing performed, if any:

ERI tests with FatesTwoStream PASS (until compare_baserest) when rebased on master.

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
