### PR TITLE
ctsm5.3.050: Doc infrastructure and docs: fixes and improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_documentation.md
+++ b/.github/ISSUE_TEMPLATE/03_documentation.md
@@ -5,9 +5,9 @@ about: Something should be added to or fixed in the documentation
 ---
 
 
-### What sort(s) of issue is this?
+### What sort(s) of documentation issue is this?
 - [ ] Something is missing.
-- [ ] Something is (or might be) incorrect.
+- [ ] Something is (or might be) incorrect or outdated.
 - [ ] Something is confusing.
 - [ ] Something is broken.
 

--- a/.github/workflows/docker-image-common.yml
+++ b/.github/workflows/docker-image-common.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Build docs using Docker (Podman has trouble on GitHub runners)
         id: build-docs
         run: |
-          cd doc && ./build_docs -b ${PWD}/_build -c -d --container-cli-tool docker -i $IMAGE_TAG
+          cd doc && ./build_docs -b ${PWD}/_build -c -d -i $IMAGE_TAG
 
 
   check-version:

--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           bin/git-fleximod update -o
           cd doc
-          ./build_docs_to_publish -d --container-cli-tool docker --site-root https://escomp.github.io/CTSM
+          ./build_docs_to_publish -d --site-root https://escomp.github.io/CTSM
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Build docs using Docker (Podman has trouble on GitHub runners)
         id: build-docs
         run: |
-          cd doc && ./build_docs -b ${PWD}/_build -c -d --container-cli-tool docker
+          cd doc && ./build_docs -b ${PWD}/_build -c -d

--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 [submodule "doc-builder"]
 path = doc/doc-builder
 url = https://github.com/ESMCI/doc-builder
-fxtag = v2.2.5
+fxtag = v2.2.6
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 [submodule "doc-builder"]
 path = doc/doc-builder
 url = https://github.com/ESMCI/doc-builder
-fxtag = v2.2.4
+fxtag = v2.2.5
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -123,8 +123,8 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 
 [submodule "doc-builder"]
 path = doc/doc-builder
-url = https://github.com/ESMCI/doc-builder
-fxtag = v2.2.3
+url = https://github.com/samsrabin/doc-builder
+fxtag = f67aa2d63018977b3ec5e7d92f80d2f64319c319
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -123,8 +123,8 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 
 [submodule "doc-builder"]
 path = doc/doc-builder
-url = https://github.com/samsrabin/doc-builder
-fxtag = f67aa2d63018977b3ec5e7d92f80d2f64319c319
+url = https://github.com/ESMCI/doc-builder
+fxtag = v2.2.4
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,123 @@
 ===============================================================
+Tag name: ctsm5.3.050
+Originator(s): samrabin (Sam Rabin)
+Date: Thu May 29 11:26:21 MDT 2025
+One-line Summary: Fix Linux Podman; prefer Linux Docker; update docs docs.
+
+Purpose and description of changes
+----------------------------------
+
+- Fixes Podman builds on Ubuntu (mostly; see ESMCI/doc-builder#27)
+- Docker now preferred on non-Mac systems
+- Improves docs docs
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description):
+- [Issue #3163: Docs docs: Extraneous variable in a command](https://github.com/ESCOMP/CTSM/issues/3163)
+
+Notes of particular relevance for users
+---------------------------------------
+
+User's Guide section on docs updated with new instructions.
+
+
+Notes of particular relevance for developers:
+---------------------------------------------
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+- If you're running doc/testing.sh locally, you'll need both Docker and Podman installed.
+
+
+Testing summary:
+----------------
+
+All required testing happened in GitHub workflows on the PR.
+
+
+Other details
+-------------
+
+List any git submodules updated: doc-builder
+
+Pull Requests that document the changes (include PR ids):
+- [Pull Request #3184: ctsm5.3.050: Doc infrastructure and docs: fixes and improvements by samsrabin](https://github.com/ESCOMP/CTSM/pull/3184)
+
+===============================================================
+===============================================================
+Tag name: ctsm5.3.049
+Originator(s): samrabin (Sam Rabin)
+Date: Tue May 27 12:49:00 MDT 2025
+One-line Summary: Switch docs to use Podman
+
+Purpose and description of changes
+----------------------------------
+
+Updates doc-builder to a version that prefers to use podman instead of docker. Also updates documentation to instruct docs-writers to use Podman instead of Docker, along with some other improvements.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+[Remove any lines that don't apply. Remove entire section if nothing applies.]
+
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+
+Notes of particular relevance for users
+---------------------------------------
+
+User's Guide section on docs updated with new instructions.
+
+
+Testing summary:
+----------------
+
+All required testing happened in GitHub workflows on the PR.
+
+
+Other details
+-------------
+
+List any git submodules updated: doc-builder
+
+Pull Requests that document the changes (include PR ids):
+- [Pull Request #3153: ctsm5.3.049: Preferentially use Podman for ctsm-docs container by samsrabin](https://github.com/ESCOMP/CTSM/pull/3153)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.3.048
 Originator(s): samrabin (Sam Rabin, UCAR/TSS)
 Date: Mon May 26 18:30:59 MDT 2025

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,7 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.050 samrabin 05/29/2025 Fix Linux Podman; prefer Linux Docker; update docs docs.
+       ctsm5.3.049 samrabin 05/27/2025 Switch docs to use Podman
        ctsm5.3.048 samrabin 05/26/2025 Automatically publish docs to this repo
        ctsm5.3.047 samrabin 05/26/2025 Merge b4b-dev to master
        ctsm5.3.046   rgknox 05/26/2025 For FATES set itype to ispval and a few unused variables to nan to help prevent future problems

--- a/doc/ctsm-docs_container/Dockerfile
+++ b/doc/ctsm-docs_container/Dockerfile
@@ -29,4 +29,4 @@ CMD ["/bin/bash", "-l"]
 
 LABEL org.opencontainers.image.title="Container for building CTSM documentation"
 LABEL org.opencontainers.image.source=https://github.com/ESCOMP/CTSM
-LABEL org.opencontainers.image.version="v1.0.2b"
+LABEL org.opencontainers.image.version="v1.0.2c"

--- a/doc/source/users_guide/working-with-documentation/building-docs-multiple-versions.rst
+++ b/doc/source/users_guide/working-with-documentation/building-docs-multiple-versions.rst
@@ -12,6 +12,8 @@ If you'd like to try, this will generate a local site for you in ``_publish/`` a
    :end-before: VERSION LINKS WILL NOT RESOLVE
    :append: open _publish/index.html
 
+**Note:** This is not yet supported with Podman on Linux (including Ubuntu VM on Windows). See `doc-builder Issue #27: build_docs_to_publish fails on Linux (maybe just Ubuntu?) with Podman <https://github.com/ESMCI/doc-builder/issues/27>`_.
+
 
 How this works
 --------------

--- a/doc/source/users_guide/working-with-documentation/building-docs-multiple-versions.rst
+++ b/doc/source/users_guide/working-with-documentation/building-docs-multiple-versions.rst
@@ -5,7 +5,7 @@ Building multiple versions of the documentation
 
 There is a menu in the lower left of the webpage that lets readers switch between different versions of the documentation. To build a website with this menu properly set up—so that all our versions appear and all the links work—you need to use ``docs/build_docs_to_publish`` instead of ``docs/build_docs``.
 
-If you'd like to try, this will generate a local site for you in ``_publish/`` and then open it:
+Note that this is not necessary in order for you to contribute an update to the documentation. GitHub will test this automatically when you open a PR. But if you'd like to try, this will generate a local site for you in ``_publish/`` and then open it:
 
 .. literalinclude:: ../../../testing.sh
    :start-at: ./build_docs_to_publish

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
@@ -12,9 +12,9 @@ To test whether you already have the required Python version, open a Terminal wi
 python3 --version
 ```
 
-If python3 is already set up, you'll see a version number. If that version is 3.7 or later, you should be ready as far as Python goes; continue to :ref:`docs-git-tools`.
+If python3 is already set up, you'll see a version number. If that version is 3.7 or later, you should be ready as far as Python goes; continue to :ref:`additional-reqs`.
 
-If not, recent versions of macOS should print a messsage saying, "xcode-select: No developer tools were found, requesting install." A dialog box will then pop up that says, "The 'python3' command requires the command line developer tools. Would you like to install the tools now?" Press Install and go through the installation process. This will take a while; once it's done, test by doing ``python3 --version`` again. (You may need to open a new Terminal window.) If the printed version number looks good, continue to :ref:`docs-git-tools`.
+If not, recent versions of macOS should print a messsage saying, "xcode-select: No developer tools were found, requesting install." A dialog box will then pop up that says, "The 'python3' command requires the command line developer tools. Would you like to install the tools now?" Press Install and go through the installation process. This will take a while; once it's done, test by doing ``python3 --version`` again. (You may need to open a new Terminal window.) If the printed version number looks good, continue to :ref:`additional-reqs`.
 
 ..
   The paragraph above was tested 2025-04-25 on a fresh-ish installation of macOS 15.3.2.
@@ -32,7 +32,7 @@ echo alias python3="$(which python)" >> ~/.zshrc
 
 This will make it so that bash scripts, like what we use to build our docs, know what to do for `python3`. `python3` will also be available in new Terminal sessions if your shell is `zsh` (the default since macOS 10.15) or `bash`.
 
-If you were able to do this, you can continue to :ref:`docs-git-tools`.
+If you were able to do this, you can continue to :ref:`additional-reqs`.
 
 ### Conda
 If your `python` doesn't exist or is too old, we suggest using Python via Conda. First, check whether you already have Conda installed:
@@ -56,7 +56,7 @@ conda run -n base python3 --version
 
 Repeat with all your Conda environments as needed until you find one that's Python 3.7 or later. Let's say your `ENVNAME` environment works. In that case, just make sure to do `conda activate ENVNAME` before running the commands in the documentation-building instructions.
 
-If you don't have Conda yet, go on to the next section. Otherwise, continue to :ref:`docs-git-tools`.
+If you don't have Conda yet, go on to the next section. Otherwise, continue to :ref:`additional-reqs`.
 
 .. _installing-conda-for-docs:
 
@@ -68,8 +68,9 @@ We suggest installing Conda, if needed, via Miniforge:
 
 You should now have `conda` and an up-to-date version of `python3` available, although will need to open another new Terminal window for it to work.
 
+.. _additional-reqs:
+
 ## Additional requirements
-The remaining software you need to install depends on which documentation-building method(s) you plan to use.
 
 ### Container (recommended)
 We use Podman to build and run our containers. The recommended way to install Podman is with Homebrew. (:ref:`install-homebrew-mac`)

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
@@ -79,13 +79,13 @@ We use Podman to build and run our containers. The recommended way to install Po
 1. Set up and start a Podman "virtual machine" with `podman machine init --now`.
 1. Test your installation by doing `podman run --rm hello-world`. If it worked, you should see ASCII art of the Podman logo.
 
-### Non-container method
+### Non-container method (not recommended)
 
 Install Conda, if needed (see :ref:`installing-conda-for-docs`). Then follow the instructions for setting up the `ctsm_pylib` Conda environment in Sect. :numref:`using-ctsm-pylib`.
 
 .. _docs-git-tools:
 
-## Git tools
+### Git tools
 Note: Do this section after handling Python, because the Python installation process might bring the Git tools with it.
 
 To test whether you have the required Git tools already, open a Terminal window and try the following:

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
@@ -19,7 +19,7 @@ If not, recent versions of macOS should print a messsage saying, "xcode-select: 
 ..
   The paragraph above was tested 2025-04-25 on a fresh-ish installation of macOS 15.3.2.
 
-If instead `python3` gives "command not found," or the version is less than 3.7, you might need to install Python; continue to :ref:`aliasing-python3-to-python`.
+If instead `python3` gives "command not found," or the version is less than 3.7, you might need to install Python; continue to :ref:`aliasing-python3-to-python`. Otherwise, continue to :ref:`additional-reqs`.
 
 .. _aliasing-python3-to-python:
 
@@ -32,41 +32,17 @@ echo alias python3="$(which python)" >> ~/.zshrc
 
 This will make it so that bash scripts, like what we use to build our docs, know what to do for `python3`. `python3` will also be available in new Terminal sessions if your shell is `zsh` (the default since macOS 10.15) or `bash`.
 
-If you were able to do this, you can continue to :ref:`additional-reqs`.
+If you were able to do this, you can continue to :ref:`additional-reqs`. If not, continue to the next section.
 
 ### Conda
-If your `python` doesn't exist or is too old, we suggest using Python via Conda. First, check whether you already have Conda installed:
-```shell
-conda env list
-```
+If your `python` doesn't exist or is too old, we suggest using Python via Conda. First, check whether you already have Conda installed: :ref:`do-i-already-have-conda` If not, install Conda (:ref:`installing-conda-for-docs`), then come back here.
 
-If that shows you something like
-```
-# conda environments:
-#
-base           /Users/you/...
-another_env    /Users/you/.../...
-...
-```
-
-instead of the "command not found" error, then you do have conda installed! (Note that the second column doesn't really matter.) Try this to check the Python version in the `base` Conda environment:
+Try this to check the Python version in the `base` Conda environment:
 ```shell
 conda run -n base python3 --version
 ```
 
 Repeat with all your Conda environments as needed until you find one that's Python 3.7 or later. Let's say your `ENVNAME` environment works. In that case, just make sure to do `conda activate ENVNAME` before running the commands in the documentation-building instructions.
-
-If you don't have Conda yet, go on to the next section. Otherwise, continue to :ref:`additional-reqs`.
-
-.. _installing-conda-for-docs:
-
-### Installing Conda
-We suggest installing Conda, if needed, via Miniforge:
-
-1. [Download Miniforge](https://conda-forge.org/download/) and install it. (:ref:`what-kind-of-mac-chip`) You can also [install Miniforge via Homebrew](https://formulae.brew.sh/cask/miniforge#default), if you already have that installed. (:ref:`install-homebrew-mac`)
-2. Activate Conda permanently in your shell by opening a new Terminal window and doing `conda init "$(basename $SHELL)"`.
-
-You should now have `conda` and an up-to-date version of `python3` available, although will need to open another new Terminal window for it to work.
 
 .. _additional-reqs:
 
@@ -111,3 +87,32 @@ For certain steps in this installation process, you may need to know whether you
 ### How do I install Homebrew?
 1. Install Homebrew using the instructions at https://brew.sh/. Make sure to follow the instructions during this process for adding Homebrew to your path.
 1. Check your installation by making sure that `brew --version` doesn't error.
+
+.. _do-i-already-have-conda:
+
+### Do I already have Conda installed?
+You can check whether you have Conda installed like so:
+```shell
+conda env list
+```
+
+If that shows you something like
+```
+# conda environments:
+#
+base           /Users/you/...
+another_env    /Users/you/.../...
+...
+```
+
+instead of the "command not found" error, then you do have conda installed! (Note that the second column doesn't really matter.) 
+
+.. _installing-conda-for-docs:
+
+### How do I install Conda?
+We suggest installing Conda, if needed, via Miniforge:
+
+1. [Download Miniforge](https://conda-forge.org/download/) and install it. (:ref:`what-kind-of-mac-chip`) You can also [install Miniforge via Homebrew](https://formulae.brew.sh/cask/miniforge#default), if you already have that installed. (:ref:`install-homebrew-mac`)
+2. Activate Conda permanently in your shell by opening a new Terminal window and doing `conda init "$(basename $SHELL)"`.
+
+You should now have `conda` and an up-to-date version of `python3` available, although will need to open another new Terminal window for it to work.

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-mac.md
@@ -48,16 +48,21 @@ Repeat with all your Conda environments as needed until you find one that's Pyth
 
 ## Additional requirements
 
-### Container (recommended)
-We use Podman to build and run our containers. The recommended way to install Podman is with Homebrew. (:ref:`install-homebrew-mac`)
+.. _container-or-conda-mac:
+
+### Container software or Conda environment
+We recommend building the software in what's called a container—basically a tiny little operating system with just some apps and utilities needed by the doc-building process. This is nice because, if we change the doc-building process in ways that require new versions of those apps and utilities, that will be completely invisible to you. You won't need to manually do anything to update your setup to work with the new process; it'll just happen automatically.
+
+We recommend using the container software Podman, which you can install with Homebrew. (:ref:`install-homebrew-mac`)
 
 1. Install Podman with `brew install podman`.
 1. Set up and start a Podman "virtual machine" with `podman machine init --now`.
 1. Test your installation by doing `podman run --rm hello-world`. If it worked, you should see ASCII art of the Podman logo.
 
-### Non-container method (not recommended)
+You may not be able to install Podman or any other containerization software, so there is an alternative method: a Conda environment.
 
-Install Conda, if needed (see :ref:`installing-conda-for-docs`). Then follow the instructions for setting up the `ctsm_pylib` Conda environment in Sect. :numref:`using-ctsm-pylib`.
+1. Install Conda, if needed (see :ref:`installing-conda-for-docs`).
+1. Follow the instructions for setting up the `ctsm_pylib` Conda environment in Sect. :numref:`using-ctsm-pylib`.
 
 .. _docs-git-tools:
 

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-windows.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-windows.md
@@ -8,14 +8,11 @@ Note that you may need administrator privileges on your PC (or approval from you
 
 We don't support building our documentation in the native Windows command-line environment. Thus, you will need to install a little version of Linux to use instead.
 
-The first step is to install Windows Subsystem for Linux (WSL), if you haven't already:
-
-1. Download and install it from the Microsoft Store.
+1. Download and install Ubuntu from the Microsoft Store.
 1. Restart your computer.
+1. Try opening Ubuntu.
 
-Next, download and install Ubuntu (a version of Linux) via the Microsoft Store.
-
-Finally, try opening Ubuntu. If you run into an error, you may need to manually enable WSL. To do so: Open Control Panel, go to "Programs" > "Programs and Features" > "Turn Windows features on or off". Check the box next to "Windows Subsystem for Linux" and click OK.
+If Ubuntu opens in that last step but you see an error, you may need to manually enable Windows Subsystem for Linux (WSL). To do so: Open Control Panel, go to "Programs" > "Programs and Features" > "Turn Windows features on or off". Check the box next to "Windows Subsystem for Linux" and click OK.
 
 ## Podman
 Follow the [installation instructions in the Ubuntu section on Podman's website](https://podman.io/docs/installation#ubuntu), entering the commands into your Ubuntu terminal:

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-windows.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-windows.md
@@ -4,19 +4,58 @@
 
 Note that you may need administrator privileges on your PC (or approval from your IT department) for various steps here.
 
-## Linux subsystem
+.. _install-wsl:
 
-We don't support building our documentation in the native Windows command-line environment. Thus, you will need to install a little version of Linux to use instead.
+## Install Linux subsystem
+
+We don't support building our documentation in the native Windows command-line environment. Thus, you will need to install a little version of Linux inside a virtual machine (VM) to use instead.
 
 1. Download and install Ubuntu from the Microsoft Store.
 1. Restart your computer.
-1. Try opening Ubuntu.
+1. Open Ubuntu.
 
 If Ubuntu opens in that last step but you see an error, you may need to manually enable Windows Subsystem for Linux (WSL). To do so: Open Control Panel, go to "Programs" > "Programs and Features" > "Turn Windows features on or off". Check the box next to "Windows Subsystem for Linux" and click OK.
 
-## Podman
-Follow the [installation instructions in the Ubuntu section on Podman's website](https://podman.io/docs/installation#ubuntu), entering the commands into your Ubuntu terminal:
+## Install utilities
+Enter the following commands **into your Ubuntu terminal** to install any missing utilities we need (the `which ... ||` should make it so that no installation happens if you already have it):
 ```shell
 sudo apt-get update
-sudo apt-get -y install podman
+
+# Podman: The software that will run the container in which the docs are built
+which podman || sudo apt-get -y install podman
+
+# make: Part of the docs-building process
+which make || sudo apt-get -y install make
+
+# git and git-lfs, needed for getting and contributing to the CTSM code and docs
+which git || sudo apt-get -y install git
+which git-lfs || sudo apt-get -y install git-lfs
 ```
+
+## Set up your permissions
+This will make sure that you "own" your home directory in the Ubuntu VM. **In your Ubuntu terminal**, do:
+```shell
+chown -R $USER:$USER $HOME
+```
+
+.. _editing-text-files-wsl:
+
+## Editing text files in an Ubuntu VM
+If you prefer using an old-school text editor like `vim`, it's probably already installed, or can be installed with `sudo apt-get -y install EDITOR_NAME`. If you prefer a more user-friendly interface, there are several options.
+
+You may be able to edit files in your Ubuntu VM in the Ubuntu terminal by using the name of the Windows executable. For Notepad, for instance, you would do 
+```shell
+notepad.exe file_i_want_to_edit.rst
+```
+
+If you use [VS Code](https://code.visualstudio.com/), you can install the [WSL VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl). Then you can open any file or folder in your Ubuntu VM by doing
+```shell
+code path/to/file-or-folder
+```
+
+You can also install a user-friendly text editor in Ubuntu. This may be slower and have unexpected differences in behavior from what you expect from Windows apps, but it does work. For example:
+- [gedit](https://gedit-text-editor.org/): `sudo apt-get install -y gedit`
+- [Kate](https://kate-editor.org/): `sudo apt-get install -y kate`
+- [VS Code](https://code.visualstudio.com/) (if you don't already have it installed on Windows): `sudo snap install code --classic`
+
+You can use all of those to open and edit files, but Kate and VS Code let you open entire folders, which can be convenient. In any case, you'd do `EDITOR_NAME path/to/thing/youre/editing` to open it, where `EDITOR_NAME` is `gedit`, `kate`, or `code`, respectively.

--- a/doc/source/users_guide/working-with-documentation/building-docs-prereqs-windows.md
+++ b/doc/source/users_guide/working-with-documentation/building-docs-prereqs-windows.md
@@ -16,13 +16,13 @@ We don't support building our documentation in the native Windows command-line e
 
 If Ubuntu opens in that last step but you see an error, you may need to manually enable Windows Subsystem for Linux (WSL). To do so: Open Control Panel, go to "Programs" > "Programs and Features" > "Turn Windows features on or off". Check the box next to "Windows Subsystem for Linux" and click OK.
 
+.. _windows-docs-ubuntu-utilities:
+
 ## Install utilities
 Enter the following commands **into your Ubuntu terminal** to install any missing utilities we need (the `which ... ||` should make it so that no installation happens if you already have it):
 ```shell
+# Refresh the list of available software
 sudo apt-get update
-
-# Podman: The software that will run the container in which the docs are built
-which podman || sudo apt-get -y install podman
 
 # make: Part of the docs-building process
 which make || sudo apt-get -y install make
@@ -30,7 +30,29 @@ which make || sudo apt-get -y install make
 # git and git-lfs, needed for getting and contributing to the CTSM code and docs
 which git || sudo apt-get -y install git
 which git-lfs || sudo apt-get -y install git-lfs
+
+# Chromium: A web browser engine that's the basis for popular browsers like Google
+# Chrome and Microsoft Edge
+which chromium || sudo apt-get -y install chromium
 ```
+
+.. _container-or-conda-windows:
+
+## Install container software or Conda environment
+
+We recommend building the software in what's called a container—basically a tiny little operating system with just some apps and utilities needed by the doc-building process. This is nice because, if we change the doc-building process in ways that require new versions of those apps and utilities, that will be completely invisible to you. You won't need to manually do anything to update your setup to work with the new process; it'll just happen automatically.
+
+We recommend using the container software Podman.
+
+1. Install Podman with `sudo apt-get -y install podman`.
+1. Set up and start a Podman "virtual machine" with `podman machine init --now`.
+1. Test your installation by doing `podman run --rm hello-world`. If it worked, you should see ASCII art of the Podman logo.
+
+You may not be able to install Podman or any other containerization software, so there is an alternative method: a Conda environment.
+
+1. Check whether you already have Conda installed by doing `which conda`. If that doesn't print anything, [install Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install#linux).
+1. Follow the instructions for setting up the `ctsm_pylib` Conda environment in Sect. :numref:`using-ctsm-pylib`.
+
 
 ## Set up your permissions
 This will make sure that you "own" your home directory in the Ubuntu VM. **In your Ubuntu terminal**, do:

--- a/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
+++ b/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
@@ -15,22 +15,28 @@ The CTSM documentation is built from files in the `doc/source/tech_note/` and `d
 
 Editing the documentation is as simple as opening the source file for the page you want to edit, then changing text. Make sure to use either reStructuredText or Markdown syntax, depending on the file's extension (.rst or .md, respectively). Note that "opening the source file" isn't completely straightforward on Windows; see :ref:`editing-text-files-wsl`.
 
-If you're confident in your changes, or you're _not_ confident in your ability to preview and test the documentation (see [Building the documentation (recommended method)](#building-the-documentation-recommended-method) below), all you need to do is commit your changes and submit a pull request to the [CTSM GitHub repo](https://github.com/ESCOMP/CTSM). Automated testing will check the updated documentation for any errors, and a CTSM software engineer will review your PR. If everything looks good, they will merge it into the codebase and update the website.
+If you're confident in your changes, or you're _not_ confident in your ability to preview and test the documentation (see [Building the documentation (recommended method)](#building-the-documentation) below), all you need to do is commit your changes and submit a pull request to the [CTSM GitHub repo](https://github.com/ESCOMP/CTSM). Automated testing will check the updated documentation for any errors, and a CTSM software engineer will review your PR. If everything looks good, they will merge it into the codebase and update the website.
 
-.. _building-the-documentation-recommended-method:
+.. _building-the-documentation:
 
-## Building the documentation (recommended method)
+## Building the documentation
 We strongly suggest building the documentation on your personal computer before submitting a pull request, so that you can preview what your changes will look like. The recommended way to do this is using the `doc-builder` tool in conjunction with a "containerized" version of some required software.
 
 ### Directories
-You will need a place to build the documentation. It's fine if that doesn't exist; the build tool will make it for you. The only restriction is that, at least for the recommended method described here, **your build directory must be somewhere in your CTSM clone**. (We recommend starting the name of your build directory with `_build` because CTSM knows to ignore such directories when it comes to `git`.) The instructions here assume you want to do your build in `/path/to/ctsm_clone/_build/`.
+You will need a place to build the documentation. It's fine if that doesn't exist; the build tool will make it for you. The only restriction is that, at least for the recommended method described here, **your build directory must be somewhere in your CTSM clone**. (We recommend starting the name of your build directory with `_build` because CTSM knows to ignore such directories when it comes to `git`.) The instructions here assume you want to do your build in `doc/_build/`.
 
-### Building a preview
-All you need to do is
+### Building the docs
+All you need to do to build the docs with our recommended method is
 ```shell
 cd doc
-./build_docs -b /path/to/ctsm_clone/_build -c -d
+./build_docs -b _build -c -d
 ```
+
+This runs a complicated series of scripts and software that culminate in something called Sphinx converting the .rst and .md files into HTML webpages.
+
+The `-c` means "do a clean build." If you leave it off, Sphinx will only rebuild files it thinks have changed since the last time you built the docs. It's not always right, which can lead to problems. If you get unexpected errors without `-c`, rerunning with `-c` is the first troubleshooting step.
+
+The `-d` means "run using the container." If you're not using the container and are instead using the `ctsm_pylib` Conda environment **(not recommended)**, leave off `-d`, and make sure you've activated `ctsm_pylib` before running the above command. See the "Container software or Conda environment" sections for :ref:`Mac <container-or-conda-mac>` or :ref:`Windows <container-or-conda-windows>` for more information on these two methods.
 
 (Do `./build_docs --help` for more information and options.)
 

--- a/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
+++ b/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
@@ -21,19 +21,17 @@ If you're confident in your changes, or you're _not_ confident in your ability t
 We strongly suggest building the documentation on your personal computer before submitting a pull request, so that you can preview what your changes will look like. The recommended way to do this is using the `doc-builder` tool in conjunction with a "containerized" version of some required software.
 
 ### Directories
-You will need a place to build the documentation. It's fine if that doesn't exist; the build tool will make it for you. The only restriction is that, at least for the recommended method described here, **your build directory must be somewhere in your user home directory**, which we represent as `$HOME`. The instructions here assume you want to do your build in `$HOME/path/to/build-dir/`.
-
-Your CTSM clone, from which you're building the documentation, also needs to be somewhere in your user home directory.
+You will need a place to build the documentation. It's fine if that doesn't exist; the build tool will make it for you. The only restriction is that, at least for the recommended method described here, **your build directory must be somewhere in your CTSM clone**. (We recommend starting the name of your build directory with `_build` because CTSM knows to ignore such directories when it comes to `git`.) The instructions here assume you want to do your build in `/path/to/ctsm_clone/_build/`.
 
 ### Building a preview
 All you need to do is
 ```shell
 cd doc
-./build_docs -b $HOME/path/to/build-dir -c -d
+./build_docs -b /path/to/ctsm_clone/_build -c -d
 ```
 
 (Do `./build_docs --help` for more information and options.)
 
-You can then open the documentation in a web browser by browsing to `$HOME/path/to/build-dir/html/` and opening `index.html`.
+You can then open the documentation in a web browser by browsing to `/path/to/ctsm_clone/_build/` and opening `index.html`.
 
 Note that there is a menu in the lower left of the webpage that lets readers switch between different versions of the documentation. The links to versions in this menu will not work when using the build command given above. If you wish to preview this version switching functionality, or you're building the docs in the process of actually updating the website, see :ref:`building-docs-multiple-versions`.

--- a/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
+++ b/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
@@ -50,13 +50,13 @@ The process for viewing your build in a web browser differs depending on what ki
 
 You can open your build of the documentation in your default browser with
 ```shell
-open _build/index.html
+open _build/html/index.html
 ```
 
 ### Windows (Ubuntu VM)
 
 Assuming you installed Chromium in the :ref:`windows-docs-ubuntu-utilities` setup step, you can open your build of the documentation like so:
 ```shell
-chromium _build/index.html &
+chromium _build/html/index.html &
 ```
 This will generate a lot of warnings in the terminal that seem to be inconsequential to our purpose here. You may need to press Ctrl-C and/or Enter a few times to clear them and return your cursor to the prompt.

--- a/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
+++ b/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
@@ -4,14 +4,16 @@
 .. _editing-the-documentation:
 
 ## One-time setup
-In addition to a CTSM checkout in which to work, you will need to have some software installed in order to build the documentation:
+You will need to have some software installed on your computer in order to build and the documentation and view the results:
 - :ref:`building-docs-prereqs-mac`
 - :ref:`building-docs-prereqs-windows`
 
 ## Editing the documentation
+First, you will need a clone of CTSM to get all the documentation files and infrastructure. (If you're on Windows, you will make this clone in your :ref:`Ubuntu VM <install-wsl>`.) Note that you will clone this to your own computer, not Derecho or any cluster or anything.
+
 The CTSM documentation is built from files in the `doc/source/tech_note/` and `doc/source/users_guide/` directories. These files are written in a mixture of what are called "markup languages." You may already be familiar—for better or for worse—with the LaTeX markup language. Fortunately, our documentation is simpler than that. It was originally written entirely in [reStructuredText](http://www.sphinx-doc.org/en/stable/rest.html), and it still mostly is, as you can tell by the predominance of .rst files. However, it's also possible to write Markdown documents (.md), which is nice because it's a much simpler and more widespread format (although see :ref:`tips-for-working-with-markdown`). If you've formatted text on GitHub, for instance, you've used Markdown.
 
-Editing the documentation is as simple as opening the source file for the page you want to edit, then changing text. Make sure to use either reStructuredText or Markdown syntax, depending on the file's extension (.rst or .md, respectively).
+Editing the documentation is as simple as opening the source file for the page you want to edit, then changing text. Make sure to use either reStructuredText or Markdown syntax, depending on the file's extension (.rst or .md, respectively). Note that "opening the source file" isn't completely straightforward on Windows; see :ref:`editing-text-files-wsl`.
 
 If you're confident in your changes, or you're _not_ confident in your ability to preview and test the documentation (see [Building the documentation (recommended method)](#building-the-documentation-recommended-method) below), all you need to do is commit your changes and submit a pull request to the [CTSM GitHub repo](https://github.com/ESCOMP/CTSM). Automated testing will check the updated documentation for any errors, and a CTSM software engineer will review your PR. If everything looks good, they will merge it into the codebase and update the website.
 

--- a/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
+++ b/doc/source/users_guide/working-with-documentation/docs-intro-and-recommended.md
@@ -40,6 +40,23 @@ The `-d` means "run using the container." If you're not using the container and 
 
 (Do `./build_docs --help` for more information and options.)
 
-You can then open the documentation in a web browser by browsing to `/path/to/ctsm_clone/_build/` and opening `index.html`.
+## Viewing your built docs
 
-Note that there is a menu in the lower left of the webpage that lets readers switch between different versions of the documentation. The links to versions in this menu will not work when using the build command given above. If you wish to preview this version switching functionality, or you're building the docs in the process of actually updating the website, see :ref:`building-docs-multiple-versions`.
+Note that there is a menu in the lower left of the webpage that lets readers switch between different versions of the documentation. The links to versions in this menu will not work when using the build command given above. If you wish to preview this version switching functionality, see :ref:`building-docs-multiple-versions`.
+
+The process for viewing your build in a web browser differs depending on what kind of computer you have.
+
+### Mac
+
+You can open your build of the documentation in your default browser with
+```shell
+open _build/index.html
+```
+
+### Windows (Ubuntu VM)
+
+Assuming you installed Chromium in the :ref:`windows-docs-ubuntu-utilities` setup step, you can open your build of the documentation like so:
+```shell
+chromium _build/index.html &
+```
+This will generate a lot of warnings in the terminal that seem to be inconsequential to our purpose here. You may need to press Ctrl-C and/or Enter a few times to clear them and return your cursor to the prompt.

--- a/doc/testing.sh
+++ b/doc/testing.sh
@@ -9,7 +9,7 @@ echo "~~~~~ Build all docs using container"
 # Also do a custom --conf-py-path
 rm -rf _build _publish
 d1="$PWD/_publish_container"
-./build_docs_to_publish -r _build -d --site-root "$PWD/_publish" ${containercli}
+./build_docs_to_publish -r _build -d --site-root "$PWD/_publish"
 # VERSION LINKS WILL NOT RESOLVE IN _publish_container
 cp -a _publish "${d1}"
 
@@ -26,10 +26,10 @@ echo "~~~~~ Make sure container version is identical to no-container version"
 diff -qr "${d1}" "${d2}"
 
 # Check that -r -v works
-echo "~~~~~ Check that -r -v works"
+echo "~~~~~ Check that -r -v works (Docker)"
 # Also do a custom --conf-py-path
 rm -rf _build_container
-./build_docs -r _build_container -v latest -d ${containercli} -c --conf-py-path doc-builder/test/conf.py --static-path ../_static --templates-path ../_templates
+./build_docs -r _build_container -v latest -d -c --conf-py-path doc-builder/test/conf.py --static-path ../_static --templates-path ../_templates --container-cli-tool docker
 
 # Check that Makefile method works
 echo "~~~~~ Check that Makefile method works"
@@ -37,9 +37,9 @@ rm -rf _build
 make SPHINXOPTS="-W --keep-going" BUILDDIR=${PWD}/_build html
 
 # Check that -b works
-echo "~~~~~ Check that -b works"
+echo "~~~~~ Check that -b works (Podman)"
 rm -rf _build_container
-./build_docs -b _build_container -d ${containercli} -c
+./build_docs -b _build_container -d -c --container-cli-tool docker
 
 # Check that doc-builder tests pass
 # Don't run if on a GitHub runner; failing 🤷. Trust that doc-builder does this test.

--- a/doc/testing.sh
+++ b/doc/testing.sh
@@ -4,11 +4,6 @@ set -x
 
 rm -rf _publish*
 
-# For some reason, Podman has trouble on GH Actions runners, so force use of Docker
-if [[ "${GITHUB_ACTIONS}" != "" ]]; then
-    containercli="--container-cli-tool docker"
-fi
-
 # Build all docs using container
 echo "~~~~~ Build all docs using container"
 # Also do a custom --conf-py-path


### PR DESCRIPTION
### Description of changes
- Fixes Podman builds on Ubuntu (mostly; see ESMCI/doc-builder#27)
- Docker now preferred on non-Mac systems
- Improves docs docs

### Specific notes

**Contributors other than yourself, if any:** @slevis-lmwg and @katierocci for Windows testing!

**CTSM Issues Fixed:**
- Resolves #3163

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** Yes

**Testing performed, if any:** See checks on this PR.