### PR TITLE
Documenting some experimentation to allow vectorization as part of the 2026 NVIDIA hackathon

### DIFF
--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -197,6 +197,7 @@ contains
      !
      ! !LOCAL VARIABLES:
      integer  :: i     ! index of water tracer or bulk
+     integer :: rep
      real(r8) :: dtime ! land model time step (sec)
 
      real(r8) :: qflx_liq_above_canopy_patch(bounds%begp:bounds%endp)        ! liquid water input above canopy (rain plus irrigation) [mm/s]
@@ -246,6 +247,7 @@ contains
           qflx_liq_above_canopy = qflx_liq_above_canopy_patch(begp:endp), &
           forc_snow_patch       = forc_snow_patch(begp:endp))
 
+     do rep = 1, 100
      call BulkFlux_CanopyInterceptionAndThroughfall(bounds, num_nolakep, filter_nolakep, &
           ! Inputs
           patch                 = patch, &
@@ -261,6 +263,7 @@ contains
           qflx_intercepted_snow = b_waterflux_inst%qflx_intercepted_snow_patch(begp:endp), &
           qflx_intercepted_liq  = b_waterflux_inst%qflx_intercepted_liq_patch(begp:endp), &
           check_point_for_interception_and_excess = check_point_for_interception_and_excess(begp:endp))
+     end do
 
      ! Calculate canopy interception and throughfall for each tracer
      !

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -196,6 +196,7 @@ contains
      type(water_type)       , intent(inout) :: water_inst
      !
      ! !LOCAL VARIABLES:
+     integer :: fp, p
      integer  :: i     ! index of water tracer or bulk
      integer :: rep
      real(r8) :: dtime ! land model time step (sec)
@@ -206,6 +207,18 @@ contains
      real(r8) :: tracer_forc_snow_patch(bounds%begp:bounds%endp)             ! For one tracer: atm snow, patch-level [mm/s]
 
      logical  :: check_point_for_interception_and_excess(bounds%begp:bounds%endp)
+
+     integer :: patch_col_filtered(num_nolakep)
+     integer :: frac_veg_nosno_filtered(num_nolakep)
+     real(r8) :: elai_filtered(num_nolakep)
+     real(r8) :: esai_filtered(num_nolakep)
+     real(r8) :: forc_snow_filtered(num_nolakep)
+     real(r8) :: qflx_liq_above_canopy_filtered(num_nolakep)
+     real(r8) :: qflx_through_snow_filtered(num_nolakep)
+     real(r8) :: qflx_through_liq_filtered(num_nolakep)
+     real(r8) :: qflx_intercepted_snow_filtered(num_nolakep)
+     real(r8) :: qflx_intercepted_liq_filtered(num_nolakep)
+     logical :: check_point_for_interception_and_excess_filtered(num_nolakep)
 
      character(len=*), parameter :: subname = 'CanopyInterceptionAndThroughfall'
      !-----------------------------------------------------------------------
@@ -247,22 +260,39 @@ contains
           qflx_liq_above_canopy = qflx_liq_above_canopy_patch(begp:endp), &
           forc_snow_patch       = forc_snow_patch(begp:endp))
 
+     do fp = 1, num_nolakep
+        p = filter_nolakep(fp)
+        patch_col_filtered(fp) = patch%column(p)
+        frac_veg_nosno_filtered(fp) = canopystate_inst%frac_veg_nosno_patch(p)
+        elai_filtered(fp) = canopystate_inst%elai_patch(p)
+        esai_filtered(fp) = canopystate_inst%esai_patch(p)
+        forc_snow_filtered(fp) = forc_snow_patch(p)
+        qflx_liq_above_canopy_filtered(fp) = qflx_liq_above_canopy_patch(p)
+     end do
      do rep = 1, 100
-     call BulkFlux_CanopyInterceptionAndThroughfall(bounds, num_nolakep, filter_nolakep, &
+     call BulkFlux_CanopyInterceptionAndThroughfall(bounds, num_nolakep, &
           ! Inputs
-          patch                 = patch, &
-          col                   = col, &
-          frac_veg_nosno        = canopystate_inst%frac_veg_nosno_patch(begp:endp), &
-          elai                  = canopystate_inst%elai_patch(begp:endp), &
-          esai                  = canopystate_inst%esai_patch(begp:endp), &
-          forc_snow             = forc_snow_patch(begp:endp), &
-          qflx_liq_above_canopy = qflx_liq_above_canopy_patch(begp:endp), &
+          patch_col             = patch_col_filtered, &
+          col_itype             = col%itype(begc:endc), &
+          frac_veg_nosno        = frac_veg_nosno_filtered, &
+          elai                  = elai_filtered, &
+          esai                  = esai_filtered, &
+          forc_snow             = forc_snow_filtered, &
+          qflx_liq_above_canopy = qflx_liq_above_canopy_filtered, &
           ! Outputs
-          qflx_through_snow     = b_waterflux_inst%qflx_through_snow_patch(begp:endp), &
-          qflx_through_liq      = b_waterflux_inst%qflx_through_liq_patch(begp:endp), &
-          qflx_intercepted_snow = b_waterflux_inst%qflx_intercepted_snow_patch(begp:endp), &
-          qflx_intercepted_liq  = b_waterflux_inst%qflx_intercepted_liq_patch(begp:endp), &
-          check_point_for_interception_and_excess = check_point_for_interception_and_excess(begp:endp))
+          qflx_through_snow     = qflx_through_snow_filtered, &
+          qflx_through_liq      = qflx_through_liq_filtered, &
+          qflx_intercepted_snow = qflx_intercepted_snow_filtered, &
+          qflx_intercepted_liq  = qflx_intercepted_liq_filtered, &
+          check_point_for_interception_and_excess = check_point_for_interception_and_excess_filtered)
+     end do
+     do fp = 1, num_nolakep
+        p = filter_nolakep(fp)
+        b_waterflux_inst%qflx_through_snow_patch(p) = qflx_through_snow_filtered(fp)
+        b_waterflux_inst%qflx_through_liq_patch(p) = qflx_through_liq_filtered(fp)
+        b_waterflux_inst%qflx_intercepted_snow_patch(p) = qflx_intercepted_snow_filtered(fp)
+        b_waterflux_inst%qflx_intercepted_liq_patch(p) = qflx_intercepted_liq_filtered(fp)
+        check_point_for_interception_and_excess(p) = check_point_for_interception_and_excess_filtered(fp)
      end do
 
      ! Calculate canopy interception and throughfall for each tracer
@@ -480,8 +510,8 @@ contains
    end subroutine SumFlux_TopOfCanopyInputs
 
    !-----------------------------------------------------------------------
-   subroutine BulkFlux_CanopyInterceptionAndThroughfall(bounds, num_nolakep, filter_nolakep, &
-        patch, col, &
+   subroutine BulkFlux_CanopyInterceptionAndThroughfall(bounds, num_nolakep, &
+        patch_col, col_itype, &
         frac_veg_nosno, elai, esai, forc_snow, qflx_liq_above_canopy, &
         qflx_through_snow, qflx_through_liq, &
         qflx_intercepted_snow, qflx_intercepted_liq, &
@@ -493,46 +523,45 @@ contains
      ! !ARGUMENTS:
      type(bounds_type), intent(in) :: bounds
      integer, intent(in) :: num_nolakep
-     integer, intent(in), contiguous :: filter_nolakep(:)
-     type(patch_type), intent(in) :: patch
-     type(column_type), intent(in) :: col
+     integer, intent(in), contiguous :: patch_col(:)
+     integer, intent(in), contiguous :: col_itype(:)  ! NOTE: unlike other args, this one is dimensioned begc:endc
 
-     integer  , intent(in), contiguous    :: frac_veg_nosno( bounds%begp: )                          ! fraction of vegetation not covered by snow (0 OR 1)
-     real(r8) , intent(in), contiguous    :: elai( bounds%begp: )                                    ! canopy one-sided leaf area index with burying by snow
-     real(r8) , intent(in), contiguous    :: esai( bounds%begp: )                                    ! canopy one-sided stem area index with burying by snow
-     real(r8) , intent(in), contiguous    :: forc_snow( bounds%begp: )                               ! atm snow (mm H2O/s)
-     real(r8) , intent(in), contiguous    :: qflx_liq_above_canopy( bounds%begp: )                   ! liquid water input above canopy (rain plus irrigation) (mm H2O/s)
+     integer  , intent(in), contiguous    :: frac_veg_nosno( : )                          ! fraction of vegetation not covered by snow (0 OR 1)
+     real(r8) , intent(in), contiguous    :: elai( : )                                    ! canopy one-sided leaf area index with burying by snow
+     real(r8) , intent(in), contiguous    :: esai( : )                                    ! canopy one-sided stem area index with burying by snow
+     real(r8) , intent(in), contiguous    :: forc_snow( : )                               ! atm snow (mm H2O/s)
+     real(r8) , intent(in), contiguous    :: qflx_liq_above_canopy( : )                   ! liquid water input above canopy (rain plus irrigation) (mm H2O/s)
 
-     real(r8) , intent(inout), contiguous :: qflx_through_snow( bounds%begp: )                       ! canopy throughfall of snow (mm H2O/s)
-     real(r8) , intent(inout), contiguous :: qflx_through_liq( bounds%begp: )                        ! canopy throughfall of liquid (mm H2O/s)
-     real(r8) , intent(inout), contiguous :: qflx_intercepted_snow( bounds%begp: )                   ! canopy interception of snow (mm H2O/s)
-     real(r8) , intent(inout), contiguous :: qflx_intercepted_liq( bounds%begp: )                    ! canopy interception of liquid (mm H2O/s)
-     logical  , intent(inout), contiguous :: check_point_for_interception_and_excess( bounds%begp: ) ! whether each patch in the filter needs to have the interception calculations (here) and snow/liquid excess calculations (elsewhere) computed
+     real(r8) , intent(inout), contiguous :: qflx_through_snow( : )                       ! canopy throughfall of snow (mm H2O/s)
+     real(r8) , intent(inout), contiguous :: qflx_through_liq( : )                        ! canopy throughfall of liquid (mm H2O/s)
+     real(r8) , intent(inout), contiguous :: qflx_intercepted_snow( : )                   ! canopy interception of snow (mm H2O/s)
+     real(r8) , intent(inout), contiguous :: qflx_intercepted_liq( : )                    ! canopy interception of liquid (mm H2O/s)
+     logical  , intent(inout), contiguous :: check_point_for_interception_and_excess( : ) ! whether each patch in the filter needs to have the interception calculations (here) and snow/liquid excess calculations (elsewhere) computed
      !
      ! !LOCAL VARIABLES:
-     integer :: fp, p, c
+     integer :: p, c
      real(r8) :: fpiliq  ! coefficient of interception for liquid
      real(r8) :: fpisnow ! coefficient of interception for snow
 
      character(len=*), parameter :: subname = 'BulkFlux_CanopyInterceptionAndThroughfall'
      !-----------------------------------------------------------------------
 
-     SHR_ASSERT_FL((ubound(frac_veg_nosno, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(elai, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(esai, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(forc_snow, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(qflx_liq_above_canopy, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(qflx_through_snow, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(qflx_through_liq, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(qflx_intercepted_snow, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(qflx_intercepted_liq, 1) == bounds%endp), sourcefile, __LINE__)
-     SHR_ASSERT_FL((ubound(check_point_for_interception_and_excess, 1) == bounds%endp), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(patch_col, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(frac_veg_nosno, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(elai, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(esai, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(forc_snow, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(qflx_liq_above_canopy, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(qflx_through_snow, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(qflx_through_liq, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(qflx_intercepted_snow, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(qflx_intercepted_liq, 1) == num_nolakep), sourcefile, __LINE__)
+     SHR_ASSERT_FL((ubound(check_point_for_interception_and_excess, 1) == num_nolakep), sourcefile, __LINE__)
 
      call t_startf("CanIntAndThrough")
 
-     do fp = 1, num_nolakep
-        p = filter_nolakep(fp)
-        c = patch%column(p)
+     do p = 1, num_nolakep
+        c = patch_col(p)
 
         check_point_for_interception_and_excess(p) = &
              (frac_veg_nosno(p) == 1 .and. (forc_snow(p) + qflx_liq_above_canopy(p)) > 0._r8)
@@ -559,7 +588,7 @@ contains
            ! with frac_veg_nosno == 0.
            qflx_intercepted_snow(p) = 0._r8
            qflx_intercepted_liq(p) = 0._r8
-           if (col%itype(c) == icol_sunwall .or. col%itype(c) == icol_shadewall) then
+           if (col_itype(c) == icol_sunwall .or. col_itype(c) == icol_shadewall) then
               qflx_through_snow(p) = 0._r8
               qflx_through_liq(p)  = 0._r8
            else

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -567,7 +567,7 @@ contains
              (frac_veg_nosno(p) == 1 .and. (forc_snow(p) + qflx_liq_above_canopy(p)) > 0._r8)
         if (check_point_for_interception_and_excess(p)) then
            ! Coefficient of interception
-           if (use_clm5_fpi) then
+           if (.true.) then
               fpiliq = params_inst%interception_fraction * tanh(elai(p) + esai(p))
            else
               fpiliq = 0.25_r8*(1._r8 - exp(-0.5_r8*(elai(p) + esai(p))))

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -11,6 +11,7 @@ module CanopyHydrologyMod
   !
   ! !USES:
 #include "shr_assert.h"
+  use perf_mod, only : t_startf, t_stopf
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_log_mod     , only : errMsg => shr_log_errMsg
   use shr_sys_mod     , only : shr_sys_flush
@@ -524,6 +525,8 @@ contains
      SHR_ASSERT_FL((ubound(qflx_intercepted_liq, 1) == bounds%endp), sourcefile, __LINE__)
      SHR_ASSERT_FL((ubound(check_point_for_interception_and_excess, 1) == bounds%endp), sourcefile, __LINE__)
 
+     call t_startf("CanIntAndThrough")
+
      do fp = 1, num_nolakep
         p = filter_nolakep(fp)
         c = patch%column(p)
@@ -562,6 +565,8 @@ contains
            end if
         end if
      end do
+
+     call t_stopf("CanIntAndThrough")
 
    end subroutine BulkFlux_CanopyInterceptionAndThroughfall
 

--- a/src/biogeophys/CanopyHydrologyMod.F90
+++ b/src/biogeophys/CanopyHydrologyMod.F90
@@ -493,21 +493,21 @@ contains
      ! !ARGUMENTS:
      type(bounds_type), intent(in) :: bounds
      integer, intent(in) :: num_nolakep
-     integer, intent(in) :: filter_nolakep(:)
+     integer, intent(in), contiguous :: filter_nolakep(:)
      type(patch_type), intent(in) :: patch
      type(column_type), intent(in) :: col
 
-     integer  , intent(in)    :: frac_veg_nosno( bounds%begp: )                          ! fraction of vegetation not covered by snow (0 OR 1)
-     real(r8) , intent(in)    :: elai( bounds%begp: )                                    ! canopy one-sided leaf area index with burying by snow
-     real(r8) , intent(in)    :: esai( bounds%begp: )                                    ! canopy one-sided stem area index with burying by snow
-     real(r8) , intent(in)    :: forc_snow( bounds%begp: )                               ! atm snow (mm H2O/s)
-     real(r8) , intent(in)    :: qflx_liq_above_canopy( bounds%begp: )                   ! liquid water input above canopy (rain plus irrigation) (mm H2O/s)
+     integer  , intent(in), contiguous    :: frac_veg_nosno( bounds%begp: )                          ! fraction of vegetation not covered by snow (0 OR 1)
+     real(r8) , intent(in), contiguous    :: elai( bounds%begp: )                                    ! canopy one-sided leaf area index with burying by snow
+     real(r8) , intent(in), contiguous    :: esai( bounds%begp: )                                    ! canopy one-sided stem area index with burying by snow
+     real(r8) , intent(in), contiguous    :: forc_snow( bounds%begp: )                               ! atm snow (mm H2O/s)
+     real(r8) , intent(in), contiguous    :: qflx_liq_above_canopy( bounds%begp: )                   ! liquid water input above canopy (rain plus irrigation) (mm H2O/s)
 
-     real(r8) , intent(inout) :: qflx_through_snow( bounds%begp: )                       ! canopy throughfall of snow (mm H2O/s)
-     real(r8) , intent(inout) :: qflx_through_liq( bounds%begp: )                        ! canopy throughfall of liquid (mm H2O/s)
-     real(r8) , intent(inout) :: qflx_intercepted_snow( bounds%begp: )                   ! canopy interception of snow (mm H2O/s)
-     real(r8) , intent(inout) :: qflx_intercepted_liq( bounds%begp: )                    ! canopy interception of liquid (mm H2O/s)
-     logical  , intent(inout) :: check_point_for_interception_and_excess( bounds%begp: ) ! whether each patch in the filter needs to have the interception calculations (here) and snow/liquid excess calculations (elsewhere) computed
+     real(r8) , intent(inout), contiguous :: qflx_through_snow( bounds%begp: )                       ! canopy throughfall of snow (mm H2O/s)
+     real(r8) , intent(inout), contiguous :: qflx_through_liq( bounds%begp: )                        ! canopy throughfall of liquid (mm H2O/s)
+     real(r8) , intent(inout), contiguous :: qflx_intercepted_snow( bounds%begp: )                   ! canopy interception of snow (mm H2O/s)
+     real(r8) , intent(inout), contiguous :: qflx_intercepted_liq( bounds%begp: )                    ! canopy interception of liquid (mm H2O/s)
+     logical  , intent(inout), contiguous :: check_point_for_interception_and_excess( bounds%begp: ) ! whether each patch in the filter needs to have the interception calculations (here) and snow/liquid excess calculations (elsewhere) computed
      !
      ! !LOCAL VARIABLES:
      integer :: fp, p, c


### PR DESCRIPTION
I am opening this PR just to document some of the work I did for the recent NVIDIA hackathon with @samsrabin and @ekluzek , towards #627 and related issues. I don't think anything here is worth bringing in at this time, but wanted to save this for future reference. (See also https://github.com/billsacks/prototypes-fortran_vectorization.)

I did my testing in the context of the nvidia-hackathon-26 branch, but here rebased my changes onto master for ease of opening a PR.

I first looked at the intel vectorization reports (by adding the compilation flags `-qopt-report=3 -vec-threshold0`; the latter tells intel to ignore its heuristics on profitability of vectorization and vectorize whenever possible, giving the estimated speedup/slowdown in the optimization report). Conclusions from this were that the important changes for good vectorization speedup are:
- Declaring array arguments to be contiguous
- Changing indirect indexing to direct indexing (getting rid of filters)
- Adding the `-fimf-use-svml` compilation flag for the sake of the math routines in this target subroutine

Then I did timings. Because this target routine is such a small fraction of the overall runtime, I added a loop with 100 repetitions to get more precise results. I first tried putting the timer outside the subroutine call, but then wondered how much of the timing change was due to the subroutine call itself (e.g., due to a different amount of time being needed to do the subroutine call with local arrays vs. members of a derived type), so then put the timer inside the subroutine as it is in this PR... but from comparing timings from both, it seems like the overhead of the subroutine call is a relatively small amount of time, so I think the results / conclusions are about the same with the timer either inside or outside the subroutine.

In my initial timings, with our standard compilation flags, I saw unexpected results: Using filtered/compressed arrays and adding the `contiguous` attribute on the array arguments actually led to a *slowdown* relative to the baseline with ifx. My hypothesis (partly based on looking at intel's optimization report) is that this code change leads the compiler to predict a benefit from vectorization, so it vectorizes the loop, but in reality, performance is worse with vectorization, probably due to using non-vector forms of the math libraries.

Then I redid some timings after adding `-fimf-use-svml`. Here I focus on ifx timings, and am just giving the mean timing from the timing files.

Baseline timing (only code changes were adding a timer and adding 100 repetitions; no `-fimf-use-svml` flag): 0.1664 

Adding `-fimf-use-svml` flag: 0.1348

Additionally adding `contiguous` attribute: 0.1074

Additionally changing to filtered/compressed arrays (note that this does *not* include the time needed to filter / unfilter the arrays): 0.0816

Note that using filtered versions but without the `contiguous` attribute gave a time of 0.2518  – so it seems that contiguous is important when using vectorized code?

Back to using contiguous plus filtered, and additionally removing the `use_clm5_fpi` conditional (out of curiosity about how much the conditional is slowing things down): 0.0709.