### PR TITLE
Pass nutrient supplementation status to FATES

### DIFF
--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -1151,10 +1151,11 @@ module CLMFatesInterfaceMod
       logical  :: after_start_of_harvest_ts
       integer  :: iharv
       logical  :: nitr_suppl                             ! Is CLM currently supplementing N
-      logical, parameter :: phos_dummy_suppl = .false.   ! This argument is needed for FATES
+      logical, parameter :: phos_dummy_suppl = .true .   ! This argument is needed for FATES
                                                          ! to specify if phosphorus is being
                                                          ! supplemented, this is not cycled in CLM
-                                                         ! so we set it to false
+                                                         ! so we set it to TRUE (which essentially
+                                                         ! means it is NOT limiting)
       !-----------------------------------------------------------------------
 
       ! ---------------------------------------------------------------------------------

--- a/src/utils/clmfates_interfaceMod.F90
+++ b/src/utils/clmfates_interfaceMod.F90
@@ -79,6 +79,7 @@ module CLMFatesInterfaceMod
    use clm_varctl        , only : use_lch4
    use clm_varctl        , only : fates_history_dimlevel
    use clm_varctl        , only : nsrest, nsrBranch
+   use clm_varctl        , only : carbon_only
    use clm_varcon        , only : tfrz
    use clm_varcon        , only : spval
    use clm_varcon        , only : denice
@@ -1149,6 +1150,11 @@ module CLMFatesInterfaceMod
       real(r8) :: s_node, smp_node         ! local for relative water content and potential
       logical  :: after_start_of_harvest_ts
       integer  :: iharv
+      logical  :: nitr_suppl                             ! Is CLM currently supplementing N
+      logical, parameter :: phos_dummy_suppl = .false.   ! This argument is needed for FATES
+                                                         ! to specify if phosphorus is being
+                                                         ! supplemented, this is not cycled in CLM
+                                                         ! so we set it to false
       !-----------------------------------------------------------------------
 
       ! ---------------------------------------------------------------------------------
@@ -1330,10 +1336,16 @@ module CLMFatesInterfaceMod
 
       end do
 
+      if(carbon_only)then
+         nitr_suppl = .true.
+      else
+         nitr_suppl = .false.
+      end if
+      
       ! Nutrient uptake fluxes have been accumulating with each short
       ! timestep, here, we unload them from the boundary condition
       ! structures into the cohort structures.
-      call UnPackNutrientAquisitionBCs(this%fates(nc)%sites, this%fates(nc)%bc_in)
+      call UnPackNutrientAquisitionBCs(this%fates(nc)%sites, this%fates(nc)%bc_in, nitr_suppl, phos_dummy_suppl)
 
       ! Distribute any seeds from neighboring gridcells into the current gridcell
       ! Global seed availability array populated by WrapGlobalSeedDispersal call


### PR DESCRIPTION
### Description of changes

This set of changes passes nitrogen supplementation status to FATES. This status is needed when deciding whether or not to dynamically adjust leaf to fine root ratios based on nutrient storage. This status prevents plants from reducing root mass while soils have artificially high nitrogen during supplementation.

### Specific notes

This is coupled with FATES PR: [1443](https://github.com/NGEET/fates/pull/1443)

Contributors other than yourself, if any: @sharma-bharat @glemieux @walkeranthonyp
CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)? No, this should have not impact on answers on any configuration. This will only be relevant when we fully couple FATES-CLM-CN.

Any User Interface Changes (namelist or namelist defaults changes)?

No

Does this create a need to change or add documentation? Did you do so?

Not yet needed, no N limitations with FATES

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on derecho for intel/gnu and izumi for intel/gnu/nag/nvhpc is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
