### PR TITLE
ctsm5.4.032: Simplify messaging during docs build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 [submodule "doc-builder"]
 path = doc/doc-builder
 url = https://github.com/ESMCI/doc-builder
-fxtag = v3.0.1
+fxtag = v3.1.0
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder

--- a/doc/build_docs
+++ b/doc/build_docs
@@ -6,10 +6,24 @@ if [ ! -f doc-builder/build_docs ]; then
     ${script_dir}/../bin/git-fleximod update doc-builder
 fi
 
-echo "Running: make fetch-images"
-make fetch-images
+# Check if --verbose or -V was passed
+verbose=false
+for arg in "$@"; do
+    case "$arg" in
+        --verbose|-V) verbose=true; break ;;
+    esac
+done
 
-echo "Running: ./doc-builder/build_docs $@"
+if $verbose; then
+    echo "Running: make fetch-images"
+    make fetch-images
+else
+    make fetch-images > /dev/null 2>&1
+fi
+
+if $verbose; then
+    echo "Running: ./doc-builder/build_docs $@"
+fi
 ./doc-builder/build_docs "$@"
 
 exit 0

--- a/doc/build_docs_to_publish
+++ b/doc/build_docs_to_publish
@@ -6,13 +6,27 @@ if [ ! -f doc-builder/build_docs_to_publish ]; then
     "${script_dir}"/../bin/git-fleximod update doc-builder
 fi
 
+# Check if --verbose or -V was passed
+verbose=false
+for arg in "$@"; do
+    case "$arg" in
+        --verbose|-V) verbose=true; break ;;
+    esac
+done
+
 cd "${script_dir}"
 
-echo "Running: make fetch-images"
-make fetch-images
+if $verbose; then
+    echo "Running: make fetch-images"
+    make fetch-images
+else
+    make fetch-images > /dev/null 2>&1
+fi
 
-echo "Running: ./doc-builder/build_docs_to_publish $@"
-pwd
+if $verbose; then
+    echo "Running: ./doc-builder/build_docs_to_publish $@"
+    pwd
+fi
 ./doc-builder/build_docs_to_publish "$@"
 
 exit 0


### PR DESCRIPTION
**Note: This should come in to master ASAP so it's ready before the documentation hackathon today.**

### Description of changes

This change to the doc-builder version greatly reduces what gets printed to the screen by default, making it easier to identify the cause of problems due to Sphinx complaints. The user can add `--verbose|-V` if the full output is desired.

As an example, with `--verbose`:
```
Running: make fetch-images
git lfs install --force
Updated Git hooks.
Git LFS initialized.
git lfs pull --exclude="" --include=""
Running: ./doc-builder/build_docs -b _build -d -c --verbose
options: Namespace(build_dir='_build', repo_root=None, site_root=None, build_in_container=True, container_cli_tool=None, conf_py_path='doc-builder/conf.py', static_path='_static', templates_path='_templates', doc_version=[None], version_display_name=None, clean=True, container_image=None, build_target='html', num_make_jobs=4, versions=False, warnings_as_warnings=False, verbose=True)
podman run --name build_docs_mylibymg --user 502:20 --mount type=bind,source=/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity,target=/home/user/mounted_home --workdir /home/user/mounted_home/doc -t --rm -e current_version=None ghcr.io/escomp/ctsm/ctsm-docs:v2.0.1 make SPHINXOPTS=-W --keep-going BUILDDIR=/home/user/mounted_home/doc/_build -e version_display_name=None -e html_static_path=_static -e templates_path=_templates -e version_dropdown= -j 4 clean
Done.
podman run --name build_docs_mylibymg --user 502:20 --mount type=bind,source=/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity,target=/home/user/mounted_home --workdir /home/user/mounted_home/doc -t --rm -e current_version=None ghcr.io/escomp/ctsm/ctsm-docs:v2.0.1 make SPHINXOPTS=-W --keep-going -c 'doc-builder' BUILDDIR=/home/user/mounted_home/doc/_build -e version_display_name=None -e html_static_path=_static -e templates_path=_templates -e version_dropdown= -j 4 html
sphinx-build -M html "source" "/home/user/mounted_home/doc/_build" -c "doc-builder" -W --keep-going -c 'doc-builder'
Running Sphinx v8.2.3
loading translations [en]... done
making output directory... done
Converting `source_suffix = ['.rst', '.md']` to `source_suffix = {'.rst': 'restructuredtext', '.md': 'restructuredtext'}`.
loading intersphinx inventory 'python' from https://docs.python.org/objects.inv ...
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'dollarmath'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 118 source files that are out of date
updating environment: [new config] 118 added, 0 changed, 0 removed
reading sources... [100%] users_guide/working-with-documentation/tips-for-working-with-rst
/home/user/mounted_home/doc/source/tech_note/Crop_Irrigation/CLM50_Tech_Note_Crop_Irrigation.rst:168: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets...
copying static files...
Writing evaluated template result to /home/user/mounted_home/doc/_build/html/_static/basic.css
Writing evaluated template result to /home/user/mounted_home/doc/_build/html/_static/documentation_options.js
Writing evaluated template result to /home/user/mounted_home/doc/_build/html/_static/language_data.js
Writing evaluated template result to /home/user/mounted_home/doc/_build/html/_static/js/versions.js
copying static files: done
copying extra files...
copying extra files: done
copying assets: done
writing output... [100%] users_guide/working-with-documentation/tips-for-working-with-rst
generating indices... genindex done
writing additional pages... search done
copying images... [100%] users_guide/using-mesh-maker/test_c240918_global.png
dumping search index in English (code: en)... done
dumping object inventory... done
build finished with problems, 1 warning (with warnings treated as errors).
make: *** [Makefile:42: html] Error 1
Traceback (most recent call last):
  File "/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity/doc/./doc-builder/build_docs", line 14, in <module>
    build_docs.main()
  File "/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity/doc/doc-builder/doc_builder/build_docs.py", line 444, in main
    run_build_command(build_command=build_command, version=version, options=opts)
  File "/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity/doc/doc-builder/doc_builder/build_docs.py", line 305, in run_build_command
    result = _try_build_command(build_command, verbose, env)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity/doc/doc-builder/doc_builder/build_docs.py", line 322, in _try_build_command
    result = subprocess.run(build_command, env=env, check=True, capture_output=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/samrabin/miniforge3/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['podman', 'run', '--name', 'build_docs_mylibymg', '--user', '502:20', '--mount', 'type=bind,source=/Users/samrabin/Documents/git_repos/ctsm_devcontainer-and-docverbosity,target=/home/user/mounted_home', '--workdir', '/home/user/mounted_home/doc', '-t', '--rm', '-e', 'current_version=None', 'ghcr.io/escomp/ctsm/ctsm-docs:v2.0.1', 'make', "SPHINXOPTS=-W --keep-going -c 'doc-builder'", 'BUILDDIR=/home/user/mounted_home/doc/_build', '-e', 'version_display_name=None', '-e', 'html_static_path=_static', '-e', 'templates_path=_templates', '-e', 'version_dropdown=', '-j', '4', 'html']' returned non-zero exit status 2.
```

Without `--verbose`:
```
Cleaning documentation build directory...
Done.
Building documentation...
/home/user/mounted_home/doc/source/tech_note/Crop_Irrigation/CLM50_Tech_Note_Crop_Irrigation.rst:168: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
Documentation build completed, but with problems that must be resolved.
Re-run with --verbose for full output.
```


### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed:** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** Manual testing; GitHub docs tests.