### PR TITLE
ctsm5.3.055: Remove broken FTorch submodule

### DIFF
--- a/.github/workflows/docs-omnibus.yml
+++ b/.github/workflows/docs-omnibus.yml
@@ -51,4 +51,4 @@ jobs:
       # TODO: Split testing.sh tests into their own steps in this job
       - name: Text Sphinx builds with omnibus script
         run: |
-          cd doc && conda run -n ctsm_pylib ./testing.sh
+          cd doc && ./testing.sh

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -32,4 +32,4 @@ jobs:
           echo
           echo "Checking if git fleximod matches expected externals"
           echo
-          git diff --exit-code
+          git add . && git diff --quiet && git diff --cached --quiet

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -32,4 +32,4 @@ jobs:
           echo
           echo "Checking if git fleximod matches expected externals"
           echo
-          git add . && git diff --quiet && git diff --cached --quiet
+          git add . && git diff --exit-code && git diff --cached --exit-code

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
       - id: run-fleximod
         run: |
-          $GITHUB_WORKSPACE/bin/git-fleximod update
+          $GITHUB_WORKSPACE/bin/git-fleximod update -o
           echo
           echo "Update complete, checking status"
           echo

--- a/.gitmodules
+++ b/.gitmodules
@@ -128,13 +128,3 @@ fxtag = v2.2.6
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder
-
-# FTorch is an optional library useful for AI and Machine Learning
-# In order to use it -- it must be checked out with git-fleximod
-[submodule "FTorch"]
-path = libraries/FTorch
-url = https://github.com/ESCOMP/FTorch_interface
-fxtag = v0.0.5
-fxrequired = ToplevelOptional
-# Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
-fxDONOTUSEurl = https://github.com/ESCOMP/FTorch_interface

--- a/.gitmodules
+++ b/.gitmodules
@@ -84,7 +84,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/cime
 [submodule "cmeps"]
 path = components/cmeps
 url = https://github.com/ESCOMP/CMEPS.git
-fxtag = cmeps1.0.48
+fxtag = cmeps1.0.51
 fxrequired = ToplevelRequired
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESCOMP/CMEPS.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -84,7 +84,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/cime
 [submodule "cmeps"]
 path = components/cmeps
 url = https://github.com/ESCOMP/CMEPS.git
-fxtag = cmeps1.0.51
+fxtag = cmeps1.0.48
 fxrequired = ToplevelRequired
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESCOMP/CMEPS.git

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,58 @@
 ===============================================================
+Tag name: ctsm5.3.055
+Originator(s): samrabin (Sam Rabin, UCAR/TSS)
+Date: Thu Jun  5 13:59:20 MDT 2025
+One-line Summary: Remove FTorch
+
+Purpose and description of changes
+----------------------------------
+
+Incorrect CMEPS version causes a build failure.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+
+List of CTSM issues fixed (include CTSM Issue # and description):
+- [Issue #3210: build-and-deploy failure at ctsm5.3.053](https://github.com/ESCOMP/CTSM/issues/3210)
+- [Issue #3214: Build fails with FTorch checked out](https://github.com/ESCOMP/CTSM/issues/3214)
+
+
+Testing summary:
+----------------
+
+Model now builds successfully on Izumi with all optional submodules checked out.
+
+
+Other details
+-------------
+[Remove any lines that don't apply. Remove entire section if nothing applies.]
+
+List any git submodules updated (cime, rtm, mosart, cism, fates, etc.):
+- FTorch removed
+
+Pull Requests that document the changes (include PR ids):
+- [Pull Request #3211: ctsm5.3.055: Remove broken FTorch submodule by samsrabin](https://github.com/ESCOMP/CTSM/pull/3211)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.3.054
 Originator(s): samrabin (Sam Rabin, UCAR/TSS)
 Date: Mon Jun  2 11:39:50 MDT 2025

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.055 samrabin 06/05/2025 Remove FTorch
        ctsm5.3.054 samrabin 06/02/2025 CDEPS: Allow anomaly forcings with any DATM
        ctsm5.3.053 samrabin 05/30/2025 Fix and improve anomaly forcings for ISSP cases
        ctsm5.3.052     erik 05/30/2025 Changes to MEGAN needed for coupled cases

--- a/doc/testing.sh
+++ b/doc/testing.sh
@@ -38,7 +38,7 @@ rm -rf _build_container
 # Check that Makefile method works
 echo "~~~~~ Check that Makefile method works"
 rm -rf _build
-make SPHINXOPTS="-W --keep-going" BUILDDIR=${PWD}/_build html
+conda run -n ctsm_pylib make SPHINXOPTS="-W --keep-going" BUILDDIR=${PWD}/_build html
 
 # Check that -b works
 echo "~~~~~ Check that -b works (Podman)"

--- a/doc/testing.sh
+++ b/doc/testing.sh
@@ -2,6 +2,10 @@
 set -e
 set -x
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "${SCRIPT_DIR}"
+
+../bin/git-fleximod update -o
 rm -rf _publish*
 
 # Build all docs using container


### PR DESCRIPTION
### Description of changes

As of ctsm5.3.051 (#3125), `bin/git-fleximod checkout -o` [results in an unclean state](https://github.com/ESCOMP/CTSM/issues/3210#issuecomment-2925808249), which [prevents the documentation from deploying](https://github.com/ESCOMP/CTSM/actions/runs/15365441594/job/43237738393). This PR resolves the issue. It also edits a couple of GitHub workflows to catch such problems in the future.

Additionally, ctsm5.3.051 did not bring in the version of CMEPS required for FTorch to build properly—see #3214. Fixing it is going to be a big task, so for now we're just removing it. Issue to add it back: #3228

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:**
- Resolves #3210
- Resolves #3214

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** GitHub workflows, plus:
- [x] `SMS_D.f10_f10_mg37.I2000Clm60BgcCrop.izumi_nag.clm-crop` to check build