### PR TITLE
Get pFUnit-based unit tests working on my Mac

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,13 @@ find_package(ESMF REQUIRED)
 # This adds include directories needed for ESMF
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${ESMF_F90COMPILEPATHS} ")
 # This (which is *not* done in the share CMakeLists.txt) adds all directories and
-# libraries needed when linking ESMF, including any dependencies of ESMF (but it does
-# *not* include the "-lesmf" itself).
+# libraries needed when linking ESMF, including any dependencies of ESMF. (But note that
+# this does *not* include the "-lesmf" itself). In particular, note that this includes any
+# link flags needed to link against PIO, which is needed on some systems (including
+# derecho); bringing in these PIO-related link flags via this ESMF mechanism allows us to
+# avoid explicitly including PIO as a link library, which wouldn't work on systems where
+# there is no separate PIO library and instead ESMF is built with its internal PIO
+# library.
 link_libraries(${ESMF_INTERFACE_LINK_LIBRARIES})
 
 # Add source directories from other share code (csm_share, etc.). This should be
@@ -70,10 +75,10 @@ foreach (sourcefile ${share_sources})
   endif()
 
   # Remove shr_pio_mod from share_sources. This is needed to avoid an explicit dependency
-  # on PIO. It appears that this removal is needed on some systems but not on others: the
-  # unit test build works without this removal on a Mac with a pre-built PIO library, but
-  # I think didn't work on a Mac without a pre-built PIO (where ESMF was built with its
-  # internal PIO).
+  # on PIO. This removal is needed on some systems but not on others: the unit test build
+  # works without this removal on a Mac with a pre-built PIO library, but failed (with
+  # error message, "Cannot open module file 'pio.mod'") on a Mac without a pre-built PIO
+  # (where ESMF was built with its internal PIO).
   string(REGEX MATCH "shr_pio_mod.F90" match_found ${sourcefile})
   if(match_found)
     list(REMOVE_ITEM share_sources ${sourcefile})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,21 +17,6 @@ set(CLM_ROOT "..")
 # NetCDF is required -- because PIO and NetCDF are required by the standard default ESMF libraries
 find_package(NetCDF 4.7.4 REQUIRED Fortran)
 
-# The following - for finding PIO - is copied from the share CMakeLists.txt
-if (DEFINED ENV{PIO_ROOT})
-  message("PIO_ROOT is $ENV{PIO_ROOT}")
-else()
-  if (DEFINED PIO)
-    set(PIO_PATH ${PIO})
-  else()
-    set(PIO_PATH $ENV{PIO})
-  endif()
-  find_package(PIO REQUIRED COMPONENT C Fortran PATH ${PIO_PATH})
-endif()
-# The following line differs a bit from what's in the share CMakeLists.txt
-include_directories(${PIO_Fortran_INCLUDE_DIR})
-link_libraries(${PIO_Fortran_LIBRARIES})
-
 # The following - for finding ESMF - is copied from the share CMakeLists.txt
 if (DEFINED ENV{ESMF_ROOT})
   list(APPEND CMAKE_MODULE_PATH $ENV{ESMF_ROOT}/cmake)
@@ -69,14 +54,25 @@ add_subdirectory(${CLM_ROOT}/src/self_tests clm_self_tests)
 add_subdirectory(unit_test_stubs)
 add_subdirectory(unit_test_shr)
 
-# Remove shr_mpi_mod from share_sources.
-# This is needed because we want to use the mock shr_mpi_mod in place of the real one
+# Remove some things from share_sources
 #
 # TODO: this should be moved into a general-purpose function in Sourcelist_utils.
-# Then this block of code could be replaced with a single call, like:
+# Then each removal could be replaced with a single call, like:
 # remove_source_file(${share_sources} "shr_mpi_mod.F90")
 foreach (sourcefile ${share_sources})
+  # Remove shr_mpi_mod from share_sources.
+  # This is needed because we want to use the mock shr_mpi_mod in place of the real one
   string(REGEX MATCH "shr_mpi_mod.F90" match_found ${sourcefile})
+  if(match_found)
+    list(REMOVE_ITEM share_sources ${sourcefile})
+  endif()
+
+  # Remove shr_pio_mod from share_sources. This is needed to avoid an explicit dependency
+  # on PIO. It appears that this removal is needed on some systems but not on others: the
+  # unit test build works without this removal on a Mac with a pre-built PIO library, but
+  # I think didn't work on a Mac without a pre-built PIO (where ESMF was built with its
+  # internal PIO).
+  string(REGEX MATCH "shr_pio_mod.F90" match_found ${sourcefile})
   if(match_found)
     list(REMOVE_ITEM share_sources ${sourcefile})
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,10 @@ endif()
 find_package(ESMF REQUIRED)
 # This adds include directories needed for ESMF
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${ESMF_F90COMPILEPATHS} ")
-# The following line differs a bit from what's in the share CMakeLists.txt
-link_directories(${ESMF_LIBSDIR})
+# This (which is *not* done in the share CMakeLists.txt) adds all directories and
+# libraries needed when linking ESMF, including any dependencies of ESMF (but it does
+# *not* include the "-lesmf" itself).
+link_libraries(${ESMF_INTERFACE_LINK_LIBRARIES})
 
 # Add source directories from other share code (csm_share, etc.). This should be
 # done first, so that in case of name collisions, the CLM versions take

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CIME_initial_setup)
 
 #list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../tools/mksurfdata_esmf/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../share/cmake")
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../component/cmeps/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../components/cmeps/cmake")
 
 project(clm_tests Fortran C)
 
@@ -14,9 +14,33 @@ include(CIME_utils)
 set(CLM_ROOT "..")
 
 # find needed external packages
-# This is where ESMF could be asked for, but it's already included in the share build brought in below
 # NetCDF is required -- because PIO and NetCDF are required by the standard default ESMF libraries
 find_package(NetCDF 4.7.4 REQUIRED Fortran)
+
+# The following - for finding PIO - is copied from the share CMakeLists.txt
+if (DEFINED ENV{PIO_ROOT})
+  message("PIO_ROOT is $ENV{PIO_ROOT}")
+else()
+  if (DEFINED PIO)
+    set(PIO_PATH ${PIO})
+  else()
+    set(PIO_PATH $ENV{PIO})
+  endif()
+  find_package(PIO REQUIRED COMPONENT C Fortran PATH ${PIO_PATH})
+endif()
+# The following line differs a bit from what's in the share CMakeLists.txt
+include_directories(${PIO_Fortran_INCLUDE_DIR})
+link_libraries(${PIO_Fortran_LIBRARIES})
+
+# The following - for finding ESMF - is copied from the share CMakeLists.txt
+if (DEFINED ENV{ESMF_ROOT})
+  list(APPEND CMAKE_MODULE_PATH $ENV{ESMF_ROOT}/cmake)
+endif()
+find_package(ESMF REQUIRED)
+# This adds include directories needed for ESMF
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${ESMF_F90COMPILEPATHS} ")
+# The following line differs a bit from what's in the share CMakeLists.txt
+link_directories(${ESMF_LIBSDIR})
 
 # Add source directories from other share code (csm_share, etc.). This should be
 # done first, so that in case of name collisions, the CLM versions take
@@ -58,16 +82,8 @@ foreach (sourcefile ${share_sources})
   endif()
 endforeach()
 
-# Bring in PIO, jsut because it's needed for the default ESMF library and included in other submodules like share and cmeps
-if (DEFINED PIO)
-  set(PIO_PATH ${PIO})
-else()
-  set(PIO_PATH $ENV{PIO})
-endif()
-
 # Build libraries containing stuff needed for the unit tests.
 # Eventually, these add_library calls should probably be distributed into the correct location, rather than being in this top-level CMakeLists.txt file.
-# This line of bringing in the share library also brings in ESMF and PIO
 add_library(csm_share ${share_sources} ${drv_sources_needed})
 declare_generated_dependencies(csm_share "${share_genf90_sources}")
 add_library(clm ${clm_sources})
@@ -77,24 +93,13 @@ add_dependencies(clm csm_share esmf)
 # We need to look for header files here, in order to pick up shr_assert.h
 include_directories(${CLM_ROOT}/share/include)
 
-
-# PIO2 library to the include and the linking step
-add_compile_definitions(PIO2)
-
-add_library(pioc STATIC IMPORTED)
-add_library(piof STATIC IMPORTED)
-set_property(TARGET pioc PROPERTY IMPORTED_LOCATION $ENV{PIO}/lib/libpioc.so)
-set_property(TARGET piof PROPERTY IMPORTED_LOCATION $ENV{PIO}/lib/libpiof.so)
-
 # Tell cmake to look for libraries & mod files here, because this is where we built libraries
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories (${ESMF_F90COMPILEPATHS})
-include_directories ($ENV{PIO}/include)
 include_directories (${NETCDF}/include)
 
 # Directories and libraries to include in the link step
 link_directories(${CMAKE_CURRENT_BINARY_DIR})
-link_libraries( pioc piof netcdf )
+link_libraries( netcdf )
 
 # Add the test directories
 # Note: it's possible that these could be added by each source directory that


### PR DESCRIPTION
### Description of changes

With recent versions of CTSM, the unit test build wasn't working on my Mac, and @adrifoster was having the same problem. The problem was that the unit test build wasn't finding the esmf library. I don't understand how this was working on derecho; my best guess is that the modules are adding something needed to the link line that isn't added on a simpler system that doesn't use modules.

This PR explicitly finds ESMF and adds necessary includes and link line flags. This borrows from what's done for the share unit test build, though differs somewhat from that. This also removes some things that are unneeded. It also removes `shr_pio_mod.F90` from the unit test build. I believe that that change (credit to @adrifoster ) allows the unit test build to work in either of two configurations: either with a separately-built PIO library (which is now the recommended configuration for CESM) or without that and instead building ESMF with its internal PIO library (which is the default build for ESMF and is simpler to set up). Some of the other diffs in this PR were also made with that goal of supporting both of these configurations. Thus, PIO isn't referenced directly in the unit test build; instead, if it's needed, it will be picked up via ESMF's link libraries (in the line `link_libraries(${ESMF_INTERFACE_LINK_LIBRARIES})`; note that that line adds some duplicate things to the link line, which results in some warnings, but this doesn't seem to cause any issues).

I have tested this on my Mac (with the current version of https://github.com/billsacks/mac_cime_configuration - `37262a9bca308179e50524d39c9e45e1b205bb18`) and on derecho. Unit tests build in both places. (The first commit on this branch worked on my Mac and on derecho, but not on Adrianna's Mac, where she didn't have a separate PIO library. The second commit worked on my Mac and Adrianna's Mac but not on derecho. The third - and latest - commit works on my Mac and derecho; I'm hopeful it will work for Adrianna, too.)

(I had some related discussion with @ekluzek a few months ago: https://github.com/ESCOMP/CTSM/pull/2853#discussion_r1823145082 . He mentioned needing to remove the find of ESMF from CTSM's unit test build, but things are working for me now that it's back.)

### Specific notes

Contributors other than yourself, if any: @adrifoster 

CTSM Issues Fixed (include github issue #): 
  Fixes #2453

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Does this create a need to change or add documentation? Did you do so? No

Testing performed, if any:
- pFUnit-based unit testing on derecho (using the instructions in `README.unit_testing`)
- pFUnit-based unit testing on my Mac
