### PR TITLE
[WIP] subset_data: Fix conversion of Longitude to string

### DIFF
--- a/python/ctsm/longitude.py
+++ b/python/ctsm/longitude.py
@@ -177,6 +177,13 @@ class Longitude:
         self._check_lons_same_type(other)
         return self._lon >= other._lon
 
+    def __str__(self):
+        """
+        We don't allow implicit string conversion because the user should always specify the
+        Longitude type they want
+        """
+        raise NotImplementedError("Use Longitude.get_str() instead of implicit string conversion")
+
     def get(self, lon_type_out):
         """
         Get the longitude value, converting longitude type if needed
@@ -188,6 +195,14 @@ class Longitude:
         if lon_type_out == 360:
             return _convert_lon_type_180_to_360(self._lon)
         raise RuntimeError(f"Add handling for lon_type_out {lon_type_out}")
+
+    def get_str(self, lon_type_out):
+        """
+        Get the longitude value as a string, converting longitude type if needed
+        """
+        lon_out = self.get(lon_type_out)
+        # Use float() because the standard in CTSM filenames is to put .0 after whole-number values
+        return str(float(lon_out))
 
     def lon_type(self):
         """

--- a/python/ctsm/site_and_regional/regional_case.py
+++ b/python/ctsm/site_and_regional/regional_case.py
@@ -160,6 +160,20 @@ class RegionalCase(BaseCase):
         f_out = f_in.isel({y_dim: yind, x_dim: xind})
         return f_out
 
+    def _get_lon_strings(self):
+        """
+        Get the string versions of the region's longitudes
+        """
+        if isinstance(self.lon1, Longitude):
+            lon1_str = self.lon1.get_str(self.lon1.lon_type())
+        else:
+            lon1_str = str(self.lon1)
+        if isinstance(self.lon2, Longitude):
+            lon2_str = self.lon2.get_str(self.lon2.lon_type())
+        else:
+            lon2_str = str(self.lon2)
+        return lon1_str, lon2_str
+
     def create_tag(self):
         """
         Create a tag for a region which is either the region name
@@ -169,9 +183,8 @@ class RegionalCase(BaseCase):
         if self.reg_name:
             self.tag = self.reg_name
         else:
-            self.tag = "{}-{}_{}-{}".format(
-                str(self.lon1), str(self.lon2), str(self.lat1), str(self.lat2)
-            )
+            lon1_str, lon2_str = self._get_lon_strings()
+            self.tag = "{}-{}_{}-{}".format(lon1_str, lon2_str, str(self.lat1), str(self.lat2))
 
     def check_region_bounds(self):
         """
@@ -179,10 +192,11 @@ class RegionalCase(BaseCase):
         """
         # If you're calling this, lat/lon bounds need to have been provided
         if any(x is None for x in [self.lon1, self.lon2, self.lat1, self.lat2]):
+            lon1_str, lon2_str = self._get_lon_strings()
             raise argparse.ArgumentTypeError(
                 "Latitude and longitude bounds must be provided and not None.\n"
-                + f"   lon1: {self.lon1}\n"
-                + f"   lon2: {self.lon2}\n"
+                + f"   lon1: {lon1_str}\n"
+                + f"   lon2: {lon2_str}\n"
                 + f"   lat1: {self.lat1}\n"
                 + f"   lat2: {self.lat2}"
             )

--- a/python/ctsm/site_and_regional/single_point_case.py
+++ b/python/ctsm/site_and_regional/single_point_case.py
@@ -159,9 +159,12 @@ class SinglePointCase(BaseCase):
             plon_orig = plon_in.get(plon_type)
             plon_out = plon_in.get(f_lon_type)
             if plon_orig != plon_out:
-                print(
-                    f"Converted plon from type {plon_type} (value {plon_orig}) "
-                    f"to type {f_lon_type} (value {plon_out})"
+                logger.info(
+                    "Converted plon from type %s (value %f) to type %s (value %f)",
+                    plon_type,
+                    plon_orig,
+                    f_lon_type,
+                    plon_out,
                 )
         return plon_out
 

--- a/python/ctsm/site_and_regional/single_point_case.py
+++ b/python/ctsm/site_and_regional/single_point_case.py
@@ -176,7 +176,7 @@ class SinglePointCase(BaseCase):
         if self.site_name:
             self.tag = self.site_name
         else:
-            self.tag = "{}_{}".format(str(self.plon), str(self.plat))
+            self.tag = "{}_{}".format(self.plon.get_str(self.plon.lon_type()), str(self.plat))
 
     def check_dom_pft(self):
         """
@@ -336,7 +336,11 @@ class SinglePointCase(BaseCase):
         Create domain file for this SinglePointCase class.
         """
         logger.info("----------------------------------------------------------------------")
-        logger.info("Creating domain file at %s, %s.", str(self.plon), str(self.plat))
+        logger.info(
+            "Creating domain file at %s, %s.",
+            self.plon.get_str(self.plon.lon_type()),
+            str(self.plat),
+        )
 
         # specify files
         fdomain_in = os.path.join(indir, file)
@@ -370,7 +374,7 @@ class SinglePointCase(BaseCase):
         logger.info("----------------------------------------------------------------------")
         logger.info(
             "Creating land use file at %s, %s.",
-            str(self.plon),
+            self.plon.get_str(self.plon.lon_type()),
             str(self.plat),
         )
 
@@ -505,7 +509,7 @@ class SinglePointCase(BaseCase):
         logger.info("----------------------------------------------------------------------")
         logger.info(
             "Creating surface dataset file at %s, %s",
-            str(self.plon),
+            self.plon.get_str(self.plon.lon_type()),
             str(self.plat),
         )
 
@@ -580,7 +584,7 @@ class SinglePointCase(BaseCase):
         logger.info("----------------------------------------------------------------------")
         logger.info(
             "Creating DATM domain file at %s, %s",
-            str(self.plon),
+            self.plon.get_str(self.plon.lon_type()),
             str(self.plat),
         )
 
@@ -649,7 +653,9 @@ class SinglePointCase(BaseCase):
         with open(file, "w") as nl_file:
             self.write_to_file("# Change below line if you move the subset data directory", nl_file)
             self.write_to_file("./xmlchange {}={}".format(USRDAT_DIR, self.out_dir), nl_file)
-            self.write_to_file("./xmlchange PTS_LON={}".format(str(self.plon)), nl_file)
+            self.write_to_file(
+                "./xmlchange PTS_LON={}".format(self.plon.get_str(self.plon.lon_type())), nl_file
+            )
             self.write_to_file("./xmlchange PTS_LAT={}".format(str(self.plat)), nl_file)
             self.write_to_file("./xmlchange MPILIB=mpi-serial", nl_file)
             if self.create_datm:
@@ -675,7 +681,9 @@ class SinglePointCase(BaseCase):
         Create all of a DATM dataset at a point.
         """
         logger.info("----------------------------------------------------------------------")
-        logger.info("Creating DATM files at %s, %s", str(self.plon), str(self.plat))
+        logger.info(
+            "Creating DATM files at %s, %s", self.plon.get_str(self.plon.lon_type()), str(self.plat)
+        )
 
         # --  create data files
         infile = []

--- a/python/ctsm/subset_data.py
+++ b/python/ctsm/subset_data.py
@@ -822,7 +822,7 @@ def subset_region(args, file_dict: dict):
         print("\nFor running this regional case with the created user_mods : ")
         print(
             "./create_newcase --case case --res CLM_USRDAT --compset I2000Clm60BgcCrop",
-            "--run-unsupported --user-mods-dirs ",
+            "--run-unsupported --user-mods-dir ",
             args.user_mods_dir,
             "\n\n",
         )

--- a/python/ctsm/test/test_sys_subset_data.py
+++ b/python/ctsm/test/test_sys_subset_data.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import inspect
 import xarray as xr
+from CIME.scripts.create_newcase import _main_func as create_newcase # pylint: disable=import-error
 
 # -- add python/ctsm  to path (needed if we want to run the test stand-alone)
 _CTSM_PYTHON = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir)
@@ -40,13 +41,35 @@ class TestSubsetDataSys(unittest.TestCase):
     """
 
     def setUp(self):
+        self.previous_dir = os.getcwd()
         self.temp_dir_out = tempfile.TemporaryDirectory()
         self.temp_dir_umd = tempfile.TemporaryDirectory()
+        self.temp_dir_caseparent = tempfile.TemporaryDirectory()
         self.inputdata_dir = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
 
     def tearDown(self):
         self.temp_dir_out.cleanup()
         self.temp_dir_umd.cleanup()
+        os.chdir(self.previous_dir)
+
+    def _check_create_newcase(self):
+        """
+        Check that you can call create_newcase using the usermods from subset_data
+        """
+        case_dir = os.path.join(self.temp_dir_caseparent.name, "case")
+        sys.argv = [
+            "create_newcase",
+            "--case",
+            case_dir,
+            "--res",
+            "CLM_USRDAT",
+            "--compset",
+            "I2000Clm60Bgc",
+            "--run-unsupported",
+            "--user-mods-dir",
+            self.temp_dir_umd.name,
+        ]
+        create_newcase()
 
     def _check_result_file_matches_expected(self, expected_output_files, caller_n):
         """
@@ -167,15 +190,21 @@ class TestSubsetDataSys(unittest.TestCase):
         ]
         self.assertTrue(self._check_result_file_matches_expected(expected_output_files, 2))
 
+        # Check that create_newcase works
+        # SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
+        self._check_create_newcase()
+
     def test_subset_data_reg_amazon(self):
         """
         Test subset_data for Amazon region
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_reg_amazon()
 
     def test_subset_data_reg_amazon_noregname(self):
         """
         Test subset_data for Amazon region
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_reg_amazon(include_regname=False)
 
@@ -298,15 +327,21 @@ class TestSubsetDataSys(unittest.TestCase):
         ]
         self.assertTrue(self._check_result_file_matches_expected(expected_output_files, 2))
 
+        # Check that create_newcase works
+        # SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
+        self._check_create_newcase()
+
     def test_subset_data_pt_surface_amazon_type360(self):
         """
         Test subset_data --create-surface for Amazon point with longitude type 360
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_pt_surface(291)
 
     def test_subset_data_pt_surface_amazon_type180(self):
         """
         Test subset_data --create-surface for Amazon point with longitude type 180
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_pt_surface(-69)
 
@@ -314,6 +349,7 @@ class TestSubsetDataSys(unittest.TestCase):
         """
         Test subset_data --create-surface for Amazon point with longitude type 180
         without specifying a site name
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_pt_surface(-69, include_sitename=False)
 
@@ -367,21 +403,28 @@ class TestSubsetDataSys(unittest.TestCase):
         ]
         self.assertTrue(self._check_result_file_matches_expected(expected_output_files, 2))
 
+        # Check that create_newcase works
+        # SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
+        self._check_create_newcase()
+
     def test_subset_data_pt_landuse_amazon_type360(self):
         """
         Test subset_data --create-landuse for Amazon point with longitude type 360
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_pt_landuse(291)
 
     def test_subset_data_pt_landuse_amazon_type360_nositename(self):
         """
         Test subset_data --create-landuse for Amazon point with longitude type 360 and no site name
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_pt_landuse(291, include_sitename=False)
 
     def test_subset_data_pt_landuse_amazon_type180(self):
         """
         Test subset_data --create-landuse for Amazon point with longitude type 180
+        SHOULD WORK ONLY ON CESM-SUPPORTED MACHINES
         """
         self._do_test_subset_data_pt_landuse(-69)
 
@@ -430,6 +473,9 @@ class TestSubsetDataSys(unittest.TestCase):
                 )
         expected_output_files = [os.path.join("datmdata", x) for x in expected_output_files]
         self.assertTrue(self._check_result_file_matches_expected(expected_output_files, 2))
+
+        # Check that create_newcase works
+        self._check_create_newcase()
 
     def test_subset_data_pt_datm_amazon_type360(self):
         """

--- a/python/ctsm/test/test_unit_longitude.py
+++ b/python/ctsm/test/test_unit_longitude.py
@@ -446,6 +446,27 @@ class TestLongitude(unittest.TestCase):
         lon = Longitude(55, 180)
         self.assertEqual(lon.lon_type(), 180)
 
+    def test_no_implicit_string_conversion(self):
+        """Ensure that implicit string conversion is disallowed"""
+        lon = Longitude(55, 180)
+        with self.assertRaisesRegex(
+            NotImplementedError, r"Use Longitude\.get_str\(\) instead of implicit string conversion"
+        ):
+            _ = f"{lon}"
+        with self.assertRaisesRegex(
+            NotImplementedError, r"Use Longitude\.get_str\(\) instead of implicit string conversion"
+        ):
+            _ = str(lon)
+
+    def test_get_str(self):
+        """Ensure that explicit string conversion works as expected"""
+        lon = Longitude(55, 180)
+        self.assertEqual(lon.get_str(180), "55.0")
+        self.assertEqual(lon.get_str(360), "55.0")
+        lon = Longitude(-55, 180)
+        self.assertEqual(lon.get_str(180), "-55.0")
+        self.assertEqual(lon.get_str(360), "305.0")
+
 
 if __name__ == "__main__":
     unit_testing.setup_for_tests()

--- a/python/ctsm/test/test_unit_singlept_data.py
+++ b/python/ctsm/test/test_unit_singlept_data.py
@@ -19,6 +19,7 @@ sys.path.insert(1, _CTSM_PYTHON)
 from ctsm import unit_testing
 from ctsm.site_and_regional.single_point_case import SinglePointCase
 from ctsm.pft_utils import MAX_PFT_GENERICCROPS, MAX_PFT_MANAGEDCROPS
+from ctsm.longitude import Longitude
 
 # pylint: disable=invalid-name
 
@@ -29,7 +30,7 @@ class TestSinglePointCase(unittest.TestCase):
     """
 
     plat = 20.1
-    plon = 50.5
+    plon = Longitude(50.5, lon_type=180)
     site_name = None
     create_domain = True
     create_surfdata = True

--- a/python/ctsm/test/test_unit_singlept_data_surfdata.py
+++ b/python/ctsm/test/test_unit_singlept_data_surfdata.py
@@ -24,6 +24,7 @@ sys.path.insert(1, _CTSM_PYTHON)
 from ctsm import unit_testing
 from ctsm.site_and_regional.single_point_case import SinglePointCase
 from ctsm.pft_utils import MAX_PFT_GENERICCROPS, MAX_PFT_MANAGEDCROPS
+from ctsm.longitude import Longitude
 
 # pylint: disable=invalid-name
 # pylint: disable=too-many-lines
@@ -37,7 +38,7 @@ class TestSinglePointCaseSurfaceNoCrop(unittest.TestCase):
     """
 
     plat = 20.1
-    plon = 50.5
+    plon = Longitude(50.5, lon_type=180)
     site_name = None
     create_domain = True
     create_surfdata = True
@@ -658,7 +659,7 @@ class TestSinglePointCaseSurfaceCrop(unittest.TestCase):
     """
 
     plat = 20.1
-    plon = 50.5
+    plon = Longitude(50.5, lon_type=180)
     site_name = None
     create_domain = True
     create_surfdata = True

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Prec.-69.0_-12.0.1986.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Prec.-69.0_-12.0.1986.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.Prec.TMP.1986.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Prec.-69.0_-12.0.1987.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Prec.-69.0_-12.0.1987.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.Prec.TMP.1987.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Prec.-69.0_-12.0.1988.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Prec.-69.0_-12.0.1988.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.Prec.TMP.1988.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Solr.-69.0_-12.0.1986.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Solr.-69.0_-12.0.1986.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.Solr.TMP.1986.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Solr.-69.0_-12.0.1987.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Solr.-69.0_-12.0.1987.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.Solr.TMP.1987.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Solr.-69.0_-12.0.1988.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.Solr.-69.0_-12.0.1988.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.Solr.TMP.1988.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.-69.0_-12.0.1986.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.-69.0_-12.0.1986.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.TMP.1986.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.-69.0_-12.0.1987.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.-69.0_-12.0.1987.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.TMP.1987.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.-69.0_-12.0.1988.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.-69.0_-12.0.1988.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//clmforc.CRUJRAv2.5_0.5x0.5.TPQWL.TMP.1988.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/domain.crujra_v2.3_0.5x0.5_-69.0_-12.0_c250620.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_datm_amazon_type180_nositename/datmdata/domain.crujra_v2.3_0.5x0.5_-69.0_-12.0_c250620.nc
@@ -1,0 +1,1 @@
+../../test_subset_data_pt_datm_amazon_type180/datmdata//domain.crujra_v2.3_0.5x0.5_TMP_c250620.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_landuse_amazon_type360_nositename/landuse.timeseries_291.0_-12.0_amazon_hist_1850-1853_78pfts_c250618.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_landuse_amazon_type360_nositename/landuse.timeseries_291.0_-12.0_amazon_hist_1850-1853_78pfts_c250618.nc
@@ -1,0 +1,1 @@
+../test_subset_data_pt_landuse_amazon_type360/landuse.timeseries_TMP_amazon_hist_1850-1853_78pfts_c250618.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_landuse_amazon_type360_nositename/surfdata_291.0_-12.0_amazon_hist_1850_78pfts_c250618.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_landuse_amazon_type360_nositename/surfdata_291.0_-12.0_amazon_hist_1850_78pfts_c250618.nc
@@ -1,0 +1,1 @@
+../test_subset_data_pt_landuse_amazon_type360/surfdata_TMP_amazon_hist_1850_78pfts_c250618.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_surface_amazon_type180_nositename/surfdata_-69.0_-12.0_amazon_hist_16pfts_CMIP6_2000_c250617.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_pt_surface_amazon_type180_nositename/surfdata_-69.0_-12.0_amazon_hist_16pfts_CMIP6_2000_c250617.nc
@@ -1,0 +1,1 @@
+../test_subset_data_pt_surface_amazon_type180/surfdata_TMP_amazon_hist_16pfts_CMIP6_2000_c250617.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_reg_amazon_noregname/domain.lnd.5x5pt-amazon_navy_291.0-299.0_-12.0--7.0_c250508.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_reg_amazon_noregname/domain.lnd.5x5pt-amazon_navy_291.0-299.0_-12.0--7.0_c250508.nc
@@ -1,0 +1,1 @@
+../test_subset_data_reg_amazon/domain.lnd.5x5pt-amazon_navy_TMP_c250508.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_reg_amazon_noregname/domain.lnd.5x5pt-amazon_navy_291.0-299.0_-12.0--7.0_c250508_ESMF_UNSTRUCTURED_MESH.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_reg_amazon_noregname/domain.lnd.5x5pt-amazon_navy_291.0-299.0_-12.0--7.0_c250508_ESMF_UNSTRUCTURED_MESH.nc
@@ -1,0 +1,1 @@
+../test_subset_data_reg_amazon/domain.lnd.5x5pt-amazon_navy_TMP_c250508_ESMF_UNSTRUCTURED_MESH.nc

--- a/python/ctsm/test/testinputs/expected_result_files/test_subset_data_reg_amazon_noregname/surfdata_291.0-299.0_-12.0--7.0_amazon_hist_16pfts_CMIP6_2000_c250508.nc
+++ b/python/ctsm/test/testinputs/expected_result_files/test_subset_data_reg_amazon_noregname/surfdata_291.0-299.0_-12.0--7.0_amazon_hist_16pfts_CMIP6_2000_c250508.nc
@@ -1,0 +1,1 @@
+../test_subset_data_reg_amazon/surfdata_TMP_amazon_hist_16pfts_CMIP6_2000_c250508.nc


### PR DESCRIPTION
# WORK IN PROGRESS; DO NOT REVIEW
# SUBJECT TO FORCE PUSHES

### Description of changes

Resolves an issue in `subset_data` where Longitude types were being implicitly converted to string to look like `<ctsm.longitude.Longitude object at 0x7f34cb836a90>`. Now, implicit string conversion is disallowed—the user must specify the type of longitude they want.

Also adds Python testing:
- Unit tests of implicit and explicit string conversion of Longitude objects
- System tests of string values in names of `subset_data` output files
- System testing that `create_newcase` works with `subset_data` outputs

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:**
- Resolves #3279

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- Python unit tests
- Python system tests
- A manual run like so:

```bash
outdir=$PWD/outdir_issue_3279
user_mods_dir=$outdir/user_mods
casedir=~/cases_ctsm/issue_3279

tools/site_and_regional/subset_data point --lat 45.402252 --lon 267.201915 --site ccc3_crujra --create-surface --create-datm --datm-syr 2000 --datm-eyr 2000 --create-user-mods --outdir $outdir --user-mods-dir $user_mods_dir

cime/scripts/create_newcase --case $casedir --res CLM_USRDAT --compset I2000Clm60Bgc --run-unsupported --user-mods-dir $user_mods_dir

cd $casedir
./case.setup
./shell_commands
qcmd -- ./case.build
./case.submit
```