### PR TITLE
New tool: query_paramfile

### DIFF
--- a/python/ctsm/query_parameters/query_paramfile.py
+++ b/python/ctsm/query_parameters/query_paramfile.py
@@ -1,0 +1,23 @@
+import argparse
+import xarray as xr
+
+
+def get_arguments():
+    parser = argparse.ArgumentParser(description="Print values of a variable from a netCDF file.")
+    parser.add_argument("-i", "--input", required=True, help="Input netCDF file")
+    parser.add_argument("variable", help="Name of variable to extract")
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = get_arguments()
+
+    ds = xr.open_dataset(args.input, decode_timedelta=False)
+    data = ds[args.variable].values
+    print(f"{args.variable}: {data}")
+    ds.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ctsm/query_parameters/query_paramfile.py
+++ b/python/ctsm/query_parameters/query_paramfile.py
@@ -10,18 +10,27 @@ def get_arguments():
     )
     parser.add_argument("-i", "--input", required=True, help="Input netCDF file")
     parser.add_argument("variables", help="Comma-separated list of variable names to extract")
+    parser.add_argument(
+        "-p",
+        "--pft",
+        help="Comma-separated list of PFT names to print (only applies to PFT-specific variables)",
+    )
     args = parser.parse_args()
     return args
 
 
-def print_values(ds, var):
+def print_values(ds, var, selected_pfts, pft_names):
     data = ds[var].values
     if PFTNAME_VAR in ds[var].coords:
         print(var + ":")
-        pft_names = [pft.decode().strip() for pft in ds[PFTNAME_VAR].values]
-        max_name_len = max(len(name) for name in pft_names)
-        for p, pft_name in enumerate(pft_names):
-            print(f"   {pft_name:<{max_name_len}}: {data[p]}")
+        indices = range(len(pft_names))
+        if selected_pfts is not None:
+            indices = [i for i, name in enumerate(pft_names) if name in selected_pfts]
+            max_name_len = max(len(pft_names[i]) for i in indices) if indices else 0
+        else:
+            max_name_len = max(len(name) for name in pft_names)
+        for p in indices:
+            print(f"   {pft_names[p]:<{max_name_len}}: {data[p]}")
     else:
         print(f"{var}: {data}")
 
@@ -33,9 +42,20 @@ def main():
 
     ds = xr.open_dataset(args.input, decode_timedelta=False)
 
+    selected_pfts = None
+    if args.pft:
+        selected_pfts = [p.strip() for p in args.pft.split(",")]
+        pft_names = [pft.decode().strip() for pft in ds[PFTNAME_VAR].values]
+        pfts_not_in_file = []
+        for pft in selected_pfts:
+            if pft not in pft_names:
+                pfts_not_in_file += [pft]
+        if pfts_not_in_file:
+            raise KeyError(f"PFT(s) not found in parameter file: {', '.join(pfts_not_in_file)}")
+
     for var in variable_names:
         if var in ds.variables:
-            print_values(ds, var)
+            print_values(ds, var, selected_pfts, pft_names)
         else:
             print(f"Variable '{var}' not found in {args.input}")
 

--- a/python/ctsm/query_parameters/query_paramfile.py
+++ b/python/ctsm/query_parameters/query_paramfile.py
@@ -1,6 +1,8 @@
 import argparse
 import xarray as xr
 
+PFTNAME_VAR = "pftname"
+
 
 def get_arguments():
     parser = argparse.ArgumentParser(
@@ -14,7 +16,13 @@ def get_arguments():
 
 def print_values(ds, var):
     data = ds[var].values
-    print(f"{var}: {data}")
+    if PFTNAME_VAR in ds[var].coords:
+        print(var + ":")
+        for p, pft_name in enumerate(ds[PFTNAME_VAR].values):
+            pft_name = pft_name.decode().strip()
+            print(f"   {pft_name}: {data[p]}")
+    else:
+        print(f"{var}: {data}")
 
 
 def main():

--- a/python/ctsm/query_parameters/query_paramfile.py
+++ b/python/ctsm/query_parameters/query_paramfile.py
@@ -18,9 +18,10 @@ def print_values(ds, var):
     data = ds[var].values
     if PFTNAME_VAR in ds[var].coords:
         print(var + ":")
-        for p, pft_name in enumerate(ds[PFTNAME_VAR].values):
-            pft_name = pft_name.decode().strip()
-            print(f"   {pft_name}: {data[p]}")
+        pft_names = [pft.decode().strip() for pft in ds[PFTNAME_VAR].values]
+        max_name_len = max(len(name) for name in pft_names)
+        for p, pft_name in enumerate(pft_names):
+            print(f"   {pft_name:<{max_name_len}}: {data[p]}")
     else:
         print(f"{var}: {data}")
 

--- a/python/ctsm/query_parameters/query_paramfile.py
+++ b/python/ctsm/query_parameters/query_paramfile.py
@@ -3,19 +3,33 @@ import xarray as xr
 
 
 def get_arguments():
-    parser = argparse.ArgumentParser(description="Print values of a variable from a netCDF file.")
+    parser = argparse.ArgumentParser(
+        description="Print values of one or more variables from a netCDF file."
+    )
     parser.add_argument("-i", "--input", required=True, help="Input netCDF file")
-    parser.add_argument("variable", help="Name of variable to extract")
+    parser.add_argument("variables", help="Comma-separated list of variable names to extract")
     args = parser.parse_args()
     return args
+
+
+def print_values(ds, var):
+    data = ds[var].values
+    print(f"{var}: {data}")
 
 
 def main():
     args = get_arguments()
 
+    variable_names = [v.strip() for v in args.variables.split(",")]
+
     ds = xr.open_dataset(args.input, decode_timedelta=False)
-    data = ds[args.variable].values
-    print(f"{args.variable}: {data}")
+
+    for var in variable_names:
+        if var in ds.variables:
+            print_values(ds, var)
+        else:
+            print(f"Variable '{var}' not found in {args.input}")
+
     ds.close()
 
 

--- a/tools/query_parameters/query_paramfile
+++ b/tools/query_parameters/query_paramfile
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+For description and instructions, please see README.
+"""
+
+import os
+import sys
+
+_CTSM_PYTHON = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                            os.pardir,
+                            os.pardir,
+                            'python')
+sys.path.insert(1, _CTSM_PYTHON)
+
+from ctsm.query_parameters.query_paramfile import main
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
### Description of changes
```
usage: query_paramfile [-h] -i INPUT [-p PFT] variables

Print values of one or more variables from a netCDF file.

positional arguments:
  variables          Comma-separated list of variable names to extract

options:
  -h, --help         show this help message and exit
  -i, --input INPUT  Input netCDF file
  -p, --pft PFT      Comma-separated list of PFT names to print (only applies to PFT-specific variables)
```

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:**
- Contributes to #3394

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** Yes; no.

**Testing performed, if any:** Some initial manual tests.