### PR TITLE
Don't run workflows on plain tag creation

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -4,6 +4,7 @@ name: Test building ctsm-docs Docker image and using it to build the docs
 # Configures this workflow to run every time a change in the Docker container setup is pushed or included in a PR
 on:
   push:
+    branches: ['*']
     paths:
       - 'doc/ctsm-docs_container/**'
       - '!doc/ctsm-docs_container/README.md'

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -4,6 +4,7 @@ name: Test building ctsm-docs Docker image and using it to build the docs
 # Configures this workflow to run every time a change in the Docker container setup is pushed or included in a PR
 on:
   push:
+    # Run when a change to these files is pushed to any branch. Without the "branches:" line, for some reason this will be run whenever a tag is pushed, even if the listed files aren't changed.
     branches: ['*']
     paths:
       - 'doc/ctsm-docs_container/**'
@@ -12,6 +13,7 @@ on:
       - '.github/workflows/docker-image-common.yml'
 
   pull_request:
+    # Run on pull requests that change the listed files
     paths:
       - 'doc/ctsm-docs_container/**'
       - '!doc/ctsm-docs_container/README.md'

--- a/.github/workflows/docs-ctsm_pylib.yml
+++ b/.github/workflows/docs-ctsm_pylib.yml
@@ -2,6 +2,7 @@ name: Test building docs with ctsm_pylib
 
 on:
   push:
+    branches: ['*']
     paths:
       - 'python/conda_env_ctsm_py.txt'
 

--- a/.github/workflows/docs-ctsm_pylib.yml
+++ b/.github/workflows/docs-ctsm_pylib.yml
@@ -2,11 +2,13 @@ name: Test building docs with ctsm_pylib
 
 on:
   push:
+    # Run when a change to these files is pushed to any branch. Without the "branches:" line, for some reason this will be run whenever a tag is pushed, even if the listed files aren't changed.
     branches: ['*']
     paths:
       - 'python/conda_env_ctsm_py.txt'
 
   pull_request:
+    # Run on pull requests that change the listed files
     paths:
       - 'python/conda_env_ctsm_py.txt'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Test building docs when they're updated
 
 on:
   push:
+    # Run when a change to these files is pushed to any branch. Without the "branches:" line, for some reason this will be run whenever a tag is pushed, even if the listed files aren't changed.
     branches: ['*']
     paths:
       - 'doc/**'
@@ -11,6 +12,7 @@ on:
       - '!doc/UpdateChangelog.pl'
 
   pull_request:
+    # Run on pull requests that change the listed files
     paths:
       - 'doc/**'
       - '!doc/*ChangeLog*'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Test building docs when they're updated
 
 on:
   push:
+    branches: ['*']
     paths:
       - 'doc/**'
       - '!doc/*ChangeLog*'

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -3,7 +3,11 @@ name: git-fleximod test
 # Test git-fleximod update and cleanliness
 # Based closely on workflow from CESM repo
 #
-on: [push, pull_request]
+on:
+  push:
+    # Run when a change to any is pushed to any branch. Without the "branches:" line, for some reason this will be run whenever a tag is pushed, even if no files are changed.
+    branches: ['*']
+  pull_request:
 
 jobs:
   fleximod-test:

--- a/.github/workflows/formatting_python.yml
+++ b/.github/workflows/formatting_python.yml
@@ -2,6 +2,7 @@ name: Check Python formatting
 
 on:
   push:
+    # Run when a change to these files is pushed to any branch. Without the "branches:" line, for some reason this will be run whenever a tag is pushed, even if the listed files aren't changed.
     branches: ['*']
     paths:
       - 'python/**'
@@ -9,6 +10,7 @@ on:
       - 'cime_config/buildlib/**'
       - 'cime_config/buildnml/**'
   pull_request:
+    # Run on pull requests that change the listed files
     paths:
       - 'python/**'
       - 'cime_config/SystemTests/**'

--- a/.github/workflows/formatting_python.yml
+++ b/.github/workflows/formatting_python.yml
@@ -2,6 +2,7 @@ name: Check Python formatting
 
 on:
   push:
+    branches: ['*']
     paths:
       - 'python/**'
       - 'cime_config/SystemTests/**'


### PR DESCRIPTION
### Description of changes

Some workflows currently run on the push of a new tag, even if there are no changes associated with the tag. This is duplicative, because the workflows will have already run before the tag was created (either due to `push:` or `pull_request:` conditions).

This workflow makes it so that the push of a new tag will not trigger workflows unless it comes with actual changes to files.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:**
- Resolves #3142

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** Tested in a separate repo and it seems to work as expected.