### PR TITLE
wetlands.n04.ctsm5.4.044: Change seasonal deciduous onset

### DIFF
--- a/doc/source/tech_note/Vegetation_Phenology_Turnover/CLM50_Tech_Note_Vegetation_Phenology_Turnover.rst
+++ b/doc/source/tech_note/Vegetation_Phenology_Turnover/CLM50_Tech_Note_Vegetation_Phenology_Turnover.rst
@@ -412,7 +412,9 @@ and the associated nitrogen fluxes are:
 
 where :math:`{f}_{stor,xfer}` is the fraction of current storage pool moved into the transfer pool for display over the incipient onset period. This fraction is set to 0.5, based on the observation that seasonal deciduous trees are capable of replacing their canopies from storage reserves in the event of a severe early-season disturbance such as frost damage or defoliation due to insect herbivory.
 
-If the onset criteria are not met before the summer solstice, then :math:`{GDD}_{sum}` is set to 0.0 and the growing-degree-day accumulation will not start again until the following winter solstice. This mechanism prevents the initiation of very short growing seasons late in the summer in cold climates. The onset counter is decremented on each time step after initiation of the onset period, until it reaches zero, signaling the end of the onset period:
+The *min_critical_daylength_onset* parameter specifies a daylength below which onset may not occur.  If the onset criterion (:math:`{GDD}_{sum} > {GDD}_{sum\_crit}`) is not attained before the daylength becomes less than this parameter in autumn, then :math:`{GDD}_{sum}` is set to 0 and the growing-degree-day accumulation will not start again until the following winter solstice. In cold climates, this mechanism ensures that if the onset criteria are not met, the accumulation does not continue into the following year.
+
+The onset counter is decremented on each time step after initiation of the onset period, until it reaches zero, signaling the end of the onset period:
 
 .. math::
    :label: t_onset_decrement

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1292,7 +1292,8 @@ contains
     ! In that case, it will take until the next winter solstice
     ! before the growing degree-day summation starts again.
 
-    if (onset_gddflag == 1._r8 .and. ws_flag == 0._r8) then
+    if (onset_gddflag == 1._r8 .and. ws_flag == 0._r8.and. &
+         dayl<min_critical_daylength_onset) then
         onset_gddflag = 0._r8
         onset_gdd = 0._r8
     end if
@@ -1323,7 +1324,7 @@ contains
         ! matter for reasonable values between the two degenerate cases.
         else if (season_decid_temperate == 0 .and.  onset_gddflag == 1.0_r8 .and. &
                 soila10 > SHR_CONST_TKFRZ .and. &
-                t_a5min > SHR_CONST_TKFRZ .and. ws_flag==1.0_r8 .and. &
+                t_a5min > SHR_CONST_TKFRZ .and. &
                 dayl>min_critical_daylength_onset .and. &
                 snow_5day<params_inst%snow5d_thresh_for_onset) then
            do_onset = .true.

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1289,8 +1289,14 @@ contains
     ! Test to turn off growing degree-day sum, if on.
     ! This test resets the growing degree day sum if it gets past
     ! the summer solstice without reaching the threshold value.
-    ! In that case, it will take until the next winter solstice
-    ! before the growing degree-day summation starts again.
+    ! After the summer solstice, a daylength criterion is used
+    ! to trigger the reset: if daylength is less than  the
+    ! parameter value, gdd is reset.  This criterion was added to
+    ! allow for situations in the high latitudes when using only
+    ! the summer solstice as a trigger caused some vegetation to never
+    ! achieve onset.
+    ! If the conditional is met, it will take until the next winter 
+    ! solstice before the growing degree-day summation starts again.
 
     if (onset_gddflag == 1._r8 .and. ws_flag == 0._r8.and. &
          dayl<min_critical_daylength_onset) then

--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -1319,15 +1319,16 @@ contains
        ! shrub, C3 arctic grass)
        if (onset_gdd > crit_onset_gdd .and.  season_decid_temperate == 1) then
            do_onset = .true.
-        ! Note: The check "dayl>min_critical_daylength_onset" in the if
-        ! statement was added because for some coastal
-        ! points the other triggers could allow onset in January/February
-        ! which isn't sustainable and is a degenerate case. To prevent this
-        ! condition was added, but now the other conditions aren't triggered
-        ! until much later so it's value just needs to be high enough to prevent
-        ! the degenerate case of happening too early, and low enough that it
-        ! doesn't restrict onset. As such the value of this parameter shouldn't
-        ! matter for reasonable values between the two degenerate cases.
+           ! Note: The "dayl>min_critical_daylength_onset" criterion
+           ! was added because for some coastal points, onset was triggered 
+           ! too early (e.g January/February).  This criterion ensures that 
+           ! onset does not occur too early, and at the same time (because the
+           ! criterion is symmetric about the solstices), it does not allow
+           ! onset when the day length becomes less than
+           ! min_critical_daylength_onset after the summer solstice.
+           ! The value of min_critical_daylength_onset needs to be high
+           ! enough to prevent onset happening too early, and low enough
+           ! that it doesn't restrict onset.
         else if (season_decid_temperate == 0 .and.  onset_gddflag == 1.0_r8 .and. &
                 soila10 > SHR_CONST_TKFRZ .and. &
                 t_a5min > SHR_CONST_TKFRZ .and. &


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->


### Description of changes

Change the seasonal deciduous onset check.  Currently, if the gdd accumulation has not been reached by the solstice (as indicated by the ws_flag), the trigger is reset.  In some high latitude areas, the c3 arctic grass does not pass the criteria by the solstice, and so it never grows.  The change is to add the dayl<min_critical_daylength_onset criteria.  This allows for a longer time period, but still resets the trigger once day length becomes less than the min_critical_daylength_onset value.  I used min_critical_daylength_onset because it already existed and provided a convenient value, but it would be a different parameter/value.

<!-- Description goes here -->

### Specific notes

**Contributors other than yourself, if any:**
- discussed issue with @wwieder 
 
**CTSM issues resolved or otherwise addressed, if any:**
Resolves #3985 

**If answers are expected to change, describe (delete this line otherwise):**
yes, this is designed to encourage c3 arctic grass to grow, which will change answers wherever it was previously not triggering onset

**Any user interface changes (namelist or namelist defaults changes)?**

**Testing planned or performed, if any:**
- [x] 25 year AD run that branched of WIEMIP development simulations + 25 years of 'pAD' to quantify effects of code changes. In these simulations I also increased soil N to ensure plant survival (which resulted in unintended LAI changes in tropical regions).
- [x] Results from [preliminary simulations are posted here](https://webext.cgd.ucar.edu/I1850/wetland_pheno_test/seasonal_decid_mod_postAD_1_25_vs_seasonal_decid_ctrl_postAD_1_25/website/)


### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
<!-- Delete all list items below if this PR is purely Tech Note and/or User's Guide updates -->
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors. **Briefly describe tested configuration(s):**
    Global AD and pAD simulations 
- [x] This PR changes answers, see link to diagnostics above
- [x] I have reviewed relevant parts of the CLM documentation [Tech Note](https://escomp.github.io/CTSM/tech_note/index.html) or [User's Guide](https://escomp.github.io/CTSM/users_guide/index.html) to determine if anything needs to be changed or added. **If it does, describe:** Tech note Phenology chapter
- [x] This PR either (a) does not create a need to update the documentation or (b) includes required documentation updates (see [guidelines for contributing documentation](https://escomp.github.io/CTSM/users_guide/working-with-documentation/docs-intro.html#contribution-guidelines)). **Which?:** b

Phenology documentation will have to be updated, saying we relaxed the solstice requirement for leafout in the seasonally decid. phenology code. 