### PR TITLE
Fix failing LII2 tests in ctsm5.4 branch

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1298,14 +1298,14 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000_64bitoffset.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->
 <finidat hgrid="ne30np4.pg3" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".true." irrigate=".false."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_ne30_102_pSASU.clm2.r.0081-01-01-00000_64bitoffset.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_ne30_102_pSASU.clm2.r.0081-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
 <finidat hgrid="1.9x2.5" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -98,20 +98,6 @@
   </test>
 
   <!-- aux_clm test suite failures -->
-  <test name="LII2FINIDATAREAS_D_P256x2_Ld1.f09_t232.I1850Clm60BgcCrop.derecho_intel.clm-default">
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>#3252</issue>
-      <comment>Works with finidat = 'ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000.nc' and fails with finidat = 'ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000_64bitoffset.nc'.</comment>
-    </phase>
-  </test>
-  <test name="LII2FINIDATAREAS_D_P256x2_Ld1.f09_t232.I1850Clm60BgcCrop.derecho_intel.clm-default--clm-matrixcnOn_ignore_warnings">
-    <phase name="RUN">
-      <status>FAIL</status>
-      <issue>#3252</issue>
-      <comment>Works with finidat = 'ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000.nc' and fails with finidat = 'ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000_64bitoffset.nc'.</comment>
-    </phase>
-  </test>
   <test name="SMS_Ld2_D_PS.f09_g17.I1850Clm50BgcCropCmip6.derecho_intel.clm-basic_interp">
     <phase name="RUN">
       <status>FAIL</status>


### PR DESCRIPTION
### Description of changes
Stop pointing to the modified finidat with suffix 64bitoffset. That finidat became unnecessary when #3132 got merged.

### Specific notes

CTSM Issues Fixed (include github issue #):
Resolves #3252 

Testing performed, if any:
See issue