### PR TITLE
alpha-ctsm5.4.CMIP7.15.ctsm5.3.079: Updates to default_data_[1850,2000].cfg & modify_smallville.sh

### DIFF
--- a/tools/modify_input_files/modify_smallville.sh
+++ b/tools/modify_input_files/modify_smallville.sh
@@ -7,14 +7,14 @@ module load nco
 # This script runs from the mksurfdata_esmf/Makefile.
 # When running standalone, it may need "subset_data_single_point/" in front
 # of each landuse.timeseries file name.
- file_to_2100="landuse.timeseries_1x1_smallvilleIA_SSP2-4.5_1850-2100_78pfts_c$(date +%y%m%d).nc"
- file_to_1855="landuse.timeseries_1x1_smallvilleIA_SSP2-4.5_1850-1855_78pfts_c$(date +%y%m%d).nc"
- file_lake="landuse.timeseries_1x1_smallvilleIA_SSP2-4.5_1850-1855_78pfts_dynLakes_c$(date +%y%m%d).nc"
- file_urban="landuse.timeseries_1x1_smallvilleIA_SSP2-4.5_1850-1855_78pfts_dynUrban_c$(date +%y%m%d).nc"
- file_pft="landuse.timeseries_1x1_smallvilleIA_SSP2-4.5_1850-1855_78pfts_dynPft_c$(date +%y%m%d).nc"
+ file_whole="landuse.timeseries_1x1_smallvilleIA_hist_1850-2023_78pfts_c$(date +%y%m%d).nc"
+ file_to_1855="landuse.timeseries_1x1_smallvilleIA_synth_hist_1850-1855_78pfts_c$(date +%y%m%d).nc"
+ file_lake="landuse.timeseries_1x1_smallvilleIA_synth_hist_1850-1855_78pfts_dynLakes_c$(date +%y%m%d).nc"
+ file_urban="landuse.timeseries_1x1_smallvilleIA_synth_hist_1850-1855_78pfts_dynUrban_c$(date +%y%m%d).nc"
+ file_pft="landuse.timeseries_1x1_smallvilleIA_synth_hist_1850-1855_78pfts_dynPft_c$(date +%y%m%d).nc"
 
 # Trim the file to just the years 1850-1855
-ncks -d time,0,5 $file_to_2100 $file_to_1855
+ncks -d time,0,5 $file_whole $file_to_1855
 
 # Replace all values in the LAKE and CROP variables
 ncap2 -s "PCT_LAKE=array(0.,0.,PCT_CROP); PCT_LAKE={0.,50.,25.,25.,25.,25.} ; PCT_LAKE_MAX=array(50.,50.,PCT_CROP_MAX); PCT_CROP=array(0.,0.,PCT_LAKE); PCT_CROP={0.,25.,12.,12.,12.,12.}; PCT_CROP_MAX=array(25.,25.,PCT_LAKE_MAX)" $file_to_1855 $file_lake

--- a/tools/site_and_regional/default_data_1850.cfg
+++ b/tools/site_and_regional/default_data_1850.cfg
@@ -15,12 +15,12 @@ precname = CLMCRUJRA2024.Precip
 tpqwname = CLMCRUJRA2024.TPQW
 
 [surfdat]
-dir = lnd/clm2/surfdata_esmf/ctsm5.3.0
-surfdat_78pft = surfdata_0.9x1.25_hist_1850_78pfts_c240908.nc
+dir = lnd/clm2/surfdata_esmf/ctsm5.4.0
+surfdat_78pft = surfdata_0.9x1.25_hist_1850_78pfts_c251022.nc
 
 [landuse]
-dir = lnd/clm2/surfdata_esmf/ctsm5.3.0
-landuse_78pft = landuse.timeseries_0.9x1.25_SSP2-4.5_1850-2100_78pfts_c240908.nc
+dir = lnd/clm2/surfdata_esmf/ctsm5.4.0
+landuse_78pft = landuse.timeseries_0.9x1.25_hist_1850-2023_78pfts_c251022.nc
 
 [domain]
 file = share/domains/domain.lnd.fv0.9x1.25_gx1v7.151020.nc

--- a/tools/site_and_regional/default_data_2000.cfg
+++ b/tools/site_and_regional/default_data_2000.cfg
@@ -1,5 +1,5 @@
 [main]
-clmforcingindir = /glade/campaign/cesm/cesmdata/cseg/inputdata
+clmforcingindir = /glade/campaign/cesm/cesmdata/inputdata
 
 [datm]
 dir = atm/datm7/atm_forcing.datm7.CRUJRA.0.5d.c20241231/three_stream
@@ -15,16 +15,16 @@ precname = CLMCRUJRA2024.Precip
 tpqwname = CLMCRUJRA2024.TPQW
 
 [surfdat]
-dir = lnd/clm2/surfdata_esmf/ctsm5.3.0
-surfdat_16pft = surfdata_0.9x1.25_hist_2000_16pfts_c240908.nc
-surfdat_78pft = surfdata_0.9x1.25_hist_2000_78pfts_c240908.nc
+dir = lnd/clm2/surfdata_esmf/ctsm5.4.0
+surfdat_16pft = surfdata_0.9x1.25_hist_2000_16pfts_c251022.nc
+surfdat_78pft = surfdata_0.9x1.25_hist_2000_78pfts_c251022.nc
 mesh_dir = share/meshes/
 mesh_surf = fv0.9x1.25_141008_ESMFmesh.nc
 
 [landuse]
-dir = lnd/clm2/surfdata_esmf/ctsm5.3.0
-landuse_16pft = landuse.timeseries_0.9x1.25_SSP2-4.5_1850-2100_78pfts_c240908.nc
-landuse_78pft = landuse.timeseries_0.9x1.25_SSP2-4.5_1850-2100_78pfts_c240908.nc
+dir = lnd/clm2/surfdata_esmf/ctsm5.4.0
+landuse_16pft = landuse.timeseries_0.9x1.25_hist_1850-2023_78pfts_c251022.nc
+landuse_78pft = landuse.timeseries_0.9x1.25_hist_1850-2023_78pfts_c251022.nc
 
 [domain]
 file = share/domains/domain.lnd.fv0.9x1.25_gx1v7.151020.nc


### PR DESCRIPTION
### Description of changes
Having made CTSM5.4 fsurdat/landuse files with `make all` (all-subset excluded), we then update a few .cfg and .sh files before running `make all-subset`. Then we can also proceed with making new NEON/PLUMBER datasets.

### Specific notes

CTSM Issues Fixed (include github issue #):
Addresses a checkbox in #2851.

Are answers expected to change (and if so in what way)?
Using the new fsurdat/landuse files will lead to new answers.

Any User Interface Changes (namelist or namelist defaults changes)?
The .cfg files listed above are changing.

Testing performed, if any:
- `make all-subset` worked with the changes in this PR
- `neon_surf_wrapper` and `plumber2_surf_wrapper` also worked