### PR TITLE
Fix string replacements in lreprstruct test

### DIFF
--- a/cime_config/SystemTests/lreprstruct.py
+++ b/cime_config/SystemTests/lreprstruct.py
@@ -16,6 +16,8 @@ baselines.
 
 """
 
+import re
+
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.test_utils.user_nl_utils import append_to_user_nl_files
@@ -53,13 +55,16 @@ class LREPRSTRUCT(SystemTestsCompareTwo):
         user_nl_clm_path = os.path.join(self._get_caseroot(), "user_nl_clm")
         with open(user_nl_clm_path) as f:
             user_nl_clm_text = f.read()
-        for grain_output in re.findall("GRAIN\w*", user_nl_clm_text):
-            user_nl_clm_text = user_nl_clm_text.replace(
-                grain_output,
+
+        def replace_grain(match):
+            grain_output = match.group()
+            return (
                 grain_output.replace("GRAIN", "REPRODUCTIVE1")
                 + "', '"
-                + grain_output.replace("GRAIN", "REPRODUCTIVE2"),
+                + grain_output.replace("GRAIN", "REPRODUCTIVE2")
             )
+
+        user_nl_clm_text = re.sub(r"GRAIN\w*", replace_grain, user_nl_clm_text)
         with open(user_nl_clm_path, "w") as f:
             f.write(user_nl_clm_text)
 


### PR DESCRIPTION
Resolves https://github.com/ESCOMP/CTSM/issues/3313

### Description of changes

The previous logic caused problems if "GRAIN" appeared in two (or more) strings, where one was a substring of the other. For example, in LREPRSTRUCT_Ly1_P128x1.f10_f10_mg37.I1850Clm50BgcCrop.derecho_gnu.clm-ciso--clm-cropMonthOutput, before this replacement, one line contained 'GRAINN_TO_FOOD' and a later line contained (among other things) "'GRAINN_TO_FOOD_PERHARV', 'GRAINN_TO_FOOD_ANN'". This was problematic because the first replacement of GRAINN_TO_FOOD incorrectly led to replacements in the later strings as well.

This new logic should solve this issue.

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):
Resolves #3313  

Are answers expected to change (and if so in what way)? Possible field diffs for the LREPRSTRUCT test

Any User Interface Changes (namelist or namelist defaults changes)? No

Does this create a need to change or add documentation? Did you do so? No

Testing performed, if any:
- Created & built LREPRSTRUCT_Ly1_P128x1.f10_f10_mg37.I1850Clm50BgcCrop.derecho_gnu.clm-ciso--clm-cropMonthOutput, compared user_nl_clm with before; but did *not* try running the test
