### PR TITLE
Fix #3110 (Initialization of historical using CTSM5.4 surface datasets fails)

### DIFF
--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -3021,6 +3021,14 @@ always fill with the closest natural veg patch / column, regardless of the value
 flag. So interpolation from non-crop to crop cases can be done without setting this flag.
 </entry>
 
+<entry id="init_interp_fill_missing_urban_with_HD" type="logical" category="datasets"
+       group="clm_initinterp_inparm" valid_values="" >
+If FALSE (which is the default): If an output type cannot be found in the input for initInterp,
+code aborts
+If TRUE: If an output type cannot be found in the input, fill with closest urban high density
+(HD) landunit
+</entry>
+
 <entry id="init_interp_method" type="char*64" category="datasets"
        group="clm_initinterp_inparm"
        valid_values="general,use_finidat_areas" >


### PR DESCRIPTION
### Description of changes

If a urban tall building district (TBD)  type is not found in the input restart file and TBD type is required by init_interp, allow the user to specify init_interp_fill_missing_urban_with_HD = .true. in order to fill TBD in the init_interp output file with urban high density (HD), utilizing the init_interp routines.

### Specific notes

Contributors other than yourself, if any: @erik

CTSM Issues Fixed (include github issue #): #3110 

Are answers expected to change (and if so in what way)?  No

Any User Interface Changes (namelist or namelist defaults changes)? Yes

Does this create a need to change or add documentation? Did you do so? Yes. No.

Testing performed, if any:
Nothing yet.