### PR TITLE
Generate TRENDY2026 fsurdat/landuse files

### DIFF
--- a/python/ctsm/toolchain/gen_mksurfdata_namelist.py
+++ b/python/ctsm/toolchain/gen_mksurfdata_namelist.py
@@ -426,16 +426,16 @@ def check_ssp_years(start_year, end_year):
     """
     Check years associated with SSP period
     """
-    if int(start_year) > 2023:
+    if int(start_year) > 2026:
         error_msg = (
-            "ERROR: if start-year > 2023 must add an --ssp_rcp "
+            "ERROR: if start-year > 2026 must add an --ssp_rcp "
             "argument that is not none: valid opts for ssp-rcp "
             f"are {valid_opts}"
         )
         sys.exit(error_msg)
-    elif int(end_year) > 2023:
+    elif int(end_year) > 2026:
         error_msg = (
-            "ERROR: if end-year > 2023 must add an --ssp-rcp "
+            "ERROR: if end-year > 2026 must add an --ssp-rcp "
             "argument that is not none: valid opts for ssp-rcp "
             f"are {valid_opts}"
         )
@@ -516,14 +516,14 @@ def determine_pft_years(start_year, end_year, potveg):
         pft_years = "2005"
     elif int(start_year) >= 850 and int(end_year) <= 1849:
         pft_years = "0850-1849"
-    elif int(start_year) >= 1700 and int(start_year) <= 2100 and int(end_year) <= 2023:
-        pft_years = "1700-2023"
+    elif int(start_year) >= 1700 and int(start_year) <= 2100 and int(end_year) <= 2026:
+        pft_years = "1700-2026"
     elif int(start_year) >= 1700 and int(start_year) <= 2100 and int(end_year) <= 2100:
-        pft_years = "1700-2023"
-        pft_years_ssp = "2024-2100"
-    elif int(start_year) >= 2023 and int(start_year) <= 2100 and int(end_year) <= 2100:
+        pft_years = "1700-2026"
+        pft_years_ssp = "2027-2100"
+    elif int(start_year) >= 2026 and int(start_year) <= 2100 and int(end_year) <= 2100:
         pft_years = "-999"
-        pft_years_ssp = "2024-2100"
+        pft_years_ssp = "2027-2100"
     else:
         error_msg = (
             f"ERROR: start_year is {start_year} and end_year is "
@@ -615,7 +615,7 @@ def write_nml_rawinput(
             # write everything else
             nlfile.write(f"  {key} = '{value}' \n")
 
-    if start_year <= 2023:
+    if start_year <= 2026:
         mksrf_fvegtyp = rawdata_files["mksrf_fvegtyp"]
         mksrf_fvegtyp_mesh = rawdata_files["mksrf_fvegtyp_mesh"]
         mksrf_fhrvtyp = rawdata_files["mksrf_fvegtyp"]
@@ -678,7 +678,7 @@ def handle_transient_run(
     with open(landuse_fname, "w", encoding="utf-8") as landuse_file:
         for year in range(start_year, end_year + 1):
             year_str = str(year)
-            if year <= 2023:
+            if year <= 2026:
                 file1 = rawdata_files["mksrf_fvegtyp"]
                 file2 = rawdata_files["mksrf_fvegtyp_urban"]
                 file3 = rawdata_files["mksrf_fvegtyp_lake"]
@@ -796,15 +796,15 @@ def determine_input_rawdata(start_year, input_path, attribute_list):
                     max_match_child = child2
 
         if max_match_child is None:
-            # For years greater than 2023 - mksrf_fvegtyp_ssp must have a match
-            if start_year > 2023:
+            # For years greater than 2026 - mksrf_fvegtyp_ssp must have a match
+            if start_year > 2026:
                 if "mksrf_fvegtyp_ssp" not in child1.tag:
                     error_msg = f"ERROR: {child1.tag} has no matches"
                     sys.exit(error_msg)
                 else:
                     continue
             else:
-                # For years less than 2023 - mksrf_fvegtyp must have a match
+                # For years less than 2026 - mksrf_fvegtyp must have a match
                 if "mksrf_fvegtyp" not in child1.tag:
                     error_msg = f"ERROR: {child1.tag} has no matches"
                     sys.exit(error_msg)

--- a/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
+++ b/tools/mksurfdata_esmf/gen_mksurfdata_namelist.xml
@@ -10,7 +10,7 @@
 
   <mksrf_flai>
     <entry>
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_pftlai_clm6_histLUH3_2005_c251012.nc</data_filename>
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_pftlai_clm5_histLUH2_2005_c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
     </entry>
   </mksrf_flai>
@@ -21,7 +21,7 @@
 
   <mksrf_fsoicol>
     <entry>
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_soilcolor_clm6_histLUH3_2005_c251012.nc</data_filename>
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_soilcolor_clm5_histLUH2_2005_c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
     </entry>
   </mksrf_fsoicol>
@@ -213,28 +213,28 @@ version of the raw dataset will probably go away.
     </entry>
 
     <entry pft_years="1700">
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_landuse_clm6_histLUH3_1700.c251012.nc</data_filename>
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_landuse_clm5_histLUH2_1700.c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>lnd/clm2/rawdata/lake_area/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_1850.cdf5.c20220325.nc</lake_filename>
       <urban_filename>lnd/clm2/rawdata/CTSM54RawData/urban_properties/urban_properties_CMIP7_ThreeClass_1700_c250423.nc</urban_filename>
     </entry>
 
     <entry pft_years="1850">
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_landuse_clm6_histLUH3_1850.c251012.nc</data_filename>
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_landuse_clm5_histLUH2_1850.c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>lnd/clm2/rawdata/lake_area/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_1850.cdf5.c20220325.nc</lake_filename>
       <urban_filename>lnd/clm2/rawdata/CTSM54RawData/urban_properties/urban_properties_CMIP7_ThreeClass_1850_c250423.nc</urban_filename>
     </entry>
 
     <entry pft_years="2000">
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_landuse_clm6_histLUH3_2000.c251012.nc</data_filename>
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_landuse_clm5_histLUH2_2000.c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>lnd/clm2/rawdata/lake_area/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_2000.cdf5.c20220325.nc</lake_filename>
       <urban_filename>lnd/clm2/rawdata/CTSM54RawData/urban_properties/urban_properties_CMIP7_ThreeClass_2000_c250423.nc</urban_filename>
     </entry>
 
     <entry pft_years="2005">
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_landuse_clm6_histLUH3_2005.c251012.nc</data_filename>
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_landuse_clm5_histLUH2_2005.c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>lnd/clm2/rawdata/lake_area/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_2005.cdf5.c20220325.nc</lake_filename>
       <urban_filename>lnd/clm2/rawdata/CTSM54RawData/urban_properties/urban_properties_CMIP7_ThreeClass_2005_c250423.nc</urban_filename>
@@ -248,11 +248,11 @@ version of the raw dataset will probably go away.
       <urban_filename>lnd/clm2/rawdata/gao_oneill_urban/historical/urban_properties_GaoOneil_05deg_ThreeClass_1850_cdf5_c20220910.nc</urban_filename>
     </entry>
 
-    <!-- Historical period from 1700 to 2023 -->
+    <!-- Historical period from 1700 to 2026 -->
     <!-- Lake and urban data from 1700 to 1849 is copied from 1850 -->
-    <!-- Lake data from 2018 to 2023 is copied from 2017 -->
-    <entry pft_years="1700-2023" >
-      <data_filename>lnd/clm2/rawdata/CTSM54RawData/CLM6_LUH3_HIST_CMIP7/mksrf_landuse_clm6_histLUH3_%y.c251012.nc</data_filename>
+    <!-- Urban data from 2024 to 2026 is copied from 2023 and NOT ./rimport-ed -->
+    <entry pft_years="1700-2026" >
+      <data_filename>/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026/mksrf_landuse_clm5_histLUH2_%y.c260729.nc</data_filename>
       <mesh_filename>lnd/clm2/mappingdata/grids/UNSTRUCTgrid_0.25x0.25_nomask_cdf5_c200129.nc</mesh_filename>
       <lake_filename>lnd/clm2/rawdata/lake_area/mksurf_lake_0.05x0.05_hist_clm5_hydrolakes_%y.cdf5.c20220325.nc</lake_filename>
       <urban_filename>lnd/clm2/rawdata/CTSM54RawData/urban_properties/urban_properties_CMIP7_ThreeClass_%y_c250423.nc</urban_filename>


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->


### Description of changes

See title. Same as #3337 but for TRENDY2026.

I start these PRs to show my work. As with #3337, we do not expect to merge this PR anywhere, unless the CTSM were to adopt the TRENDY2026 data as default.

Branched from ctsm5.4.047

### Specific notes

**Contributors other than yourself, if any:**
@adrifoster 

**CTSM issues resolved or otherwise addressed, if any:**

**If answers are expected to change, describe (delete this line otherwise):**
Answers will change, due to new pft, lai, and soicol raw datasets.

**Any user interface changes (namelist or namelist defaults changes)?**
mksurfdata_esmf can now handle pft data out to 2026 for IHist cases.

- @lawrencepj1 provided pft, lai, and soicol raw datasets here:
`/glade/campaign/cesm/development/lmwg/clm5landusedatatoolsproduction/clm5timeseriesdata/clm5timeseriestrendy2026surfdata/CLM5_LUH2_HIST_TRENDY2026`
- To extend the urban data, I simply copied the existing 2023 file from `lnd/clm2/rawdata/CTSM54RawData/urban_properties` to 2024, 2025, 2026 files in the same directory.

**Testing planned or performed, if any:**
- [x] With this PR's changes, I submitted mksurfdata_esmf to generate the fsurdat/flanduse files (currently waiting in the queue):
```
./gen_mksurfdata_namelist --start-year 1700 --end-year 2026 --res 0.9x1.25
./gen_mksurfdata_jobscript_single --number-of-nodes 2 --tasks-per-node 128 --jobscript-file surfdata_0.9x1.25_hist_1700_78pfts_c260730.jobscript --namelist-file surfdata_0.9x1.25_hist_1700_78pfts_c260730.namelist
qsub surfdata_0.9x1.25_hist_1700_78pfts_c260730.jobscript
```
- [ ] TRENDY2026 spin-up
