### PR TITLE
Set init_interp_fill_missing_urban_with_hd = .true. always

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2359,6 +2359,7 @@ sub setup_logic_urban {
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'urban_hac');
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'urban_explicit_ac');
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'urban_traffic');
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'init_interp_fill_missing_urban_with_HD');
 }
 
 #-------------------------------------------------------------------------------

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -2500,6 +2500,10 @@ lnd/clm2/surfdata_esmf/NEON/ctsm5.3.0/surfdata_1x1_NEON_TOOL_hist_2000_78pfts_c2
 
 <init_interp_method>general</init_interp_method>
 
+<!-- Temporary for alpha-ctsm5.4.CMIP7 branch as of tag alpha-ctsm5.4.CMIP7.09.ctsm5.3.068
+     See issue https://github.com/ESCOMP/CTSM/issues/3363 about how to resolve this before finalizing ctsm5.4 -->
+<init_interp_fill_missing_urban_with_HD>.true.</init_interp_fill_missing_urban_with_HD>
+
 <!-- =========================================  -->
 <!-- Defaults for excess ice                    -->
 <!-- =========================================  -->


### PR DESCRIPTION
### Description of changes
See title.

### Specific notes

CTSM Issues Fixed (include github issue #):
Discussed in #3363 (especially this [post](https://github.com/ESCOMP/CTSM/issues/3363#issuecomment-3192660385))

Testing performed, if any:
aux_clm IN PROGRESS