### PR TITLE
ctsm5.4.042: Move $nl_flags->{'use_hillslope'} to a more effective spot

### DIFF
--- a/bld/CLMBuildNamelist.pm
+++ b/bld/CLMBuildNamelist.pm
@@ -2264,7 +2264,6 @@ sub setup_logic_params_file {
   # get param data
   my ($opts, $nl_flags, $definition, $defaults, $nl) = @_;
 
-  $nl_flags->{'use_hillslope'} = $nl->get_value('use_hillslope');
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'paramfile',
               'phys'=>$nl_flags->{'phys'},
               'use_hillslope'=>$nl_flags->{'use_hillslope'},
@@ -3678,8 +3677,11 @@ sub setup_logic_hillslope {
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_transmissivity_method' );
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_pft_distribution_method' );
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_soil_profile_method' );
+
+  $nl_flags->{'use_hillslope'} = $nl->get_value('use_hillslope');
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_hillslope_routing', 'use_hillslope'=>$nl_flags->{'use_hillslope'} );
   add_default($opts, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'hillslope_fsat_equals_zero', 'use_hillslope'=>$nl_flags->{'use_hillslope'} );
+
   my $use_hillslope = $nl->get_value('use_hillslope');
   my $use_hillslope_routing = $nl->get_value('use_hillslope_routing');
   if ( (! &value_is_true($use_hillslope)) && &value_is_true($use_hillslope_routing) ) {

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,78 @@
 ===============================================================
+Tag name: ctsm5.4.042
+Originator(s): slevis (Samuel Levis,UCAR/TSS,303-665-1310)
+Date: Fri May 22 04:07:30 PM MDT 2026
+One-line Summary: Get hillslope_fsat_equals_zero .true. for use_hillslope
+
+Purpose and description of changes
+----------------------------------
+
+ hillslope_fsat_equals_zero was intended to be .true. for use_hillslope = .true. but was coming back false:
+ - First because of the lack of this line in CLMBuildNamelist.pm:
+   $nl_flags->{'use_hillslope'} = $nl->get_value('use_hillslope');
+ - And since ctsm5.4.040 due to the placement of said line in sub setup_logic_params_file, which is called after sub setup_logic_hillslope
+
+ Here I'm moving that line into sub setup_logic_hillslope, which fixes the problem without breaking anything else.
+
+Significant changes to scientifically-supported configurations
+--------------------------------------------------------------
+
+Does this tag change answers significantly for any of the following physics configurations?
+(Details of any changes will be given in the "Answer changes" section below.)
+
+    [Put an [X] in the box for any configuration with significant answer changes.]
+
+[x] clm6_0 hillslope hydrology
+
+[ ] clm5_0
+
+[ ] ctsm5_0-nwp
+
+[ ] clm4_5
+
+
+Bugs fixed
+----------
+List of CTSM issues fixed (include CTSM Issue # and description) [one per line]:
+ Resolves #4030 Bug: hillslope_fsat_equals_zero is .false. when use_hillslope = .true.
+
+Notes of particular relevance for users
+---------------------------------------
+Changes made to namelist defaults (e.g., changed parameter values):
+ Now get the correct hillslope_fsat_equals_zero for use_hillslope = .true..
+
+Testing summary:
+----------------
+
+ [PASS means all tests PASS; OK means tests PASS other than expected fails.]
+
+  build-namelist tests (if CLMBuildNamelist.pm has changed):
+
+    derecho - OK (2 expected failures)
+
+  regular tests (aux_clm: https://github.com/ESCOMP/CTSM/wiki/System-Testing-Guide#pre-merge-system-testing):
+
+    derecho ----- OK
+    izumi ------- OK
+
+Answer changes
+--------------
+Changes answers relative to baseline: Yes
+
+  Summarize any changes to answers, i.e.,
+    - what code configurations: use_hillslope = .true.
+    - what platforms/compilers: all
+    - nature of change: larger than roundoff
+
+ No simulations have been run with the bug-fix, yet.
+
+Other details
+-------------
+Pull Requests that document the changes (include PR ids):
+ https://github.com/ESCOMP/ctsm/pull/4046
+
+===============================================================
+===============================================================
 Tag name: ctsm5.4.041
 Originator(s): samrabin (Sam Rabin, UCAR/TSS)
 Date: Thu May 21 14:33:36 MDT 2026

--- a/doc/ChangeSum
+++ b/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+       ctsm5.4.042   slevis 05/22/2026 Get hillslope_fsat_equals_zero .true. for use_hillslope
        ctsm5.4.041 samrabin 05/21/2026 Merge b4b-dev 2026-05-21
        ctsm5.4.040 multiple 05/20/2026 Paramfile updates
        ctsm5.4.039 multiple 05/14/2026 Add FATES namelist option to initialize cohorts with diameter at breast height (DBH)


### PR DESCRIPTION
### Description of changes

In particular I'm moving the line
`  $nl_flags->{'use_hillslope'} = $nl->get_value('use_hillslope');`
from sub setup_logic_params_file in bld/CLMBuildNamelist.pm to sub setup_logic_hillslope (because it's called before setup_logic_params_file), in order to get the intended `hillslope_fsat_equals_zero` (i.e., .true.) when `use_hillslope = .true.`.

### Specific notes

**Contributors other than yourself, if any:**

**CTSM issues resolved or otherwise addressed, if any:**
Resolves #4030 

**If answers are expected to change, describe (delete this line otherwise):**
Answers change for Hillslope cases only; the changes are greater than roundoff 

**Any user interface changes (namelist or namelist defaults changes)?**
Now get the correct hillslope_fsat_equals_zero for `use_hillslope = .true.`

**Testing planned or performed, if any:**
- [x] ./build-namelist_test.pl OK (2 expected fails)
- [x] aux_clm on derecho OK (Hillslope cases DIFF from the baseline)

### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors. **Briefly describe tested configuration(s):** aux_clm test-suite
- [x] (c) I have not performed a scientific evaluation of the answer changes in hillslope cases.
- [x] This PR (a) does not create a new need to update the documentation and the hillslope updates to the User's Guide have already been assigned.