### PR TITLE
Add a failing test as a reminder for mosart history issue

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -403,5 +403,10 @@
       <issue>#3383</issue>
     </phase>
   </test>
-
+  <test name="ERI_Ld41.f10_f10_mg37.I2000Clm60BgcCrop.derecho_intel.clm-default">
+    <phase name="COMPARE_base_hybrid">
+     <status>FAIL</status>
+     <issue>#3494</issue>
+    </phase>
+  </test>
 </expectedFails>

--- a/cime_config/testdefs/testlist_clm.xml
+++ b/cime_config/testdefs/testlist_clm.xml
@@ -4668,5 +4668,15 @@
     </options>
   </test>
 
+  <test name="ERI_Ld41" grid="f10_f10_mg37" compset="I2000Clm60BgcCrop" testmods="clm/default">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_clm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:30:00</option>
+      <option name="comment"> Placeholder failing test for mosart hybrid history issue which appears for tests longer than Ld33</option>
+    </options>
+  </test>
+
 
 </testlist>


### PR DESCRIPTION
### Description of changes

Add a longer ERI test to show that any ERI test with MOSART will fail if their length is not years or longer than a month

### Specific notes

Are answers expected to change (and if so in what way)?

No

Testing performed, if any:

All tests in #3494  plus:
`ERI_Ld41.f10_f10_mg37.I2000Clm60BgcCrop.derecho_intel.clm-default `
Will result in `COMPARE_base_hybrid (EXPECTED FAILURE)`