### PR TITLE
Comment out fields failing in #3661 so test may catch future problems

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -48,7 +48,7 @@
     <phase name="COMPARE_base_rest">
       <status>FAIL</status>
       <issue>#3661</issue>
-      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
+      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields; as per #3661, we commented out the failing fields to allow this test to catch new problems as they arise.</comment>
     </phase>
   </test>
   <test name="SUBSETDATAPOINT_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default">

--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -44,13 +44,6 @@
       <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
     </phase>
   </test>
-  <test name="ERP_P64x2_D_Ld3.f10_f10_mt232.IHistClm60BgcCropCrujra.derecho_gnu.clm-default--clm-all_outputs">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>#3661</issue>
-      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields; as per #3661, we commented out the failing fields to allow this test to catch new problems as they arise.</comment>
-    </phase>
-  </test>
   <test name="SUBSETDATAPOINT_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default">
     <phase name="NLCOMP">
       <status>FAIL</status>

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -138,6 +138,7 @@ contains
          avgflag='A', long_name='Leaf CN ratio used for flexible CN', &
          ptr_patch=this%actual_leafcn )
     this%actual_storage_leafcn(begp:endp) = spval
+!   Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !   call hist_addfld1d (fname='LEAFCN_STORAGE', units='gC/gN', &
 !        avgflag='A', long_name='Storage Leaf CN ratio used for flexible CN', &
 !        ptr_patch=this%actual_storage_leafcn, default='inactive')

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -138,9 +138,9 @@ contains
          avgflag='A', long_name='Leaf CN ratio used for flexible CN', &
          ptr_patch=this%actual_leafcn )
     this%actual_storage_leafcn(begp:endp) = spval
-    call hist_addfld1d (fname='LEAFCN_STORAGE', units='gC/gN', &
-         avgflag='A', long_name='Storage Leaf CN ratio used for flexible CN', &
-         ptr_patch=this%actual_storage_leafcn, default='inactive')
+!   call hist_addfld1d (fname='LEAFCN_STORAGE', units='gC/gN', &
+!        avgflag='A', long_name='Storage Leaf CN ratio used for flexible CN', &
+!        ptr_patch=this%actual_storage_leafcn, default='inactive')
 
   end subroutine InitHistory
 

--- a/src/biogeochem/VOCEmissionMod.F90
+++ b/src/biogeochem/VOCEmissionMod.F90
@@ -274,89 +274,89 @@ contains
             ptr_patch=this%vocflx_tot_patch, set_lake=0._r8, set_urb=0._r8, default='inactive')
 
        this%gamma_out_patch(begp:endp)   = spval
-       call hist_addfld1d (fname='GAMMA', units='non',  &
-            avgflag='A', long_name='total gamma for VOC calc', &
-            ptr_patch=this%gamma_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMA', units='non',  &
+!           avgflag='A', long_name='total gamma for VOC calc', &
+!           ptr_patch=this%gamma_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaL_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='GAMMAL', units='non',  &
-            avgflag='A', long_name='gamma L for VOC calc', &
-            ptr_patch=this%gammaL_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMAL', units='non',  &
+!           avgflag='A', long_name='gamma L for VOC calc', &
+!           ptr_patch=this%gammaL_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaT_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='GAMMAT', units='non',  &
-            avgflag='A', long_name='gamma T for VOC calc', &
-            ptr_patch=this%gammaT_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMAT', units='non',  &
+!           avgflag='A', long_name='gamma T for VOC calc', &
+!           ptr_patch=this%gammaT_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaP_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='GAMMAP', units='non',  &
-            avgflag='A', long_name='gamma P for VOC calc', &
-            ptr_patch=this%gammaP_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMAP', units='non',  &
+!           avgflag='A', long_name='gamma P for VOC calc', &
+!           ptr_patch=this%gammaP_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaA_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='GAMMAA', units='non',  &
-            avgflag='A', long_name='gamma A for VOC calc', &
-            ptr_patch=this%gammaA_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMAA', units='non',  &
+!           avgflag='A', long_name='gamma A for VOC calc', &
+!           ptr_patch=this%gammaA_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaS_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='GAMMAS', units='non',  &
-            avgflag='A', long_name='gamma S for VOC calc', &
-            ptr_patch=this%gammaS_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMAS', units='non',  &
+!           avgflag='A', long_name='gamma S for VOC calc', &
+!           ptr_patch=this%gammaS_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaC_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='GAMMAC', units='non',  &
-            avgflag='A', long_name='gamma C for VOC calc', &
-            ptr_patch=this%gammaC_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='GAMMAC', units='non',  &
+!           avgflag='A', long_name='gamma C for VOC calc', &
+!           ptr_patch=this%gammaC_out_patch, set_lake=0._r8, default='inactive')
 
        this%EOPT_out_patch(begp:endp) = spval
-       call hist_addfld1d (fname='EOPT', units='non',  &
-            avgflag='A', long_name='Eopt coefficient for VOC calc', &
-            ptr_patch=this%Eopt_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='EOPT', units='non',  &
+!           avgflag='A', long_name='Eopt coefficient for VOC calc', &
+!           ptr_patch=this%Eopt_out_patch, set_lake=0._r8, default='inactive')
 
        this%topt_out_patch(begp:endp)    = spval
-       call hist_addfld1d (fname='TOPT', units='non',  &
-            avgflag='A', long_name='topt coefficient for VOC calc', &
-            ptr_patch=this%topt_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='TOPT', units='non',  &
+!           avgflag='A', long_name='topt coefficient for VOC calc', &
+!           ptr_patch=this%topt_out_patch, set_lake=0._r8, default='inactive')
 
        this%alpha_out_patch(begp:endp)    = spval
-       call hist_addfld1d (fname='ALPHA', units='non',  &
-            avgflag='A', long_name='alpha coefficient for VOC calc', &
-            ptr_patch=this%alpha_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='ALPHA', units='non',  &
+!           avgflag='A', long_name='alpha coefficient for VOC calc', &
+!           ptr_patch=this%alpha_out_patch, set_lake=0._r8, default='inactive')
 
        this%cp_out_patch(begp:endp)      = spval
-       call hist_addfld1d (fname='currentPatch', units='non',  &
-            avgflag='A', long_name='currentPatch coefficient for VOC calc', &
-            ptr_patch=this%cp_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='currentPatch', units='non',  &
+!           avgflag='A', long_name='currentPatch coefficient for VOC calc', &
+!           ptr_patch=this%cp_out_patch, set_lake=0._r8, default='inactive')
 
        this%paru_out_patch(begp:endp)    = spval
-       call hist_addfld1d (fname='PAR_sun', units='umol/m2/s', &
-            avgflag='A', long_name='sunlit PAR', &
-            ptr_patch=this%paru_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='PAR_sun', units='umol/m2/s', &
+!           avgflag='A', long_name='sunlit PAR', &
+!           ptr_patch=this%paru_out_patch, set_lake=0._r8, default='inactive')
 
        this%par24u_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='PAR24_sun', units='umol/m2/s', &
-            avgflag='A', long_name='sunlit PAR (24 hrs)', &
-            ptr_patch=this%par24u_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='PAR24_sun', units='umol/m2/s', &
+!           avgflag='A', long_name='sunlit PAR (24 hrs)', &
+!           ptr_patch=this%par24u_out_patch, set_lake=0._r8, default='inactive')
 
        this%par240u_out_patch(begp:endp) = spval
-       call hist_addfld1d (fname='PAR240_sun', units='umol/m2/s', &
-            avgflag='A', long_name='sunlit PAR (240 hrs)', &
-            ptr_patch=this%par240u_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='PAR240_sun', units='umol/m2/s', &
+!           avgflag='A', long_name='sunlit PAR (240 hrs)', &
+!           ptr_patch=this%par240u_out_patch, set_lake=0._r8, default='inactive')
 
        this%para_out_patch(begp:endp)    = spval
-       call hist_addfld1d (fname='PAR_shade', units='umol/m2/s', &
-            avgflag='A', long_name='shade PAR', &
-            ptr_patch=this%para_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='PAR_shade', units='umol/m2/s', &
+!           avgflag='A', long_name='shade PAR', &
+!           ptr_patch=this%para_out_patch, set_lake=0._r8, default='inactive')
 
        this%par24a_out_patch(begp:endp)  = spval
-       call hist_addfld1d (fname='PAR24_shade', units='umol/m2/s', &
-            avgflag='A', long_name='shade PAR (24 hrs)', &
-            ptr_patch=this%par24a_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='PAR24_shade', units='umol/m2/s', &
+!           avgflag='A', long_name='shade PAR (24 hrs)', &
+!           ptr_patch=this%par24a_out_patch, set_lake=0._r8, default='inactive')
 
        this%par240a_out_patch(begp:endp) = spval
-       call hist_addfld1d (fname='PAR240_shade', units='umol/m2/s', &
-            avgflag='A', long_name='shade PAR (240 hrs)', &
-            ptr_patch=this%par240a_out_patch, set_lake=0._r8, default='inactive')
+!      call hist_addfld1d (fname='PAR240_shade', units='umol/m2/s', &
+!           avgflag='A', long_name='shade PAR (240 hrs)', &
+!           ptr_patch=this%par240a_out_patch, set_lake=0._r8, default='inactive')
 
     end if
 

--- a/src/biogeochem/VOCEmissionMod.F90
+++ b/src/biogeochem/VOCEmissionMod.F90
@@ -274,86 +274,103 @@ contains
             ptr_patch=this%vocflx_tot_patch, set_lake=0._r8, set_urb=0._r8, default='inactive')
 
        this%gamma_out_patch(begp:endp)   = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMA', units='non',  &
 !           avgflag='A', long_name='total gamma for VOC calc', &
 !           ptr_patch=this%gamma_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaL_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMAL', units='non',  &
 !           avgflag='A', long_name='gamma L for VOC calc', &
 !           ptr_patch=this%gammaL_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaT_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMAT', units='non',  &
 !           avgflag='A', long_name='gamma T for VOC calc', &
 !           ptr_patch=this%gammaT_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaP_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMAP', units='non',  &
 !           avgflag='A', long_name='gamma P for VOC calc', &
 !           ptr_patch=this%gammaP_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaA_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMAA', units='non',  &
 !           avgflag='A', long_name='gamma A for VOC calc', &
 !           ptr_patch=this%gammaA_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaS_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMAS', units='non',  &
 !           avgflag='A', long_name='gamma S for VOC calc', &
 !           ptr_patch=this%gammaS_out_patch, set_lake=0._r8, default='inactive')
 
        this%gammaC_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='GAMMAC', units='non',  &
 !           avgflag='A', long_name='gamma C for VOC calc', &
 !           ptr_patch=this%gammaC_out_patch, set_lake=0._r8, default='inactive')
 
        this%EOPT_out_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='EOPT', units='non',  &
 !           avgflag='A', long_name='Eopt coefficient for VOC calc', &
 !           ptr_patch=this%Eopt_out_patch, set_lake=0._r8, default='inactive')
 
        this%topt_out_patch(begp:endp)    = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='TOPT', units='non',  &
 !           avgflag='A', long_name='topt coefficient for VOC calc', &
 !           ptr_patch=this%topt_out_patch, set_lake=0._r8, default='inactive')
 
        this%alpha_out_patch(begp:endp)    = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='ALPHA', units='non',  &
 !           avgflag='A', long_name='alpha coefficient for VOC calc', &
 !           ptr_patch=this%alpha_out_patch, set_lake=0._r8, default='inactive')
 
        this%cp_out_patch(begp:endp)      = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='currentPatch', units='non',  &
 !           avgflag='A', long_name='currentPatch coefficient for VOC calc', &
 !           ptr_patch=this%cp_out_patch, set_lake=0._r8, default='inactive')
 
        this%paru_out_patch(begp:endp)    = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='PAR_sun', units='umol/m2/s', &
 !           avgflag='A', long_name='sunlit PAR', &
 !           ptr_patch=this%paru_out_patch, set_lake=0._r8, default='inactive')
 
        this%par24u_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='PAR24_sun', units='umol/m2/s', &
 !           avgflag='A', long_name='sunlit PAR (24 hrs)', &
 !           ptr_patch=this%par24u_out_patch, set_lake=0._r8, default='inactive')
 
        this%par240u_out_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='PAR240_sun', units='umol/m2/s', &
 !           avgflag='A', long_name='sunlit PAR (240 hrs)', &
 !           ptr_patch=this%par240u_out_patch, set_lake=0._r8, default='inactive')
 
        this%para_out_patch(begp:endp)    = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='PAR_shade', units='umol/m2/s', &
 !           avgflag='A', long_name='shade PAR', &
 !           ptr_patch=this%para_out_patch, set_lake=0._r8, default='inactive')
 
        this%par24a_out_patch(begp:endp)  = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='PAR24_shade', units='umol/m2/s', &
 !           avgflag='A', long_name='shade PAR (24 hrs)', &
 !           ptr_patch=this%par24a_out_patch, set_lake=0._r8, default='inactive')
 
        this%par240a_out_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='PAR240_shade', units='umol/m2/s', &
 !           avgflag='A', long_name='shade PAR (240 hrs)', &
 !           ptr_patch=this%par240a_out_patch, set_lake=0._r8, default='inactive')

--- a/src/biogeophys/EnergyFluxType.F90
+++ b/src/biogeophys/EnergyFluxType.F90
@@ -670,9 +670,9 @@ contains
 
     if (use_cn) then
        this%rresis_patch(begp:endp,:) = spval
-       call hist_addfld2d (fname='RRESIS', units='proportion', type2d='levgrnd', &
-            avgflag='A', long_name='root resistance in each soil layer', &
-            ptr_patch=this%rresis_patch, l2g_scale_type='veg', default='inactive')
+!      call hist_addfld2d (fname='RRESIS', units='proportion', type2d='levgrnd', &
+!           avgflag='A', long_name='root resistance in each soil layer', &
+!           ptr_patch=this%rresis_patch, l2g_scale_type='veg', default='inactive')
     end if
 
     this%errsoi_col(begc:endc) = spval

--- a/src/biogeophys/EnergyFluxType.F90
+++ b/src/biogeophys/EnergyFluxType.F90
@@ -670,6 +670,7 @@ contains
 
     if (use_cn) then
        this%rresis_patch(begp:endp,:) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld2d (fname='RRESIS', units='proportion', type2d='levgrnd', &
 !           avgflag='A', long_name='root resistance in each soil layer', &
 !           ptr_patch=this%rresis_patch, l2g_scale_type='veg', default='inactive')

--- a/src/biogeophys/FrictionVelocityMod.F90
+++ b/src/biogeophys/FrictionVelocityMod.F90
@@ -268,38 +268,47 @@ contains
             ptr_patch=this%fv_patch, default='inactive')
 
        this%rah1_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='RAH1', units='s/m', &
 !           avgflag='A', long_name='aerodynamical resistance ', &
 !           ptr_patch=this%rah1_patch, default='inactive')
        this%rah2_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='RAH2', units='s/m', &
 !           avgflag='A', long_name='aerodynamical resistance ', &
 !           ptr_patch=this%rah2_patch, default='inactive')
        this%raw1_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='RAW1', units='s/m', &
 !           avgflag='A', long_name='aerodynamical resistance ', &
 !           ptr_patch=this%raw1_patch, default='inactive')
        this%raw2_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='RAW2', units='s/m', &
 !           avgflag='A', long_name='aerodynamical resistance ', &
 !           ptr_patch=this%raw2_patch, default='inactive')
        this%ustar_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='USTAR', units='m/s', &
 !           avgflag='A', long_name='friction velocity ', &
 !           ptr_patch=this%ustar_patch, default='inactive')
        this%um_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='UM', units='m/s', &
 !           avgflag='A', long_name='wind speed plus stability effect', &
 !           ptr_patch=this%um_patch, default='inactive')
        this%uaf_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='UAF', units='m/s', &
 !           avgflag='A', long_name='canopy air speed ', &
 !           ptr_patch=this%uaf_patch, default='inactive')
        this%taf_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='TAF', units='K', &
 !           avgflag='A', long_name='canopy air temperature', &
 !           ptr_patch=this%taf_patch, default='inactive')
        this%qaf_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='QAF', units='kg/kg', &
 !           avgflag='A', long_name='canopy air humidity', &
 !           ptr_patch=this%qaf_patch, default='inactive')
@@ -312,6 +321,7 @@ contains
             avgflag='A', long_name='dimensionless stability parameter', &
             ptr_patch=this%zeta_patch, default='inactive')
        this%vpd_patch(begp:endp) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld1d (fname='VPD', units='kPa', &
 !           avgflag='A', long_name='vapor pressure deficit', &
 !           ptr_patch=this%vpd_patch, default='inactive')

--- a/src/biogeophys/FrictionVelocityMod.F90
+++ b/src/biogeophys/FrictionVelocityMod.F90
@@ -268,41 +268,41 @@ contains
             ptr_patch=this%fv_patch, default='inactive')
 
        this%rah1_patch(begp:endp) = spval
-       call hist_addfld1d (fname='RAH1', units='s/m', &
-            avgflag='A', long_name='aerodynamical resistance ', &
-            ptr_patch=this%rah1_patch, default='inactive')
+!      call hist_addfld1d (fname='RAH1', units='s/m', &
+!           avgflag='A', long_name='aerodynamical resistance ', &
+!           ptr_patch=this%rah1_patch, default='inactive')
        this%rah2_patch(begp:endp) = spval
-       call hist_addfld1d (fname='RAH2', units='s/m', &
-            avgflag='A', long_name='aerodynamical resistance ', &
-            ptr_patch=this%rah2_patch, default='inactive')
+!      call hist_addfld1d (fname='RAH2', units='s/m', &
+!           avgflag='A', long_name='aerodynamical resistance ', &
+!           ptr_patch=this%rah2_patch, default='inactive')
        this%raw1_patch(begp:endp) = spval
-       call hist_addfld1d (fname='RAW1', units='s/m', &
-            avgflag='A', long_name='aerodynamical resistance ', &
-            ptr_patch=this%raw1_patch, default='inactive')
+!      call hist_addfld1d (fname='RAW1', units='s/m', &
+!           avgflag='A', long_name='aerodynamical resistance ', &
+!           ptr_patch=this%raw1_patch, default='inactive')
        this%raw2_patch(begp:endp) = spval
-       call hist_addfld1d (fname='RAW2', units='s/m', &
-            avgflag='A', long_name='aerodynamical resistance ', &
-            ptr_patch=this%raw2_patch, default='inactive')
+!      call hist_addfld1d (fname='RAW2', units='s/m', &
+!           avgflag='A', long_name='aerodynamical resistance ', &
+!           ptr_patch=this%raw2_patch, default='inactive')
        this%ustar_patch(begp:endp) = spval
-       call hist_addfld1d (fname='USTAR', units='m/s', &
-            avgflag='A', long_name='friction velocity ', &
-            ptr_patch=this%ustar_patch, default='inactive')
+!      call hist_addfld1d (fname='USTAR', units='m/s', &
+!           avgflag='A', long_name='friction velocity ', &
+!           ptr_patch=this%ustar_patch, default='inactive')
        this%um_patch(begp:endp) = spval
-       call hist_addfld1d (fname='UM', units='m/s', &
-            avgflag='A', long_name='wind speed plus stability effect', &
-            ptr_patch=this%um_patch, default='inactive')
+!      call hist_addfld1d (fname='UM', units='m/s', &
+!           avgflag='A', long_name='wind speed plus stability effect', &
+!           ptr_patch=this%um_patch, default='inactive')
        this%uaf_patch(begp:endp) = spval
-       call hist_addfld1d (fname='UAF', units='m/s', &
-            avgflag='A', long_name='canopy air speed ', &
-            ptr_patch=this%uaf_patch, default='inactive')
+!      call hist_addfld1d (fname='UAF', units='m/s', &
+!           avgflag='A', long_name='canopy air speed ', &
+!           ptr_patch=this%uaf_patch, default='inactive')
        this%taf_patch(begp:endp) = spval
-       call hist_addfld1d (fname='TAF', units='K', &
-            avgflag='A', long_name='canopy air temperature', &
-            ptr_patch=this%taf_patch, default='inactive')
+!      call hist_addfld1d (fname='TAF', units='K', &
+!           avgflag='A', long_name='canopy air temperature', &
+!           ptr_patch=this%taf_patch, default='inactive')
        this%qaf_patch(begp:endp) = spval
-       call hist_addfld1d (fname='QAF', units='kg/kg', &
-            avgflag='A', long_name='canopy air humidity', &
-            ptr_patch=this%qaf_patch, default='inactive')
+!      call hist_addfld1d (fname='QAF', units='kg/kg', &
+!           avgflag='A', long_name='canopy air humidity', &
+!           ptr_patch=this%qaf_patch, default='inactive')
        this%obu_patch(begp:endp) = spval
        call hist_addfld1d (fname='OBU', units='m', &
             avgflag='A', long_name='Obukhov length scale', &
@@ -312,9 +312,9 @@ contains
             avgflag='A', long_name='dimensionless stability parameter', &
             ptr_patch=this%zeta_patch, default='inactive')
        this%vpd_patch(begp:endp) = spval
-       call hist_addfld1d (fname='VPD', units='kPa', &
-            avgflag='A', long_name='vapor pressure deficit', &
-            ptr_patch=this%vpd_patch, default='inactive')
+!      call hist_addfld1d (fname='VPD', units='kPa', &
+!           avgflag='A', long_name='vapor pressure deficit', &
+!           ptr_patch=this%vpd_patch, default='inactive')
        this%num_iter_patch(begp:endp) = spval
        call hist_addfld1d (fname='num_iter', units='unitless', &
             avgflag='A', long_name='number of iterations', &

--- a/src/biogeophys/SoilStateType.F90
+++ b/src/biogeophys/SoilStateType.F90
@@ -215,14 +215,14 @@ contains
          ptr_col=this%smp_l_col, set_spec=spval, l2g_scale_type='veg')
 
     this%root_conductance_patch(begp:endp,:) = spval
-    call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
-         avgflag='A', long_name='root conductance each soil layer', &
-         ptr_patch=this%root_conductance_patch, default='inactive')
+!   call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
+!        avgflag='A', long_name='root conductance each soil layer', &
+!        ptr_patch=this%root_conductance_patch, default='inactive')
     
     this%soil_conductance_patch(begp:endp,:) = spval
-    call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
-         avgflag='A', long_name='soil conductance in each soil layer', &
-         ptr_patch=this%soil_conductance_patch, default='inactive')
+!   call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
+!        avgflag='A', long_name='soil conductance in each soil layer', &
+!        ptr_patch=this%soil_conductance_patch, default='inactive')
 
     if (use_cn) then
        this%bsw_col(begc:endc,:) = spval 
@@ -291,9 +291,9 @@ contains
 
     if (use_cn) then
        this%eff_porosity_col(begc:endc,:) = spval
-       call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
-            avgflag='A', long_name='effective porosity = porosity - vol_ice', &
-            ptr_col=this%eff_porosity_col, default='inactive')
+!      call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
+!           avgflag='A', long_name='effective porosity = porosity - vol_ice', &
+!           ptr_col=this%eff_porosity_col, default='inactive')
     end if
 
     if (use_cn) then

--- a/src/biogeophys/SoilStateType.F90
+++ b/src/biogeophys/SoilStateType.F90
@@ -258,9 +258,9 @@ contains
 
     this%thk_col(begc:endc,-nlevsno+1:0) = spval
     data2dptr => this%thk_col(:,-nlevsno+1:0)
-    call hist_addfld2d (fname='SNO_TK', units='W/m-K', type2d='levsno', &
-         avgflag='A', long_name='Thermal conductivity', &
-         ptr_col=data2dptr, no_snow_behavior=no_snow_normal, default='inactive')
+!   call hist_addfld2d (fname='SNO_TK', units='W/m-K', type2d='levsno', &
+!        avgflag='A', long_name='Thermal conductivity', &
+!        ptr_col=data2dptr, no_snow_behavior=no_snow_normal, default='inactive')
 
     call hist_addfld2d (fname='SNO_TK_ICE', units='W/m-K', type2d='levsno', &
          avgflag='A', long_name='Thermal conductivity (ice landunits only)', &

--- a/src/biogeophys/SoilStateType.F90
+++ b/src/biogeophys/SoilStateType.F90
@@ -215,11 +215,13 @@ contains
          ptr_col=this%smp_l_col, set_spec=spval, l2g_scale_type='veg')
 
     this%root_conductance_patch(begp:endp,:) = spval
+!   Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !   call hist_addfld2d (fname='KROOT', units='1/s', type2d='levsoi', &
 !        avgflag='A', long_name='root conductance each soil layer', &
 !        ptr_patch=this%root_conductance_patch, default='inactive')
     
     this%soil_conductance_patch(begp:endp,:) = spval
+!   Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !   call hist_addfld2d (fname='KSOIL', units='1/s', type2d='levsoi', &
 !        avgflag='A', long_name='soil conductance in each soil layer', &
 !        ptr_patch=this%soil_conductance_patch, default='inactive')
@@ -258,6 +260,7 @@ contains
 
     this%thk_col(begc:endc,-nlevsno+1:0) = spval
     data2dptr => this%thk_col(:,-nlevsno+1:0)
+!   Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !   call hist_addfld2d (fname='SNO_TK', units='W/m-K', type2d='levsno', &
 !        avgflag='A', long_name='Thermal conductivity', &
 !        ptr_col=data2dptr, no_snow_behavior=no_snow_normal, default='inactive')
@@ -291,6 +294,7 @@ contains
 
     if (use_cn) then
        this%eff_porosity_col(begc:endc,:) = spval
+!      Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !      call hist_addfld2d (fname='EFF_POROSITY', units='proportion', type2d='levgrnd', &
 !           avgflag='A', long_name='effective porosity = porosity - vol_ice', &
 !           ptr_col=this%eff_porosity_col, default='inactive')

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -358,12 +358,12 @@ contains
          ptr_patch=this%rh_ref2m_u_patch, set_nourb=spval)
 
     this%rh_af_patch(begp:endp) = spval
-    call hist_addfld1d ( &
-         fname=this%info%fname('RHAF'), &
-         units='fraction', &
-         avgflag='A', &
-         long_name=this%info%lname('fractional humidity of canopy air'), &
-         ptr_patch=this%rh_af_patch, set_spec=spval, default='inactive')
+!   call hist_addfld1d ( &
+!        fname=this%info%fname('RHAF'), &
+!        units='fraction', &
+!        avgflag='A', &
+!        long_name=this%info%lname('fractional humidity of canopy air'), &
+!        ptr_patch=this%rh_af_patch, set_spec=spval, default='inactive')
 
     if(use_luna)then
        call hist_addfld1d ( &

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -358,6 +358,7 @@ contains
          ptr_patch=this%rh_ref2m_u_patch, set_nourb=spval)
 
     this%rh_af_patch(begp:endp) = spval
+!   Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !   call hist_addfld1d ( &
 !        fname=this%info%fname('RHAF'), &
 !        units='fraction', &
@@ -544,6 +545,7 @@ contains
 
     this%bw_col(begc:endc,-nlevsno+1:0) = spval
     data2dptr => this%bw_col(:,-nlevsno+1:0)
+!   Commented out failing fields (see https://github.com/ESCOMP/CTSM/issues/3661) to allow all_outputs test to catch new problems as they arise
 !   call hist_addfld2d ( &
 !        fname=this%info%fname('SNO_BW'), &
 !        units='kg/m3', type2d='levsno', &

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -544,12 +544,12 @@ contains
 
     this%bw_col(begc:endc,-nlevsno+1:0) = spval
     data2dptr => this%bw_col(:,-nlevsno+1:0)
-    call hist_addfld2d ( &
-         fname=this%info%fname('SNO_BW'), &
-         units='kg/m3', type2d='levsno', &
-         avgflag='A', &
-         long_name=this%info%lname('Partial density of water in the snow pack (ice + liquid)'), &
-         ptr_col=data2dptr, no_snow_behavior=no_snow_normal, default='inactive')
+!   call hist_addfld2d ( &
+!        fname=this%info%fname('SNO_BW'), &
+!        units='kg/m3', type2d='levsno', &
+!        avgflag='A', &
+!        long_name=this%info%lname('Partial density of water in the snow pack (ice + liquid)'), &
+!        ptr_col=data2dptr, no_snow_behavior=no_snow_normal, default='inactive')
 
     call hist_addfld2d ( &
          fname=this%info%fname('SNO_BW_ICE'), &


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->


### Description of changes

<!-- Description goes here -->
Commented out fields listed in https://github.com/ESCOMP/CTSM/issues/3661#issuecomment-5037903430 to allow all_outputs test to catch future problems.

### Specific notes

**Contributors other than yourself, if any:**

**CTSM issues resolved or otherwise addressed, if any:**
Contributes to #3661 

**Testing planned or performed, if any:**
- [x] `ERP_P36x2_D_Ld3.f10_f10_mg37.I1850Clm50BgcCrop.derecho_gnu.clm-default--clm-all_outputs` only field lists differ after commenting out the previously failing fields
- [x] Repeating with `ERP_P64x2_D_Ld3.f10_f10_mt232.IHistClm60BgcCropCrujra.derecho_gnu.clm-default--clm-all_outputs` which is the current all_outputs test
- [x] derecho: `./run_sys_tests -s aux_clm -c ctsm5.4.047 --skip-generate`
Resubmitting `ERP_D_P64x2_Ld3.f10_f10_mg37.I2000Clm50BgcCru.derecho_intel.clm-noFUN_flexCN--clm-matrixcnOn_ignore_warnings` until it passes (known issue)
- [x] aux_clm on izumi
- [x] The last commit in this PR adds more comment lines, so I'm taking the risk of not repeating the above testing
<!-- (List what testing you did to show your changes worked as expected) -->



### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
<!-- Delete all list items below if this PR is purely Tech Note and/or User's Guide updates -->
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors. **Briefly describe tested configuration(s):** See above for testing performed.
- [x] This does not change answers
<!-- If (c) above, include your analyses in the "Description of changes" section. -->
- [x] This PR does not create a need to update the documentation
