### PR TITLE
ctsm5.3.074: Update ctsm6 default paramfile and IC files

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2763,6 +2763,9 @@ SIMYR:    foreach my $sim_yr ( @sim_years ) {
                    $log->fatal_error("Problem interpreting init_interp_attributes from the namelist_defaults file: $pair");
                 }
              }
+             # Add init_interp_fill_missing_urban_with_HD defaults as a function of sim_year and phys
+             add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'init_interp_fill_missing_urban_with_HD',
+                      'sim_year'=>$settings{'sim_year'}, 'phys'=>$physv->as_string() );
           }
        } else {
          $try = $done

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1372,7 +1372,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_esmf/ctsm5.2/clmi.I2000Clm50BgcCrop.2011-01-01.1.9x2.5_gx1v7_gl4_simyr2000_c240223.nc
 </finidat>
 
-<!-- Present day no crop spinup f09/f19 grid with irrigation on -->
+<!-- 1979 no crop spinup f09/f19 grid with irrigation on -->
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1380,7 +1380,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup f09/f19 grid with irrigation on -->
+<!-- 1979 no crop spinup f09/f19 grid with irrigation on -->
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1392,6 +1392,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
      finidat files for CAM resolutions for being coupled to CAM
 -->
 <!-- clm5_0 and cam7.0 -->
+<!-- 1979 no crop spinup f09 grid with irrigation on -->
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1399,6 +1400,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
 </finidat>
 
+<!-- 1979 no crop spinup f19 grid with irrigation on -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1406,7 +1408,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.1.9x2.5_gx1v7_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTIC grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1414,7 +1416,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.FHISTSp.1979-01-01.ARCTIC_ne30x4_mt12_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTICGRIS grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTICGRIS grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTICGRIS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1475,12 +1477,14 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Repeat above for clm6_0 -->
 <!-- slevis-lmwg, ekluzek 2024/10/11: do_transient_pfts was removed here to bypass a bug that doesn't allow
            do_transient_pfts=.true. when use_init_interp=.false. -->
+<!-- 1979 crop spinup f09 grid with irrigation on -->
 <finidat hgrid="0.9x1.25" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
+<!-- 1979 crop spinup ne30 grid with irrigation on -->
 <finidat hgrid="ne30np4.pg3" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
@@ -1488,7 +1492,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTIC grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1496,7 +1500,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.FHISTSp.1979-01-01.ARCTIC_ne30x4_mt12_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTICGRIS grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTICGRIS grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTICGRIS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1526,6 +1530,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
      finidat files for CAM resolutions for being coupled to CAM
 -->
 <!-- clm5_0 and cam6.0-->
+<!-- 1979 no crop spinup f09 grid with irrigation on -->
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1533,6 +1538,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.0.9x1.25_gx1v7_simyr1979_c200806.nc
 </finidat>
 
+<!-- 1979 no crop spinup f19 grid with irrigation on -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1540,7 +1546,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.BHIST.2000-01-01.1.9x2.5_gx1v7_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTIC grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1548,7 +1554,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.FHISTSp.1979-01-01.ARCTIC_ne30x4_mt12_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTICGRIS grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTICGRIS grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTICGRIS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1591,7 +1597,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Repeat above for clm6_0 -->
 <!-- clm6_0 and cam6.0-->
 
-<!-- Present day no crop spinup ARCTIC grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTIC grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTIC.ne30x4"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."
@@ -1599,7 +1605,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.FHISTSp.1979-01-01.ARCTIC_ne30x4_mt12_simyr1979_c200806.nc
 </finidat>
 
-<!-- Present day no crop spinup ARCTICGRIS grid with irrigation on -->
+<!-- 1979 no crop spinup ARCTICGRIS grid with irrigation on -->
 <finidat hgrid="ne0np4.ARCTICGRIS.ne30x8"    maxpft="17"  mask="tx0.1v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" do_transient_pfts=".false." use_excess_ice=".false."
          ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".true."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1299,6 +1299,33 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.I1850Clm50SpCru.1706-01-01.0.9x1.25_gx1v7_simyr1850_c200806.nc
 </finidat>
 
+<!-- CTSM6_0 1850 and 2000 SP irrigate off -->
+<finidat hgrid="0.9x1.25"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         phys="clm6_0"
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_f09_121_1850.clm2.r.0041-01-01-00000.nc
+</finidat>
+<finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         phys="clm6_0"
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_ne30_120_1850.clm2.r.0041-01-01-00000.nc
+</finidat>
+
+<finidat hgrid="0.9x1.25"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="20000101"  sim_year="2000" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         phys="clm6_0"
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_f09_121_HIST.clm2.r.2000-01-01-00000.nc
+</finidat>
+<finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
+         ic_ymd="20000101"  sim_year="2000" do_transient_pfts=".false." use_excess_ice=".false."
+         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         phys="clm6_0"
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_ne30_120_HIST.clm2.r.2000-01-01-00000.nc
+</finidat>
+
 <!-- CTSM6_0 - use clm6_0_CRUJRA2024 BgcCrop at f09 for all clm6_0 options -->
 <finidat hgrid="0.9x1.25" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1484,6 +1484,20 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 
+<!-- Repeat for 2010 -->
+<finidat hgrid="0.9x1.25"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="20100101" sim_year="2010" use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         phys="clm6_0"
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2010-01-01-00000.nc
+</finidat>
+<finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
+         ic_ymd="20100101" sim_year="2010" use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         phys="clm6_0"
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2010-01-01-00000.nc
+</finidat>
+
 <!-- clm5_0 and cam7.0 -->
 <!-- 2003 -->
 <finidat hgrid="1.9x2.5"   maxpft="17"  mask="gx1v7" use_cn=".false." use_cndv=".false." use_fates=".false."

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -547,7 +547,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm5.3.041.Nfix_params.v13.c250221_upplim250.nc</paramfile>
+<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params_cal115_c250813.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c250311.nc</paramfile>
 <paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c250311.nc</paramfile>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1332,7 +1332,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".false."
-         phys="clm6_0"
+         phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_f09_121_1850.clm2.r.0041-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
@@ -1366,7 +1366,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="ne30np4.pg3" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".true."
-         phys="clm6_0"
+         phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
@@ -1509,7 +1509,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true."
-         phys="clm6_0"
+         phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -547,7 +547,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params_cal115_c250813.nc</paramfile>
+<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params_cal115_c250813_cdf5.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c250311.nc</paramfile>
 <paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c250311.nc</paramfile>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1386,7 +1386,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0"
+         phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm53065_54surfdata_PPEcal115_115_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -872,15 +872,15 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <!-- 1850 for CLM6.0 -->
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_GSWP3v1"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. phys=clm6_0 use_excess_ice=.true.
+>hgrid=0.9x1.25 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. phys=clm6_0 use_excess_ice=.true.
 </init_interp_attributes>
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm6_0_CRUJRA2024 use_excess_ice=.true.
+>hgrid=0.9x1.25 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.false. glc_nex=10 do_transient_pfts=.false. lnd_tuning_mode=clm6_0_CRUJRA2024 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="1.9x2.5"
->mask=gx1v7 use_cn=.true. do_transient_pfts=.false. use_excess_ice=.true. use_crop=.false. irrigate=.false.
+>mask=tx2_3v2 use_cn=.true. do_transient_pfts=.false. use_excess_ice=.true. use_crop=.false. irrigate=.false.
 </init_interp_attributes>
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"
@@ -908,7 +908,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=1.9x2.5 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nex=10 do_transient_pfts=.false. use_excess_ice=.true.
+>hgrid=0.9x1.25 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.true. glc_nex=10 do_transient_pfts=.false. use_excess_ice=.true.
 </init_interp_attributes>
 <init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -845,6 +845,21 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.false. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
 </init_interp_attributes>
 
+<!-- SP 1850, 2000 for f09 and ne30 -->
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0" use_cn=".false."
+>hgrid=0.9x1.25 maxpft=17 mask=tx2_3v2 use_cn=.false. use_crop=.false. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
+</init_interp_attributes>
+<init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." phys="clm6_0" use_cn=".false."
+>hgrid=ne30np4.pg3 maxpft=17 mask=tx2_3v2 use_cn=.false. use_crop=.false. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
+</init_interp_attributes>
+
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0" use_cn=".false."
+>hgrid=0.9x1.25 maxpft=17 mask=tx2_3v2 use_cn=.false. use_crop=.false. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
+</init_interp_attributes>
+<init_interp_attributes sim_year="2000" use_cndv=".false." use_fates=".false." phys="clm6_0" use_cn=".false."
+>hgrid=ne30np4.pg3 maxpft=17 mask=tx2_3v2 use_cn=.false. use_crop=.false. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.true.
+</init_interp_attributes>
+
 <!-- These two needs to specify use_cn=F/T since there is a version for both, other files just use the BGC version -->
 <init_interp_attributes sim_year="1850" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm5_0_GSWP3v1" use_cn=".false."
 >hgrid=0.9x1.25 maxpft=17 mask=gx1v7 use_cn=.false. use_crop=.false. irrigate=.true. glc_nec=10 do_transient_pfts=.false. use_excess_ice=.false.
@@ -1178,15 +1193,25 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </init_interp_attributes>
 
 
+<!-- 2010 -->
+<init_interp_attributes sim_year="2010" use_cndv=".false." use_fates=".false." phys="clm6_0"
+                        hgrid="0.9x1.25"
+>maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. glc_nec=10 use_excess_ice=.true.
+</init_interp_attributes>
+<init_interp_attributes sim_year="2010" use_cndv=".false." use_fates=".false." phys="clm6_0"
+                        hgrid="ne30np4.pg3"
+>maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. glc_nec=10 use_excess_ice=.true.
+</init_interp_attributes>
+
 <!-- If an exact match for these grids and start years -->
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
                         hgrid="0.9x1.25"
->maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
+>maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
                         hgrid="1.9x2.5"
->hgrid=0.9x1.25 maxpft=79 mask=gx1v7 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
+>hgrid=0.9x1.25 mask=tx2_3v2 glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"
@@ -1201,7 +1226,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
 			hgrid="ne30np4.pg3"
->maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. irrigate=.true. glc_nec=10 use_excess_ice=.true.
+>maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam7.0"
@@ -1299,29 +1324,29 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 >lnd/clm2/initdata_map/clmi.I1850Clm50SpCru.1706-01-01.0.9x1.25_gx1v7_simyr1850_c200806.nc
 </finidat>
 
-<!-- CTSM6_0 1850 and 2000 SP irrigate off -->
+<!-- CTSM6_0 1850 and 2000 SP -->
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".false."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_f09_121_1850.clm2.r.0041-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         ic_ymd="18500101"  sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".false."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_ne30_120_1850.clm2.r.0041-01-01-00000.nc
 </finidat>
 
 <finidat hgrid="0.9x1.25"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101"  sim_year="2000" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         ic_ymd="20000101"  sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".false."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_f09_121_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"  maxpft="17"  mask="tx2_3v2" use_cn=".false." use_cndv=".false." use_fates=".false."
-         ic_ymd="20000101"  sim_year="2000" do_transient_pfts=".false." use_excess_ice=".false."
-         ic_tod="0" glc_nec="10" use_crop=".false." irrigate=".false."
+         ic_ymd="20000101"  sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_tod="0" glc_nec="10" use_crop=".false."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_SP_ne30_120_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
@@ -1329,21 +1354,21 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- CTSM6_0 - use clm6_0_CRUJRA2024 BgcCrop at f09 for all clm6_0 options -->
 <finidat hgrid="0.9x1.25" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->
 <finidat hgrid="ne30np4.pg3" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
-         use_crop=".true." irrigate=".false."
+         use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
 <finidat hgrid="1.9x2.5" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
-         use_crop=".false." irrigate=".false."
+         use_crop=".false."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm53065_54surfdata_PPEcal115_115_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
@@ -1385,7 +1410,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- NB: This f19 2000 finidat comes from a spin-up with use_crop=".false." -->
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm53065_54surfdata_PPEcal115_115_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
@@ -1473,13 +1498,13 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
            do_transient_pfts=.true. when use_init_interp=.false. -->
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
@@ -1487,13 +1512,13 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Repeat for 2010 -->
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20100101" sim_year="2010" use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2010-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20100101" sim_year="2010" use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2010-01-01-00000.nc
 </finidat>
@@ -1518,17 +1543,17 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Repeat above for clm6_0 -->
 <!-- slevis-lmwg, ekluzek 2024/10/11: do_transient_pfts was removed here to bypass a bug that doesn't allow
            do_transient_pfts=.true. when use_init_interp=.false. -->
-<!-- 1979 crop spinup f09 grid with irrigation on -->
+<!-- 1979 crop spinup f09 grid -->
 <finidat hgrid="0.9x1.25" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
-<!-- 1979 crop spinup ne30 grid with irrigation on -->
+<!-- 1979 crop spinup ne30 grid -->
 <finidat hgrid="ne30np4.pg3" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
-         ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
+         ic_tod="0" glc_nec="10" use_crop=".true."
          phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -183,6 +183,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Default urban traffic flux -->
 <urban_traffic>.false.</urban_traffic>
 
+<!-- Default "fill missing urban with HD" -->
+<init_interp_fill_missing_urban_with_HD>.false.</init_interp_fill_missing_urban_with_HD>
+<init_interp_fill_missing_urban_with_HD sim_year="1850" phys="clm6_0">.true.</init_interp_fill_missing_urban_with_HD>
+
 <!-- Soil state settings -->
 <organic_frac_squared               >.false.</organic_frac_squared>
 <organic_frac_squared phys="clm4_5" >.true.</organic_frac_squared>
@@ -1355,7 +1359,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true."
-         phys="clm6_0"
+         phys="clm6_0" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1211,7 +1211,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." phys="clm6_0"
                         hgrid="1.9x2.5"
->hgrid=0.9x1.25 mask=tx2_3v2 glc_nec=10 use_excess_ice=.true.
+>hgrid=0.9x1.25 maxpft=79 mask=tx2_3v2 use_cn=.true. use_crop=.true. glc_nec=10 use_excess_ice=.true.
 </init_interp_attributes>
 
 <init_interp_attributes sim_year="1979" use_cndv=".false." use_fates=".false." lnd_tuning_mode="clm6_0_cam6.0"

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -547,7 +547,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params_cal115_c250813_cdf5.nc</paramfile>
+<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params_cal115_c250813.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c250311.nc</paramfile>
 <paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c250311.nc</paramfile>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1303,14 +1303,14 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->
 <finidat hgrid="ne30np4.pg3" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".true." irrigate=".false."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
@@ -1357,9 +1357,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 <!-- NB: This f19 2000 finidat comes from a spin-up with use_crop=".false." -->
 <finidat hgrid="1.9x2.5"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
-         ic_ymd="20110101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
+         ic_ymd="20000101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm53065_54surfdata_PPEcal115_115_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 
@@ -1447,13 +1447,13 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 
@@ -1481,14 +1481,14 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <finidat hgrid="0.9x1.25" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
 <!-- 1979 crop spinup ne30 grid with irrigation on -->
 <finidat hgrid="ne30np4.pg3" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
-         phys="clm6_0" use_init_interp=".true."
+         phys="clm6_0"
 >lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
 

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -1300,25 +1300,25 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 </finidat>
 
 <!-- CTSM6_0 - use clm6_0_CRUJRA2024 BgcCrop at f09 for all clm6_0 options -->
-<finidat hgrid="0.9x1.25" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="0.9x1.25" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="18500101" sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".false."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_snowTherm_100_pSASU.clm2.r.0161-01-01-00000_64bitoffset.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding ne30 -->
 <finidat hgrid="ne30np4.pg3" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".true." irrigate=".false."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_ne30_102_pSASU.clm2.r.0081-01-01-00000_64bitoffset.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 <!-- Corresponding f19 -->
-<finidat hgrid="1.9x2.5" mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="1.9x2.5" mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          sim_year="1850" do_transient_pfts=".false." use_excess_ice=".true."
          use_crop=".false." irrigate=".false."
          phys="clm6_0"
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm530_f19_g17_Bgc_exice_pSASU.clm60.r.0161-01-01.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm53065_54surfdata_PPEcal115_115_pSASU.clm2.r.0161-01-01-00000.nc
 </finidat>
 
 <!--
@@ -1355,12 +1355,12 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
          lnd_tuning_mode="clm5_0_GSWP3v1" use_init_interp=".true."
 >lnd/clm2/initdata_esmf/ctsm5.3/clmi.f19_interp_from.I1850Clm50BgcCrop-ciso.1366-01-01.0.9x1.25_gx1v7_simyr1850_c240223.nc
 </finidat>
-<!-- NB: This pSASU finidat is from an f09 1850 (rather than f19 2000) spin-up -->
-<finidat hgrid="1.9x2.5"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<!-- NB: This f19 2000 finidat comes from a spin-up with use_crop=".false." -->
+<finidat hgrid="1.9x2.5"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20110101" sim_year="2000" do_transient_pfts=".false." use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm52026_f09_pSASU.clm2.r.0421-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm53065_54surfdata_PPEcal115_115_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 
 
@@ -1442,17 +1442,17 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- clm6_0 and cam7.0 -->
 <!-- slevis-lmwg, ekluzek 2024/10/11: do_transient_pfts was removed here to bypass a bug that doesn't allow
            do_transient_pfts=.true. when use_init_interp=.false. -->
-<finidat hgrid="0.9x1.25"    maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="0.9x1.25"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_ne30_102_HIST.clm2.r.2000-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3"    maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="20000101" sim_year="2000" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.4/ctsm53041_54surfdata_ne30_102_HIST.clm2.r.2000-01-01-00000.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2000-01-01-00000.nc
 </finidat>
 
 <!-- clm5_0 and cam7.0 -->
@@ -1475,17 +1475,17 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Repeat above for clm6_0 -->
 <!-- slevis-lmwg, ekluzek 2024/10/11: do_transient_pfts was removed here to bypass a bug that doesn't allow
            do_transient_pfts=.true. when use_init_interp=.false. -->
-<finidat hgrid="0.9x1.25" maxpft="79"  mask="gx1v7" use_cn=".true." use_cndv=".false." use_fates=".false."
+<finidat hgrid="0.9x1.25" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_f09_g17_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
 <finidat hgrid="ne30np4.pg3" maxpft="79"  mask="tx2_3v2" use_cn=".true." use_cndv=".false." use_fates=".false."
          ic_ymd="19790101"  sim_year="1979" use_excess_ice=".true."
          ic_tod="0" glc_nec="10" use_crop=".true." irrigate=".true."
          phys="clm6_0" use_init_interp=".true."
->lnd/clm2/initdata_esmf/ctsm5.3/ctsm53n04ctsm52028_ne30pg3t232_BgcCrop_exice_hist.clm60.r.1979-01-01.nc
+>lnd/clm2/initdata_esmf/ctsm5.4/ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.1979-01-01-00000.nc
 </finidat>
 
 <!-- Present day no crop spinup ARCTIC grid with irrigation on -->

--- a/bld/unit_testers/build-namelist_test.pl
+++ b/bld/unit_testers/build-namelist_test.pl
@@ -538,9 +538,9 @@ foreach my $phys ( "clm5_0", "clm6_0" ) {
    $mode = "-phys $phys CAM_SETS_DRV_FLDS";
    &make_config_cache($phys);
    foreach my $options (
-                      "--res 1.9x2.5 --mask gx1v7 --bgc sp --use_case 20thC_transient --namelist '&a start_ymd=19790101/' --lnd_tuning_mode ${phys}_cam6.0 --infile empty_user_nl_clm",
-                      "--res 1.9x2.5 --mask gx1v7 --bgc sp --use_case 20thC_transient --namelist '&a start_ymd=19790101/' --lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",
-                      "--res 1.9x2.5 --mask gx1v7 --bgc sp -no-crop --use_case 20thC_transient --namelist '&a start_ymd=19790101/' --lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",
+                      "--res 1.9x2.5 --bgc sp --use_case 20thC_transient --namelist '&a start_ymd=19790101/' --lnd_tuning_mode ${phys}_cam6.0 --infile empty_user_nl_clm",
+                      "--res 1.9x2.5 --bgc sp --use_case 20thC_transient --namelist '&a start_ymd=19790101/' --lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",
+                      "--res 1.9x2.5 --bgc sp -no-crop --use_case 20thC_transient --namelist '&a start_ymd=19790101/' --lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",
                       "--res ne0np4.ARCTIC.ne30x4 --mask tx0.1v2 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",
                       "--res ne0np4.ARCTICGRIS.ne30x8 --mask tx0.1v2 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=19790101/' -lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",
                       "--res ne0np4CONUS.ne30x8 --mask tx0.1v2 -bgc sp -use_case 20thC_transient -namelist '&a start_ymd=20130101/' -lnd_tuning_mode ${phys}_cam7.0 --infile empty_user_nl_clm",

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,99 @@
 ===============================================================
+Tag name: ctsm5.3.074
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Fri 05 Sep 2025 06:14:32 PM MDT
+One-line Summary: Update ctsm6 default paramfile and finidat files
+
+Purpose and description of changes
+----------------------------------
+
+ - Copied the new files to /inputdata and rimported them to the svn repository
+ - Updated namelist_defaults_ctsm.xml
+
+ New paramfile /glade/campaign/cesm/cesmdata/cseg/inputdata/lnd/clm2/paramdata/ctsm60_params_cal115_c250813.nc
+
+ New finidat files in /glade/campaign/cesm/cesmdata/inputdata/lnd/clm2/initdata_esmf/ctsm5.4:
+ f19 2000 Bgc ctsm53065_54surfdata_PPEcal115_115_HIST.clm2.r.2000-01-01-00000.nc
+ f19 1850 Bgc ctsm53065_54surfdata_PPEcal115_115_pSASU.clm2.r.0161-01-01-00000.nc
+
+ ne30 1979 BgcCrop ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.1979-01-01-00000.nc
+ ne30 2000 BgcCrop ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2000-01-01-00000.nc
+ ne30 2010 BgcCrop ctsm5.4_5.3.068_PPEcal115_116_HIST.clm2.r.2010-01-01-00000.nc
+ ne30 1850 BgcCrop ctsm5.4_5.3.068_PPEcal115_116_pSASU.clm2.r.0161-01-01-00000.nc
+
+ f09 1979 BgcCrop ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.1979-01-01-00000.nc
+ f09 2000 BgcCrop ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2000-01-01-00000.nc
+ f09 2010 BgcCrop ctsm5.4_5.3.068_PPEcal115f09_118_HIST.clm2.r.2010-01-01-00000.nc
+ f09 1850 BgcCrop ctsm5.4_5.3.068_PPEcal115f09_118_pSASU.clm2.r.0161-01-01-00000.nc
+
+ f09 1850 Sp ctsm5.4_5.3.068_PPEcal115_SP_f09_121_1850.clm2.r.0041-01-01-00000.nc
+ f09 2000 Sp ctsm5.4_5.3.068_PPEcal115_SP_f09_121_HIST.clm2.r.2000-01-01-00000.nc
+ ne30 1850 Sp ctsm5.4_5.3.068_PPEcal115_SP_ne30_120_1850.clm2.r.0041-01-01-00000.nc
+ ne30 2000 Sp ctsm5.4_5.3.068_PPEcal115_SP_ne30_120_HIST.clm2.r.2000-01-01-00000.nc
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Notes of particular relevance for users
+---------------------------------------
+Changes made to namelist defaults (e.g., changed parameter values):
+ Updated default files as listed above
+
+Changes to the datasets (e.g., parameter, surface or initial files):
+ Same comment
+
+Notes of particular relevance for developers:
+---------------------------------------------
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+
+Changes to tests or testing:
+
+
+Testing summary:
+----------------
+
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  build-namelist tests (if CLMBuildNamelist.pm has changed):
+
+    derecho - OK (expected failures reported in #3050)
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho -----
+    izumi -------
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: ctsm6
+    - what platforms/compilers: all
+    - nature of change: larger than roundoff/same climate
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/3460
+
+===============================================================
+===============================================================
 Tag name: ctsm5.3.073
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
 Date: Thu 28 Aug 2025 01:10:16 PM MDT

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name: ctsm5.3.074
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
-Date: Fri 05 Sep 2025 06:14:32 PM MDT
+Date: Mon 08 Sep 2025 06:04:38 PM MDT
 One-line Summary: Update ctsm6 default paramfile and finidat files
 
 Purpose and description of changes
@@ -58,10 +58,9 @@ Changes to the datasets (e.g., parameter, surface or initial files):
 
 Notes of particular relevance for developers:
 ---------------------------------------------
-Caveats for developers (e.g., code that is duplicated that requires double maintenance):
-
 Changes to tests or testing:
-
+ bld/unit_testers/build-namelist_test.pl
+ I removed "--mask gx1v7" from a few tests to allow them to pass when the mask has been updated to tx2_3v2
 
 Testing summary:
 ----------------
@@ -74,8 +73,8 @@ Testing summary:
 
   regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
 
-    derecho -----
-    izumi -------
+    derecho ----- OK
+    izumi ------- OK
 
 Answer changes
 --------------

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-       ctsm5.3.074   slevis 09/08/2025 Update ctsm6 default paramfile and finidat files
+       ctsm5.3.074   slevis 09/09/2025 Update ctsm6 default paramfile and finidat files
        ctsm5.3.073   slevis 08/28/2025 Update .gitmodules to cesm3_0_alpha07c
        ctsm5.3.072 jinmuluo 08/26/2025 New vertical movement scheme for soil nitrate
        ctsm5.3.071 samrabin 08/22/2025 Merge b4b-dev to master

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.074   slevis 09/08/2025 Update ctsm6 default paramfile and finidat files
        ctsm5.3.073   slevis 08/28/2025 Update .gitmodules to cesm3_0_alpha07c
        ctsm5.3.072 jinmuluo 08/26/2025 New vertical movement scheme for soil nitrate
        ctsm5.3.071 samrabin 08/22/2025 Merge b4b-dev to master


### PR DESCRIPTION
### Description of changes
From https://github.com/NCAR/LMWG_dev/issues/116
- [x] I copied the new temporary paramfile='/glade/work/linnia/CLM6-PPE/ctsm6_cal/paramfiles/cal115_c08132025.nc'
to /glade/campaign/cesm/cesmdata/cseg/inputdata/lnd/clm2/paramdata/ctsm60_params_cal115_c250813.nc
this time staying closer to our naming conventions (unlike with the previous temporary paramfile).

Next I converted from netCDF-4 to cdf5 and ./rimport-ed the file:
```
nccopy -k cdf5 lnd/clm2/paramdata/ctsm60_params_cal115_c250813.nc lnd/clm2/paramdata/ctsm60_params_cal115_c250813_cdf5.nc
./rimport -file lnd/clm2/paramdata/ctsm60_params_cal115_c250813_cdf5.nc
```
- [x] I have to do the same with ne30, f09, f19 finidat files.
- [x] I updated namelist_defaults_ctsm.xml with the new temporary paramfile for ctsm6
- [x] Do the same for the new finidat files.

### Specific notes

Contributors other than yourself, if any:
@linniahawkins @wwieder 

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Ctsm6 answers will change.

Any User Interface Changes (namelist or namelist defaults changes)?
namelist_defaults_ctsm.xml as explained above.