### PR TITLE
fix(biogeophys): Correct diagnostic array initialization for exact restarts

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -44,13 +44,7 @@
       <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
     </phase>
   </test>
-  <test name="ERP_P64x2_D_Ld3.f10_f10_mt232.IHistClm60BgcCropCrujra.derecho_gnu.clm-default--clm-all_outputs">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>#3661</issue>
-      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
-    </phase>
-  </test>
+
   <test name="SUBSETDATAPOINT_Ld5_D_Mmpi-serial.CLM_USRDAT.I2000Clm60BgcCropCrujra.derecho_intel.clm-default">
     <phase name="NLCOMP">
       <status>FAIL</status>

--- a/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
+++ b/src/biogeochem/NutrientCompetitionFlexibleCNMod.F90
@@ -673,6 +673,8 @@ contains
                this%actual_storage_leafcn(p) = cnveg_carbonstate_inst%leafc_storage_patch(p)  &
                     / cnveg_nitrogenstate_inst%leafn_storage_patch(p)
             end if
+         else
+            this%actual_storage_leafcn(p) = spval
          end if
 
          if (carbon_resp_opt == 1 .AND. laisun(p)+laisha(p) > 0.0_r8) then

--- a/src/biogeochem/VOCEmissionMod.F90
+++ b/src/biogeochem/VOCEmissionMod.F90
@@ -22,7 +22,7 @@ module VOCEmissionMod
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
   use fileutils          , only : getfil
-  use clm_varcon         , only : grlnd
+  use clm_varcon         , only : grlnd, spval
   use atm2lndType        , only : atm2lnd_type
   use CanopyStateType    , only : canopystate_type
   use PhotosynthesisMod  , only : photosyns_type
@@ -586,6 +586,24 @@ contains
     ! initialize variables which get passed to the atmosphere
     vocflx(bounds%begp:bounds%endp,:)   = 0._r8
     vocflx_tot(bounds%begp:bounds%endp) = 0._r8
+
+    gamma_out(bounds%begp:bounds%endp) = spval
+    gammaL_out(bounds%begp:bounds%endp) = spval
+    gammaT_out(bounds%begp:bounds%endp) = spval
+    gammaP_out(bounds%begp:bounds%endp) = spval
+    gammaA_out(bounds%begp:bounds%endp) = spval
+    gammaS_out(bounds%begp:bounds%endp) = spval
+    gammaC_out(bounds%begp:bounds%endp) = spval
+    Eopt_out(bounds%begp:bounds%endp) = spval
+    topt_out(bounds%begp:bounds%endp) = spval
+    alpha_out(bounds%begp:bounds%endp) = spval
+    cp_out(bounds%begp:bounds%endp) = spval
+    paru_out(bounds%begp:bounds%endp) = spval
+    par24u_out(bounds%begp:bounds%endp) = spval
+    par240u_out(bounds%begp:bounds%endp) = spval
+    para_out(bounds%begp:bounds%endp) = spval
+    par24a_out(bounds%begp:bounds%endp) = spval
+    par240a_out(bounds%begp:bounds%endp) = spval
 
     do imeg=1,shr_megan_megcomps_n
       meg_out(imeg)%flux_out(bounds%begp:bounds%endp) = 0._r8

--- a/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
+++ b/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
@@ -91,6 +91,8 @@ contains
     character(len=*), parameter :: subname = 'BiogeophysPreFluxCalcs'
     !-----------------------------------------------------------------------
 
+    call frictionvel_inst%TimestepInit(bounds)
+
     call SetZ0mDisp(bounds, num_nolakep, filter_nolakep, &
          clm_fates, frictionvel_inst, canopystate_inst)
 

--- a/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
+++ b/src/biogeophys/BiogeophysPreFluxCalcsMod.F90
@@ -92,6 +92,7 @@ contains
     !-----------------------------------------------------------------------
 
     call frictionvel_inst%TimestepInit(bounds)
+    call soilstate_inst%TimestepInit(bounds)
 
     call SetZ0mDisp(bounds, num_nolakep, filter_nolakep, &
          clm_fates, frictionvel_inst, canopystate_inst)

--- a/src/biogeophys/CanopyFluxesMod.F90
+++ b/src/biogeophys/CanopyFluxesMod.F90
@@ -640,6 +640,9 @@ contains
         bsha                    => energyflux_inst%bsha_patch                       ! Output: [real(r8) (:)   ]  sunlit canopy transpiration wetness factor (0 to 1)
       end if
 
+      ! Initialize diagnostic variables to spval so inactive patches don't retain stale memory
+      rhaf(begp:endp) = spval
+
       
       ! Determine step size
 

--- a/src/biogeophys/FrictionVelocityMod.F90
+++ b/src/biogeophys/FrictionVelocityMod.F90
@@ -87,6 +87,7 @@ module FrictionVelocityMod
      procedure, public :: SetRoughnessLengthsAndForcHeightsNonLake  ! Set roughness lengths and forcing heights for non-lake points
      procedure, public :: SetActualRoughnessLengths ! Set roughness lengths actually used in flux calculations
      procedure, public :: FrictionVelocity       ! Calculate friction velocity
+     procedure, public :: TimestepInit           ! Initialize diagnostic arrays to spval each timestep
      procedure, public :: MoninObukIni           ! Initialization of the Obukhov length scale
 
      procedure, public  :: InitForTesting        ! version of Init meant for unit testing
@@ -403,6 +404,36 @@ contains
     end do
    
   end subroutine InitCold
+
+  !------------------------------------------------------------------------------
+  subroutine TimestepInit(this, bounds)
+    ! Initialize diagnostic arrays to spval each timestep
+    ! to avoid carrying over stale values on patches that don't compute them
+    
+    class(frictionvel_type), intent(inout) :: this
+    type(bounds_type), intent(in) :: bounds
+    integer :: begp, endp
+    
+    begp = bounds%begp; endp = bounds%endp
+    
+    this%rah1_patch(begp:endp) = spval
+    this%rah2_patch(begp:endp) = spval
+    this%raw1_patch(begp:endp) = spval
+    this%raw2_patch(begp:endp) = spval
+    this%ustar_patch(begp:endp) = spval
+    this%um_patch(begp:endp) = spval
+    this%uaf_patch(begp:endp) = spval
+    this%taf_patch(begp:endp) = spval
+    this%qaf_patch(begp:endp) = spval
+    this%obu_patch(begp:endp) = spval
+    this%zeta_patch(begp:endp) = spval
+    this%vpd_patch(begp:endp) = spval
+    this%rb1_patch(begp:endp) = spval
+    this%u10_patch(begp:endp) = spval
+    this%u10_clm_patch(begp:endp) = spval
+    this%ram1_patch(begp:endp) = spval
+    
+  end subroutine TimestepInit
 
   !------------------------------------------------------------------------------
   subroutine ReadParams( this, params_ncid )

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -3007,9 +3007,6 @@ contains
          gs_mol_sha_ln => photosyns_inst%gs_mol_sha_ln_patch   & ! Output: [real(r8) (:,:) ]  shaded leaf stomatal conductance averaged over 1 hour before to 1 hour after local noon (umol H2O/m**2/s)
          )
 
-      root_conductance_patch(bounds%begp:bounds%endp,:) = spval
-      soil_conductance_patch(bounds%begp:bounds%endp,:) = spval
-
       par_z_sun     =>    solarabs_inst%parsun_z_patch        ! Input:  [real(r8) (:,:) ]  par absorbed per unit lai for canopy layer (w/m**2)
       lai_z_sun     =>    canopystate_inst%laisun_z_patch     ! Input:  [real(r8) (:,:) ]  leaf area index for canopy layer, sunlit or shaded
       vcmaxcint_sun =>    surfalb_inst%vcmaxcintsun_patch     ! Input:  [real(r8) (:)   ]  leaf to canopy scaling coefficient

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -3007,6 +3007,9 @@ contains
          gs_mol_sha_ln => photosyns_inst%gs_mol_sha_ln_patch   & ! Output: [real(r8) (:,:) ]  shaded leaf stomatal conductance averaged over 1 hour before to 1 hour after local noon (umol H2O/m**2/s)
          )
 
+      root_conductance_patch(bounds%begp:bounds%endp,:) = spval
+      soil_conductance_patch(bounds%begp:bounds%endp,:) = spval
+
       par_z_sun     =>    solarabs_inst%parsun_z_patch        ! Input:  [real(r8) (:,:) ]  par absorbed per unit lai for canopy layer (w/m**2)
       lai_z_sun     =>    canopystate_inst%laisun_z_patch     ! Input:  [real(r8) (:,:) ]  leaf area index for canopy layer, sunlit or shaded
       vcmaxcint_sun =>    surfalb_inst%vcmaxcintsun_patch     ! Input:  [real(r8) (:)   ]  leaf to canopy scaling coefficient

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -206,7 +206,7 @@ contains
     ! Set diagnostic variables related to the fraction of water and ice in each layer
     !
     ! !USES:
-    use clm_varcon, only : denice
+    use clm_varcon, only : denice, spval
     !
     ! !ARGUMENTS:
     type(bounds_type)        , intent(in)    :: bounds               
@@ -248,6 +248,14 @@ contains
           eff_porosity(c,j) = max(0.01_r8,watsat(c,j)-vol_ice(c,j))
           icefrac(c,j) = min(1._r8,vol_ice(c,j)/watsat(c,j))
 
+       end do
+    end do
+
+    do j = nlevsoi+1, nlevgrnd
+       do fc = 1, num_hydrologyc
+          c = filter_hydrologyc(fc)
+          eff_porosity(c,j) = spval
+          icefrac(c,j)      = spval
        end do
     end do
 

--- a/src/biogeophys/SoilHydrologyMod.F90
+++ b/src/biogeophys/SoilHydrologyMod.F90
@@ -251,6 +251,8 @@ contains
        end do
     end do
 
+    ! Initialize deeper bedrock layers (which do not have active hydrology) to spval 
+    ! to prevent them from carrying stale memory into history output variables.
     do j = nlevsoi+1, nlevgrnd
        do fc = 1, num_hydrologyc
           c = filter_hydrologyc(fc)

--- a/src/biogeophys/SoilMoistStressMod.F90
+++ b/src/biogeophys/SoilMoistStressMod.F90
@@ -383,6 +383,7 @@ contains
             ! rootr effectively defines the active root fraction in each layer      
             if (h2osoi_liqvol(c,j) .le. 0._r8 .or. t_soisno(c,j) .le. tfrz-2._r8) then
                rootr(p,j) = 0._r8
+               rresis(p,j) = 0._r8
             else
                s_node = max(h2osoi_liqvol(c,j)/eff_porosity(c,j),0.01_r8)
 

--- a/src/biogeophys/SoilStateType.F90
+++ b/src/biogeophys/SoilStateType.F90
@@ -82,6 +82,7 @@ module SoilStateType
 
      procedure, public  :: Init         
      procedure, public  :: Restart
+     procedure, public  :: TimestepInit
      procedure, private :: InitAllocate 
      procedure, private :: InitHistory  
      procedure, private :: InitCold     
@@ -392,5 +393,29 @@ contains
          end if
     
   end subroutine Restart
+
+  !------------------------------------------------------------------------
+  subroutine TimestepInit(this, bounds)
+    !
+    ! !DESCRIPTION:
+    ! Initialize arrays that need to be reset to spval each timestep
+    !
+    ! !USES:
+    use clm_varcon, only : spval
+    !
+    ! !ARGUMENTS:
+    class(soilstate_type)         :: this
+    type(bounds_type), intent(in) :: bounds
+    !
+    ! !LOCAL VARIABLES:
+    integer :: begp, endp
+    !-----------------------------------------------------------------------
+
+    begp = bounds%begp; endp = bounds%endp
+
+    this%root_conductance_patch(begp:endp,:) = spval
+    this%soil_conductance_patch(begp:endp,:) = spval
+
+  end subroutine TimestepInit
 
 end module SoilStateType

--- a/src/biogeophys/SoilTemperatureMod.F90
+++ b/src/biogeophys/SoilTemperatureMod.F90
@@ -621,7 +621,7 @@ contains
     !
     ! !USES:
     use clm_varpar      , only : nlevsno, nlevgrnd, nlevurb, nlevsoi, nlevmaxurbgrnd
-    use clm_varcon      , only : denh2o, denice, tfrz, tkwat, tkice, tkair, cpice,  cpliq, thk_bedrock, csol_bedrock
+    use clm_varcon      , only : denh2o, denice, tfrz, tkwat, tkice, tkair, cpice,  cpliq, thk_bedrock, csol_bedrock, spval
     use landunit_varcon , only : istice, istwet
     use column_varcon   , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
     use clm_varctl      , only : iulog, snow_thermal_cond_method, snow_thermal_cond_glc_method
@@ -737,6 +737,10 @@ contains
             endif
 
             ! Thermal conductivity of snow
+            ! Initialize bw to spval for inactive snow layers
+            if (j <= 0) then
+               bw(c,j) = spval
+            end if
             ! Only examine levels from snl(c)+1 -> 0 where snl(c) < 1
             if (snl(c)+1 < 1 .AND. (j >= snl(c)+1) .AND. (j <= 0)) then  
                bw(c,j) = (h2osoi_ice(c,j)+h2osoi_liq(c,j))/(frac_sno(c)*dz(c,j))

--- a/src/biogeophys/SoilTemperatureMod.F90
+++ b/src/biogeophys/SoilTemperatureMod.F90
@@ -737,9 +737,10 @@ contains
             endif
 
             ! Thermal conductivity of snow
-            ! Initialize bw to spval for inactive snow layers
+            ! Initialize bw and thk to spval for inactive snow layers
             if (j <= 0) then
                bw(c,j) = spval
+               thk(c,j) = spval
             end if
             ! Only examine levels from snl(c)+1 -> 0 where snl(c) < 1
             if (snl(c)+1 < 1 .AND. (j >= snl(c)+1) .AND. (j <= 0)) then  


### PR DESCRIPTION
### Description of changes
This change fixes exact restart (ERP) failures when `hist_all_fields = .true.` by ensuring diagnostic variables across `BiogeophysPreFluxCalcsMod`, `CanopyFluxesMod`, `FrictionVelocityMod`, `SoilHydrologyMod`, `SoilMoistStressMod`, `SoilStateType`, and `SoilTemperatureMod` are properly initialized to `spval` each timestep on inactive layers or patches. Without explicit per-timestep initialization, uninitialized array space on inactive points retained memory across timestep boundaries, causing state discrepancies when comparing base vs. restart history output.

### Specific notes

**Contributors other than yourself, if any:**
- @jpalex

**Linked issues addressed, if any:**
- Contributes to [ESCOMP/CTSM#4142](https://github.com/ESCOMP/CTSM/issues/4142)

**Description of generative AI usage:**
- Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Answer Changes & Scientific Impact
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**

### User Interface & Namelist Changes
- **Namelist / Defaults modified?** No
- **XML / Build script changes?** No

### Testing planned or performed, if any:
- [x] Executed pFUnit / CIME regression tests

**CTSM / CESM baseline hash-tag:** 7409d3218513e1d95dbc2828de9a11a8972b1386
**PR branch hash-tag:** 3a0dc8a1455978e66838fa5cef20c3ac60305190

### Requirements before merge:
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors.
- [x] In-code documentation and Fortran docstrings updated.
- [x] This PR either (a) does not create a need to update documentation or (b) includes required documentation updates. **Which?:** (a) Bug fix / restart array initialization; no documentation updates required.
