### PR TITLE
Fix restart failures for 35 diagnostic fields (#3661, #4142)

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -44,13 +44,7 @@
       <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
     </phase>
   </test>
-  <test name="ERP_P64x2_D_Ld3.f10_f10_mt232.IHistClm60BgcCropCrujra.derecho_gnu.clm-default--clm-all_outputs">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>#3661</issue>
-      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
-    </phase>
-  </test>
+
   <test name="SUBSETDATAPOINT_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default">
     <phase name="NLCOMP">
       <status>FAIL</status>

--- a/cime_config/testdefs/testmods_dirs/clm/all_outputs/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/all_outputs/user_nl_clm
@@ -1,4 +1,3 @@
 calc_human_stress_indices = 'ALL'
 hist_all_fields = .true.
 hist_wrtch4diag = .true.
-hist_fexcl1 = 'LEAFCN_STORAGE', 'GAMMA', 'GAMMAL', 'GAMMAT', 'GAMMAP', 'GAMMAA', 'GAMMAS', 'GAMMAC', 'EOPT', 'TOPT', 'ALPHA', 'currentPatch', 'PAR_sun', 'PAR24_sun', 'PAR240_sun', 'PAR_shade', 'PAR24_shade', 'PAR240_shade', 'RRESIS', 'RAH1', 'RAH2', 'RAW1', 'RAW2', 'USTAR', 'UM', 'UAF', 'TAF', 'QAF', 'VPD', 'KROOT', 'KSOIL', 'SNO_TK', 'EFF_POROSITY', 'RHAF', 'SNO_BW'

--- a/cime_config/testdefs/testmods_dirs/clm/all_outputs/user_nl_clm
+++ b/cime_config/testdefs/testmods_dirs/clm/all_outputs/user_nl_clm
@@ -1,3 +1,4 @@
 calc_human_stress_indices = 'ALL'
 hist_all_fields = .true.
 hist_wrtch4diag = .true.
+hist_fexcl1 = 'LEAFCN_STORAGE', 'GAMMA', 'GAMMAL', 'GAMMAT', 'GAMMAP', 'GAMMAA', 'GAMMAS', 'GAMMAC', 'EOPT', 'TOPT', 'ALPHA', 'currentPatch', 'PAR_sun', 'PAR24_sun', 'PAR240_sun', 'PAR_shade', 'PAR24_shade', 'PAR240_shade', 'RRESIS', 'RAH1', 'RAH2', 'RAW1', 'RAW2', 'USTAR', 'UM', 'UAF', 'TAF', 'QAF', 'VPD', 'KROOT', 'KSOIL', 'SNO_TK', 'EFF_POROSITY', 'RHAF', 'SNO_BW'

--- a/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
+++ b/src/biogeochem/NutrientCompetitionCLM45defaultMod.F90
@@ -35,6 +35,7 @@ module NutrientCompetitionCLM45defaultMod
    contains
      ! public methocs
      procedure, public :: init                                ! Initialize the class
+     procedure, public :: restart                             ! restart
      procedure, public :: calc_plant_nutrient_competition     ! calculate nutrient yield rate from competition
      procedure, public :: calc_plant_nutrient_demand          ! calculate plant nutrient demand
      !
@@ -74,6 +75,20 @@ contains
     type(bounds_type), intent(in) :: bounds
 
   end subroutine Init
+
+  !------------------------------------------------------------------------
+  subroutine Restart(this, bounds, ncid, flag)
+    !
+    ! !DESCRIPTION:
+    ! Restart for the class (currently empty for this version)
+    !
+    use ncdio_pio              , only : file_desc_t
+    class(nutrient_competition_clm45default_type) :: this
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid
+    character(len=*) , intent(in)    :: flag
+
+  end subroutine Restart
 
   !-----------------------------------------------------------------------
   subroutine calc_plant_nutrient_competition (this,                   &

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -43,8 +43,9 @@ module NutrientCompetitionFlexibleCNMod
      real(r8), pointer :: actual_leafcn(:)                    ! leaf CN ratio used by flexible CN
      real(r8), pointer :: actual_storage_leafcn(:)            ! storage leaf CN ratio used by flexible CN
    contains
-     ! public methocs
+     ! public methods
      procedure, public :: Init                                ! Initialization
+     procedure, public :: Restart                             ! Restart
      procedure, public :: calc_plant_nutrient_competition     ! calculate nutrient yield rate from competition
      procedure, public :: calc_plant_nutrient_demand          ! calculate plant nutrient demand
      !
@@ -143,6 +144,27 @@ contains
          ptr_patch=this%actual_storage_leafcn, default='inactive')
 
   end subroutine InitHistory
+
+  !------------------------------------------------------------------------
+  subroutine Restart(this, bounds, ncid, flag)
+    !
+    ! !DESCRIPTION:
+    ! Restart for the class
+    !
+    use ncdio_pio              , only : file_desc_t, ncd_double
+    use restUtilMod            , only : restartvar
+    class(nutrient_competition_FlexibleCN_type) :: this
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid
+    character(len=*) , intent(in)    :: flag
+    logical                          :: readvar
+
+    call restartvar(ncid=ncid, flag=flag, varname='LEAFCN_STORAGE', xtype=ncd_double,  & 
+         dim1name='pft', &
+         long_name='Storage Leaf CN ratio used for flexible CN', units='gC/gN', &
+         interpinic_flag='interp', readvar=readvar, data=this%actual_storage_leafcn)
+
+  end subroutine Restart
 
   !-----------------------------------------------------------------------
   subroutine calc_plant_nutrient_competition (this, &

--- a/src/biogeochem/NutrientCompetitionMethodMod.F90
+++ b/src/biogeochem/NutrientCompetitionMethodMod.F90
@@ -20,6 +20,9 @@ module NutrientCompetitionMethodMod
      ! initialization
      procedure(init_interface), public, deferred :: init
 
+     ! restart
+     procedure(restart_interface), public, deferred :: restart
+
       ! compute plant nutrient demand
      procedure(calc_plant_nutrient_demand_interface), public, deferred :: calc_plant_nutrient_demand
 
@@ -57,6 +60,24 @@ module NutrientCompetitionMethodMod
        type(bounds_type)                       , intent(in)    :: bounds
 
      end subroutine init_interface
+
+     !---------------------------------------------------------------------------
+     subroutine restart_interface(this, bounds, ncid, flag)
+       ! !DESCRIPTION:
+       ! restart for nutrient competition
+       !
+       ! !USES:
+       use decompMod              , only : bounds_type
+       use ncdio_pio              , only : file_desc_t
+       import :: nutrient_competition_method_type
+       !
+       ! !ARGUMENTS:
+       class(nutrient_competition_method_type)                 :: this
+       type(bounds_type)                       , intent(in)    :: bounds
+       type(file_desc_t)                       , intent(inout) :: ncid
+       character(len=*)                        , intent(in)    :: flag
+
+     end subroutine restart_interface
 
      !---------------------------------------------------------------------------     
      subroutine calc_plant_nutrient_demand_interface (this, bounds,                &

--- a/src/biogeochem/VOCEmissionMod.F90
+++ b/src/biogeochem/VOCEmissionMod.F90
@@ -62,6 +62,7 @@ module VOCEmissionMod
      real(r8) , pointer, private :: efisop_grc        (:,:) ! gridcell isoprene emission factors
    contains
      procedure, public  :: Init
+     procedure, public  :: Restart
      procedure, private :: InitAllocate
      procedure, private :: InitHistory
      procedure, private :: InitCold
@@ -362,8 +363,92 @@ contains
 
   end subroutine InitHistory
 
+  !------------------------------------------------------------------------
+  subroutine Restart(this, bounds, ncid, flag)
+    !
+    ! !DESCRIPTION:
+    ! Restart method for vocemis_type
+    !
+    use ncdio_pio              , only : file_desc_t, ncd_double
+    use restUtilMod            , only : restartvar
+    class(vocemis_type)              :: this
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid
+    character(len=*) , intent(in)    :: flag
+    logical                          :: readvar
+
+    call restartvar(ncid=ncid, flag=flag, varname='EOPT', xtype=ncd_double,  & 
+         dim1name='pft', long_name='Eopt coefficient', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%Eopt_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='TOPT', xtype=ncd_double,  & 
+         dim1name='pft', long_name='topt coefficient', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%topt_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='ALPHA', xtype=ncd_double,  & 
+         dim1name='pft', long_name='alpha coefficient', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%alpha_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='currentPatch', xtype=ncd_double,  & 
+         dim1name='pft', long_name='currentPatch coefficient for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%cp_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='PAR_sun', xtype=ncd_double,  & 
+         dim1name='pft', long_name='sunlit PAR for VOC calc', units='umol/m2/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%paru_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='PAR24_sun', xtype=ncd_double,  & 
+         dim1name='pft', long_name='24-hour sunlit PAR for VOC calc', units='umol/m2/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%par24u_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='PAR240_sun', xtype=ncd_double,  & 
+         dim1name='pft', long_name='240-hour sunlit PAR for VOC calc', units='umol/m2/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%par240u_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='PAR_shade', xtype=ncd_double,  & 
+         dim1name='pft', long_name='shaded PAR for VOC calc', units='umol/m2/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%para_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='PAR24_shade', xtype=ncd_double,  & 
+         dim1name='pft', long_name='24-hour shaded PAR for VOC calc', units='umol/m2/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%par24a_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='PAR240_shade', xtype=ncd_double,  & 
+         dim1name='pft', long_name='240-hour shaded PAR for VOC calc', units='umol/m2/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%par240a_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMA', xtype=ncd_double,  & 
+         dim1name='pft', long_name='total gamma for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gamma_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMAL', xtype=ncd_double,  & 
+         dim1name='pft', long_name='gamma L for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gammaL_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMAT', xtype=ncd_double,  & 
+         dim1name='pft', long_name='gamma T for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gammaT_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMAP', xtype=ncd_double,  & 
+         dim1name='pft', long_name='gamma P for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gammaP_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMAA', xtype=ncd_double,  & 
+         dim1name='pft', long_name='gamma A for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gammaA_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMAS', xtype=ncd_double,  & 
+         dim1name='pft', long_name='gamma S for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gammaS_out_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='GAMMAC', xtype=ncd_double,  & 
+         dim1name='pft', long_name='gamma C for VOC calc', units='non', &
+         interpinic_flag='interp', readvar=readvar, data=this%gammaC_out_patch)
+
+  end subroutine Restart
+
   !-----------------------------------------------------------------------
-  subroutine InitCold(this, bounds)
+  subroutine InitCold(this, bounds, soilstate_inst)
     !
     ! !DESCRIPTION:
     ! Initialize cold start conditions for module variables

--- a/src/biogeophys/EnergyFluxType.F90
+++ b/src/biogeophys/EnergyFluxType.F90
@@ -902,6 +902,11 @@ contains
          long_name='instantaneous daily minimum of transpiration wetness factor', units='', &
          interpinic_flag='interp', readvar=readvar, data=this%btran_min_inst_patch) 
 
+    call restartvar(ncid=ncid, flag=flag, varname='RRESIS', xtype=ncd_double,  &
+         dim1name='pft', &
+         long_name='aerodynamic resistance to root transpiration', units='s/m', &
+         interpinic_flag='interp', readvar=readvar, data=this%rresis_patch)
+
     call this%eflx_dynbal_dribbler%Restart(bounds, ncid, flag)
 
   end subroutine Restart

--- a/src/biogeophys/FrictionVelocityMod.F90
+++ b/src/biogeophys/FrictionVelocityMod.F90
@@ -465,6 +465,46 @@ contains
             interpinic_flag='interp', readvar=readvar, data=this%rb10_patch)
     endif
 
+    call restartvar(ncid=ncid, flag=flag, varname='RAH1', xtype=ncd_double,  &
+         dim1name='pft', long_name='aerodynamical resistance', units='s/m', &
+         interpinic_flag='interp', readvar=readvar, data=this%rah1_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='RAH2', xtype=ncd_double,  &
+         dim1name='pft', long_name='aerodynamical resistance', units='s/m', &
+         interpinic_flag='interp', readvar=readvar, data=this%rah2_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='RAW1', xtype=ncd_double,  &
+         dim1name='pft', long_name='aerodynamical resistance', units='s/m', &
+         interpinic_flag='interp', readvar=readvar, data=this%raw1_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='RAW2', xtype=ncd_double,  &
+         dim1name='pft', long_name='aerodynamical resistance', units='s/m', &
+         interpinic_flag='interp', readvar=readvar, data=this%raw2_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='USTAR', xtype=ncd_double,  &
+         dim1name='pft', long_name='friction velocity', units='m/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%ustar_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='UM', xtype=ncd_double,  &
+         dim1name='pft', long_name='wind speed plus stability effect', units='m/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%um_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='UAF', xtype=ncd_double,  &
+         dim1name='pft', long_name='canopy air speed', units='m/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%uaf_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='TAF', xtype=ncd_double,  &
+         dim1name='pft', long_name='canopy air temperature', units='K', &
+         interpinic_flag='interp', readvar=readvar, data=this%taf_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='QAF', xtype=ncd_double,  &
+         dim1name='pft', long_name='canopy air humidity', units='kg/kg', &
+         interpinic_flag='interp', readvar=readvar, data=this%qaf_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='VPD', xtype=ncd_double,  &
+         dim1name='pft', long_name='vapor pressure deficit', units='kPa', &
+         interpinic_flag='interp', readvar=readvar, data=this%vpd_patch)
+
   end subroutine Restart
 
   !-----------------------------------------------------------------------

--- a/src/biogeophys/SoilStateType.F90
+++ b/src/biogeophys/SoilStateType.F90
@@ -379,6 +379,26 @@ contains
          scale_by_thickness=.true., &
          interpinic_flag='interp', readvar=readvar, data=this%hk_l_col)
 
+    call restartvar(ncid=ncid, flag=flag, varname='KROOT', xtype=ncd_double,  &
+         dim1name='pft', dim2name='levsoi', switchdim=.true., &
+         long_name='root conductance each soil layer', units='1/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%root_conductance_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='KSOIL', xtype=ncd_double,  &
+         dim1name='pft', dim2name='levsoi', switchdim=.true., &
+         long_name='soil conductance in each soil layer', units='1/s', &
+         interpinic_flag='interp', readvar=readvar, data=this%soil_conductance_patch)
+
+    call restartvar(ncid=ncid, flag=flag, varname='EFF_POROSITY', xtype=ncd_double,  &
+         dim1name='column', dim2name='levgrnd', switchdim=.true., &
+         long_name='effective porosity = porosity - vol_ice', units='proportion', &
+         interpinic_flag='interp', readvar=readvar, data=this%eff_porosity_col)
+
+    call restartvar(ncid=ncid, flag=flag, varname='SNO_TK', xtype=ncd_double,  &
+         dim1name='column', dim2name='levsno', switchdim=.true., lowerb2=-nlevsno+1, upperb2=0, &
+         long_name='Thermal conductivity', units='W/m-K', &
+         interpinic_flag='interp', readvar=readvar, data=this%thk_col(:,-nlevsno+1:0))
+
      readrootfr = .false.
      if (flag=='read' .and. .not. readrootfr ) then
             if (masterproc) then

--- a/src/biogeophys/WaterDiagnosticBulkType.F90
+++ b/src/biogeophys/WaterDiagnosticBulkType.F90
@@ -989,6 +989,16 @@ contains
        end if
     endif
 
+    call restartvar(ncid=ncid, flag=flag, varname=this%info%fname('SNO_BW'), xtype=ncd_double,  &
+         dim1name='column', dim2name='levsno', switchdim=.true., lowerb2=-nlevsno+1, upperb2=0, &
+         long_name=this%info%lname('Partial density of water in the snow pack (ice + liquid)'), units='kg/m3', &
+         interpinic_flag='interp', readvar=readvar, data=this%bw_col(:,-nlevsno+1:0))
+
+    call restartvar(ncid=ncid, flag=flag, varname=this%info%fname('RHAF'), xtype=ncd_double,  &
+         dim1name='pft', &
+         long_name=this%info%lname('fractional humidity of canopy air'), units='fraction', &
+         interpinic_flag='interp', readvar=readvar, data=this%rh_af_patch)
+
   end subroutine RestartBulk
 
   !-----------------------------------------------------------------------

--- a/src/main/clm_instMod.F90
+++ b/src/main/clm_instMod.F90
@@ -552,6 +552,8 @@ contains
 
     call ozone_inst%restart (bounds, ncid, flag=flag)
 
+    call vocemis_inst%Restart (bounds, ncid, flag=flag)
+
     call photosyns_inst%restart (bounds, ncid, flag=flag)
 
     call soilhydrology_inst%restart (bounds, ncid, flag=flag)
@@ -592,6 +594,10 @@ contains
 
        call soilbiogeochem_nitrogenstate_inst%restart(bounds, ncid, flag=flag, &
             totvegc_col=bgc_vegetation_inst%get_totvegc_col(bounds))
+
+       if (allocated(nutrient_competition_method)) then
+          call nutrient_competition_method%Restart(bounds, ncid, flag=flag)
+       end if
 
        call crop_inst%restart(bounds, ncid, bgc_vegetation_inst%cnveg_state_inst, flag=flag)
     end if


### PR DESCRIPTION
<!-- Please fill this out to the best of your ability when opening your PR! -->

<!-- **NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).** -->

### Description of changes
This is intended as a followup to https://github.com/ESCOMP/CTSM/pull/4145.

This PR fixes exact restart failures for 35 diagnostic fields originally identified in Issue #3661 (including `LEAFCN_STORAGE`, numerous `GAMMA` fields, `RRESIS`, `USTAR`, etc.). The root cause was that these fields were placed on the history tape as "inactive" by default, but were missing the appropriate read/write logic for the restart files. This omission led to mismatches between `h0a` and `h0i` history output upon an exact restart.

To resolve this, explicit `restartvar()` calls and `Restart` subroutine hooks have been added for these diagnostic variables across several modules:
- `NutrientCompetitionFlexibleCNMod` and `NutrientCompetitionMethodMod`
- `VOCEmissionMod`
- `EnergyFluxType`
- `FrictionVelocityMod`
- `SoilStateType`
- `WaterDiagnosticBulkType`
- `clm_instMod`

Additionally, because these fields now restart perfectly, the `all_outputs` integration test override for Issue `#3661` in `ExpectedTestFails.xml` has been removed, and the `hist_fexcl1` exclusion list is no longer needed in `testmods_dirs/clm/all_outputs/user_nl_clm`.

### Specific notes

**Contributors other than yourself, if any:**
- Gemini LLM authored this fix and this description.

**CTSM issues resolved or otherwise addressed, if any:**
- Resolves #3661
- Resolves #4142

**Any user interface changes (namelist or namelist defaults changes)?**
None.

**Testing planned or performed, if any:**
- [ ] TODO: need to verify exact restart test (`ERP_P64x2_D_Ld3.f10_f10_mt232.IHistClm60BgcCropCrujra.derecho_gnu.clm-default--clm-all_outputs`) which previously failed under #3661.

### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
- [ ] The code in this PR branch builds with no errors.
- [ ] The code in this PR branch runs with no errors. 
- [ ] 
- [ ] **Briefly describe tested configuration(s):**  Exact restart tests (`all_outputs`).
- [x] This either (a) does not change answers, (b) it only changes answers at roundoff level, or (c) I have performed a scientific evaluation of the answer changes. **Which?:** (a) does not change answers for active prognostic fields (only fixes restart states for inactive diagnostic fields).
- [x] I have reviewed relevant parts of the CLM documentation [Tech Note](https://escomp.github.io/CTSM/tech_note/index.html) or [User's Guide](https://escomp.github.io/CTSM/users_guide/index.html) to determine if anything needs to be changed or added.
- [x] This PR either (a) does not create a need to update the documentation or (b) includes required documentation updates. **Which?:** (a) does not create a need to update the documentation.