### PR TITLE
alpha-ctsm5.4.CMIP7.15.ctsm5.3.082: Update the alpha54 branch to ctsm5.3.082

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -3753,8 +3753,12 @@ sub setup_logic_c_isotope {
   #
   my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
 
-  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c13', 'bgc_mode'=>$nl_flags->{'bgc_mode'}, 'phys'=>$nl_flags->{'phys'});
-  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c14', 'bgc_mode'=>$nl_flags->{'bgc_mode'}, 'phys'=>$nl_flags->{'phys'});
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c13', 
+              'bgc_mode'=>$nl_flags->{'bgc_mode'}, 'phys'=>$nl_flags->{'phys'},
+              'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'}, ssp_rcp=>$nl_flags->{'ssp_rcp'} );
+  add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c14', 
+              'bgc_mode'=>$nl_flags->{'bgc_mode'}, 'phys'=>$nl_flags->{'phys'},
+              'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'}, ssp_rcp=>$nl_flags->{'ssp_rcp'} );
   my $use_c13 = $nl->get_value('use_c13');
   my $use_c14 = $nl->get_value('use_c14');
   if ( $nl_flags->{'bgc_mode'} ne "sp" && $nl_flags->{'bgc_mode'} ne "fates" ) {
@@ -3767,7 +3771,7 @@ sub setup_logic_c_isotope {
       }
     }
     if ( &value_is_true($use_c14) ) {
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c14_bombspike', 'bgc_mode'=>$nl_flags->{'bgc_mode'}, 'phys'=>$nl_flags->{'phys'});
+      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c14_bombspike', 'use_c14'=>$use_c14 );
       my $use_c14_bombspike = $nl->get_value('use_c14_bombspike');
       if ( &value_is_true($use_c14_bombspike) ) {
          add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'atm_c14_filename',
@@ -3781,7 +3785,7 @@ sub setup_logic_c_isotope {
       }
     }
     if ( &value_is_true($use_c13) ) {
-      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c13_timeseries', 'bgc_mode'=>$nl_flags->{'bgc_mode'}, 'phys'=>$nl_flags->{'phys'});
+      add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_c13_timeseries', 'use_c13'=>$use_c13 );
       my $use_c13_timeseries = $nl->get_value('use_c13_timeseries');
       if ( &value_is_true($use_c13_timeseries) ) {
          add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'atm_c13_filename',

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -115,11 +115,22 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <use_c14>.false.</use_c14>
 <use_c13_timeseries>.false.</use_c13_timeseries>
 <use_c14_bombspike>.false.</use_c14_bombspike>
+<!-- Turn timeseries on if Carbon isotopes are on -->
+<use_c13_timeseries use_c13=".true.">.true.</use_c13_timeseries>
+<use_c14_bombspike use_c14=".true.">.true.</use_c14_bombspike>
 
-<use_c13 phys="clm6_0" bgc_mode="bgc" >.true.</use_c13>
-<use_c14 phys="clm6_0" bgc_mode="bgc" >.true.</use_c14>
-<use_c13_timeseries phys="clm6_0" bgc_mode="bgc" >.true.</use_c13_timeseries>
-<use_c14_bombspike phys="clm6_0" bgc_mode="bgc" >.true.</use_c14_bombspike>
+<!-- Turn Carbon isotopes on for clm6_0 physics with BGC on with CRUJRA or CAM7 forcing and for historical period-->
+<!-- NOTE: Have Carbon isotopes off for older physics as those earlier versions were run that way. 
+       They can only be on for BGC compsets (NOT SP or FATES).
+       
+       Also, we configured the defaults the following ways:
+       - On only for CRUJRA2024 or CAM7 forcing because that is how the CESM3.0 clm6_0 simulations were run
+       - In contrast to above, it's turned off for other forcing options as we haven't run simulations with those configurations
+      - It's also only turned on for Historical periods and NOT future scenarios because we don't have CMIP7 data for them -->
+<use_c13 phys="clm6_0" bgc_mode="bgc" lnd_tuning_mode="clm6_0_CRUJRA2024" ssp_rcp="hist">.true.</use_c13>
+<use_c14 phys="clm6_0" bgc_mode="bgc" lnd_tuning_mode="clm6_0_CRUJRA2024" ssp_rcp="hist">.true.</use_c14>
+<use_c13 phys="clm6_0" bgc_mode="bgc" lnd_tuning_mode="clm6_0_cam7.0" ssp_rcp="hist">.true.</use_c13>
+<use_c14 phys="clm6_0" bgc_mode="bgc" lnd_tuning_mode="clm6_0_cam7.0" ssp_rcp="hist">.true.</use_c14>
 
 <!-- Carbon isotope concentration files -->
 <atm_c13_filename use_c13=".true." use_c13_timeseries=".true." ssp_rcp="hist"     >lnd/clm2/isotopes/atm_delta_C13_CMIP6_1850-2015_yearly_v2.0_c190528.nc</atm_c13_filename>
@@ -141,6 +152,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Irrigation default (Note, the use-cases also set this) -->
 <irrigate                                                             >.false.</irrigate>
 <irrigate               use_cndv=".false."  sim_year_range="1850-2100">.true.</irrigate>
+<irrigate phys="clm6_0" use_cndv=".false."  sim_year_range="1850-2000">.true.</irrigate>
 <irrigate phys="clm4_5" use_cndv=".false."  sim_year_range="1850-2100">.false.</irrigate>
 
 <!-- Saturation excess runoff for crops  -->
@@ -2282,8 +2294,7 @@ lnd/clm2/surfdata_esmf/NEON/ctsm5.3.0/surfdata_1x1_NEON_TOOL_hist_2000_78pfts_c2
 <stream_year_first_popdens use_fates=".true." sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_first_popdens>
 <stream_year_last_popdens  use_fates=".true." sim_year="constant" sim_year_range="1000-1004" >2000</stream_year_last_popdens>
 
-<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." phys="clm6_0" >lnd/clm2/firedata/clmforc.Li_2025_CMIP7_SSP3CMIP6_hdm_0.5x0.5_simyr1850-2100_c250717.nc</stream_fldfilename_popdens>
-<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true."               >lnd/clm2/firedata/clmforc.Li_2017_HYDEv3.2_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2016_c180202.nc</stream_fldfilename_popdens>
+<stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." >lnd/clm2/firedata/clmforc.Li_2025_CMIP7_hdm_0.5x0.5_simyr1850-2025_c251013.nc</stream_fldfilename_popdens>
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." ssp_rcp="SSP1-1.9" >lnd/clm2/firedata/clmforc.Li_2018_SSP1_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c181205.nc
 </stream_fldfilename_popdens>
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." ssp_rcp="SSP1-2.6" >lnd/clm2/firedata/clmforc.Li_2018_SSP1_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c181205.nc
@@ -2301,8 +2312,7 @@ lnd/clm2/surfdata_esmf/NEON/ctsm5.3.0/surfdata_1x1_NEON_TOOL_hist_2000_78pfts_c2
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_cn=".true." ssp_rcp="SSP5-3.4" >lnd/clm2/firedata/clmforc.Li_2018_SSP5_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c181205.nc
 </stream_fldfilename_popdens>
 
-<stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true." phys="clm6_0" >lnd/clm2/firedata/clmforc.Li_2025_CMIP7_SSP3CMIP6_hdm_0.5x0.5_simyr1850-2100_c250717.nc</stream_fldfilename_popdens>
-<stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true."               >lnd/clm2/firedata/clmforc.Li_2017_HYDEv3.2_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2016_c180202.nc</stream_fldfilename_popdens>
+<stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true." >lnd/clm2/firedata/clmforc.Li_2025_CMIP7_hdm_0.5x0.5_simyr1850-2025_c251013.nc</stream_fldfilename_popdens>
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true." ssp_rcp="SSP1-1.9" >lnd/clm2/firedata/clmforc.Li_2018_SSP1_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c181205.nc
 </stream_fldfilename_popdens>
 <stream_fldfilename_popdens hgrid="0.5x0.5"   use_fates=".true." ssp_rcp="SSP1-2.6" >lnd/clm2/firedata/clmforc.Li_2018_SSP1_CMIP6_hdm_0.5x0.5_AVHRR_simyr1850-2100_c181205.nc

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,231 @@
 ===============================================================
+Tag name: ctsm5.3.082
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Fri 24 Oct 2025 11:17:41 AM MDT
+One-line Summary: Update to CMIP7 population density file for non-SSP cases
+
+Purpose and description of changes
+----------------------------------
+
+ Update two lines in namelist_defaults_ctsm.xml.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+ Resolves #3545 Update to official CMIP7 pop. density data
+
+Notes of particular relevance for users
+---------------------------------------
+Changes made to namelist defaults (e.g., changed parameter values):
+ Updated pop. density file for non-SSP cases.
+
+Changes to the datasets (e.g., parameter, surface or initial files):
+ Updated pop. density file for non-SSP cases.
+
+Testing summary:
+----------------
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: non-SSP
+    - what platforms/compilers: all
+    - nature of change: larger than roundoff/same climate
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/3563
+
+===============================================================
+===============================================================
+Tag name: ctsm5.3.081
+Originator(s): erik (Erik Kluzek,UCAR/TSS,303-497-1326)
+Date: Wed 22 Oct 2025 05:31:52 PM MDT
+One-line Summary: Change defaults for when Carbon isotopes are turned on, and turn on irrigate for Sp/Bgc cases for clm6_0 historical transient cases
+
+Purpose and description of changes
+----------------------------------
+
+Only turn C13/C14 for clm6_0 and BGC, and also require the DATM forcing to be CRUJRA2024 or CAM7 and for the historical period. So for example SSP compsets won't have C13/C14 on, single point compsets won't, or for using older forcing (like CAM6, or GSWP3v1, Qian, or CRUv7). Also whenever use_c13 or use_c14 is on turn on the corresponding time series file.
+
+Also change default for irrigate to on for historical SP/BGC cases.
+
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+   Fixes #3527 -- irrigation settings for control vs historical cases
+   Fixes #3551 -- Turn on relevent Carbon isotope time-series when use_c13/c14 is on
+   Some work on #3346 -- CMIP7 Carbon isotope data
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users (e.g., need to interpolate initial conditions):
+   This just changes the defaults for when Carbon isotopes are turned on, to make it less often
+   Users can still turn it on by hand for the cases that they want.
+
+Changes made to namelist defaults (e.g., changed parameter values):
+   Carbon isotope timeseries files are turned on whenever use_c13/use_c14 is turned on so it uses
+   the historical
+   Turn irrigate on for clm6_0 historical
+   Carbon isotopes only turned on by default for clm6_0 when CRUJRA2024 or CAM7 forcing is used
+   and only for historical cases and not SSP's
+
+Testing summary: regular
+----------------
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  build-namelist tests (if CLMBuildNamelist.pm has changed):
+
+    derecho - OK (differences in namelists are all as expected)
+
+  python testing (if python code has changed; see instructions in python/README.md; document testing done):
+
+    derecho - PASS
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+If the tag used for baseline comparisons was NOT the previous tag, note that here: previous
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: HistClm60 compsets and tests with the ciso testmod
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: HistClm60Sp/HistClm60Bgc now with irriage on
+         cases with use_c13/use_c14 now have c13/c14 isotope timeseries files on
+    - what platforms/compilers: all
+    - nature of change (roundoff; larger than roundoff/same climate; new climate):
+      Carbon Isotopes -- are diagnostic and only change fields on history files
+           Cases that now have C13/C14 isotopes on now use timeseries files rather
+           than the default pre-industrial so change answers for C13/C14 fields 
+      Irrigate turned on for HistClm60Bgc/HistClm60Sp compsets will change answers 
+
+Other details
+-------------
+
+Pull Requests that document the changes (include PR ids):
+(https://github.com/ESCOMP/ctsm/pull)
+
+https://github.com/ESCOMP/CTSM/pull/3549
+
+===============================================================
+===============================================================
+Tag name: ctsm5.3.080
+Originator(s): samrabin (Sam Rabin, UCAR/TSS)
+Date: Thu Oct 16 13:41:08 MDT 2025
+One-line Summary: Merge b4b-dev to master
+
+Purpose and description of changes
+----------------------------------
+
+Merge b4b-dev to master. Includes these PRs:
+- [ESCOMP/CTSM Pull Request #3193: resolve issue #103: Example 1.7 typo by linniahawkins](https://github.com/ESCOMP/CTSM/pull/3193)
+- [ESCOMP/CTSM Pull Request #3518: Update of the leaching doc by jinmuluo](https://github.com/ESCOMP/CTSM/pull/3518)
+- [ESCOMP/CTSM Pull Request #3548: Finishing adding RC14_CANAIR history output by ekluzek](https://github.com/ESCOMP/CTSM/pull/3548)
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[ ] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+
+List of CTSM issues fixed in the included PRs:
+- [ESCOMP/CTSM Issue #103: Example 1.7 typo](https://github.com/ESCOMP/CTSM/issues/103)
+- [ESCOMP/CTSM Issue #3488: Add RC14_CANAIR as optional to history output so that C14 time series data can be verified](https://github.com/ESCOMP/CTSM/issues/3488)
+- [ESCOMP/CTSM Issue #3490: Change history averaging of RC13_CANAIR and RC14_CANAIR so that zero's aren't averaged in](https://github.com/ESCOMP/CTSM/issues/3490)
+
+
+Notes of particular relevance for users
+---------------------------------------
+
+Changes to documentation:
+- Updated leaching documentation
+- Typo fix
+
+
+Testing summary:
+----------------
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+
+Other details
+-------------
+
+Pull Requests that document the changes (include PR ids):
+- [ESCOMP/CTSM Pull Request #3553: b4b-dev merge 2025-10-16 by samsrabin](https://github.com/ESCOMP/CTSM/pull/3553)
+
+===============================================================
+===============================================================
 Tag name: ctsm5.3.079
 Originator(s): samrabin (Sam Rabin, UCAR/TSS)
 Date: Mon Oct  6 21:41:11 MDT 2025

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,8 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.3.082   slevis 10/24/2025 Update to CMIP7 population density file for non-SSP cases
+       ctsm5.3.081     erik 10/22/2025 Change defaults for when Carbon isotopes are turned on, and turn on irrigate for Sp/Bgc cases for clm6_0 historical transient cases
+       ctsm5.3.080 samrabin 10/16/2025 Merge b4b-dev to master
        ctsm5.3.079 samrabin 10/06/2025 Update submodules to match versions in cesm3_0_alpha07e
        ctsm5.3.078   slevis 10/03/2025 Merge b4b-dev to master
        ctsm5.3.077   rgknox 10/02/2025 Adjustment of timestep albedo filtering with FATES

--- a/doc/source/tech_note/External_Nitrogen_Cycle/CLM50_Tech_Note_External_Nitrogen_Cycle.rst
+++ b/doc/source/tech_note/External_Nitrogen_Cycle/CLM50_Tech_Note_External_Nitrogen_Cycle.rst
@@ -133,6 +133,45 @@ where :math:`{WS}_{tot\_soil}` (kgH\ :sub:`2`\ O m\ :sup:`-2`) is the total mass
 
    NF_{leached} =\min \left(NF_{leached} ,\frac{NS_{sminn} sf}{\Delta t} \right).
 
+Alternative way of evaluating the Leaching Losses of Nitrogen
+--------------------------------------------------------------
+
+The previous leaching mechanism is not designed for describing the vertical transport of :math:`{NO}_{3}^{-}` in soil, an alternative way to evaluate the vertical convective, diffusive, and dispersive of dissolved :math:`{NO}_{3}^{-}` in soil is provided in (:ref:`Luo et al. 2025 <Luoetal2025>`). 
+To obtain the vertical profile of soil mineral N after vertical movement of each timestep, the vertical transport equation is summarized in :eq:`22.20`.
+
+.. math::
+   :label: 22.20
+
+   \frac{\partial NS_{sminn}}{\partial t} = \frac{\partial J}{\partial z} + S
+
+where :math:`NS_{sminn} (gN m^{-3})` is the soil :math:`{NO}_{3}^{-}` concentration in each layer, :math:`J (gN m^{-2} s^{-1})` is the different vertical transport terms (:math:`J_{convective}, J_{diffusive}, J_{dispersive}`) between two soil layers, and :math:`S` is the sources or sinks fluxes.
+Different transport terms are explained below 
+
+.. math::
+   :label: 22.21
+
+   J_{convective} = sf \frac{SN_{sminn}q_{out}}{\theta} 
+
+where :math:`q_{out} (mH_{2}Os^{-1})` is the darcy flow of water, :math:`\theta (m^3H_{2}O m^{-3}soil)` is the soil water content.
+
+.. math::
+   :label: 22.22
+
+   J_{diffusive} = -D_{aq} \frac{\theta^{7/3}}{\phi^{2}} \frac{\partial SN_{sminn}}{ \partial z}
+
+where :math:`\partial SN_{sminn}/ \partial z` is the concentration gradient, :math:`D_{aq}` is the nitrate aqueous diffusion coefficient which is taken as :math:`1.7*10^{-9} m^{2}s^{-1}`, and :math:`\phi (m^3m^{-3})` is soil porosity.
+
+.. math::
+   :label: 22.23
+
+   J_{dispersive} = -D_{dis} \frac{\theta^{7/3}}{\phi^{2}} \frac{\partial SN_{sminn}}{ \partial z}
+
+where :math:`D_{dis}` is the dispersion coefficient, which equal to :math:`L_{dis} q_{out} \theta ^{-1}`, for simplicity reasons, :math:`L_{dis}` is taken as 0.1 meter.
+
+Finally, the classical convective-diffusion algorithm described in (:ref:`Patankar.2018 <Patankaretal2018>`) is used to discrete and solve the :math:`{NO}_{3}^{-}` vertical transport :eq:`22.20` in soils. 
+The advantage of this leaching mechanism is the soil :math:`{NO}_{3}^{-}` is able to move vertically (both upward or downward) with soil water movement, the mass of :math:`{NO}_{3}^{-}` reaches bedrock layer is finally taken as the  :math:`NF_{leached}`.
+
+
 Losses of Nitrogen Due to Fire
 -----------------------------------
 

--- a/doc/source/tech_note/References/CLM50_Tech_Note_References.rst
+++ b/doc/source/tech_note/References/CLM50_Tech_Note_References.rst
@@ -843,6 +843,10 @@ Lowe, P.R. 1977. An approximating polynomial for the computation of saturation v
 
 Luo, Y., Hui, D., and Zhang, D. 2006. Elevated CO2 stimulates net accumulations of carbon and nitrogen in land ecosystems: a meta-analysis. Ecology 87:53-63.
 
+.. _Luoetal2025:
+
+Luo J, Hess P G, Hall S, et al. Agricultural emissions of reactive nitrogen gases from constrained simulations using the Community Land Model. Authorea Preprints, 2025.
+
 .. _Magilletal1997:
 
 Magill, A.H. et al., 1997. Biogeochemical response of forest ecosystems to simulated chronic nitrogen deposition. Ecological Applications, 7: 402-415.
@@ -1047,6 +1051,10 @@ Parton, W. et al. 1996. Generalized model for N2 and N2O production from nitrifi
 .. _Partonetal2001:
 
 Parton, W.J. et al. 2001. Generalized model for NOx and N2O emissions from soils. J. Geophys. Res. 106(D15):17403-17419.
+
+.. _Patankaretal2018:
+
+Patankar S., 2018. Numerical heat transfer and fluid flow[M]. CRC press., Boca Raton, section 5.2, 80-95 pp
 
 .. _Paterson1994:
 

--- a/doc/source/users_guide/setting-up-and-running-a-case/customizing-the-clm-namelist.rst
+++ b/doc/source/users_guide/setting-up-and-running-a-case/customizing-the-clm-namelist.rst
@@ -186,7 +186,7 @@ Example: user_nl_clm namelist outputting some files in 1D Vector format
    hist_fincl5 = 'TG'
    hist_fincl6 = 'TG'
    hist_dov2xy = .true., .false., .false., .false.
-   hist_type2d_pertape = ' ', 'GRID', 'COLS', ' '
+   hist_type1d_pertape = ' ', 'GRID', 'COLS', ' '
    hist_nhtfrq = 0, -24, -24, -24
 
 .. warning:: ``LAND`` and ``COLS`` are also options to the pertape averaging, but currently there is a bug with them and they fail to work.


### PR DESCRIPTION
Are answers expected to change (and if so in what way)?
Yes, updating from ctsm5.3.079 to .082 changes answers.

Any User Interface Changes (namelist or namelist defaults changes)?
Have been documented in the ChangeLog going from .079 to .082.

Testing performed, if any:
aux_clm on derecho is in progress.