### PR TITLE
Add a testmod that allows transient ERI tests to work

### DIFF
--- a/cime_config/testdefs/testmods_dirs/clm/transientERI/README
+++ b/cime_config/testdefs/testmods_dirs/clm/transientERI/README
@@ -1,0 +1,6 @@
+This testmod has changes that are needed in a transient (e.g., HIST) ERI test.
+
+This testmod is meant to be a mix-in with other testmods (e.g.,
+'clm-something--clm-transientERI'), so it does not have an include of the default testmod
+or any other testmods (it is assumed that any needed includes come from the primary
+testmod of the test, and that this is just added on top of that).

--- a/cime_config/testdefs/testmods_dirs/clm/transientERI/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/transientERI/user_nl_clm
@@ -1,0 +1,5 @@
+
+! The following is needed in a transient ERI test so that the hybrid case works,
+! given the 2-year jump from the initial case to the hybrid case:
+! https://github.com/ESMCI/cime/blob/f0b9d218e97eb92ea84decaf6ae1bfc263b8ddc9/CIME/SystemTests/eri.py#L93
+check_finidat_year_consistency = .false.


### PR DESCRIPTION
### Description of changes

Add a testmod that allows transient ERI tests to work.

With this testmod, the following test passes: `ERI_Ld9.ne30pg3_t232.BHISTC_LTso.derecho_intel.allactive-defaultio--clm-transientERI`.

I'm not sure yet if we want to take this approach or a different approach.

I haven't added any tests using this new testmod. CTSM should probably add a transient ERI test, since it sounds like CAM and possibly CESM will be adding transient ERI tests and it would probably be good for CTSM to catch any problems before they make it to those levels. (That said, I'm not sure if there is actually much additional ERI-specific code covered in a transient ERI test compared with non-transient ERI tests. I haven't given this much thought.)

See https://github.com/ESMCI/cime/issues/4811 for some context

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Does this create a need to change or add documentation? Did you do so? no

Testing performed, if any:
ERI_Ld9.ne30pg3_t232.BHISTC_LTso.derecho_intel.allactive-defaultio--clm-transientERI
