### PR TITLE
Move nml parameters

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -1874,11 +1874,6 @@ sub process_namelist_inline_logic {
   #####################################
   setup_logic_canopy($opts,  $nl_flags, $definition, $defaults, $nl);
 
-  ########################################
-  # namelist group: soilhydrology_inparm #
-  ########################################
-  setup_logic_hydrology_params($opts,  $nl_flags, $definition, $defaults, $nl);
-
   #####################################
   # namelist group: irrigation_inparm #
   #####################################
@@ -3327,28 +3322,6 @@ sub setup_logic_supplemental_nitrogen {
 
 #-------------------------------------------------------------------------------
 
-sub setup_logic_hydrology_params {
-  #
-  # Logic for hydrology parameters
-  #
-  my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
-
-  my $lower = $nl->get_value( 'lower_boundary_condition'  );
-  my $var   = "baseflow_scalar";
-  if ( $lower == 1 || $lower == 2 ) {
-     add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl,
-                 $var, 'lower_boundary_condition' => $lower );
-  }
-  my $val   = $nl->get_value( $var );
-  if ( defined($val) ) {
-     if ( $lower != 1 && $lower != 2 ) {
-        $log->fatal_error("baseflow_scalar is only used for lower_boundary_condition of flux or zero-flux");
-     }
-  }
-}
-
-#-------------------------------------------------------------------------------
-
 sub setup_logic_irrigation_parameters {
   my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
 
@@ -4708,18 +4681,6 @@ sub setup_logic_atm_forcing {
       }
    }
 
-   foreach $var ("precip_repartition_glc_all_snow_t",
-                 "precip_repartition_glc_all_rain_t",
-                 "precip_repartition_nonglc_all_snow_t",
-                 "precip_repartition_nonglc_all_rain_t") {
-      if ( &value_is_true($nl->get_value("repartition_rain_snow")) ) {
-         add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var);
-      } else {
-         if (defined($nl->get_value($var))) {
-            $log->fatal_error("$var can only be set if repartition_rain_snow is true");
-         }
-      }
-   }
 }
 
 #-------------------------------------------------------------------------------
@@ -5259,7 +5220,7 @@ sub write_output_files {
                clm_soilhydrology_inparm dynamic_subgrid cnvegcarbonstate
                finidat_consistency_checks dynpft_consistency_checks
                clm_initinterp_inparm century_soilbgcdecompcascade
-               soilhydrology_inparm luna friction_velocity mineral_nitrogen_dynamics
+               luna friction_velocity mineral_nitrogen_dynamics
                soilwater_movement_inparm rooting_profile_inparm
                soil_resis_inparm  bgc_shared canopyfluxes_inparm aerosol
                clmu_inparm clm_soilstate_inparm clm_nitrogen clm_snowhydrology_inparm hillslope_hydrology_inparm hillslope_properties_inparm

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -205,11 +205,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <soil_resis_method               >1</soil_resis_method>
 <soil_resis_method phys="clm4_5" >0</soil_resis_method>
 
-<!-- Soil hydrology -->
-<baseflow_scalar                lower_boundary_condition="2">0.001d00</baseflow_scalar>
-<baseflow_scalar                lower_boundary_condition="1">1.d-2</baseflow_scalar>
-<baseflow_scalar phys="clm4_5"  lower_boundary_condition="2">1.d-2</baseflow_scalar>
-
 <!-- Friction velocity -->
 <zetamaxstable               use_biomass_heat_storage=".true." >2.0d00</zetamaxstable>
 <zetamaxstable phys="clm4_5"                                   >2.0d00</zetamaxstable>
@@ -230,20 +225,6 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <lapse_rate_longwave>0.032</lapse_rate_longwave>
 
 <longwave_downscaling_limit>0.5</longwave_downscaling_limit>
-
-<precip_repartition_nonglc_all_snow_t>0.</precip_repartition_nonglc_all_snow_t>
-<precip_repartition_nonglc_all_rain_t>2.</precip_repartition_nonglc_all_rain_t>
-<!-- For CLM5 and following, we assume rain at somewhat cooler temperatures. The main
-     motivation is to increase glacier melt, which otherwise is too low in
-     CESM2. The physical justification is that the 0 - 2 C ramp used elsewhere
-     makes sense for typical atmospheric profiles; but over glaciers, inversions
-     are more common, so it is more reasonable to expect rain despite
-     below-freezing near-surface temperatures. -->
-<precip_repartition_glc_all_snow_t               >-2.</precip_repartition_glc_all_snow_t>
-<precip_repartition_glc_all_rain_t               >0.</precip_repartition_glc_all_rain_t>
-<!-- For CLM45, we used the same rain-snow partitioning for glaciers as for other landunits -->
-<precip_repartition_glc_all_snow_t phys="clm4_5" >0.</precip_repartition_glc_all_snow_t>
-<precip_repartition_glc_all_rain_t phys="clm4_5" >2.</precip_repartition_glc_all_rain_t>
 
 <!-- lnd2atm defaults -->
 <melt_non_icesheet_ice_runoff               >.true.</melt_non_icesheet_ice_runoff>

--- a/bld/namelist_files/namelist_definition_ctsm.xml
+++ b/bld/namelist_files/namelist_definition_ctsm.xml
@@ -414,12 +414,6 @@ Max number of iterations used in subr. CanopyFluxes. For many years, 40 was the 
 If TRUE use clm5 equation for fraction of intercepted precipitation
 </entry>
 
-<entry id="baseflow_scalar" type="real" category="clm_physics"
-       group="soilhydrology_inparm" valid_values="" >
-Scalar multiplier for base flow rate
-(ONLY used if lower_boundary_condition is not aquifer or table)
-</entry>
-
 <entry id="soilwater_movement_method" type="integer" category="clm_physics"
        group="soilwater_movement_inparm" valid_values="0,1" >
 Index of solution method of Richards equation.
@@ -1692,30 +1686,6 @@ The pre-normalized, downscaled longwave is restricted to be in the range
 [lwrad*(1-longwave_downscaling_limit), lwrad*(1+longwave_downscaling_limit)]
 This parameter must be in the range [0,1]
 Only relevant if glcmec_downscale_longwave is .true.
-</entry>
-
-<entry id="precip_repartition_glc_all_snow_t" type="real" category="clm_physics"
-       group="atm2lnd_inparm" valid_values="" >
-Temperature below which all precipitation falls as snow, for glacier columns (deg C)
-Only relevant if repartition_rain_snow is .true.
-</entry>
-
-<entry id="precip_repartition_glc_all_rain_t" type="real" category="clm_physics"
-       group="atm2lnd_inparm" valid_values="" >
-Temperature above which all precipitation falls as rain, for glacier columns (deg C)
-Only relevant if repartition_rain_snow is .true.
-</entry>
-
-<entry id="precip_repartition_nonglc_all_snow_t" type="real" category="clm_physics"
-       group="atm2lnd_inparm" valid_values="" >
-Temperature below which all precipitation falls as snow, for non-glacier columns (deg C)
-Only relevant if repartition_rain_snow is .true.
-</entry>
-
-<entry id="precip_repartition_nonglc_all_rain_t" type="real" category="clm_physics"
-       group="atm2lnd_inparm" valid_values="" >
-Temperature above which all precipitation falls as rain, for non-glacier columns (deg C)
-Only relevant if repartition_rain_snow is .true.
 </entry>
 
 <!-- ========================================================================================  -->

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -40,7 +40,6 @@ module SoilHydrologyMod
   save
   !
   ! !PUBLIC MEMBER FUNCTIONS:
-  public :: SoilHydReadNML       ! Read in the Soil hydrology namelist
   public :: SetSoilWaterFractions ! Set diagnostic variables related to the fraction of water and ice in each layer
   public :: SetFloodc            ! Apply gridcell flood water flux to non-lake columns
   public :: SetQflxInputs        ! Set the flux of water into the soil from the top
@@ -62,13 +61,13 @@ module SoilHydrologyMod
   type, private :: params_type
      real(r8) :: aq_sp_yield_min         ! Minimum aquifer specific yield (unitless)
      real(r8) :: n_baseflow              ! Drainage power law exponent (unitless)
+     real(r8) :: baseflow_scalar         ! Scalar multiplier for base flow rate ()
      real(r8) :: perched_baseflow_scalar ! Scalar multiplier for perched base flow rate (kg/m2/s)
      real(r8) :: e_ice                   ! Soil ice impedance factor (unitless)
   end type params_type
   type(params_type), public ::  params_inst
   
   !-----------------------------------------------------------------------
-  real(r8), private   :: baseflow_scalar = 1.e-2_r8
   real(r8), parameter :: tolerance = 1.e-12_r8                   ! tolerance for checking whether sublimation is greater than ice in top soil layer
 
   integer, private :: head_gradient_method    ! Method for calculating hillslope saturated head gradient
@@ -190,71 +189,14 @@ contains
     call readNcdioScalar(ncid, 'aq_sp_yield_min', subname, params_inst%aq_sp_yield_min)
     ! Drainage power law exponent (unitless)
     call readNcdioScalar(ncid, 'n_baseflow', subname, params_inst%n_baseflow)
+    ! Scalar multiplier for base flow rate ()
+    call readNcdioScalar(ncid, 'baseflow_scalar', subname, params_inst%baseflow_scalar)
     ! Scalar multiplier for perched base flow rate (kg/m2/s)
     call readNcdioScalar(ncid, 'perched_baseflow_scalar', subname, params_inst%perched_baseflow_scalar)
     ! Soil ice impedance factor (unitless)
     call readNcdioScalar(ncid, 'e_ice', subname, params_inst%e_ice)
 
   end subroutine readParams
-
-  !-----------------------------------------------------------------------
-  subroutine soilHydReadNML( NLFilename )
-    !
-    ! !DESCRIPTION:
-    ! Read the namelist for soil hydrology
-    !
-    ! !USES:
-    use fileutils      , only : getavu, relavu, opnfil
-    use shr_nl_mod     , only : shr_nl_find_group_name
-    use spmdMod        , only : masterproc, mpicom
-    use shr_mpi_mod    , only : shr_mpi_bcast
-    use clm_varctl     , only : iulog
-    use shr_log_mod    , only : errMsg => shr_log_errMsg
-    !
-    ! !ARGUMENTS:
-    character(len=*), intent(in) :: NLFilename ! Namelist filename
-    !
-    ! !LOCAL VARIABLES:
-    integer :: ierr                 ! error code
-    integer :: unitn                ! unit for namelist file
-
-    character(len=*), parameter :: subname = 'soilHydReadNML'
-    character(len=*), parameter :: nmlname = 'soilhydrology_inparm'
-    !-----------------------------------------------------------------------
-    namelist /soilhydrology_inparm/ baseflow_scalar
-
-    ! Initialize options to default values, in case they are not specified in
-    ! the namelist
-
-
-    if (masterproc) then
-       unitn = getavu()
-       write(iulog,*) 'Read in '//nmlname//'  namelist'
-       call opnfil (NLFilename, unitn, 'F')
-       call shr_nl_find_group_name(unitn, nmlname, status=ierr)
-       if (ierr == 0) then
-          read(unitn, nml=soilhydrology_inparm, iostat=ierr)
-          if (ierr /= 0) then
-             call endrun(msg="ERROR reading "//nmlname//"namelist"//errmsg(sourcefile, __LINE__))
-          end if
-       else
-          call endrun(msg="ERROR could NOT find "//nmlname//"namelist"//errmsg(sourcefile, __LINE__))
-       end if
-       call relavu( unitn )
-    end if
-
-    call shr_mpi_bcast (baseflow_scalar, mpicom)
-
-    if (masterproc) then
-       write(iulog,*) ' '
-       write(iulog,*) nmlname//' settings:'
-       write(iulog,nml=soilhydrology_inparm)
-       write(iulog,*) ' '
-    end if
-
-  end subroutine soilhydReadNML
-
-
   
   !-----------------------------------------------------------------------
   subroutine SetSoilWaterFractions(bounds, num_hydrologyc, filter_hydrologyc, &
@@ -2391,7 +2333,7 @@ contains
             ! Non-hillslope columns
             ! baseflow is power law expression relative to bedrock layer
             if(zwt(c) <= zi(c,nbedrock(c))) then
-               qflx_latflow_out(c) = ice_imped_col(c) * baseflow_scalar &
+               qflx_latflow_out(c) = ice_imped_col(c) * params_inst%baseflow_scalar &
                     * tan(rpi/180._r8*col%topo_slope(c))* &
                     (zi(c,nbedrock(c)) - zwt(c))**(params_inst%n_baseflow)
             endif

--- a/src/main/controlMod.F90
+++ b/src/main/controlMod.F90
@@ -46,7 +46,7 @@ module controlMod
   use SoilBiogeochemLittVertTranspMod  , only: som_adv_flux, max_depth_cryoturb
   use SoilBiogeochemVerticalProfileMod , only: surfprof_exp
   use SoilBiogeochemNitrifDenitrifMod  , only: no_frozen_nitrif_denitrif
-  use SoilHydrologyMod                 , only: soilHydReadNML, hillslope_hydrology_ReadNML
+  use SoilHydrologyMod                 , only: hillslope_hydrology_ReadNML
   use CNFireFactoryMod                 , only: CNFireReadNML
   use CanopyFluxesMod                  , only: CanopyFluxesReadNML
   use shr_drydep_mod                   , only: n_drydep
@@ -616,7 +616,6 @@ contains
        call CNFUNReadNML( NLFilename )
     end if
 
-    call soilHydReadNML(   NLFilename )
     if ( use_hillslope ) then
        call hillslope_hydrology_ReadNML(   NLFilename )
     endif

--- a/src/main/ncdio_pio.F90.in
+++ b/src/main/ncdio_pio.F90.in
@@ -62,6 +62,7 @@ module ncdio_pio
   public :: ncd_inqdname       ! inquire dimension name
   public :: ncd_inqdlen        ! inquire dimension length
   public :: ncd_inqfdims       ! inquire file dimnesions
+  public :: ncd_inqnvars       ! inquire number of variables on file
   public :: ncd_defvar         ! define variables
   public :: ncd_inqvid         ! inquire variable id
   public :: ncd_inqvname       ! inquire variable name
@@ -678,7 +679,7 @@ contains
     !-----------------------------------------------------------------------
 
     vname = ''
-    status = PIO_inq_varname(ncid,vardesc,vname)
+    status = PIO_inq_varname(ncid,varid,vname)
 
   end subroutine ncd_inqvname
 
@@ -896,6 +897,26 @@ contains
     status = PIO_inquire(ncid, nattributes=nattributes)
 
   end subroutine ncd_inqnatts
+
+  !-----------------------------------------------------------------------
+  subroutine ncd_inqnvars(ncid, nvariables)
+    !
+    ! !DESCRIPTION:
+    ! Inquire number of variables
+    !
+    ! !ARGUMENTS:
+    class(file_desc_t), intent(inout) :: ncid ! netcdf file id
+    integer           , intent(out)   :: nvariables ! number of variables
+    !
+    ! !LOCAL VARIABLES:
+    integer :: status
+
+    character(len=*), parameter :: subname = 'ncd_inqnvars'
+    !-----------------------------------------------------------------------
+
+    status = PIO_inquire(ncid, nvariables=nvariables)
+
+  end subroutine ncd_inqnvars
 
   !-----------------------------------------------------------------------
   subroutine ncd_inqattname(ncid, varid, attnum, attname)


### PR DESCRIPTION
### Description of changes
move namelist parameters to parameter file.  parameters moved are: baseflow_scalar, precip_repartition_nonglc_all_rain_t, precip_repartition_nonglc_all_snow_t, precip_repartition_glc_all_rain_t, precip_repartition_glc_all_snow_t

### Specific notes

Contributors other than yourself, if any:

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?

Any User Interface Changes (namelist or namelist defaults changes)?

Does this create a need to change or add documentation? Did you do so?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on derecho for intel/gnu and izumi for intel/gnu/nag/nvhpc is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
