### PR TITLE
Avoid mksurfdata_esmf pitfall with --model-mesh-nx, ny

### DIFF
--- a/tools/mksurfdata_esmf/src/mkinputMod.F90
+++ b/tools/mksurfdata_esmf/src/mkinputMod.F90
@@ -342,6 +342,18 @@ contains
        call shr_sys_abort('nglcec must be at least 1')
     end if
 
+    ! Reorder user's mksrf_fgrid_mesh_nx and mksrf_fgrid_mesh_ny for 1D
+    ! cases if they set model-mesh-nx = 1 instead of model-mesh-ny = 1.
+    ! This way the follow-up if-statements works.
+    if (mksrf_fgrid_mesh_nx == 1) then
+       mksrf_fgrid_mesh_nx = mksrf_fgrid_mesh_ny
+       mksrf_fgrid_mesh_ny = 1
+       if (root_task) then
+          write(ndiag,'(a)') 'WARNING: The code reversed your mksrf_fgrid_mesh_nx and mksrf_fgrid_mesh_ny to '
+          write(ndiag,*) 'the expected by the code ', mksrf_fgrid_mesh_nx, mksrf_fgrid_mesh_ny
+       end if
+    end if
+
     if (mksrf_fgrid_mesh_ny == 1) then
        outnc_1d = .true.
        outnc_dims = 1


### PR DESCRIPTION
### Description of changes
Adding a mksurfdata_esmf warning about the code automatically changing the order of user selected --model-mesh-nx, ny when the user has set nx to 1, because the code expects ny set to 1 instead.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Fixes #2847 

Are answers expected to change (and if so in what way)?
No

Any User Interface Changes (namelist or namelist defaults changes)?
A warning in mksurfdata_esmf's .log output

Does this create a need to change or add documentation? Did you do so?
No

Testing performed, if any:
Submitted mksurfdata_esmf both ways as documented in #2847 and got b4b same results. In the case that had to be reversed, the .log file included a warning explaining the situation.