### PR TITLE
docs(lilac): generalize Homebrew and ESMF paths in CTSM documentation

### DIFF
--- a/doc/source/lilac/obtaining-building-and-running/obtaining-and-building-ctsm.rst
+++ b/doc/source/lilac/obtaining-building-and-running/obtaining-and-building-ctsm.rst
@@ -41,7 +41,7 @@ On a machine that has *not* been ported to CIME, you will need to provide some a
 information. Run ``./lilac/build_ctsm -h`` for details, but the basic command will look
 like this::
 
-  ./lilac/build_ctsm ~/ctsm_build_dir --os Darwin --compiler gnu --netcdf-path /usr/local --esmf-mkfile-path /Users/sacks/ESMF/esmf8.0.0/lib/libO/Darwin.gfortranclang.64.mpich3.default/esmf.mk --max-mpitasks-per-node 4 --no-pnetcdf
+  ./lilac/build_ctsm ~/ctsm_build_dir --os Darwin --compiler gnu --netcdf-path ${NETCDF_PATH:-${MAC_PREFIX:-/opt/homebrew}} --esmf-mkfile-path ${ESMFMKFILE:-$HOME/software/esmf/esmf.mk} --max-mpitasks-per-node 4 --no-pnetcdf
 
 In both cases, you will then need to include the necessary information in the include and
 link lines of the atmosphere model's build. For a Makefile-based build, this can be done
@@ -230,7 +230,7 @@ model performance.
 
 Example usage for a Mac (a simple case) is::
 
-  ./lilac/build_ctsm ~/ctsm_build_dir --os Darwin --compiler gnu --netcdf-path /usr/local --esmf-mkfile-path /Users/sacks/ESMF/esmf8.0.0/lib/libO/Darwin.gfortranclang.64.mpich3.default/esmf.mk --max-mpitasks-per-node 4 --no-pnetcdf
+  ./lilac/build_ctsm ~/ctsm_build_dir --os Darwin --compiler gnu --netcdf-path ${NETCDF_PATH:-${MAC_PREFIX:-/opt/homebrew}} --esmf-mkfile-path ${ESMFMKFILE:-$HOME/software/esmf/esmf.mk} --max-mpitasks-per-node 4 --no-pnetcdf
 
 Example usage for NCAR's ``derecho`` machine (a more complex case) is::
 


### PR DESCRIPTION
### Description of changes
Generalizes hardcoded developer paths in LILAC build documentation:
1. **Homebrew Prefix Generalization:** Replaces hardcoded `/usr/local` with `${NETCDF_PATH:-${MAC_PREFIX:-/opt/homebrew}}` to support both Apple Silicon (`/opt/homebrew`) and Intel Macs (`/usr/local`).
2. **ESMF Path Generalization:** Replaces hardcoded developer home directory `/Users/sacks/ESMF/...` with generic environment variable fallbacks `${ESMFMKFILE:-$HOME/software/esmf/esmf.mk}`.

### Specific notes

**Contributors other than yourself, if any:**
- @billsacks
- @johnpaulalex

**Linked issues addressed, if any:**
<!-- Note: Only refer to relevant GitHub issues here. Always use direct fully qualified links. Do NOT reference or list other PRs/pull requests. -->
- None

**Description of generative AI usage:**
- Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Answer Changes & Scientific Impact
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**

### User Interface & Namelist Changes
- **Namelist / Defaults modified?** No
- **XML / Build script changes?** No (`doc/source/lilac/obtaining-building-and-running/obtaining-and-building-ctsm.rst`)

### Testing planned or performed, if any:
- [x] Verified documentation markup rendering.

**CTSM / CESM baseline hash-tag:** `41db637f1`
**PR branch hash-tag:** `5f9592173`

### Requirements before merge:
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors.
- [x] In-code documentation and Fortran docstrings updated.
- [x] This PR either (a) does not create a need to update documentation or (b) includes required documentation updates. **Which?:** (a) Documentation update.