### PR TITLE
First set of crop parameter changes for CLM6

### DIFF
--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -560,7 +560,7 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm6_0" >lnd/clm2/paramdata/clm60_params.ctsm6_li2024.c250822.nc</paramfile>
+<paramfile phys="clm6_0" >lnd/clm2/paramdata/clm60_params.ctsm6_li2024.c250822.crop_omni02.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c250311.nc</paramfile>
 <paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c250311.nc</paramfile>
 


### PR DESCRIPTION
### Description of changes
Calibrating yield for about 2000-2024 while minimizing failed seasons:
- Corn: Don't change anything. It's high for 2000-2010 but looks good after that.
- Cotton: Increase max growing season length from 160 days to 270 days. Causes overwintering, so this will probably need to be reverted! But useful for now to explore how much an extreme change could help with the high failure rate.
- Rice: Revert CLM5 `arooti` changes.
- Soybean: It's low for this period but nothing I tried helped much. Removing mxmat helped a bit, so increase max growing season length from 150 days to 180 days.
- Sugarcane: Increase max growing season length from 300 days to 360.
- Wheat: Revert CLM5 arooti changes.  Need a pretty big drop in yields and this didn't do it in my test, but that was without grainfill triggering max LAI and thus much more failed crop area. (There were no crop phase parameter changes in CLM5.)

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:** None

**Are answers expected to change (and if so in what way)?** Yes, for any run with prognostic crops.

**Any User Interface Changes (namelist or namelist defaults changes)?**
- New `paramfile` for `clm6_0`.

**Does this create a need to change or add documentation? Did you do so?** Yes; no.
- [ ] Update documentation where needed with new parameters.

**Testing performed, if any:** Scientific testing of the same changes on top of `master`'s paramfile looked good.
- [ ] `aux_clm`
- [ ] Anything else?