### PR TITLE
ctsm5.4.040: Update clm6 paramfiles and add a new one for hillslope hydrology

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2264,9 +2264,10 @@ sub setup_logic_params_file {
   # get param data
   my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
 
+  $nl_flags->{'use_hillslope'} = $nl->get_value('use_hillslope');
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'paramfile',
               'phys'=>$nl_flags->{'phys'},
-              'use_hillslope'=>$nl->get_value('use_hillslope'),
+              'use_hillslope'=>$nl_flags->{'use_hillslope'},
               'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'},
               'use_flexibleCN'=>$nl_flags->{'use_flexibleCN'} );
 }

--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2266,6 +2266,7 @@ sub setup_logic_params_file {
 
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'paramfile',
               'phys'=>$nl_flags->{'phys'},
+              'use_hillslope'=>$nl->get_value('use_hillslope'),
               'lnd_tuning_mode'=>$nl_flags->{'lnd_tuning_mode'},
               'use_flexibleCN'=>$nl_flags->{'use_flexibleCN'} );
 }

--- a/bld/namelist_files/namelist_defaults_ctsm.xml
+++ b/bld/namelist_files/namelist_defaults_ctsm.xml
@@ -600,9 +600,10 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- ================================================================== -->
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
-<!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params.c260303.nc</paramfile>
-<paramfile phys="clm6_0" lnd_tuning_mode="clm6_0_cam7.0">lnd/clm2/paramdata/ctsm60-cam70_params.c260305.nc</paramfile>
+<!-- CLM parameter files (relative to {csmdata}) -->
+<paramfile phys="clm6_0" >lnd/clm2/paramdata/ctsm60_params.c260518.nc</paramfile>
+<paramfile phys="clm6_0" lnd_tuning_mode="clm6_0_cam7.0">lnd/clm2/paramdata/ctsm60-cam70_params.c260518.nc</paramfile>
+<paramfile phys="clm6_0" use_hillslope=".true.">lnd/clm2/paramdata/ctsm60-HH_params.c260518.nc</paramfile>
 <paramfile phys="clm5_0" >lnd/clm2/paramdata/clm50_params.c260305.nc</paramfile>
 <paramfile phys="clm4_5" >lnd/clm2/paramdata/clm45_params.c260305.nc</paramfile>
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -66,6 +66,7 @@ Changes answers relative to baseline: Yes
        - LMWG_dev issue number(s):
  https://github.com/NCAR/LMWG_dev/issues/164
  https://github.com/NCAR/LMWG_dev/issues/167
+ Not changing finidat files in the defaults at this time due to various non-standard things in these test simulations.
 
 Other details
 -------------

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,78 @@
+===============================================================
+Tag name: ctsm5.4.040
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Mon May 18 03:29:57 PM MDT 2026
+One-line Summary: Paramfile updates
+
+Purpose and description of changes
+----------------------------------
+
+ Updating the clm6 paramfiles.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[X] clm6_0
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+ Resolves #3659
+
+Notes of particular relevance for users
+---------------------------------------
+Changes to the parameter file (output of tools/param_utils/compare_paramfiles):
+ Changing two paramfiles and adding a new one for hillslope hydrology in namelist_defaults
+
+Contributors:
+ @wwieder @linniahawkins
+
+Testing summary:
+----------------
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  build-namelist tests (if CLMBuildNamelist.pm has changed):
+
+    derecho - OK (2 expected failures)
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: clm6
+    - what platforms/compilers: all
+    - nature of change: larger than roundoff, possibly climate changing
+
+   If this tag changes climate list the run(s) done to evaluate the new
+   climate. Preferably in https://github.com/NCAR/LMWG_dev (or give details below)
+       - LMWG_dev issue number(s):
+ https://github.com/NCAR/LMWG_dev/issues/164
+ https://github.com/NCAR/LMWG_dev/issues/167
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/4029
+
+===============================================================
 ==============================================================
 Tag name: ctsm5.4.039
 Originator(s): mvdebolskiy (Matvey Debolskiy, University of Oslo, matvey.debolskiy@geo.uio.no)

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name: ctsm5.4.040
 Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
-Date: Mon May 18 03:29:57 PM MDT 2026
+Date: Wed May 20 04:13:57 PM MDT 2026
 One-line Summary: Paramfile updates
 
 Purpose and description of changes

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.4.040 multiple 05/18/2026 Paramfile updates
        ctsm5.4.039 multiple 05/14/2026 Add FATES namelist option to initialize cohorts with diameter at breast height (DBH)
        ctsm5.4.038   slevis 05/07/2026 Merge b4b-dev to master
        ctsm5.4.037 multiple 05/04/2026 Fix for FATES year-boundary restart issue

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,6 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
-       ctsm5.4.040 multiple 05/18/2026 Paramfile updates
+       ctsm5.4.040 multiple 05/20/2026 Paramfile updates
        ctsm5.4.039 multiple 05/14/2026 Add FATES namelist option to initialize cohorts with diameter at breast height (DBH)
        ctsm5.4.038   slevis 05/07/2026 Merge b4b-dev to master
        ctsm5.4.037 multiple 05/04/2026 Fix for FATES year-boundary restart issue


### PR DESCRIPTION
### Description of changes

Updating the clm6 paramfiles.

### Specific notes

**Contributors other than yourself, if any:**
@wwieder @linniahawkins 

**CTSM issues resolved or otherwise addressed, if any:**
Resolves #3659 

**If answers are expected to change, describe (delete this line otherwise):**
Answers change from the baseline due to changing param values in the CLM6 paramfiles.

**Any user interface changes (namelist or namelist defaults changes)?**
Changing two paramfiles and adding a new one for hillslope hydrology in namelist_defaults.

**Testing planned or performed, if any:**
- [x] ./build-namelist_test.pl OK
- [x] derecho `./run_sys_tests -s aux_clm -c ctsm5.4.039 -g ctsm5.4.040`
- [x] izumi `./run_sys_tests -s aux_clm -c ctsm5.4.039 -g ctsm5.4.040`

### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors. **Briefly describe tested configuration(s):** aux_clm
- [x] This either (a) does not change answers, (b) it only changes answers at roundoff level, or (c) I have performed a scientific evaluation of the answer changes. **Answer: (c) Simulations https://github.com/NCAR/LMWG_dev/issues/164 and https://github.com/NCAR/LMWG_dev/issues/167**
- [x] I have reviewed relevant parts of the CLM documentation [Tech Note](https://escomp.github.io/CTSM/tech_note/index.html) or [User's Guide](https://escomp.github.io/CTSM/users_guide/index.html) to determine if anything needs to be changed or added. **If it does, describe:**
- [x] This PR either (a) does not create a need to update the documentation or (b) includes required documentation updates (see [guidelines for contributing documentation](https://escomp.github.io/CTSM/users_guide/working-with-documentation/docs-intro.html#contribution-guidelines)). **Answer: (a)**
- [x] Update ChangeLog: Mention issues lmwg_dev 164 and 167 as the test runs, we are not pointing to new IC in the defaults because of various non-standard things in these runs
