### PR TITLE
doc builder: Improve verbosity filter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 [submodule "doc-builder"]
 path = doc/doc-builder
 url = https://github.com/ESMCI/doc-builder
-fxtag = v3.1.0
+fxtag = v3.1.1
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder


### PR DESCRIPTION
### Description of changes

Resolves issues @slevis-lmwg experienced [here](https://github.com/ESCOMP/CTSM/pull/3967#issuecomment-4383109469):
- `CRITICAL` messages from Sphinx build were getting filtered out in non-verbose mode
- Spurious warning message about image platform not matching expected was _not_ getting filtered out.

This led to it seeming like the image platform thing was the problem.

The new version of doc-builder, when not verbose:
- Includes `CRITICAL` messages
- Suppresses "image platform does not match expected" warning

So before:
```
Cleaning documentation build directory...
Done.
Building documentation...
WARNING: The requested image's platform (linux/amd64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
Documentation build completed, but with problems that must be resolved.
Re-run with --verbose for full output.
```

After:
```
Cleaning documentation build directory...
Done.
Building documentation...
/home/user/mounted_home/doc/source/tech_note/FUN/CLM50_Tech_Note_FUN.rst:4: CRITICAL: Duplicate ID: "equation-n-cost-fix". [docutils]
Documentation build completed, but with problems that must be resolved.
Re-run with --verbose for full output.
```

### Specific notes

**Contributors other than yourself, if any:** None

**CTSM Issues Fixed (include github issue #):** None

**Are answers expected to change (and if so in what way)?** No

**Any User Interface Changes (namelist or namelist defaults changes)?** No

**Does this create a need to change or add documentation? Did you do so?** No

**Testing performed, if any:** Manual testing.