### PR TITLE
Make snow resetting dependent on glacier region

### DIFF
--- a/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -29,6 +29,7 @@ Module HydrologyNoDrainageMod
   use WaterStateBulkType    , only : waterstatebulk_type
   use WaterDiagnosticBulkType    , only : waterdiagnosticbulk_type
   use CanopyStateType   , only : canopystate_type
+  use glcBehaviorMod    , only : glc_behavior_type
   use LandunitType      , only : lun                
   use ColumnType        , only : col                
   use TopoMod, only : topo_type
@@ -141,7 +142,7 @@ contains
        atm2lnd_inst, soilstate_inst, energyflux_inst, temperature_inst, &
        water_inst, &
        soilhydrology_inst, saturated_excess_runoff_inst, infiltration_excess_runoff_inst, &
-       aerosol_inst, canopystate_inst, scf_method, soil_water_retention_curve, topo_inst)
+       aerosol_inst, canopystate_inst, scf_method, soil_water_retention_curve, topo_inst, glc_behavior)
     !
     ! !DESCRIPTION:
     ! This is the main subroutine to execute the calculation of soil/snow
@@ -194,6 +195,7 @@ contains
     class(snow_cover_fraction_base_type), intent(in) :: scf_method
     class(soil_water_retention_curve_type), intent(in) :: soil_water_retention_curve
     class(topo_type)   , intent(in)    :: topo_inst
+    type(glc_behavior_type), intent(in) :: glc_behavior
     !
     ! !LOCAL VARIABLES:
     integer  :: g,l,c,j,fc                    ! indices
@@ -385,7 +387,7 @@ contains
 
       ! Snow capping
       call SnowCapping(bounds, num_nolakec, filter_nolakec, num_snowc, filter_snowc, &
-           topo_inst, aerosol_inst, water_inst)
+           topo_inst, glc_behavior, aerosol_inst, water_inst)
 
       ! Natural compaction and metamorphosis.
       call SnowCompaction(bounds, num_snowc, filter_snowc, &

--- a/src/biogeophys/LakeHydrologyMod.F90
+++ b/src/biogeophys/LakeHydrologyMod.F90
@@ -27,6 +27,7 @@ module LakeHydrologyMod
   use AerosolMod           , only : aerosol_type
   use EnergyFluxType       , only : energyflux_type
   use FrictionVelocityMod  , only : frictionvel_type
+  use glcBehaviorMod       , only : glc_behavior_type
   use LakeStateType        , only : lakestate_type
   use SoilStateType        , only : soilstate_type
   use TemperatureType      , only : temperature_type
@@ -57,7 +58,7 @@ contains
        num_shlakesnowc, filter_shlakesnowc, num_shlakenosnowc, filter_shlakenosnowc, &
        scf_method, water_inst, &
        atm2lnd_inst, temperature_inst, soilstate_inst, &
-       energyflux_inst, aerosol_inst, lakestate_inst, topo_inst)
+       energyflux_inst, aerosol_inst, lakestate_inst, topo_inst, glc_behavior)
     !
     ! !DESCRIPTION:
     ! WARNING: This subroutine assumes lake columns have one and only one pft.
@@ -106,6 +107,7 @@ contains
     type(aerosol_type)     , intent(inout) :: aerosol_inst
     type(lakestate_type)   , intent(inout) :: lakestate_inst
     class(topo_type)   , intent(in)    :: topo_inst
+    type(glc_behavior_type), intent(in)    :: glc_behavior
     !
     ! !LOCAL VARIABLES:
     integer  :: p,fp,g,l,c,j,fc,jtop                            ! indices
@@ -411,7 +413,7 @@ contains
          atm2lnd_inst, aerosol_inst, water_inst)
 
     call SnowCapping(bounds, num_lakec, filter_lakec, num_shlakesnowc, filter_shlakesnowc, &
-         topo_inst, aerosol_inst, water_inst)
+         topo_inst, glc_behavior, aerosol_inst, water_inst)
 
     ! Natural compaction and metamorphosis.
 

--- a/src/main/clm_driver.F90
+++ b/src/main/clm_driver.F90
@@ -902,7 +902,7 @@ contains
             water_inst, soilhydrology_inst, &
             saturated_excess_runoff_inst, &
             infiltration_excess_runoff_inst, &
-            aerosol_inst, canopystate_inst, scf_method, soil_water_retention_curve, topo_inst)
+            aerosol_inst, canopystate_inst, scf_method, soil_water_retention_curve, topo_inst, glc_behavior)
 
        ! The following needs to be done after HydrologyNoDrainage (because it needs
        ! waterfluxbulk_inst%qflx_snwcp_ice_col), but before HydrologyDrainage (because
@@ -944,7 +944,7 @@ contains
             filter(nc)%num_lakenosnowc, filter(nc)%lakenosnowc,                              &
             scf_method, water_inst, &
             atm2lnd_inst, temperature_inst, soilstate_inst, &
-            energyflux_inst, aerosol_inst, lakestate_inst, topo_inst)
+            energyflux_inst, aerosol_inst, lakestate_inst, topo_inst, glc_behavior)
 
        !  Calculate column-integrated aerosol masses, and
        !  mass concentrations for radiative calculations and output

--- a/src/main/glcBehaviorMod.F90
+++ b/src/main/glcBehaviorMod.F90
@@ -84,6 +84,9 @@ module glcBehaviorMod
      ! sent to the river model as ice (a crude parameterization of iceberg calving).
      logical, allocatable, public :: ice_runoff_melted_grc(:)
 
+     ! Whether reset_snow and reset_snow_glc apply to the given grid cell
+     logical, allocatable, public :: do_reset_snow_grc(:)
+
      ! ------------------------------------------------------------------------
      ! Private data
      ! ------------------------------------------------------------------------
@@ -357,6 +360,16 @@ contains
           this%collapse_to_atm_topo_grc(g) = .false.
           this%allow_multiple_columns_grc(g) = .true.
        end if
+
+       ! FIXME:(wjs, 2025-03-27) If we keep this behavior of having reset_snow depend on
+       ! the glacier region, then this should come from a new glacier region behavior
+       ! namelist variable rather than being hard-coded like it currently is
+       if (my_id == 2) then
+          ! Greenland
+          this%do_reset_snow_grc(g) = .true.
+       else
+          this%do_reset_snow_grc(g) = .false.
+       end if
     end do
 
   contains
@@ -562,6 +575,7 @@ contains
     allocate(this%melt_replaced_by_ice_grc(begg:endg)); this%melt_replaced_by_ice_grc(:) = .false.
     allocate(this%collapse_to_atm_topo_grc(begg:endg)); this%collapse_to_atm_topo_grc(:) = .false.
     allocate(this%ice_runoff_melted_grc(begg:endg)); this%ice_runoff_melted_grc(:) = .false.
+    allocate(this%do_reset_snow_grc(begg:endg)); this%do_reset_snow_grc(:) = .false.
 
   end subroutine InitAllocate
 


### PR DESCRIPTION
### Description of changes

For now this is a hack, hard-coded to only do snow resetting over Greenland. If we want this behavior long-term, we should introduce a new glacier region behavior namelist flag controlling this behavior; this would require changes in glcBehaviorMod.F90 in addition to other changes to add the new namelist flag. (The changes in this commit outside of glcBehaviorMod.F90 could remain as they currently are.)

I am opening this as a draft PR to share these changes, because @gustavo-marques wants them for some test runs, and others have asked for a change like this in the past. If there's some desire to have this long-term, then we should add a namelist flag to replace the hard-coded behavior. If there's no desire to have it long-term, then we can close it.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Does this create a need to change or add documentation? Did you do so?

Testing performed, if any:
- SMS_D_Ld3_P8x1.f10_f10_mg37.I2000Clm50BgcCropQianRs.green_gnu.clm-default: passes and bit-for-bit with baseline
- SMS_D_Ld3_P8x1.f10_f10_mg37.I2000Clm50BgcCropQianRs.green_gnu.clm-default with `reset_snow = .true.` and `reset_snow_glc = .true.`: passes; manual inspection of SNOW_DEPTH suggests this new code is working as intended (over Greenland, looks like baseline with these reset_flags, elsewhere looks like baseline without these reset flags)
