### PR TITLE
Make npcropmin/max private to pftconMod

### DIFF
--- a/src/biogeochem/CNAllocationMod.F90
+++ b/src/biogeochem/CNAllocationMod.F90
@@ -15,7 +15,7 @@ module CNAllocationMod
   use clm_varcon           , only : secspday
   use clm_varctl           , only : use_c13, use_c14, iulog
   use PatchType            , only : patch
-  use pftconMod            , only : pftcon, npcropmin
+  use pftconMod            , only : pftcon, is_prognostic_crop
   use CropType             , only : crop_type
   use CropType             , only : cphase_planted, cphase_leafemerge, cphase_grainfill
   use PhotosynthesisMod    , only : photosyns_type
@@ -191,7 +191,7 @@ contains
        mr = leaf_mr(p) + froot_mr(p)
        if (woody(ivt(p)) == 1.0_r8) then
           mr = mr + livestem_mr(p) + livecroot_mr(p)
-       else if (ivt(p) >= npcropmin) then
+       else if (is_prognostic_crop(ivt(p))) then
           if (croplive(p)) then
              reproductive_mr_tot = 0._r8
              do k = 1, nrepr
@@ -500,7 +500,7 @@ contains
        end if
 
        f4   = flivewd(ivt(p))
-       if (ivt(p) >= npcropmin) then
+       if (is_prognostic_crop(ivt(p))) then
           g1 = 0.25_r8
        else
           g1 = grperc(ivt(p))
@@ -521,7 +521,7 @@ contains
           c_allometry(p) = (1._r8+g1a)*(1._r8+f1+f3*(1._r8+f2))
           n_allometry(p) = 1._r8/cnl + f1/cnfr + (f3*f4*(1._r8+f2))/cnlw + &
                (f3*(1._r8-f4)*(1._r8+f2))/cndw
-       else if (ivt(p) >= npcropmin) then ! skip generic crops
+       else if (is_prognostic_crop(ivt(p))) then ! skip generic crops
           cng = graincn(ivt(p))
           f1 = aroot(p) / aleaf(p)
           f3 = astem(p) / aleaf(p)

--- a/src/biogeochem/CNC14DecayMod.F90
+++ b/src/biogeochem/CNC14DecayMod.F90
@@ -11,7 +11,7 @@ module CNC14DecayMod
   use clm_varctl                         , only : spinup_state
   use CNSharedParamsMod                  , only : use_matrixcn
   use decompMod                          , only : bounds_type
-  use pftconMod                          , only : npcropmin
+  use pftconMod                          , only : is_prognostic_crop
   use CNVegCarbonStateType               , only : cnveg_carbonstate_type
   use CNVegCarbonFluxType                , only : cnveg_carbonflux_type
   use SoilBiogeochemDecompCascadeConType , only : decomp_cascade_con, use_soil_matrixcn
@@ -205,12 +205,7 @@ contains
          gresp_xfer(p)         = gresp_xfer(p)          * (1._r8 - decay_const * dt)
          pft_ctrunc(p)         = pft_ctrunc(p)          * (1._r8 - decay_const * dt)
 
-         ! NOTE(wjs, 2017-02-02) This isn't a completely robust way to check if this is a
-         ! prognostic crop patch (at the very least it should also check if <= npcropmax;
-         ! ideally it should use a prognostic_crop flag that doesn't seem to exist
-         ! currently). But I'm just being consistent with what's done elsewhere (e.g., in
-         ! CStateUpdate1).
-         if (patch%itype(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(patch%itype(p))) then ! skip 2 generic crops
             cropseedc_deficit(p)  = cropseedc_deficit(p)   * (1._r8 - decay_const * dt)
          end if
       end do

--- a/src/biogeochem/CNCIsoFluxMod.F90
+++ b/src/biogeochem/CNCIsoFluxMod.F90
@@ -1357,7 +1357,7 @@ contains
     !
     ! !USES:
 !DML
-    use pftconMod  , only : npcropmin
+    use pftconMod  , only : is_prognostic_crop
     use clm_varctl , only : use_grainproduct
 !DML
 
@@ -1404,7 +1404,7 @@ contains
             end do
 
 !DML
-            if (ivt(p) >= npcropmin) then ! add livestemc to litter
+            if (is_prognostic_crop(ivt(p))) then ! add livestemc to litter
                ! stem litter carbon fluxes
                do i = i_litr_min, i_litr_max
                   phenology_c_to_litr_c(c,j,i) = &

--- a/src/biogeochem/CNCStateUpdate1Mod.F90
+++ b/src/biogeochem/CNCStateUpdate1Mod.F90
@@ -10,7 +10,7 @@ module CNCStateUpdate1Mod
   use clm_time_manager                   , only : get_step_size_real
   use clm_varpar                         , only : i_litr_min, i_litr_max, i_cwd
   use clm_varpar                         , only : i_met_lit, i_str_lit, i_phys_som, i_chem_som
-  use pftconMod                          , only : npcropmin, nc3crop, pftcon
+  use pftconMod                          , only : is_prognostic_crop, nc3crop, pftcon
   use abortutils                         , only : endrun
   use decompMod                          , only : bounds_type
   use CNVegCarbonStateType               , only : cnveg_carbonstate_type
@@ -290,7 +290,7 @@ contains
               cs_veg%deadcrootc_patch(p)      = cs_veg%deadcrootc_patch(p)      + cf_veg%deadcrootc_xfer_to_deadcrootc_patch(p)*dt
               cs_veg%deadcrootc_xfer_patch(p) = cs_veg%deadcrootc_xfer_patch(p) - cf_veg%deadcrootc_xfer_to_deadcrootc_patch(p)*dt
            end if
-           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+           if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
              ! lines here for consistency; the transfer terms are zero
               cs_veg%livestemc_patch(p)       = cs_veg%livestemc_patch(p)      + cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
               cs_veg%livestemc_xfer_patch(p)  = cs_veg%livestemc_xfer_patch(p) - cf_veg%livestemc_xfer_to_livestemc_patch(p)*dt
@@ -313,7 +313,7 @@ contains
               cs_veg%livecrootc_patch(p) = cs_veg%livecrootc_patch(p) - cf_veg%livecrootc_to_deadcrootc_patch(p)*dt
               cs_veg%deadcrootc_patch(p) = cs_veg%deadcrootc_patch(p) + cf_veg%livecrootc_to_deadcrootc_patch(p)*dt
            end if
-           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+           if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
               cs_veg%livestemc_patch(p)  = cs_veg%livestemc_patch(p)  - cf_veg%livestemc_to_litter_patch(p)*dt
               cs_veg%livestemc_patch(p)  = cs_veg%livestemc_patch(p)  - &
                    (cf_veg%livestemc_to_biofuelc_patch(p) + cf_veg%livestemc_to_removedresiduec_patch(p))*dt
@@ -337,7 +337,7 @@ contains
 
            ! This part below MUST match exactly the code for the non-matrix part
            ! above!
-           if (ivt(p) >= npcropmin) then
+           if (is_prognostic_crop(ivt(p))) then
               cs_veg%cropseedc_deficit_patch(p) = cs_veg%cropseedc_deficit_patch(p) &
                    - cf_veg%crop_seedc_to_leaf_patch(p) * dt
               do k = repr_grain_min, repr_grain_max
@@ -359,7 +359,7 @@ contains
               cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livestem_curmr_patch(p)*dt
               cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livecroot_curmr_patch(p)*dt
            end if
-           if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+           if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
               cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%livestem_curmr_patch(p)*dt
               do k = 1, nrepr
                  cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%reproductive_curmr_patch(p,k)*dt
@@ -432,7 +432,7 @@ contains
                ! NOTE: The equivalent changes for matrix code are in CNPhenology EBK (11/26/2019)
             end if !not use_matrixcn
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             if (carbon_resp_opt == 1) then
                cf_veg%cpool_to_livestemc_patch(p) = cf_veg%cpool_to_livestemc_patch(p) - cf_veg%cpool_to_livestemc_resp_patch(p)
                cf_veg%cpool_to_livestemc_storage_patch(p) = cf_veg%cpool_to_livestemc_storage_patch(p) - &
@@ -468,7 +468,7 @@ contains
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livecroot_gr_patch(p)*dt
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadcroot_gr_patch(p)*dt
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_gr_patch(p)*dt
             do k = 1, nrepr
                cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_reproductive_gr_patch(p,k)*dt
@@ -484,7 +484,7 @@ contains
             cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livecroot_gr_patch(p)*dt
             cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_deadcroot_gr_patch(p)*dt
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_livestem_gr_patch(p)*dt
             do k = 1, nrepr
                cs_veg%gresp_xfer_patch(p) = cs_veg%gresp_xfer_patch(p) - cf_veg%transfer_reproductive_gr_patch(p,k)*dt
@@ -501,7 +501,7 @@ contains
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livecroot_storage_gr_patch(p)*dt
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_deadcroot_storage_gr_patch(p)*dt
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cs_veg%cpool_patch(p) = cs_veg%cpool_patch(p) - cf_veg%cpool_livestem_storage_gr_patch(p)*dt
 
             do k = 1, nrepr
@@ -539,7 +539,7 @@ contains
                ! NOTE: The equivalent changes for matrix code are in CNPhenology EBK (11/26/2019)
             end if !not use_matrixcn
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             ! lines here for consistency; the transfer terms are zero
             if(.not. use_matrixcn)then
                ! lines here for consistency; the transfer terms are zero
@@ -556,7 +556,7 @@ contains
             end if !not use_matrixcn
          end if
 
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%livestem_xsmr_patch(p)*dt
             do k = 1, nrepr
                cs_veg%xsmrpool_patch(p) = cs_veg%xsmrpool_patch(p) - cf_veg%reproductive_xsmr_patch(p,k)*dt

--- a/src/biogeochem/CNFUNMod.F90
+++ b/src/biogeochem/CNFUNMod.F90
@@ -1271,7 +1271,7 @@ fix_loop:   do FIX =plants_are_fixing, plants_not_fixing !loop around percentage
                !           Calculate appropriate degree of retranslocation
                !-------------------------------------------------------------------------------
       
-               if(leafc(p).gt.0.0_r8.and.litterfall_n_step(p,istp)* fixerfrac>0.0_r8.and. (.not. is_prognostic_crop(ivt(p))))then
+               if (leafc(p) > 0.0_r8 .and. (litterfall_n_step(p,istp) * fixerfrac) > 0.0_r8 .and. (.not. is_prognostic_crop(ivt(p)))) then
                   call fun_retranslocation(p,dt,npp_to_spend,&
                                 litterfall_c_step(p,istp)* fixerfrac,&
                                 litterfall_n_step(p,istp)* fixerfrac,&

--- a/src/biogeochem/CNFUNMod.F90
+++ b/src/biogeochem/CNFUNMod.F90
@@ -23,7 +23,7 @@ module CNFUNMod
   use clm_varctl                      , only : iulog
   use PatchType                       , only : patch
   use ColumnType                      , only : col
-  use pftconMod                       , only : pftcon, npcropmin
+  use pftconMod                       , only : pftcon
   use decompMod                       , only : bounds_type
   use clm_varctl                      , only : use_nitrif_denitrif,use_flexiblecn
   use CNSharedParamsMod               , only : use_matrixcn
@@ -284,7 +284,7 @@ module CNFUNMod
    use clm_varctl      , only : use_nitrif_denitrif
    use PatchType       , only : patch
    use subgridAveMod   , only : p2c
-   use pftconMod       , only : npcropmin
+   use pftconMod       , only : is_prognostic_crop
    use CNVegMatrixMod  , only : matrix_update_phn
 !
 ! !ARGUMENTS: 
@@ -1271,7 +1271,7 @@ fix_loop:   do FIX =plants_are_fixing, plants_not_fixing !loop around percentage
                !           Calculate appropriate degree of retranslocation
                !-------------------------------------------------------------------------------
       
-               if(leafc(p).gt.0.0_r8.and.litterfall_n_step(p,istp)* fixerfrac>0.0_r8.and.ivt(p) <npcropmin)then
+               if(leafc(p).gt.0.0_r8.and.litterfall_n_step(p,istp)* fixerfrac>0.0_r8.and. (.not. is_prognostic_crop(ivt(p))))then
                   call fun_retranslocation(p,dt,npp_to_spend,&
                                 litterfall_c_step(p,istp)* fixerfrac,&
                                 litterfall_n_step(p,istp)* fixerfrac,&

--- a/src/biogeochem/CNFireEmissionsMod.F90
+++ b/src/biogeochem/CNFireEmissionsMod.F90
@@ -347,7 +347,7 @@ contains
     use pftconMod       , only : nbrdlf_evr_shrub, nbrdlf_dcd_brl_shrub
     use pftconMod       , only : nc3_arctic_grass, nc3_nonarctic_grass
     use pftconMod       , only : nc3crop, nc3irrig
-    use pftconMod       , only : npcropmin, npcropmax
+    use pftconMod       , only : is_prognostic_crop
     implicit none
     integer, intent(in) :: veg_type
 
@@ -376,7 +376,7 @@ contains
     else if ( veg_type == nc3crop             .or.  veg_type <= nc3irrig             ) then
        ztop = 1.e3_r8 ! m
     ! Prognostic crops
-    else if ( veg_type >= npcropmin           .and. veg_type <= npcropmax            ) then
+    else if (is_prognostic_crop(veg_type)) then
        ztop = 1.e3_r8 ! m
     else
        call endrun('ERROR:: undefined veg_type' )

--- a/src/biogeochem/CNGRespMod.F90
+++ b/src/biogeochem/CNGRespMod.F90
@@ -7,7 +7,7 @@ module CNGRespMod
   !
   ! !USES:
   use shr_kind_mod           , only : r8 => shr_kind_r8
-  use pftconMod              , only : npcropmin, pftcon
+  use pftconMod              , only : is_prognostic_crop, pftcon
   use CNVegcarbonfluxType    , only : cnveg_carbonflux_type
   use PatchType              , only : patch    
   use CanopyStateType        , only : canopystate_type              
@@ -145,7 +145,7 @@ contains
          respfact_livecroot_storage = 1.0_r8 	
          respfact_livestem_storage = 1.0_r8 	
          
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cpool_livestem_gr(p) = cpool_to_livestemc(p) * grperc(ivt(p)) * respfact_livestem     
 
             cpool_livestem_storage_gr(p) = cpool_to_livestemc_storage(p) * grperc(ivt(p)) * grpnow(ivt(p)) * &

--- a/src/biogeochem/CNGapMortalityMod.F90
+++ b/src/biogeochem/CNGapMortalityMod.F90
@@ -121,7 +121,7 @@ contains
     use clm_varpar       , only: nlevdecomp_full
     use clm_varcon       , only: secspday
     use clm_varctl       , only: use_cndv, spinup_state
-    use pftconMod        , only: npcropmin
+    use pftconMod        , only: is_prognostic_crop
     !
     ! !ARGUMENTS:
     type(bounds_type)                      , intent(in)    :: bounds
@@ -348,7 +348,7 @@ contains
             end if !use_matrixcn
          end if
 
-         if (ivt(p) < npcropmin) then
+         if (.not. is_prognostic_crop(ivt(p))) then
             if(.not. use_matrixcn)then
                cnveg_nitrogenflux_inst%m_retransn_to_litter_patch(p) = cnveg_nitrogenstate_inst%retransn_patch(p) * m
             else

--- a/src/biogeochem/CNMRespMod.F90
+++ b/src/biogeochem/CNMRespMod.F90
@@ -13,7 +13,7 @@ module CNMRespMod
   use decompMod              , only : bounds_type
   use abortutils             , only : endrun
   use shr_log_mod            , only : errMsg => shr_log_errMsg
-  use pftconMod              , only : npcropmin, pftcon
+  use pftconMod              , only : is_prognostic_crop, pftcon
   use SoilStateType          , only : soilstate_type
   use CanopyStateType        , only : canopystate_type
   use TemperatureType        , only : temperature_type
@@ -265,7 +265,7 @@ contains
          if (woody(ivt(p)) == 1) then
             livestem_mr(p) = livestemn(p)*br*tc
             livecroot_mr(p) = livecrootn(p)*br_root*tc
-         else if (ivt(p) >= npcropmin) then
+         else if (is_prognostic_crop(ivt(p))) then
             livestem_mr(p) = livestemn(p)*br*tc
             do k = 1, nrepr
                reproductive_mr(p,k) = reproductiven(p,k)*br*tc

--- a/src/biogeochem/CNNStateUpdate1Mod.F90
+++ b/src/biogeochem/CNNStateUpdate1Mod.F90
@@ -17,7 +17,7 @@ module CNNStateUpdate1Mod
   use SoilBiogeochemDecompCascadeConType, only : decomp_method, mimics_decomp, use_soil_matrixcn
   use CNSharedParamsMod               , only : use_matrixcn
   use clm_varcon                      , only : nitrif_n2o_loss_frac
-  use pftconMod                       , only : npcropmin, pftcon
+  use pftconMod                       , only : is_prognostic_crop, pftcon
   use decompMod                       , only : bounds_type
   use CNVegNitrogenStateType          , only : cnveg_nitrogenstate_type
   use CNVegNitrogenFluxType           , only : cnveg_nitrogenflux_type
@@ -228,7 +228,7 @@ contains
                ns_veg%deadcrootn_xfer_patch(p) = ns_veg%deadcrootn_xfer_patch(p) - nf_veg%deadcrootn_xfer_to_deadcrootn_patch(p)*dt
             end if
 
-            if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
                ! lines here for consistency; the transfer terms are zero
                ns_veg%livestemn_patch(p)       = ns_veg%livestemn_patch(p)      + nf_veg%livestemn_xfer_to_livestemn_patch(p)*dt
                ns_veg%livestemn_xfer_patch(p)  = ns_veg%livestemn_xfer_patch(p) - nf_veg%livestemn_xfer_to_livestemn_patch(p)*dt
@@ -287,7 +287,7 @@ contains
                ! NOTE: The equivalent changes for matrix code are in CNPhenology EBK (11/26/2019)
             end if !not use_matrixcn
          end if 
-         if (ivt(p) >= npcropmin) then ! Beth adds retrans from froot
+         if (is_prognostic_crop(ivt(p))) then ! Beth adds retrans from froot
             !
             ! State update without the matrix solution
             !
@@ -391,7 +391,7 @@ contains
             end if ! not use_matrixcn
          end if
 
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             ns_veg%npool_patch(p)                 = ns_veg%npool_patch(p)              - nf_veg%npool_to_livestemn_patch(p)*dt
             ns_veg%npool_patch(p)                 = ns_veg%npool_patch(p)              - nf_veg%npool_to_livestemn_storage_patch(p)*dt
             do k = 1, nrepr
@@ -452,7 +452,7 @@ contains
             ! NOTE: The equivalent changes for matrix code are in CNPhenology EBK (11/26/2019)
          end if  ! not use_matrixcn
 
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             ! lines here for consistency; the transfer terms are zero
 
             !

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -3350,7 +3350,7 @@ contains
     ! pools during the phenological offset period.
     !
     ! !USES:
-    use pftconMod        , only : npcropmin
+    use pftconMod        , only : is_prognostic_crop
     use pftconMod        , only : nmiscanthus, nirrig_miscanthus, nswitchgrass, nirrig_switchgrass
     
     use CNSharedParamsMod, only : use_fun
@@ -3526,7 +3526,7 @@ contains
                end if ! use_matrixcn
                ! this assumes that offset_counter == dt for crops
                ! if this were ever changed, we'd need to add code to the "else"
-               if (ivt(p) >= npcropmin) then
+               if (is_prognostic_crop(ivt(p))) then
 
                   ! How many harvests have occurred?
                   h = crop_inst%harvest_count(p)
@@ -4371,7 +4371,7 @@ ptch: do fp = 1,num_soilp
     !
     ! !USES:
     use clm_varpar , only : nlevdecomp
-    use pftconMod  , only : npcropmin
+    use pftconMod  , only : is_prognostic_crop
     use clm_varctl , only : use_grainproduct
     !
     ! !ARGUMENTS:
@@ -4449,7 +4449,7 @@ ptch: do fp = 1,num_soilp
             ! new ones for now (slevis)
             ! also for simplicity I've put "food" into the litter pools
             
-            if (ivt(p) >= npcropmin) then ! add livestemc to litter
+            if (is_prognostic_crop(ivt(p))) then ! add livestemc to litter
                do i = i_litr_min, i_litr_max
                   ! stem litter carbon fluxes
                   phenology_c_to_litr_c(c,j,i) = &

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -2691,8 +2691,9 @@ contains
     ! initialized, and after pftcon file is read in.
     !
     ! !USES:
-    use pftconMod       , only: npcropmin, npcropmax
     use clm_time_manager, only: get_calday
+    use pftconMod, only: is_prognostic_crop
+    use clm_varpar, only: mxpft
     !
     ! !ARGUMENTS:
     type(bounds_type), intent(in) :: bounds  
@@ -2713,8 +2714,8 @@ contains
     ! Convert planting dates into julian day
     minplantjday(:,:) = huge(1)
     maxplantjday(:,:) = huge(1)
-    do n = npcropmin, npcropmax
-       if (pftcon%is_pft_known_to_model(n)) then
+    do n = 1, mxpft
+       if (is_prognostic_crop(n) .and. pftcon%is_pft_known_to_model(n)) then
           minplantjday(n, inNH) = int( get_calday( pftcon%mnNHplantdate(n), 0 ) )
           maxplantjday(n, inNH) = int( get_calday( pftcon%mxNHplantdate(n), 0 ) )
 

--- a/src/biogeochem/CNVegCarbonFluxType.F90
+++ b/src/biogeochem/CNVegCarbonFluxType.F90
@@ -27,7 +27,7 @@ module CNVegCarbonFluxType
   use clm_varctl                         , only : use_grainproduct
   use clm_varctl                         , only : iulog
   use landunit_varcon                    , only : istsoil, istcrop, istdlak 
-  use pftconMod                          , only : npcropmin, pftcon
+  use pftconMod                          , only : is_prognostic_crop, pftcon
   use CropReprPoolsMod                   , only : nrepr, repr_grain_min, repr_grain_max, repr_structure_min, repr_structure_max
   use CropReprPoolsMod                   , only : get_repr_hist_fname, get_repr_rest_fname, get_repr_longname
   use LandunitType                       , only : lun                
@@ -4921,7 +4921,7 @@ contains
                this%livestem_mr_patch(p) + &
                this%livecroot_mr_patch(p)
        end if
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%mr_patch(p) = &
                   this%mr_patch(p) + &
@@ -4939,7 +4939,7 @@ contains
             this%cpool_deadstem_gr_patch(p)  + &
             this%cpool_livecroot_gr_patch(p) + &
             this%cpool_deadcroot_gr_patch(p)
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%current_gr_patch(p) = this%current_gr_patch(p) + &
                   this%cpool_reproductive_gr_patch(p,k)
@@ -4955,7 +4955,7 @@ contains
             this%transfer_deadstem_gr_patch(p)  + &
             this%transfer_livecroot_gr_patch(p) + &
             this%transfer_deadcroot_gr_patch(p)
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%transfer_gr_patch(p) = this%transfer_gr_patch(p) + &
                   this%transfer_reproductive_gr_patch(p,k)
@@ -4971,7 +4971,7 @@ contains
             this%cpool_livecroot_storage_gr_patch(p) + &
             this%cpool_deadcroot_storage_gr_patch(p)
 
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%storage_gr_patch(p) = this%storage_gr_patch(p) + &
                   this%cpool_reproductive_storage_gr_patch(p,k)
@@ -4985,7 +4985,7 @@ contains
             this%storage_gr_patch(p)
 
        ! autotrophic respiration (AR) adn 
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           this%ar_patch(p) =           &
                this%mr_patch(p)      + &
                this%gr_patch(p)
@@ -5045,7 +5045,7 @@ contains
             this%cpool_to_deadstemc_patch(p)              + &
             this%deadstemc_xfer_to_deadstemc_patch(p)
 
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%agnpp_patch(p) =      &
                   this%agnpp_patch(p) + &
@@ -5139,7 +5139,7 @@ contains
             this%gru_livecrootc_to_litter_patch(p)            + &
             this%gru_deadcrootc_to_litter_patch(p)
 
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           this%litfall_patch(p) =      &
                this%litfall_patch(p) + &
                this%livestemc_to_litter_patch(p)

--- a/src/biogeochem/CNVegCarbonStateType.F90
+++ b/src/biogeochem/CNVegCarbonStateType.F90
@@ -9,7 +9,7 @@ module CNVegCarbonStateType
   use shr_infnan_mod , only : nan => shr_infnan_nan, assignment(=)
   use shr_const_mod  , only : SHR_CONST_PDB
   use shr_log_mod    , only : errMsg => shr_log_errMsg
-  use pftconMod      , only : noveg, npcropmin, pftcon, nc3crop, nc3irrig
+  use pftconMod      , only : noveg, is_prognostic_crop, pftcon, nc3crop, nc3irrig
   use clm_varcon     , only : spval, c3_r2, c4_r2, c14ratio
   use clm_varctl     , only : iulog, use_cndv, use_crop
   use CNSharedParamsMod, only : use_matrixcn
@@ -1532,7 +1532,7 @@ contains
                    this%matrix_cap_frootc_patch(p)         = cnvegcstate_const%initial_vegC * ratio           
                    this%matrix_cap_frootc_storage_patch(p) = 0._r8    
                 end if
-             else if (patch%itype(p) >= npcropmin) then ! prognostic crop types
+             else if (is_prognostic_crop(patch%itype(p))) then ! prognostic crop types
                 this%leafc_patch(p)                        = 0._r8
                 this%leafc_storage_patch(p)                = 0._r8
                 this%frootc_patch(p)                       = 0._r8            
@@ -4578,7 +4578,7 @@ contains
             this%gresp_storage_patch(p)      + &
             this%gresp_xfer_patch(p)
 
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%storvegc_patch(p) =            &
                   this%storvegc_patch(p)       + &

--- a/src/biogeochem/CNVegMatrixMod.F90
+++ b/src/biogeochem/CNVegMatrixMod.F90
@@ -35,7 +35,7 @@ module CNVegMatrixMod
                                               ncphouttrans,nnphouttrans,ncgmouttrans,nngmouttrans,ncfiouttrans,nnfiouttrans
   use perf_mod                       , only : t_startf, t_stopf
   use PatchType                      , only : patch
-  use pftconMod                      , only : pftcon,npcropmin
+  use pftconMod                      , only : pftcon,is_prognostic_crop
   use CNVegCarbonStateType           , only : cnveg_carbonstate_type
   use CNVegNitrogenStateType         , only : cnveg_nitrogenstate_type
   use CNVegCarbonFluxType            , only : cnveg_carbonflux_type     !include: callocation,ctransfer, cturnover
@@ -1140,7 +1140,7 @@ td: associate(                          &
 
       do fp = 1,num_soilp
          p = filter_soilp(fp)
-         if(ivt(p) >= npcropmin)then
+         if(is_prognostic_crop(ivt(p)))then
             ! Use one index of the grain reproductive pools to operate on
             Xvegc%V(p,igrain)     = reproductivec(p,irepr)
             Xvegc%V(p,igrain_st)  = reproductivec_storage(p,irepr)
@@ -1173,7 +1173,7 @@ td: associate(                          &
 
          do fp = 1,num_soilp
             p = filter_soilp(fp)
-            if(ivt(p) >= npcropmin)then
+            if(is_prognostic_crop(ivt(p)))then
                ! Use one index of the grain reproductive pools to operate on
                Xveg13c%V(p,igrain)     = cs13_veg%reproductivec_patch(p,irepr)
                Xveg13c%V(p,igrain_st)  = cs13_veg%reproductivec_storage_patch(p,irepr)
@@ -1207,7 +1207,7 @@ td: associate(                          &
 
          do fp = 1,num_soilp
             p = filter_soilp(fp)
-            if(ivt(p) >= npcropmin)then
+            if(is_prognostic_crop(ivt(p)))then
                ! Use one index of the grain reproductive pools to operate on
                Xveg14c%V(p,igrain)     = cs14_veg%reproductivec_patch(p,irepr)
                Xveg14c%V(p,igrain_st)  = cs14_veg%reproductivec_storage_patch(p,irepr)
@@ -1241,7 +1241,7 @@ td: associate(                          &
 
       do fp = 1,num_soilp
          p = filter_soilp(fp)
-         if(ivt(p) >= npcropmin)then
+         if(is_prognostic_crop(ivt(p)))then
             Xvegn%V(p,igrain)        = sum(reproductiven(p,:))
             Xvegn%V(p,igrain_st)     = sum(reproductiven_storage(p,:))
             Xvegn%V(p,igrain_xf)     = sum(reproductiven_xfer(p,:))
@@ -1279,7 +1279,7 @@ td: associate(                          &
 
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   ! Use one index of the grain reproductive pools to operate on
                   reproc0(p)               = max(reproductivec(p,irepr),  epsi)
                   reproc0_storage(p)       = max(reproductivec_storage(p,irepr),  epsi)
@@ -1312,7 +1312,7 @@ td: associate(                          &
 
                do fp = 1,num_soilp
                   p = filter_soilp(fp)
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      ! Use one index of the grain reproductive pools to operate on
                      cs13_veg%reproc0_patch(p)               = max(cs13_veg%reproductivec_patch(p,irepr),  epsi)
                      cs13_veg%reproc0_storage_patch(p)       = max(cs13_veg%reproductivec_storage_patch(p,irepr), epsi)
@@ -1346,7 +1346,7 @@ td: associate(                          &
 
                do fp = 1,num_soilp
                   p = filter_soilp(fp)
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      ! Use one index of the grain reproductive pools to operate on
                      cs14_veg%reproc0_patch(p)               = max(cs14_veg%reproductivec_patch(p,irepr),  epsi)
                      cs14_veg%reproc0_storage_patch(p)       = max(cs14_veg%reproductivec_storage_patch(p,irepr),  epsi)
@@ -1380,7 +1380,7 @@ td: associate(                          &
 
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   ! Use one index of the grain reproductive pools to operate on
                   repron0(p)               = max(reproductiven(p,irepr),  epsi)
                   repron0_storage(p)       = max(reproductiven_storage(p,irepr),  epsi)
@@ -1730,7 +1730,7 @@ td: associate(                          &
             end do
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   matrix_calloc_grain_acc(p)    = matrix_calloc_grain_acc(p)       + vegmatrixc_input%V(p,igrain)
                   matrix_calloc_grainst_acc(p)  = matrix_calloc_grainst_acc(p)     + vegmatrixc_input%V(p,igrain_st)
                   if(use_c13)then
@@ -2052,7 +2052,7 @@ td: associate(                          &
             end do
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   matrix_cturnover_grain_acc(p)    = matrix_cturnover_grain_acc(p) &
                                                    + (matrix_phturnover(p,igrain)+matrix_gmturnover(p,igrain)+matrix_fiturnover(p,igrain)) &
                                                    * reproductivec(p,irepr)
@@ -2110,7 +2110,7 @@ td: associate(                          &
 
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   matrix_nalloc_grain_acc(p)    = matrix_nalloc_grain_acc(p)       + vegmatrixn_input%V(p,igrain)
                   matrix_nalloc_grainst_acc(p)  = matrix_nalloc_grainst_acc(p)     + vegmatrixn_input%V(p,igrain_st)
                end if
@@ -2215,7 +2215,7 @@ td: associate(                          &
 
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   matrix_ntransfer_retransn_to_grain_acc(p)       = matrix_ntransfer_retransn_to_grain_acc(p) &
                                                                   + matrix_nphtransfer(p,iretransn_to_igrain_phn) & 
                                                                   * dt * retransn(p)!matrix_nphturnover(p,iretransn)*retransn(p)
@@ -2287,7 +2287,7 @@ td: associate(                          &
             end do
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   matrix_nturnover_grain_acc(p)       = matrix_nturnover_grain_acc(p) &
                                                       + (matrix_nphturnover(p,igrain)+matrix_ngmturnover(p,igrain)+matrix_nfiturnover(p,igrain)) &
                                                       * reproductiven(p,irepr)
@@ -2328,7 +2328,7 @@ td: associate(                          &
 
          do fp = 1,num_soilp
             p = filter_soilp(fp)
-            if(ivt(p) >= npcropmin)then
+            if(is_prognostic_crop(ivt(p)))then
                ! NOTE: This assumes only a single grain pool! (i.e nrepr is
                ! fixed at 1)!
                reproductivec(p,:)            = Xvegc%V(p,igrain)
@@ -2362,7 +2362,7 @@ td: associate(                          &
         
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   ! NOTE: This assumes only a single grain pool! (i.e nrepr is
                   ! fixed at 1)!
                   cs13_veg%reproductivec_patch(p,:)            = Xveg13c%V(p,igrain)
@@ -2396,7 +2396,7 @@ td: associate(                          &
             end do
             do fp = 1,num_soilp
                p = filter_soilp(fp)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                   ! NOTE: This assumes only a single grain pool! (i.e nrepr is
                   ! fixed at 1)!
                   cs14_veg%reproductivec_patch(p,:)            = Xveg14c%V(p,igrain)
@@ -2431,7 +2431,7 @@ td: associate(                          &
 
          do fp = 1,num_soilp
             p = filter_soilp(fp)
-            if(ivt(p) >= npcropmin)then
+            if(is_prognostic_crop(ivt(p)))then
                reproductiven(p,:)            = Xvegn%V(p,igrain)
                reproductiven_storage(p,:)    = Xvegn%V(p,igrain_st)
                reproductiven_xfer(p,:)       = Xvegn%V(p,igrain_xf)
@@ -2457,7 +2457,7 @@ td: associate(                          &
                   matrix_calloc_acc(ilivecroot_st) = matrix_calloc_livecrootst_acc(p)               
                   matrix_calloc_acc(ideadcroot)    = matrix_calloc_deadcroot_acc(p)               
                   matrix_calloc_acc(ideadcroot_st) = matrix_calloc_deadcrootst_acc(p)               
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_calloc_acc(igrain)     = matrix_calloc_grain_acc(p)               
                      matrix_calloc_acc(igrain_st)  = matrix_calloc_grainst_acc(p)               
                   end if
@@ -2474,7 +2474,7 @@ td: associate(                          &
                   matrix_ctransfer_acc(ilivecroot,ilivecroot_xf)    = matrix_ctransfer_livecrootxf_to_livecroot_acc(p)
                   matrix_ctransfer_acc(ideadcroot_xf,ideadcroot_st) = matrix_ctransfer_deadcrootst_to_deadcrootxf_acc(p)
                   matrix_ctransfer_acc(ideadcroot,ideadcroot_xf)    = matrix_ctransfer_deadcrootxf_to_deadcroot_acc(p)
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ctransfer_acc(igrain_xf,igrain_st)      = matrix_ctransfer_grainst_to_grainxf_acc(p)
                      matrix_ctransfer_acc(igrain,igrain_xf)         = matrix_ctransfer_grainxf_to_grain_acc(p)
                   end if
@@ -2499,7 +2499,7 @@ td: associate(                          &
                   matrix_ctransfer_acc(ideadcroot,ideadcroot)       = -matrix_cturnover_deadcroot_acc(p)               
                   matrix_ctransfer_acc(ideadcroot_st,ideadcroot_st) = -matrix_cturnover_deadcrootst_acc(p)               
                   matrix_ctransfer_acc(ideadcroot_xf,ideadcroot_xf) = -matrix_cturnover_deadcrootxf_acc(p)               
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ctransfer_acc(igrain,igrain)            = -matrix_cturnover_grain_acc(p)               
                      matrix_ctransfer_acc(igrain_st,igrain_st)      = -matrix_cturnover_grainst_acc(p)               
                      matrix_ctransfer_acc(igrain_xf,igrain_xf)      = -matrix_cturnover_grainxf_acc(p)               
@@ -2518,7 +2518,7 @@ td: associate(                          &
                      matrix_c13alloc_acc(ilivecroot_st) = cs13_veg%matrix_calloc_livecrootst_acc_patch(p)               
                      matrix_c13alloc_acc(ideadcroot)    = cs13_veg%matrix_calloc_deadcroot_acc_patch(p)               
                      matrix_c13alloc_acc(ideadcroot_st) = cs13_veg%matrix_calloc_deadcrootst_acc_patch(p)               
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c13alloc_acc(igrain)     = cs13_veg%matrix_calloc_grain_acc_patch(p)               
                         matrix_c13alloc_acc(igrain_st)  = cs13_veg%matrix_calloc_grainst_acc_patch(p)               
                      end if
@@ -2535,7 +2535,7 @@ td: associate(                          &
                      matrix_c13transfer_acc(ilivecroot,ilivecroot_xf)    = cs13_veg%matrix_ctransfer_livecrootxf_to_livecroot_acc_patch(p)
                      matrix_c13transfer_acc(ideadcroot_xf,ideadcroot_st) = cs13_veg%matrix_ctransfer_deadcrootst_to_deadcrootxf_acc_patch(p)
                      matrix_c13transfer_acc(ideadcroot,ideadcroot_xf)    = cs13_veg%matrix_ctransfer_deadcrootxf_to_deadcroot_acc_patch(p)
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c13transfer_acc(igrain_xf,igrain_st)      = cs13_veg%matrix_ctransfer_grainst_to_grainxf_acc_patch(p)
                         matrix_c13transfer_acc(igrain,igrain_xf)         = cs13_veg%matrix_ctransfer_grainxf_to_grain_acc_patch(p)
                      end if
@@ -2560,7 +2560,7 @@ td: associate(                          &
                      matrix_c13transfer_acc(ideadcroot,ideadcroot)       = -cs13_veg%matrix_cturnover_deadcroot_acc_patch(p)               
                      matrix_c13transfer_acc(ideadcroot_st,ideadcroot_st) = -cs13_veg%matrix_cturnover_deadcrootst_acc_patch(p)               
                      matrix_c13transfer_acc(ideadcroot_xf,ideadcroot_xf) = -cs13_veg%matrix_cturnover_deadcrootxf_acc_patch(p)               
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c13transfer_acc(igrain,igrain)            = -cs13_veg%matrix_cturnover_grain_acc_patch(p)               
                         matrix_c13transfer_acc(igrain_st,igrain_st)      = -cs13_veg%matrix_cturnover_grainst_acc_patch(p)               
                         matrix_c13transfer_acc(igrain_xf,igrain_xf)      = -cs13_veg%matrix_cturnover_grainxf_acc_patch(p)               
@@ -2580,7 +2580,7 @@ td: associate(                          &
                      matrix_c14alloc_acc(ilivecroot_st) = cs14_veg%matrix_calloc_livecrootst_acc_patch(p)               
                      matrix_c14alloc_acc(ideadcroot)    = cs14_veg%matrix_calloc_deadcroot_acc_patch(p)               
                      matrix_c14alloc_acc(ideadcroot_st) = cs14_veg%matrix_calloc_deadcrootst_acc_patch(p)               
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c14alloc_acc(igrain)     = cs14_veg%matrix_calloc_grain_acc_patch(p)               
                         matrix_c14alloc_acc(igrain_st)  = cs14_veg%matrix_calloc_grainst_acc_patch(p)               
                      end if
@@ -2597,7 +2597,7 @@ td: associate(                          &
                      matrix_c14transfer_acc(ilivecroot,ilivecroot_xf)    = cs14_veg%matrix_ctransfer_livecrootxf_to_livecroot_acc_patch(p)
                      matrix_c14transfer_acc(ideadcroot_xf,ideadcroot_st) = cs14_veg%matrix_ctransfer_deadcrootst_to_deadcrootxf_acc_patch(p)
                      matrix_c14transfer_acc(ideadcroot,ideadcroot_xf)    = cs14_veg%matrix_ctransfer_deadcrootxf_to_deadcroot_acc_patch(p)
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c14transfer_acc(igrain_xf,igrain_st)      = cs14_veg%matrix_ctransfer_grainst_to_grainxf_acc_patch(p)
                         matrix_c14transfer_acc(igrain,igrain_xf)         = cs14_veg%matrix_ctransfer_grainxf_to_grain_acc_patch(p)
                      end if
@@ -2622,7 +2622,7 @@ td: associate(                          &
                      matrix_c14transfer_acc(ideadcroot,ideadcroot)       = -cs14_veg%matrix_cturnover_deadcroot_acc_patch(p)               
                      matrix_c14transfer_acc(ideadcroot_st,ideadcroot_st) = -cs14_veg%matrix_cturnover_deadcrootst_acc_patch(p)               
                      matrix_c14transfer_acc(ideadcroot_xf,ideadcroot_xf) = -cs14_veg%matrix_cturnover_deadcrootxf_acc_patch(p)               
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c14transfer_acc(igrain,igrain)            = -cs14_veg%matrix_cturnover_grain_acc_patch(p)               
                         matrix_c14transfer_acc(igrain_st,igrain_st)      = -cs14_veg%matrix_cturnover_grainst_acc_patch(p)               
                         matrix_c14transfer_acc(igrain_xf,igrain_xf)      = -cs14_veg%matrix_cturnover_grainxf_acc_patch(p)               
@@ -2641,7 +2641,7 @@ td: associate(                          &
                   matrix_nalloc_acc(ilivecroot_st) = matrix_nalloc_livecrootst_acc(p)               
                   matrix_nalloc_acc(ideadcroot)    = matrix_nalloc_deadcroot_acc(p)               
                   matrix_nalloc_acc(ideadcroot_st) = matrix_nalloc_deadcrootst_acc(p)               
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_nalloc_acc(igrain)     = matrix_nalloc_grain_acc(p)               
                      matrix_nalloc_acc(igrain_st)  = matrix_nalloc_grainst_acc(p)               
                   end if
@@ -2658,7 +2658,7 @@ td: associate(                          &
                   matrix_ntransfer_acc(ilivecroot,ilivecroot_xf)    = matrix_ntransfer_livecrootxf_to_livecroot_acc(p)
                   matrix_ntransfer_acc(ideadcroot_xf,ideadcroot_st) = matrix_ntransfer_deadcrootst_to_deadcrootxf_acc(p)
                   matrix_ntransfer_acc(ideadcroot,ideadcroot_xf)    = matrix_ntransfer_deadcrootxf_to_deadcroot_acc(p)
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ntransfer_acc(igrain_xf,igrain_st)      = matrix_ntransfer_grainst_to_grainxf_acc(p)
                      matrix_ntransfer_acc(igrain,igrain_xf)         = matrix_ntransfer_grainxf_to_grain_acc(p)
                   end if
@@ -2677,7 +2677,7 @@ td: associate(                          &
                   matrix_ntransfer_acc(ilivecroot_st,iretransn) = matrix_ntransfer_retransn_to_livecrootst_acc(p)               
                   matrix_ntransfer_acc(ideadcroot,iretransn)    = matrix_ntransfer_retransn_to_deadcroot_acc(p)               
                   matrix_ntransfer_acc(ideadcroot_st,iretransn) = matrix_ntransfer_retransn_to_deadcrootst_acc(p)               
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ntransfer_acc(igrain,iretransn)     = matrix_ntransfer_retransn_to_grain_acc(p)               
                      matrix_ntransfer_acc(igrain_st,iretransn)  = matrix_ntransfer_retransn_to_grainst_acc(p)               
                   end if
@@ -2704,7 +2704,7 @@ td: associate(                          &
                   matrix_ntransfer_acc(ideadcroot,ideadcroot)       = -matrix_nturnover_deadcroot_acc(p)               
                   matrix_ntransfer_acc(ideadcroot_st,ideadcroot_st) = -matrix_nturnover_deadcrootst_acc(p)               
                   matrix_ntransfer_acc(ideadcroot_xf,ideadcroot_xf) = -matrix_nturnover_deadcrootxf_acc(p)               
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ntransfer_acc(igrain,igrain)            = -matrix_nturnover_grain_acc(p)               
                      matrix_ntransfer_acc(igrain_st,igrain_st)      = -matrix_nturnover_grainst_acc(p)               
                      matrix_ntransfer_acc(igrain_xf,igrain_xf)      = -matrix_nturnover_grainxf_acc(p)               
@@ -2755,7 +2755,7 @@ td: associate(                          &
                   matrix_ctransfer_acc(1:nvegcpool,ideadcroot)    = matrix_ctransfer_acc(1:nvegcpool,ideadcroot)    / deadcrootc0(p)
                   matrix_ctransfer_acc(1:nvegcpool,ideadcroot_st) = matrix_ctransfer_acc(1:nvegcpool,ideadcroot_st) / deadcrootc0_storage(p)
                   matrix_ctransfer_acc(1:nvegcpool,ideadcroot_xf) = matrix_ctransfer_acc(1:nvegcpool,ideadcroot_xf) / deadcrootc0_xfer(p)
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ctransfer_acc(1:nvegcpool,igrain)     = matrix_ctransfer_acc(1:nvegcpool,igrain)    / reproc0(p)
                      matrix_ctransfer_acc(1:nvegcpool,igrain_st)  = matrix_ctransfer_acc(1:nvegcpool,igrain_st) / reproc0_storage(p)
                      matrix_ctransfer_acc(1:nvegcpool,igrain_xf)  = matrix_ctransfer_acc(1:nvegcpool,igrain_xf) / reproc0_xfer(p)
@@ -2780,7 +2780,7 @@ td: associate(                          &
                      matrix_c13transfer_acc(1:nvegcpool,ideadcroot)    = matrix_c13transfer_acc(1:nvegcpool,ideadcroot)    / cs13_veg%deadcrootc0_patch(p)
                      matrix_c13transfer_acc(1:nvegcpool,ideadcroot_st) = matrix_c13transfer_acc(1:nvegcpool,ideadcroot_st) / cs13_veg%deadcrootc0_storage_patch(p)
                      matrix_c13transfer_acc(1:nvegcpool,ideadcroot_xf) = matrix_c13transfer_acc(1:nvegcpool,ideadcroot_xf) / cs13_veg%deadcrootc0_xfer_patch(p)
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c13transfer_acc(1:nvegcpool,igrain)     = matrix_c13transfer_acc(1:nvegcpool,igrain)    / cs13_veg%reproc0_patch(p)
                         matrix_c13transfer_acc(1:nvegcpool,igrain_st)  = matrix_c13transfer_acc(1:nvegcpool,igrain_st) / cs13_veg%reproc0_storage_patch(p)
                         matrix_c13transfer_acc(1:nvegcpool,igrain_xf)  = matrix_c13transfer_acc(1:nvegcpool,igrain_xf) / cs13_veg%reproc0_xfer_patch(p)
@@ -2806,7 +2806,7 @@ td: associate(                          &
                      matrix_c14transfer_acc(1:nvegcpool,ideadcroot)    = matrix_c14transfer_acc(1:nvegcpool,ideadcroot)    / cs14_veg%deadcrootc0_patch(p)
                      matrix_c14transfer_acc(1:nvegcpool,ideadcroot_st) = matrix_c14transfer_acc(1:nvegcpool,ideadcroot_st) / cs14_veg%deadcrootc0_storage_patch(p)
                      matrix_c14transfer_acc(1:nvegcpool,ideadcroot_xf) = matrix_c14transfer_acc(1:nvegcpool,ideadcroot_xf) / cs14_veg%deadcrootc0_xfer_patch(p)
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_c14transfer_acc(1:nvegcpool,igrain)     = matrix_c14transfer_acc(1:nvegcpool,igrain)    / cs14_veg%reproc0_patch(p)
                         matrix_c14transfer_acc(1:nvegcpool,igrain_st)  = matrix_c14transfer_acc(1:nvegcpool,igrain_st) / cs14_veg%reproc0_storage_patch(p)
                         matrix_c14transfer_acc(1:nvegcpool,igrain_xf)  = matrix_c14transfer_acc(1:nvegcpool,igrain_xf) / cs14_veg%reproc0_xfer_patch(p)
@@ -2831,7 +2831,7 @@ td: associate(                          &
                   matrix_ntransfer_acc(1:nvegnpool,ideadcroot)    = matrix_ntransfer_acc(1:nvegnpool,ideadcroot)    / deadcrootn0(p)
                   matrix_ntransfer_acc(1:nvegnpool,ideadcroot_st) = matrix_ntransfer_acc(1:nvegnpool,ideadcroot_st) / deadcrootn0_storage(p)
                   matrix_ntransfer_acc(1:nvegnpool,ideadcroot_xf) = matrix_ntransfer_acc(1:nvegnpool,ideadcroot_xf) / deadcrootn0_xfer(p)
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ntransfer_acc(1:nvegnpool,igrain)     = matrix_ntransfer_acc(1:nvegnpool,igrain)    / repron0(p)
                      matrix_ntransfer_acc(1:nvegnpool,igrain_st)  = matrix_ntransfer_acc(1:nvegnpool,igrain_st) / repron0_storage(p)
                      matrix_ntransfer_acc(1:nvegnpool,igrain_xf)  = matrix_ntransfer_acc(1:nvegnpool,igrain_xf) / repron0_xfer(p)
@@ -2923,7 +2923,7 @@ td: associate(                          &
                         deadcrootc_SASUsave(p)         = deadcrootc_SASUsave(p)         + deadcrootc(p)
                         deadcrootc_storage_SASUsave(p) = deadcrootc_storage_SASUsave(p) + deadcrootc_storage(p)
                         deadcrootc_xfer_SASUsave(p)    = deadcrootc_xfer_SASUsave(p)    + deadcrootc_xfer(p)
-                        if(ivt(p)  >= npcropmin)then
+                        if(is_prognostic_crop(ivt(p)))then
                            grainc_SASUsave(p)          = grainc_SASUsave(p)             + sum(reproductivec(p,:))
                            grainc_storage_SASUsave(p)  = grainc_storage_SASUsave(p)     + sum(reproductivec_storage(p,:))
                         end if
@@ -2946,7 +2946,7 @@ td: associate(                          &
                            cs13_veg%deadcrootc_SASUsave_patch(p)         = cs13_veg%deadcrootc_SASUsave_patch(p)         + cs13_veg%deadcrootc_patch(p)
                            cs13_veg%deadcrootc_storage_SASUsave_patch(p) = cs13_veg%deadcrootc_storage_SASUsave_patch(p) + cs13_veg%deadcrootc_storage_patch(p)
                            cs13_veg%deadcrootc_xfer_SASUsave_patch(p)    = cs13_veg%deadcrootc_xfer_SASUsave_patch(p)    + cs13_veg%deadcrootc_xfer_patch(p)
-                           if(ivt(p)  >= npcropmin)then
+                           if(is_prognostic_crop(ivt(p)))then
                               cs13_veg%grainc_SASUsave_patch(p)          = cs13_veg%grainc_SASUsave_patch(p)             + cs13_veg%reproductivec_patch(p,irepr)
                               cs13_veg%grainc_storage_SASUsave_patch(p)  = cs13_veg%grainc_storage_SASUsave_patch(p)     + cs13_veg%reproductivec_storage_patch(p,irepr)
                            end if
@@ -2970,7 +2970,7 @@ td: associate(                          &
                            cs14_veg%deadcrootc_SASUsave_patch(p)         = cs14_veg%deadcrootc_SASUsave_patch(p)         + cs14_veg%deadcrootc_patch(p)
                            cs14_veg%deadcrootc_storage_SASUsave_patch(p) = cs14_veg%deadcrootc_storage_SASUsave_patch(p) + cs14_veg%deadcrootc_storage_patch(p)
                            cs14_veg%deadcrootc_xfer_SASUsave_patch(p)    = cs14_veg%deadcrootc_xfer_SASUsave_patch(p)    + cs14_veg%deadcrootc_xfer_patch(p)
-                           if(ivt(p)  >= npcropmin)then
+                           if(is_prognostic_crop(ivt(p)))then
                               cs14_veg%grainc_SASUsave_patch(p)          = cs14_veg%grainc_SASUsave_patch(p)             + cs14_veg%reproductivec_patch(p,irepr)
                               cs14_veg%grainc_storage_SASUsave_patch(p)  = cs14_veg%grainc_storage_SASUsave_patch(p)     + cs14_veg%reproductivec_storage_patch(p,irepr)
                            end if
@@ -2993,7 +2993,7 @@ td: associate(                          &
                         deadcrootn_SASUsave(p)         = deadcrootn_SASUsave(p)         + deadcrootn(p)
                         deadcrootn_storage_SASUsave(p) = deadcrootn_storage_SASUsave(p) + deadcrootn_storage(p)
                         deadcrootn_xfer_SASUsave(p)    = deadcrootn_xfer_SASUsave(p)    + deadcrootn_xfer(p)
-                        if(ivt(p)  >= npcropmin)then
+                        if(is_prognostic_crop(ivt(p)))then
                            grainn_SASUsave(p)          = grainn_SASUsave(p)             + reproductiven(p,irepr)
                         end if
                         if(iyr .eq. nyr_forcing)then
@@ -3015,7 +3015,7 @@ td: associate(                          &
                            deadcrootc(p)         = deadcrootc_SASUsave(p)               / (nyr_forcing/nyr_SASU)
                            deadcrootc_storage(p) = deadcrootc_storage_SASUsave(p)       / (nyr_forcing/nyr_SASU)
                            deadcrootc_xfer(p)    = deadcrootc_xfer_SASUsave(p)          / (nyr_forcing/nyr_SASU)
-                           if(ivt(p)  >= npcropmin)then
+                           if(is_prognostic_crop(ivt(p)))then
                               reproductivec(p,:)          = grainc_SASUsave(p)                   / (nyr_forcing/nyr_SASU)
                               reproductivec_storage(p,:)  = grainc_storage_SASUsave(p)           / (nyr_forcing/nyr_SASU)
                            end if
@@ -3038,7 +3038,7 @@ td: associate(                          &
                               cs13_veg%deadcrootc_patch(p)         = cs13_veg%deadcrootc_SASUsave_patch(p)               / (nyr_forcing/nyr_SASU)
                               cs13_veg%deadcrootc_storage_patch(p) = cs13_veg%deadcrootc_storage_SASUsave_patch(p)       / (nyr_forcing/nyr_SASU)
                               cs13_veg%deadcrootc_xfer_patch(p)    = cs13_veg%deadcrootc_xfer_SASUsave_patch(p)          / (nyr_forcing/nyr_SASU)
-                              if(ivt(p)  >= npcropmin)then
+                              if(is_prognostic_crop(ivt(p)))then
                                  cs13_veg%reproductivec_patch(p,:)          = cs13_veg%grainc_SASUsave_patch(p)                   / (nyr_forcing/nyr_SASU)
                                  cs13_veg%reproductivec_storage_patch(p,:)  = cs13_veg%grainc_storage_SASUsave_patch(p)           / (nyr_forcing/nyr_SASU)
                               end if
@@ -3062,7 +3062,7 @@ td: associate(                          &
                               cs14_veg%deadcrootc_patch(p)         = cs14_veg%deadcrootc_SASUsave_patch(p)               / (nyr_forcing/nyr_SASU)
                               cs14_veg%deadcrootc_storage_patch(p) = cs14_veg%deadcrootc_storage_SASUsave_patch(p)       / (nyr_forcing/nyr_SASU)
                               cs14_veg%deadcrootc_xfer_patch(p)    = cs14_veg%deadcrootc_xfer_SASUsave_patch(p)          / (nyr_forcing/nyr_SASU)
-                              if(ivt(p)  >= npcropmin)then
+                              if(is_prognostic_crop(ivt(p)))then
                                  cs14_veg%reproductivec_patch(p,:)          = cs14_veg%grainc_SASUsave_patch(p)                   / (nyr_forcing/nyr_SASU)
                                  cs14_veg%reproductivec_storage_patch(p,:)  = cs14_veg%grainc_storage_SASUsave_patch(p)           / (nyr_forcing/nyr_SASU)
                               end if
@@ -3085,7 +3085,7 @@ td: associate(                          &
                            deadcrootn(p)         = deadcrootn_SASUsave(p)               / (nyr_forcing/nyr_SASU)
                            deadcrootn_storage(p) = deadcrootn_storage_SASUsave(p)       / (nyr_forcing/nyr_SASU)
                            deadcrootn_xfer(p)    = deadcrootn_xfer_SASUsave(p)          / (nyr_forcing/nyr_SASU)
-                           if(ivt(p)  >= npcropmin)then
+                           if(is_prognostic_crop(ivt(p)))then
                               reproductiven(p,:)         = grainn_SASUsave(p)                   / (nyr_forcing/nyr_SASU)
                            end if
                            leafc_SASUsave(p)              = 0
@@ -3106,7 +3106,7 @@ td: associate(                          &
                            deadcrootc_SASUsave(p)         = 0
                            deadcrootc_storage_SASUsave(p) = 0
                            deadcrootc_xfer_SASUsave(p)    = 0
-                           if(ivt(p)  >= npcropmin)then
+                           if(is_prognostic_crop(ivt(p)))then
                               grainc_SASUsave(p)          = 0
                               grainc_storage_SASUsave(p)  = 0
                            end if
@@ -3129,7 +3129,7 @@ td: associate(                          &
                               cs13_veg%deadcrootc_SASUsave_patch(p)         = 0
                               cs13_veg%deadcrootc_storage_SASUsave_patch(p) = 0
                               cs13_veg%deadcrootc_xfer_SASUsave_patch(p)    = 0
-                              if(ivt(p)  >= npcropmin)then
+                              if(is_prognostic_crop(ivt(p)))then
                                  cs13_veg%grainc_SASUsave_patch(p)          = 0
                                  cs13_veg%grainc_storage_SASUsave_patch(p)  = 0
                               end if
@@ -3153,7 +3153,7 @@ td: associate(                          &
                               cs14_veg%deadcrootc_SASUsave_patch(p)         = 0
                               cs14_veg%deadcrootc_storage_SASUsave_patch(p) = 0
                               cs14_veg%deadcrootc_xfer_SASUsave_patch(p)    = 0
-                              if(ivt(p)  >= npcropmin)then
+                              if(is_prognostic_crop(ivt(p)))then
                                  cs14_veg%grainc_SASUsave_patch(p)          = 0
                                  cs14_veg%grainc_storage_SASUsave_patch(p)  = 0
                               end if
@@ -3176,7 +3176,7 @@ td: associate(                          &
                            deadcrootn_SASUsave(p)         = 0
                            deadcrootn_storage_SASUsave(p) = 0
                            deadcrootn_xfer_SASUsave(p)    = 0
-                           if(ivt(p)  >= npcropmin)then
+                           if(is_prognostic_crop(ivt(p)))then
                               grainn_SASUsave(p)          = 0
                            end if
                         end if
@@ -3204,7 +3204,7 @@ td: associate(                          &
                      matrix_cap_deadcrootc(p)             = vegmatrixc_rt(ideadcroot)
                      matrix_cap_deadcrootc_storage(p)     = vegmatrixc_rt(ideadcroot_st)
                      matrix_cap_deadcrootc_xfer(p)        = vegmatrixc_rt(ideadcroot_xf) 
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_cap_reproc(p)              = vegmatrixc_rt(igrain)
                         matrix_cap_reproc_storage(p)      = vegmatrixc_rt(igrain_st)
                         matrix_cap_reproc_xfer(p)         = vegmatrixc_rt(igrain_xf)
@@ -3228,7 +3228,7 @@ td: associate(                          &
                         cs13_veg%matrix_cap_deadcrootc_patch(p)             = vegmatrixc13_rt(ideadcroot)
                         cs13_veg%matrix_cap_deadcrootc_storage_patch(p)     = vegmatrixc13_rt(ideadcroot_st)
                         cs13_veg%matrix_cap_deadcrootc_xfer_patch(p)        = vegmatrixc13_rt(ideadcroot_xf) 
-                        if(ivt(p) >= npcropmin)then
+                        if(is_prognostic_crop(ivt(p)))then
                            cs13_veg%matrix_cap_reproc_patch(p)              = vegmatrixc13_rt(igrain)
                            cs13_veg%matrix_cap_reproc_storage_patch(p)      = vegmatrixc13_rt(igrain_st)
                            cs13_veg%matrix_cap_reproc_xfer_patch(p)         = vegmatrixc13_rt(igrain_xf)
@@ -3253,7 +3253,7 @@ td: associate(                          &
                         cs14_veg%matrix_cap_deadcrootc_patch(p)             = vegmatrixc14_rt(ideadcroot)
                         cs14_veg%matrix_cap_deadcrootc_storage_patch(p)     = vegmatrixc14_rt(ideadcroot_st)
                         cs14_veg%matrix_cap_deadcrootc_xfer_patch(p)        = vegmatrixc14_rt(ideadcroot_xf) 
-                        if(ivt(p) >= npcropmin)then
+                        if(is_prognostic_crop(ivt(p)))then
                            cs14_veg%matrix_cap_reproc_patch(p)              = vegmatrixc14_rt(igrain)
                            cs14_veg%matrix_cap_reproc_storage_patch(p)      = vegmatrixc14_rt(igrain_st)
                            cs14_veg%matrix_cap_reproc_xfer_patch(p)         = vegmatrixc14_rt(igrain_xf)
@@ -3276,7 +3276,7 @@ td: associate(                          &
                      matrix_cap_livecrootn_xfer(p)        = vegmatrixn_rt(ilivecroot_xf)   
                      matrix_cap_deadcrootn(p)             = vegmatrixn_rt(ideadcroot)
                      matrix_cap_deadcrootn_storage(p)     = vegmatrixn_rt(ideadcroot_st)
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         matrix_cap_repron(p)              = vegmatrixn_rt(igrain)
                         matrix_cap_repron_storage(p)      = vegmatrixn_rt(igrain_st)
                         matrix_cap_repron_xfer(p)         = vegmatrixn_rt(igrain_xf)
@@ -3296,7 +3296,7 @@ td: associate(                          &
                   matrix_calloc_livecrootst_acc(p)         = 0._r8
                   matrix_calloc_deadcroot_acc(p)           = 0._r8
                   matrix_calloc_deadcrootst_acc(p)         = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_calloc_grain_acc(p)            = 0._r8
                      matrix_calloc_grainst_acc(p)          = 0._r8
                   end if
@@ -3313,7 +3313,7 @@ td: associate(                          &
                   matrix_ctransfer_livecrootxf_to_livecroot_acc(p)   = 0._r8
                   matrix_ctransfer_deadcrootst_to_deadcrootxf_acc(p) = 0._r8
                   matrix_ctransfer_deadcrootxf_to_deadcroot_acc(p)   = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ctransfer_grainst_to_grainxf_acc(p)      = 0._r8
                      matrix_ctransfer_grainxf_to_grain_acc(p)        = 0._r8
                   end if
@@ -3338,7 +3338,7 @@ td: associate(                          &
                   matrix_cturnover_deadcroot_acc(p)                  = 0._r8
                   matrix_cturnover_deadcrootst_acc(p)                = 0._r8
                   matrix_cturnover_deadcrootxf_acc(p)                = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_cturnover_grain_acc(p)                   = 0._r8 
                      matrix_cturnover_grainst_acc(p)                 = 0._r8
                      matrix_cturnover_grainxf_acc(p)                 = 0._r8
@@ -3357,7 +3357,7 @@ td: associate(                          &
                      cs13_veg%matrix_calloc_livecrootst_acc_patch(p)         = 0._r8
                      cs13_veg%matrix_calloc_deadcroot_acc_patch(p)           = 0._r8
                      cs13_veg%matrix_calloc_deadcrootst_acc_patch(p)         = 0._r8
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         cs13_veg%matrix_calloc_grain_acc_patch(p)            = 0._r8
                         cs13_veg%matrix_calloc_grainst_acc_patch(p)          = 0._r8
                      end if
@@ -3374,7 +3374,7 @@ td: associate(                          &
                      cs13_veg%matrix_ctransfer_livecrootxf_to_livecroot_acc_patch(p)   = 0._r8
                      cs13_veg%matrix_ctransfer_deadcrootst_to_deadcrootxf_acc_patch(p) = 0._r8
                      cs13_veg%matrix_ctransfer_deadcrootxf_to_deadcroot_acc_patch(p)   = 0._r8
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         cs13_veg%matrix_ctransfer_grainst_to_grainxf_acc_patch(p)      = 0._r8
                         cs13_veg%matrix_ctransfer_grainxf_to_grain_acc_patch(p)        = 0._r8
                      end if
@@ -3399,7 +3399,7 @@ td: associate(                          &
                      cs13_veg%matrix_cturnover_deadcroot_acc_patch(p)                  = 0._r8
                      cs13_veg%matrix_cturnover_deadcrootst_acc_patch(p)                = 0._r8
                      cs13_veg%matrix_cturnover_deadcrootxf_acc_patch(p)                = 0._r8
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         cs13_veg%matrix_cturnover_grain_acc_patch(p)                   = 0._r8 
                         cs13_veg%matrix_cturnover_grainst_acc_patch(p)                 = 0._r8
                         cs13_veg%matrix_cturnover_grainxf_acc_patch(p)                 = 0._r8
@@ -3419,7 +3419,7 @@ td: associate(                          &
                      cs14_veg%matrix_calloc_livecrootst_acc_patch(p)         = 0._r8
                      cs14_veg%matrix_calloc_deadcroot_acc_patch(p)           = 0._r8
                      cs14_veg%matrix_calloc_deadcrootst_acc_patch(p)         = 0._r8
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         cs14_veg%matrix_calloc_grain_acc_patch(p)            = 0._r8
                         cs14_veg%matrix_calloc_grainst_acc_patch(p)          = 0._r8
                      end if
@@ -3436,7 +3436,7 @@ td: associate(                          &
                      cs14_veg%matrix_ctransfer_livecrootxf_to_livecroot_acc_patch(p)   = 0._r8
                      cs14_veg%matrix_ctransfer_deadcrootst_to_deadcrootxf_acc_patch(p) = 0._r8
                      cs14_veg%matrix_ctransfer_deadcrootxf_to_deadcroot_acc_patch(p)   = 0._r8
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         cs14_veg%matrix_ctransfer_grainst_to_grainxf_acc_patch(p)      = 0._r8
                         cs14_veg%matrix_ctransfer_grainxf_to_grain_acc_patch(p)        = 0._r8
                      end if
@@ -3461,7 +3461,7 @@ td: associate(                          &
                      cs14_veg%matrix_cturnover_deadcroot_acc_patch(p)                  = 0._r8
                      cs14_veg%matrix_cturnover_deadcrootst_acc_patch(p)                = 0._r8
                      cs14_veg%matrix_cturnover_deadcrootxf_acc_patch(p)                = 0._r8
-                     if(ivt(p) >= npcropmin)then
+                     if(is_prognostic_crop(ivt(p)))then
                         cs14_veg%matrix_cturnover_grain_acc_patch(p)                   = 0._r8 
                         cs14_veg%matrix_cturnover_grainst_acc_patch(p)                 = 0._r8
                         cs14_veg%matrix_cturnover_grainxf_acc_patch(p)                 = 0._r8
@@ -3480,7 +3480,7 @@ td: associate(                          &
                   matrix_nalloc_livecrootst_acc(p)                   = 0._r8
                   matrix_nalloc_deadcroot_acc(p)                     = 0._r8
                   matrix_nalloc_deadcrootst_acc(p)                   = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_nalloc_grain_acc(p)                      = 0._r8
                      matrix_nalloc_grainst_acc(p)                    = 0._r8
                   end if
@@ -3497,7 +3497,7 @@ td: associate(                          &
                   matrix_ntransfer_livecrootxf_to_livecroot_acc(p)   = 0._r8
                   matrix_ntransfer_deadcrootst_to_deadcrootxf_acc(p) = 0._r8
                   matrix_ntransfer_deadcrootxf_to_deadcroot_acc(p)   = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ntransfer_grainst_to_grainxf_acc(p)      = 0._r8
                      matrix_ntransfer_grainxf_to_grain_acc(p)        = 0._r8
                   end if
@@ -3516,7 +3516,7 @@ td: associate(                          &
                   matrix_ntransfer_retransn_to_livecrootst_acc(p)    = 0._r8
                   matrix_ntransfer_retransn_to_deadcroot_acc(p)      = 0._r8
                   matrix_ntransfer_retransn_to_deadcrootst_acc(p)    = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_ntransfer_retransn_to_grain_acc(p)       = 0._r8
                      matrix_ntransfer_retransn_to_grainst_acc(p)     = 0._r8
                   end if
@@ -3543,7 +3543,7 @@ td: associate(                          &
                   matrix_nturnover_deadcroot_acc(p)                  = 0._r8
                   matrix_nturnover_deadcrootst_acc(p)                = 0._r8
                   matrix_nturnover_deadcrootxf_acc(p)                = 0._r8
-                  if(ivt(p) >= npcropmin)then
+                  if(is_prognostic_crop(ivt(p)))then
                      matrix_nturnover_grain_acc(p)                   = 0._r8
                      matrix_nturnover_grainst_acc(p)                 = 0._r8
                      matrix_nturnover_grainxf_acc(p)                 = 0._r8

--- a/src/biogeochem/CNVegNitrogenStateType.F90
+++ b/src/biogeochem/CNVegNitrogenStateType.F90
@@ -10,7 +10,7 @@ module CNVegNitrogenStateType
   use clm_varctl                         , only : use_crop
   use CNSharedParamsMod                  , only : use_fun, use_matrixcn
   use decompMod                          , only : bounds_type
-  use pftconMod                          , only : npcropmin, noveg, pftcon
+  use pftconMod                          , only : is_prognostic_crop, noveg, pftcon
   use abortutils                         , only : endrun
   use spmdMod                            , only : masterproc 
   use LandunitType                       , only : lun                
@@ -2251,7 +2251,7 @@ contains
             this%npool_patch(p)              + &
             this%retransn_patch(p)
 
-       if ( use_crop .and. patch%itype(p) >= npcropmin )then
+       if ( use_crop .and. is_prognostic_crop(patch%itype(p)) )then
           do k = 1, nrepr
              this%dispvegn_patch(p) = &
                   this%dispvegn_patch(p) + &

--- a/src/biogeochem/CNVegStructUpdateMod.F90
+++ b/src/biogeochem/CNVegStructUpdateMod.F90
@@ -38,7 +38,7 @@ contains
     !
     ! !USES:
     use pftconMod        , only : noveg, nc3crop, nc3irrig, nbrdlf_evr_shrub, nbrdlf_dcd_brl_shrub
-    use pftconMod        , only : npcropmin 
+    use pftconMod        , only : is_prognostic_crop
     use pftconMod        , only : ntmp_corn, nirrig_tmp_corn
     use pftconMod        , only : ntrp_corn, nirrig_trp_corn
     use pftconMod        , only : nsugarcane, nirrig_sugarcane
@@ -232,7 +232,7 @@ contains
 
                hbot(p) = max(0._r8, min(3._r8, htop(p)-1._r8))
 
-            else if (ivt(p) >= npcropmin) then ! prognostic crops
+            else if (is_prognostic_crop(ivt(p))) then ! prognostic crops
 
                if (tlai(p) >= laimx(ivt(p))) peaklai(p) = 1 ! used in CNAllocation
 

--- a/src/biogeochem/CropType.F90
+++ b/src/biogeochem/CropType.F90
@@ -528,7 +528,7 @@ contains
     use restUtilMod
     use ncdio_pio
     use PatchType, only : patch
-    use pftconMod, only : npcropmin, npcropmax
+    use pftconMod, only : is_prognostic_crop
     use clm_varpar, only : mxsowings, mxharvests
     ! BACKWARDS_COMPATIBILITY(wjs/ssr, 2023-01-09)
     use CNVegstateType, only : cnveg_state_type
@@ -577,7 +577,7 @@ contains
                interpinic_flag='copy', readvar=readvar, data=restyear)
           if (readvar) then
              do p = bounds%begp, bounds%endp
-                if (patch%itype(p) >= npcropmin .and. patch%itype(p) <= npcropmax .and. &
+                if (is_prognostic_crop(patch%itype(p)) .and. &
                      patch%active(p)) then
                    this%nyrs_crop_active_patch(p) = restyear
                 end if

--- a/src/biogeochem/DryDepVelocity.F90
+++ b/src/biogeochem/DryDepVelocity.F90
@@ -204,7 +204,7 @@ CONTAINS
     use pftconMod      , only : nbrdlf_evr_shrub, nbrdlf_dcd_tmp_shrub
     use pftconMod      , only : nbrdlf_dcd_brl_shrub,nc3_arctic_grass
     use pftconMod      , only : nc3_nonarctic_grass, nc4_grass, nc3crop
-    use pftconMod      , only : nc3irrig, npcropmin, npcropmax
+    use pftconMod      , only : nc3irrig, is_prognostic_crop
     use clm_varcon     , only : spval
 
     !
@@ -349,7 +349,7 @@ CONTAINS
             if (clmveg == nc4_grass                           ) wesveg = 3
             if (clmveg == nc3crop                             ) wesveg = 2
             if (clmveg == nc3irrig                            ) wesveg = 2
-            if (clmveg >= npcropmin .and. clmveg <= npcropmax ) wesveg = 2
+            if (is_prognostic_crop(clmveg)) wesveg = 2
             if (wesveg == wveg_unset )then
                write(iulog,*) 'clmveg = ', clmveg, 'lun%itype = ', lun%itype(l)
                call endrun(subgrid_index=pi, subgrid_level=subgrid_level_patch, &

--- a/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -125,7 +125,7 @@ contains
        c14_cnveg_carbonflux_inst, cnveg_nitrogenflux_inst, cnveg_nitrogenstate_inst, fpg_col)
     !
     ! !USES:
-    use pftconMod             , only : pftcon, npcropmin
+    use pftconMod             , only : pftcon, is_prognostic_crop
     use clm_varctl            , only : use_c13, use_c14
     use CNVegStateType        , only : cnveg_state_type
     use CropType              , only : crop_type
@@ -281,7 +281,7 @@ contains
          cndw = deadwdcn(ivt(p))
          fcur = fcur2(ivt(p))
 
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
            if (croplive(p).and.(.not.shr_infnan_isnan(aleaf(p)))) then
                f1 = aroot(p) / aleaf(p)
                f3 = astem(p) / aleaf(p)
@@ -357,7 +357,7 @@ contains
             cpool_to_deadcrootc(p)         = nlc * f2 * f3 * (1._r8 - f4) * fcur
             cpool_to_deadcrootc_storage(p) = nlc * f2 * f3 * (1._r8 - f4) * (1._r8 - fcur)
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cpool_to_livestemc(p)          = nlc * f3 * f4 * fcur
             cpool_to_livestemc_storage(p)  = nlc * f3 * f4 * (1._r8 - fcur)
             cpool_to_deadstemc(p)          = nlc * f3 * (1._r8 - f4) * fcur
@@ -387,7 +387,7 @@ contains
             npool_to_deadcrootn(p)         = (nlc * f2 * f3 * (1._r8 - f4) / cndw) * fcur
             npool_to_deadcrootn_storage(p) = (nlc * f2 * f3 * (1._r8 - f4) / cndw) * (1._r8 - fcur)
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cng = graincn(ivt(p))
             npool_to_livestemn(p)          = (nlc * f3 * f4 / cnlw) * fcur
             npool_to_livestemn_storage(p)  = (nlc * f3 * f4 / cnlw) * (1._r8 - fcur)
@@ -420,7 +420,7 @@ contains
             gresp_storage = gresp_storage + cpool_to_livecrootc_storage(p)
             gresp_storage = gresp_storage + cpool_to_deadcrootc_storage(p)
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             gresp_storage = gresp_storage + cpool_to_livestemc_storage(p)
             do k = 1, nrepr
                gresp_storage = gresp_storage + cpool_to_reproductivec_storage(p,k)
@@ -505,7 +505,7 @@ contains
     ! - livestemn_to_retransn
     !
     ! !USES:
-    use pftconMod              , only : npcropmin, pftcon
+    use pftconMod              , only : is_prognostic_crop, pftcon
     use pftconMod              , only : ntmp_soybean, nirrig_tmp_soybean
     use pftconMod              , only : ntrp_soybean, nirrig_trp_soybean
     use clm_time_manager       , only : get_step_size_real

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -24,7 +24,7 @@ module NutrientCompetitionFlexibleCNMod
   use LandunitType        , only : lun
   use ColumnType          , only : col
   use PatchType           , only : patch
-  use pftconMod           , only : pftcon, npcropmin
+  use pftconMod           , only : pftcon, is_prognostic_crop
   use NutrientCompetitionMethodMod, only : nutrient_competition_method_type
   use CropReprPoolsMod    , only : nrepr
   use CNPhenologyMod      , only : CropPhase
@@ -413,7 +413,7 @@ contains
             fcur = 0.0_r8
          end if
 
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             if (croplive(p)) then
                f1 = aroot(p) / aleaf(p)
                f3 = astem(p) / aleaf(p)
@@ -497,7 +497,7 @@ contains
                             + cpool_to_deadcrootc(p) + cpool_to_deadcrootc_storage(p)
             end if
          end if
-         if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
             cpool_to_livestemc(p)          = nlc * f3 * f4 * fcur
             cpool_to_livestemc_storage(p)  = nlc * f3 * f4 * (1._r8 - fcur)
             cpool_to_deadstemc(p)          = nlc * f3 * (1._r8 - f4) * fcur
@@ -548,7 +548,7 @@ contains
                   matrix_alloc(p,ideadcroot_st) = cpool_to_deadcrootc_storage(p)  / cpool_to_veg
                end if
             end if
-            if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
                if(cpool_to_veg .ne. 0)then
                   matrix_alloc(p,ilivestem)     = cpool_to_livestemc(p)  / cpool_to_veg
                   matrix_alloc(p,ilivestem_st)  = cpool_to_livestemc_storage(p)  / cpool_to_veg
@@ -586,7 +586,7 @@ contains
             gresp_storage = gresp_storage + cpool_to_livecrootc_storage(p)
             gresp_storage = gresp_storage + cpool_to_deadcrootc_storage(p)
          end if
-         if (ivt(p) >= npcropmin) then     ! skip 2 generic crops
+         if (is_prognostic_crop(ivt(p))) then     ! skip 2 generic crops
             gresp_storage = gresp_storage + cpool_to_livestemc_storage(p)
             do k = 1, nrepr
                gresp_storage = gresp_storage + cpool_to_reproductivec_storage(p,k)
@@ -594,7 +594,7 @@ contains
          end if
          cpool_to_gresp_storage(p) = gresp_storage * g1 * (1._r8 - g2)
 
-         if (use_crop_agsys .and. ivt(p) >= npcropmin) then
+         if (use_crop_agsys .and. is_prognostic_crop(ivt(p))) then
             call calc_npool_to_components_agsys( &
                  ! Inputs
                  npool = npool(p), &
@@ -708,7 +708,7 @@ contains
                end if
             end if
 
-            if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
 
                if (cnveg_nitrogenstate_inst%livestemn_storage_patch(p) == 0.0_r8) then
                   ! to avoid division by zero, and also to make livestemcn_actual(p) a very large number if livestemc(p) is zero
@@ -795,7 +795,7 @@ contains
 
             end if
 
-            if (ivt(p) >= npcropmin) then ! skip 2 generic crops
+            if (is_prognostic_crop(ivt(p))) then ! skip 2 generic crops
 
                livewdcn_max = livewdcn(ivt(p)) + 15.0_r8
 
@@ -876,7 +876,7 @@ contains
                          + npool_to_deadstemn(p) + npool_to_deadstemn_storage(p) &
                          + npool_to_livecrootn(p) + npool_to_livecrootn_storage(p)  &
                          + npool_to_deadcrootn(p) + npool_to_deadcrootn_storage(p)   
-           if (ivt(p) >= npcropmin)then
+           if (is_prognostic_crop(ivt(p)))then
                npool_to_veg = npool_to_veg + npool_to_reproductiven(p,1) + npool_to_reproductiven_storage(p,1)
            end if
            if(npool_to_veg .ne. 0._r8)then
@@ -892,7 +892,7 @@ contains
                matrix_nalloc(p,ilivecroot_st ) = npool_to_livecrootn_storage(p) / npool_to_veg
                matrix_nalloc(p,ideadcroot    ) = npool_to_deadcrootn(p)         / npool_to_veg
                matrix_nalloc(p,ideadcroot_st ) = npool_to_deadcrootn_storage(p) / npool_to_veg
-               if (ivt(p) >= npcropmin)then
+               if (is_prognostic_crop(ivt(p)))then
                   matrix_nalloc(p,igrain     ) = npool_to_reproductiven(p,1)             / npool_to_veg 
                   matrix_nalloc(p,igrain_st  ) = npool_to_reproductiven_storage(p,1)     / npool_to_veg 
                end if
@@ -916,7 +916,7 @@ contains
                tmp = matrix_update_phn(p,iretransn_to_ilivecrootst      ,matrix_nalloc(p,ilivecroot_st ) * retransn_to_npool(p) / retransn(p),dt,cnveg_nitrogenflux_inst,matrixcheck_ph,.True.)
                tmp = matrix_update_phn(p,iretransn_to_ideadcroot        ,matrix_nalloc(p,ideadcroot )    * retransn_to_npool(p) / retransn(p),dt,cnveg_nitrogenflux_inst,matrixcheck_ph,.True.)
                tmp = matrix_update_phn(p,iretransn_to_ideadcrootst      ,matrix_nalloc(p,ideadcroot_st ) * retransn_to_npool(p) / retransn(p),dt,cnveg_nitrogenflux_inst,matrixcheck_ph,.True.)
-               if(ivt(p) >= npcropmin)then
+               if(is_prognostic_crop(ivt(p)))then
                  tmp = matrix_update_phn(p,iretransn_to_igrain   ,matrix_nalloc(p,igrain    ) * retransn_to_npool(p) / retransn(p),dt,cnveg_nitrogenflux_inst,matrixcheck_ph,.True.)
                  tmp = matrix_update_phn(p,iretransn_to_igrainst ,matrix_nalloc(p,igrain_st ) * retransn_to_npool(p) / retransn(p),dt,cnveg_nitrogenflux_inst,matrixcheck_ph,.True.)
                end if
@@ -1051,7 +1051,7 @@ contains
        npool_to_deadcrootn_demand         = (nlc * f2 * f3 * (1._r8 - f4) / cndw) * fcur
        npool_to_deadcrootn_storage_demand = (nlc * f2 * f3 * (1._r8 - f4) / cndw) * (1._r8 - fcur)
     end if
-    if (ivt >= npcropmin) then ! skip 2 generic crops
+    if (is_prognostic_crop(ivt)) then ! skip 2 generic crops
 
        cng = graincn(ivt)
        npool_to_livestemn_demand          = (nlc * f3 * f4 / cnlw) * fcur
@@ -1084,7 +1084,7 @@ contains
             npool_to_deadcrootn_storage_demand
 
     end if
-    if (ivt >= npcropmin) then ! skip 2 generic crops
+    if (is_prognostic_crop(ivt)) then ! skip 2 generic crops
 
        npool_to_reproductiven_demand_tot = 0._r8
        npool_to_reproductiven_storage_demand_tot = 0._r8
@@ -1122,7 +1122,7 @@ contains
           frNdemand_npool_to_deadcrootn = 0.0_r8
           frNdemand_npool_to_deadcrootn_storage = 0.0_r8
        end if
-       if (ivt >= npcropmin) then ! skip 2 generic crops
+       if (is_prognostic_crop(ivt)) then ! skip 2 generic crops
 
           frNdemand_npool_to_livestemn = 0.0_r8
           frNdemand_npool_to_livestemn_storage = 0.0_r8
@@ -1155,7 +1155,7 @@ contains
           frNdemand_npool_to_deadcrootn = npool_to_deadcrootn_demand / total_plant_Ndemand
           frNdemand_npool_to_deadcrootn_storage = npool_to_deadcrootn_storage_demand / total_plant_Ndemand
        end if
-       if (ivt >= npcropmin) then ! skip 2 generic crops
+       if (is_prognostic_crop(ivt)) then ! skip 2 generic crops
 
           frNdemand_npool_to_livestemn = npool_to_livestemn_demand / total_plant_Ndemand
           frNdemand_npool_to_livestemn_storage = npool_to_livestemn_storage_demand / total_plant_Ndemand
@@ -1194,7 +1194,7 @@ contains
        npool_to_deadcrootn = frNdemand_npool_to_deadcrootn * npool / dt
        npool_to_deadcrootn_storage = frNdemand_npool_to_deadcrootn_storage * npool / dt
     end if
-    if (ivt >= npcropmin) then ! skip 2 generic crops
+    if (is_prognostic_crop(ivt)) then ! skip 2 generic crops
        npool_to_livestemn = frNdemand_npool_to_livestemn * npool / dt
        npool_to_livestemn_storage = frNdemand_npool_to_livestemn_storage * npool / dt
        npool_to_deadstemn = frNdemand_npool_to_deadstemn * npool / dt

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -1236,7 +1236,7 @@ contains
     use clm_time_manager  , only : get_step_size_real, is_near_local_noon
     use clm_varctl     , only : cnallocate_carbon_only
     use clm_varctl     , only : lnc_opt, reduce_dayl_factor, vcmax_opt    
-    use pftconMod      , only : nbrdlf_dcd_tmp_shrub, npcropmin
+    use pftconMod      , only : nbrdlf_dcd_tmp_shrub
 
     !
     ! !ARGUMENTS:
@@ -2727,7 +2727,7 @@ contains
     use clm_varctl        , only : cnallocate_carbon_only
     use clm_varctl        , only : lnc_opt, reduce_dayl_factor, vcmax_opt    
     use clm_varpar        , only : nlevsoi
-    use pftconMod         , only : nbrdlf_dcd_tmp_shrub, npcropmin
+    use pftconMod         , only : nbrdlf_dcd_tmp_shrub
     use ColumnType        , only : col
 
     !

--- a/src/biogeophys/TemperatureType.F90
+++ b/src/biogeophys/TemperatureType.F90
@@ -1414,7 +1414,7 @@ contains
     use shr_const_mod    , only : SHR_CONST_CDAY, SHR_CONST_TKFRZ
     use accumulMod       , only : update_accum_field, extract_accum_field, markreset_accum_field
     use clm_time_manager , only : is_doy_in_interval, get_curr_calday
-    use pftconMod        , only : npcropmin
+    use pftconMod        , only : is_prognostic_crop
     use CropType, only : crop_type
     !
     ! !ARGUMENTS
@@ -1485,7 +1485,7 @@ contains
           ((month > 9 .or.  month < 4)  .and. lat <  0._r8)
        ! Replace with read-in gdd20 accumulation season, if needed and valid
        ! (If these aren't being read in or they're invalid, they'll be -1)
-       if (stream_gdd20_seasons_tt .and. patch%itype(p) >= npcropmin) then
+       if (stream_gdd20_seasons_tt .and. is_prognostic_crop(patch%itype(p))) then
           gdd20_season_start = int(gdd20_season_starts(p))
           gdd20_season_end = int(gdd20_season_ends(p))
           if (gdd20_season_start >= 1 .and. gdd20_season_end >= 1) then

--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -22,7 +22,7 @@ module cropcalStreamMod
   use clm_varpar       , only : mxsowings
   use perf_mod         , only : t_startf, t_stopf
   use spmdMod          , only : masterproc, mpicom, iam
-  use pftconMod        , only : npcropmin, is_prognostic_crop
+  use pftconMod        , only : npcropmin, is_prognostic_crop, get_crop_n_from_veg_type
   use CNPhenologyMod  , only : generate_crop_gdds
   !
   ! !PUBLIC TYPES:
@@ -589,7 +589,7 @@ contains
           ivt = patch%itype(p)
           ! Will skip generic crops
           if (is_prognostic_crop(ivt)) then
-             n = ivt - npcropmin + 1
+             n = get_crop_n_from_veg_type(ivt)
              ! vegetated pft
              ig = g_to_ig(patch%gridcell(p))
              swindow_starts(p,1) = dataptr2d_swindow_start(ig,n)
@@ -671,7 +671,7 @@ contains
           ivt = patch%itype(p)
           ! Will skip generic crops
           if (is_prognostic_crop(ivt)) then
-             n = ivt - npcropmin + 1
+             n = get_crop_n_from_veg_type(ivt)
 
              if (n > ncft) then
                  write(iulog,'(a,i0,a,i0,a)') 'n (',n,') > ncft (',ncft,')'
@@ -722,7 +722,7 @@ contains
          ivt = patch%itype(p)
          ! Will skip generic crops
          if (is_prognostic_crop(ivt)) then
-            n = ivt - npcropmin + 1
+            n = get_crop_n_from_veg_type(ivt)
 
             if (n > ncft) then
                 write(iulog,'(a,i0,a,i0,a)') 'n (',n,') > ncft (',ncft,')'
@@ -792,7 +792,7 @@ contains
         ivt = patch%itype(p)
         ! Will skip generic crops
         if (is_prognostic_crop(ivt)) then
-           n = ivt - npcropmin + 1
+           n = get_crop_n_from_veg_type(ivt)
            ! vegetated pft
            ig = g_to_ig(patch%gridcell(p))
 

--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -615,7 +615,10 @@ contains
            if ((.not. allow_invalid_swindow_inputs) .and. any(all(swindow_starts(begp:endp,:) < 1, dim=2) .and. patch%wtgcell(begp:endp) > 0._r8 .and. is_prognostic_crop(patch%itype(begp:endp)))) then
                write(iulog, *) 'At least one crop in one gridcell has invalid prescribed sowing window start date(s). To ignore and fall back to paramfile sowing windows, set allow_invalid_swindow_inputs to .true.'
                write(iulog, *) 'Affected crops:'
-               do ivt = npcropmin, mxpft
+               do ivt = 1, mxpft
+                   if (.not. is_prognostic_crop(ivt)) then
+                       cycle
+                   end if
                    do fp = 1, num_pcropp
                        p = filter_pcropp(fp)
                        if (ivt == patch%itype(p) .and. patch%wtgcell(p) > 0._r8 .and. all(swindow_starts(p,:) < 1)) then
@@ -808,7 +811,10 @@ contains
          if ((.not. allow_invalid_gdd20_season_inputs) .and. any(gdd20_season_starts(begp:endp) < 1._r8 .and. patch%wtgcell(begp:endp) > 0._r8 .and. is_prognostic_crop(patch%itype(begp:endp)))) then
              write(iulog, *) 'At least one crop in one gridcell has invalid gdd20 season start and/or end date(s). To ignore and fall back to paramfile sowing windows for such crop-gridcells, set allow_invalid_gdd20_season_inputs to .true.'
              write(iulog, *) 'Affected crops:'
-             do ivt = npcropmin, mxpft
+             do ivt = 1, mxpft
+                 if (.not. is_prognostic_crop(ivt)) then
+                     cycle
+                 end if
                  do fp = 1, num_pcropp
                      p = filter_pcropp(fp)
                      if (ivt == patch%itype(p) .and. patch%wtgcell(p) > 0._r8 .and. gdd20_season_starts(p) < 1._r8) then

--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -22,7 +22,7 @@ module cropcalStreamMod
   use clm_varpar       , only : mxsowings
   use perf_mod         , only : t_startf, t_stopf
   use spmdMod          , only : masterproc, mpicom, iam
-  use pftconMod        , only : npcropmin
+  use pftconMod        , only : npcropmin, is_prognostic_crop
   use CNPhenologyMod  , only : generate_crop_gdds
   !
   ! !PUBLIC TYPES:
@@ -588,7 +588,7 @@ contains
           p = filter_pcropp(fp)
           ivt = patch%itype(p)
           ! Will skip generic crops
-          if (ivt >= npcropmin) then
+          if (is_prognostic_crop(ivt)) then
              n = ivt - npcropmin + 1
              ! vegetated pft
              ig = g_to_ig(patch%gridcell(p))
@@ -612,7 +612,7 @@ contains
        ! Handle invalid sowing window values
        if (any(swindow_starts(begp:endp,:) < 1 .or. swindow_ends(begp:endp,:) < 1)) then
            ! Fail if not allowing fallback to paramfile sowing windows
-           if ((.not. allow_invalid_swindow_inputs) .and. any(all(swindow_starts(begp:endp,:) < 1, dim=2) .and. patch%wtgcell(begp:endp) > 0._r8 .and. patch%itype(begp:endp) >= npcropmin)) then
+           if ((.not. allow_invalid_swindow_inputs) .and. any(all(swindow_starts(begp:endp,:) < 1, dim=2) .and. patch%wtgcell(begp:endp) > 0._r8 .and. is_prognostic_crop(patch%itype(begp:endp)))) then
                write(iulog, *) 'At least one crop in one gridcell has invalid prescribed sowing window start date(s). To ignore and fall back to paramfile sowing windows, set allow_invalid_swindow_inputs to .true.'
                write(iulog, *) 'Affected crops:'
                do ivt = npcropmin, mxpft
@@ -667,7 +667,7 @@ contains
 
           ivt = patch%itype(p)
           ! Will skip generic crops
-          if (ivt >= npcropmin) then
+          if (is_prognostic_crop(ivt)) then
              n = ivt - npcropmin + 1
 
              if (n > ncft) then
@@ -718,7 +718,7 @@ contains
 
          ivt = patch%itype(p)
          ! Will skip generic crops
-         if (ivt >= npcropmin) then
+         if (is_prognostic_crop(ivt)) then
             n = ivt - npcropmin + 1
 
             if (n > ncft) then
@@ -788,7 +788,7 @@ contains
         p = filter_pcropp(fp)
         ivt = patch%itype(p)
         ! Will skip generic crops
-        if (ivt >= npcropmin) then
+        if (is_prognostic_crop(ivt)) then
            n = ivt - npcropmin + 1
            ! vegetated pft
            ig = g_to_ig(patch%gridcell(p))
@@ -805,7 +805,7 @@ contains
      if (any(gdd20_season_starts(begp:endp) < 1._r8 .or. gdd20_season_ends(begp:endp) < 1._r8)) then
          ! Fail if not allowing fallback to paramfile sowing windows. Only need to check for
          ! values < 1 because values outside [1, 366] are set to -1 above.
-         if ((.not. allow_invalid_gdd20_season_inputs) .and. any(gdd20_season_starts(begp:endp) < 1._r8 .and. patch%wtgcell(begp:endp) > 0._r8 .and. patch%itype(begp:endp) >= npcropmin)) then
+         if ((.not. allow_invalid_gdd20_season_inputs) .and. any(gdd20_season_starts(begp:endp) < 1._r8 .and. patch%wtgcell(begp:endp) > 0._r8 .and. is_prognostic_crop(patch%itype(begp:endp)))) then
              write(iulog, *) 'At least one crop in one gridcell has invalid gdd20 season start and/or end date(s). To ignore and fall back to paramfile sowing windows for such crop-gridcells, set allow_invalid_gdd20_season_inputs to .true.'
              write(iulog, *) 'Affected crops:'
              do ivt = npcropmin, mxpft

--- a/src/cpl/share_esmf/cropcalStreamMod.F90
+++ b/src/cpl/share_esmf/cropcalStreamMod.F90
@@ -22,7 +22,7 @@ module cropcalStreamMod
   use clm_varpar       , only : mxsowings
   use perf_mod         , only : t_startf, t_stopf
   use spmdMod          , only : masterproc, mpicom, iam
-  use pftconMod        , only : npcropmin, is_prognostic_crop, get_crop_n_from_veg_type
+  use pftconMod        , only : npcropmin, is_prognostic_crop, get_crop_n_from_veg_type, get_veg_type_from_crop_n
   use CNPhenologyMod  , only : generate_crop_gdds
   !
   ! !PUBLIC TYPES:
@@ -144,7 +144,7 @@ contains
     allocate(stream_varnames_gdd20_baseline(ncft))
     allocate(stream_varnames_gdd20_season_enddate(ncft))
     do n = 1,ncft
-       ivt = npcropmin + n - 1
+       ivt = get_veg_type_from_crop_n(n)
        write(stream_varnames_sdate(n),'(a,i0)') "sdate1_",ivt
        write(stream_varnames_cultivar_gdds(n),'(a,i0)') "gdd1_",ivt
        write(stream_varnames_gdd20_baseline(n),'(a,i0)') "gdd20bl_",ivt

--- a/src/main/filterMod.F90
+++ b/src/main/filterMod.F90
@@ -316,7 +316,7 @@ contains
     !
     ! !USES:
     use decompMod       , only : bounds_level_clump
-    use pftconMod       , only : npcropmin
+    use pftconMod       , only : is_prognostic_crop
     use landunit_varcon , only : istsoil, istcrop, istice
     !
     ! !ARGUMENTS:
@@ -479,7 +479,7 @@ contains
     do p = bounds%begp,bounds%endp
        if(.not.use_fates)then
           if (patch%active(p) .or. include_inactive) then
-             if (patch%itype(p) >= npcropmin) then !skips 2 generic crop types
+             if (is_prognostic_crop(patch%itype(p))) then !skips 2 generic crop types
                 fl = fl + 1
                 this_filter(nc)%pcropp(fl) = p
              else

--- a/src/main/pftconMod.F90
+++ b/src/main/pftconMod.F90
@@ -318,6 +318,7 @@ module pftconMod
        __FILE__
 
   public :: is_prognostic_crop
+  public :: get_crop_n_from_veg_type
   !-----------------------------------------------------------------------
 
 contains
@@ -1628,6 +1629,20 @@ contains
     is_prognostic_crop = veg_type >= npcropmin
 
   end function is_prognostic_crop
+
+  !-----------------------------------------------------------------------
+  elemental integer function get_crop_n_from_veg_type(veg_type) result(crop_n)
+    !
+    ! !DESCRIPTION:
+    ! Given a vegetation type (pft, integer), return a 1-indexed number indicating where it would
+    ! be in a list of all simulated crops.
+    !
+    ! !ARGUMENTS
+    integer, intent(in) :: veg_type
+
+    crop_n = veg_type - npcropmin + 1
+
+  end function get_crop_n_from_veg_type
 
 end module pftconMod
 

--- a/src/main/pftconMod.F90
+++ b/src/main/pftconMod.F90
@@ -34,7 +34,6 @@ module pftconMod
   integer, public :: nc3_arctic_grass       ! value for C3 arctic grass
   integer, public :: nc3_nonarctic_grass    ! value for C3 non-arctic grass
   integer, public :: nc4_grass              ! value for C4 grass
-  integer, public :: npcropmin              ! value for first crop
   integer, public :: ntmp_corn              ! value for temperate corn, rain fed (rf)
   integer, public :: nirrig_tmp_corn        ! value for temperate corn, irrigated (ir)
   integer, public :: nswheat                ! value for spring temperate cereal (rf)
@@ -97,9 +96,12 @@ module pftconMod
   integer, public :: nirrig_trp_corn        !value for tropical corn (ir)
   integer, public :: ntrp_soybean           !value for tropical soybean (rf)
   integer, public :: nirrig_trp_soybean     !value for tropical soybean (ir)
-  integer, public :: npcropmax              ! value for last prognostic crop in list
   integer, public :: nc3crop                ! value for generic crop (rf)
   integer, public :: nc3irrig               ! value for irrigated generic crop (ir)
+
+  ! First and last prognostic crops
+  integer :: npcropmin              ! value for first crop
+  integer :: npcropmax              ! value for last prognostic crop in list
 
   ! Number of crop functional types actually used in the model. This includes each CFT for
   ! which is_pft_known_to_model is true. Note that this includes irrigated crops even if

--- a/src/main/pftconMod.F90
+++ b/src/main/pftconMod.F90
@@ -1647,10 +1647,9 @@ contains
     ! Given a vegetation type (pft, integer), return whether it's a prognostic crop. Does not
     ! include generic crops (those and natural PFTs will return .false.).
     !
-    ! NOTE(wjs, 2017-02-02) This isn't a completely robust way to check if this is a
-    ! prognostic crop patch (at the very least it should also check if <= npcropmax;
-    ! ideally it should use a prognostic_crop flag that doesn't seem to exist
-    ! currently).
+    ! NOTE: This isn't a completely robust way to check if this is a prognostic crop patch. At the
+    ! very least, it should also check if <= npcropmax. Ideally it would use a new prognostic_crop
+    ! flag on the parameter file iteself.
     !
     ! !ARGUMENTS
     integer, intent(in) :: veg_type

--- a/src/main/pftconMod.F90
+++ b/src/main/pftconMod.F90
@@ -107,6 +107,9 @@ module pftconMod
   ! at all, as given by the mergetoclmpft list.
   integer, public :: num_cfts_known_to_model
 
+  ! Number of prognostic crop functional types on the parameter file, even if not actually used
+  integer, public :: num_cfts_possible
+
   ! !PUBLIC TYPES:
   type, public :: pftcon_type
 
@@ -295,6 +298,7 @@ module pftconMod
      procedure, private :: InitRead
      procedure, private :: set_is_pft_known_to_model   ! Set is_pft_known_to_model based on mergetoclmpft
      procedure, private :: set_num_cfts_known_to_model ! Set the module-level variable, num_cfts_known_to_model
+     procedure, private :: set_num_cfts_possible ! Set the module-level variable, num_cfts_possible
 
   end type pftcon_type
 
@@ -1251,6 +1255,7 @@ contains
 
     call this%set_is_pft_known_to_model()
     call this%set_num_cfts_known_to_model()
+    call this%set_num_cfts_possible()
 
     ! Set vegetation family identifier (tree/shrub/grass)
     do m = 0,mxpft 
@@ -1442,6 +1447,27 @@ contains
     end do
 
   end subroutine set_num_cfts_known_to_model
+
+  !-----------------------------------------------------------------------
+  subroutine set_num_cfts_possible(this)
+    !
+    ! !DESCRIPTION:
+    ! Set the module-level variable, num_cfts_possible
+    !
+    ! !USES:
+    !
+    ! !ARGUMENTS:
+    class(pftcon_type), intent(in) :: this
+    !
+    ! !LOCAL VARIABLES:
+    integer :: m
+
+    character(len=*), parameter :: subname = 'set_num_cfts_possible'
+    !-----------------------------------------------------------------------
+
+    num_cfts_possible = npcropmax - npcropmin + 1
+
+  end subroutine set_num_cfts_possible
 
   !-----------------------------------------------------------------------
   subroutine Clean(this)

--- a/src/main/pftconMod.F90
+++ b/src/main/pftconMod.F90
@@ -319,6 +319,7 @@ module pftconMod
 
   public :: is_prognostic_crop
   public :: get_crop_n_from_veg_type
+  public :: get_veg_type_from_crop_n
   !-----------------------------------------------------------------------
 
 contains
@@ -1643,6 +1644,20 @@ contains
     crop_n = veg_type - npcropmin + 1
 
   end function get_crop_n_from_veg_type
+
+  !-----------------------------------------------------------------------
+  elemental integer function get_veg_type_from_crop_n(crop_n) result(veg_type)
+    !
+    ! !DESCRIPTION:
+    ! Given a return a 1-indexed number indicating where a PFT would be in a list of all simulated
+    ! crops, return vegetation type (ivt)
+    !
+    ! !ARGUMENTS
+    integer, intent(in) :: crop_n
+
+    veg_type = npcropmin + crop_n - 1
+
+  end function get_veg_type_from_crop_n
 
 end module pftconMod
 

--- a/src/soilbiogeochem/TillageMod.F90
+++ b/src/soilbiogeochem/TillageMod.F90
@@ -284,7 +284,7 @@ contains
     ! Written by Sam Rabin, based on original code by Michael Graham.
     !
     ! !USES
-    use pftconMod , only : npcropmin
+    use pftconMod , only : is_prognostic_crop
     use clm_varcon, only : zisoi, dzsoi_decomp
     use landunit_varcon , only : istcrop
     use PatchType , only : patch
@@ -315,7 +315,7 @@ contains
     sumwt = 0.0_r8
     do p = col%patchi(c),col%patchf(c)
         if (patch%active(p) .and. patch%wtcol(p) /= 0._r8) then
-            if (patch%itype(p) < npcropmin) then
+            if (.not. is_prognostic_crop(patch%itype(p))) then
                 ! Do not till generic crops
                 tillage_mults_1patch(:) = 1._r8
             else


### PR DESCRIPTION
### Description of changes
Making `npcropmin` and `npcropmax` private to `pftconMod` helps set up for adding an `is_prognostic_crop` parameter to the parameter file, contributing to #3388. Making these private required adding an `is_prognostic_crop()` function, the contents of which will eventually be replaced by a read of that new parameter.

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:**
- Contributes to #3388

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:**
- [x] `aux_clm` passes