### PR TITLE
Don't build docs for ChangeLog/Sum

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,16 @@ on:
   push:
     paths:
       - 'doc/**'
+      - '!doc/*ChangeLog*'
+      - '!doc/*ChangeSum*'
+      - '!doc/UpdateChangelog.pl'
 
   pull_request:
     paths:
       - 'doc/**'
+      - '!doc/*ChangeLog*'
+      - '!doc/*ChangeSum*'
+      - '!doc/UpdateChangelog.pl'
 
   workflow_dispatch:
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -4,7 +4,7 @@ Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
 Date: Fri 09 May 2025 12:28:17 PM MDT
 One-line Summary: Merge b4b-dev
 
-Purpose and description of changes
+Purpose and description       of changes
 ----------------------------------
 
  Updates to the b4b-dev branch since its last merge to master (PRs #3091 #3092), as shown by git log:

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -4,7 +4,7 @@ Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
 Date: Fri 09 May 2025 12:28:17 PM MDT
 One-line Summary: Merge b4b-dev
 
-Purpose and description       of changes
+Purpose and description of changes
 ----------------------------------
 
  Updates to the b4b-dev branch since its last merge to master (PRs #3091 #3092), as shown by git log:


### PR DESCRIPTION
### Description of changes

Skip the docs.yml workflow if these are the only changed files in `doc/**`:
- `ChangeLog`
- `ChangeSum`
- `UpdateChangelog.pl`

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** As desired, 1daa3b5 didn't trigger docs.yml.