### PR TITLE
Remove unnecessary spmdMod from unit test build

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -22,7 +22,6 @@ list(APPEND clm_sources
   SparseMatrixMultiplyMod.F90
   IssueFixedMetadataHandler.F90
   NumericsMod.F90
-  spmdMod.F90
   )
 
 sourcelist_to_parent(clm_sources)


### PR DESCRIPTION
### Description of changes

This inclusion of spmdMod in the unit test build appears to be unnecessary. I saw two issues with its inclusion:

(1) On my Mac, I was getting an error building spmdMod.F90 in unit tests because it couldn't find mpif.h. This makes sense because we don't include an MPI library in the build. I guess this was working on derecho - at least if you have the right modules loaded - but the unit test build is not designed to work with an mpi library.

(2) The stub version of spmdMod (spmdMod_stub.F90) is also still being included in the unit test build. It's unclear which of the two would actually be used at runtime.

### Specific notes

Contributors other than yourself, if any: none

CTSM Issues Fixed (include github issue #): none

Are answers expected to change (and if so in what way)? no

Any User Interface Changes (namelist or namelist defaults changes)? no

Does this create a need to change or add documentation? Did you do so? no

Testing performed, if any:

Ran Fortran unit tests on my Mac and on derecho