### PR TITLE
Added code to make st-archive handle DART files

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -2,9 +2,9 @@
   <comp_archive_spec compname="clm" compclass="lnd">
     <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rh\d?</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>lilac_hi.*\.nc$</hist_file_extension>
-    <hist_file_extension>lilac_atm_driver_h\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>h\d*.*\.nc(\.gz)?$</hist_file_extension>
+    <hist_file_extension>lilac_hi.*\.nc(\.gz)?$</hist_file_extension>
+    <hist_file_extension>lilac_atm_driver_h\d*.*\.nc(\.gz)?$</hist_file_extension>
     <hist_file_extension>e</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
@@ -28,7 +28,7 @@
   <comp_archive_spec compname="ctsm" compclass="lnd">
     <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rh\d?</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>h\d*.*\.nc(\.gz)?$</hist_file_extension>
     <hist_file_extension>e</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>


### PR DESCRIPTION
### Description of changes
Make st_archive handle compressed (.gz) CLM output files.

### Specific notes
This is very helpful for (large multi-instance, multiple short hindcast) data assimilation experiments.
config_archive.xml already handles DART's .e. files.

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): #3082 

Are answers expected to change (and if so in what way)?  No

Any User Interface Changes (namelist or namelist defaults changes)? No

Does this create a need to change or add documentation? Did you do so?  I don't believe so at this time.
Later it may be useful to add documentation about how DART files are archived, to help users find them.

Testing performed, if any:
I ran a B compset built from the tags in .gitmodules, but no development branches checked out.
I ran st_archive on the output to confirm that it handled all files correctly.
I checked out a feature branch based on master, added the code changes, and pushed to the fork
on kdraeder.
See CIME PR [#4788](https://github.com/ESMCI/cime/pull/4788) for details.


