### PR TITLE
Changes needed for unit testing to work on my Mac

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH ${CIME_CMAKE_MODULE_DIRECTORY})
 include(CIME_initial_setup)
@@ -93,7 +93,7 @@ add_library(csm_share ${share_sources} ${drv_sources_needed})
 declare_generated_dependencies(csm_share "${share_genf90_sources}")
 add_library(clm ${clm_sources})
 declare_generated_dependencies(clm "${clm_genf90_sources}")
-add_dependencies(clm csm_share esmf)
+add_dependencies(clm csm_share ESMF)
 
 # We need to look for header files here, in order to pick up shr_assert.h
 include_directories(${CLM_ROOT}/share/include)


### PR DESCRIPTION
### Description of changes

Two minor changes needed for the unit test build to work with cmake version 4.1.2 on my Mac.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): 
   Fixes #3182

Are answers expected to change (and if so in what way)? No

Any User Interface Changes (namelist or namelist defaults changes)? No

Does this create a need to change or add documentation? Did you do so? No

Testing performed, if any:
`../cime/scripts/fortran_unit_testing/run_tests.py --build-dir unit_tests.temp` on:
- My Mac (cmake 4.1.2)
- derecho (with whatever the default cmake is there; I think 3.26.6)
