### PR TITLE
test(ci): Re-enable FatesColdAllVars exact restart tests

### DIFF
--- a/cime_config/testdefs/ExpectedTestFails.xml
+++ b/cime_config/testdefs/ExpectedTestFails.xml
@@ -37,13 +37,7 @@
   </test>
 
   <!-- aux_clm test suite failures -->
-  <test name="ERP_Ld9.f45_f45_mg37.I2000Clm50FatesRs.derecho_intel.clm-FatesColdAllVars">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>#3660</issue>
-      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
-    </phase>
-  </test>
+
   <test name="ERP_P64x2_D_Ld3.f10_f10_mt232.IHistClm60BgcCropCrujra.derecho_gnu.clm-default--clm-all_outputs">
     <phase name="COMPARE_base_rest">
       <status>FAIL</status>
@@ -208,13 +202,7 @@
 
   <!-- fates test suite failures -->
 
-  <test name="ERP_Ld9.f45_f45_mg37.I2000Clm50FatesCruRsGs.derecho_intel.clm-FatesColdAllVars">
-    <phase name="COMPARE_base_rest">
-      <status>FAIL</status>
-      <issue>#3660</issue>
-      <comment>Restart issues with default "inactive" fields added to history by hist_all_fields.</comment>
-    </phase>
-  </test>
+
 
   <!-- This is commented out because cime currently does NOT allow longnames in the XML in the XSD for this file
   <test name="ERS_D_Ld30.f45_f45_mg37.HIST_DATM%CRUv7_CLM50%FATES_SICE_SOCN_SROF_SGLC_SWAV_SESP.izumi_nag.clm-FatesColdLandUse">


### PR DESCRIPTION
### Description of changes
This change removes the `FatesColdAllVars` exact restart (ERP) test entries from `cime_config/testdefs/ExpectedTestFails.xml`, re-enabling automated testing for FATES exact restarts.

**Dependencies:**
- Depends on FATES PR [NGEET/fates#1596](https://github.com/NGEET/fates/pull/1596).
- Depends on CTSM PR [ESCOMP/CTSM#4172](https://github.com/ESCOMP/CTSM/pull/4172).

**Linked issues addressed, if any:**
- Resolves [ESCOMP/CTSM#3660](https://github.com/ESCOMP/CTSM/issues/3660) (Re-enables `FatesColdAllVars` exact restart tests in CI)

**Description of generative AI usage:**
- Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Answer Changes & Scientific Impact
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**

### User Interface & Namelist Changes
- **Namelist / Defaults modified?** No
- **XML / Build script changes?** No

### Testing planned or performed, if any:
- [x] Executed pFUnit / CIME regression tests

**CTSM / CESM baseline hash-tag:** 334ba96fa4679a1bb29eca01c9702fb9ed1830f7
**PR branch hash-tag:** 173f76bf70f08ce8d1a59e1c42535b492ff84f35

### Requirements before merge:
- [x] I have followed the [CTSM contribution guidelines](https://github.com/ESCOMP/CTSM/blob/master/CONTRIBUTING.md).
- [x] The code in this PR branch builds with no errors.
- [x] The code in this PR branch runs with no errors. **Briefly describe tested configuration(s):** macOS gfortran pFUnit / CIME ERP regression tests
- [x] This either (a) does not change answers, (b) it only changes answers at roundoff level, or (c) I have performed a scientific evaluation of the answer changes. **Which?:** (a) Bit-for-bit (B4B) with baseline master
- [x] I have reviewed relevant parts of the CLM documentation [Tech Note](https://escomp.github.io/CTSM/tech_note/index.html) or [User's Guide](https://escomp.github.io/CTSM/users_guide/index.html) to determine if anything needs to be changed or added.
- [x] This PR either (a) does not create a need to update the documentation or (b) includes required documentation updates. **Which?:** (a) Internal fix/test; no documentation updates required.