### PR TITLE
Update doc-builder to v3.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 [submodule "doc-builder"]
 path = doc/doc-builder
 url = https://github.com/ESMCI/doc-builder
-fxtag = v3.2.0
+fxtag = v3.2.1
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@ fxDONOTUSEurl = https://github.com/ESMCI/mpi-serial
 [submodule "doc-builder"]
 path = doc/doc-builder
 url = https://github.com/ESMCI/doc-builder
-fxtag = v3.1.1
+fxtag = v3.2.0
 fxrequired = ToplevelOptional
 # Standard Fork to compare to with "git fleximod test" to ensure personal forks aren't committed
 fxDONOTUSEurl = https://github.com/ESMCI/doc-builder


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->


### Description of changes

All table captions are now:
- Left-aligned,
- Sticky (i.e., they don't move as you scroll horizontally in the table), and
- Limited to the size of the content column.

Before:
<img width="812" height="223" alt="screenshot_5899" src="https://github.com/user-attachments/assets/5a210dba-3deb-4a7b-bf46-01ea9269d113" />

After:
<img width="806" height="261" alt="screenshot_5898" src="https://github.com/user-attachments/assets/c444252d-58ac-471b-804c-1811c71cf505" />


### Specific notes

**Contributors other than yourself, if any:**
- Claude Opus 4.8

**CTSM issues resolved or otherwise addressed, if any:**
- None

**Any user interface changes (namelist or namelist defaults changes)?** No

**Testing planned or performed, if any:**
- [x] Local builds
- [x] PR build tests

### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).